### PR TITLE
fix: carry isAgent onto the fallback-built profile for read receipt readers

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -614,7 +614,8 @@ public final class MessagesListProcessor: Sendable {
                             inboxId: info.inboxId,
                             conversationId: info.conversationId,
                             name: info.name,
-                            avatar: info.avatar
+                            avatar: info.avatar,
+                            isAgent: info.isAgent
                         )
                         return ConversationMember(
                             profile: profile,

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -1181,6 +1181,10 @@ struct MessagesListProcessorReadReceiptTests {
         #expect(byInbox[convosAgentInboxId]?.agentVerification == .verified(.convos))
         #expect(byInbox[oauthAgentInboxId]?.isAgent == true)
         #expect(byInbox[oauthAgentInboxId]?.agentVerification == .verified(.userOAuth))
+        // Avatar views gate the verification badge on the profile's isAgent
+        // flag, so the fallback-built profile must carry it too.
+        #expect(byInbox[convosAgentInboxId]?.profile.isAgent == true)
+        #expect(byInbox[oauthAgentInboxId]?.profile.isAgent == true)
     }
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #1058. A verified agent that had just joined a chat still showed no verification badge on the read receipt, even though every other surface (member list, contact card, sender avatar) showed it as verified.

## Root cause

#1058 fixed the `ConversationMember` built by the read-receipt member-profile-cache fallback so it carries `isAgent`/`agentVerification`. But the avatar views gate the badge one level deeper: `MessageAvatarView` and `ProfileAvatarView` render the passed verification only when `profile.isAgent` is true:

```swift
agentVerification: profile.isAgent ? agentVerification : .unverified
```

The fallback in `MessagesListProcessor.resolveMember` built its `Profile` as `Profile(inboxId:conversationId:name:avatar:)`, leaving `isAgent` at its default `false` — so the badge was suppressed for any reader resolved through the cache (an agent with no message in the loaded window, e.g. one that just joined and only read). Surfaces that hydrate the profile fully set `isAgent` from `memberKind`, which is why the badge showed everywhere except the read receipt.

## Fix

Pass `isAgent: info.isAgent` when building the fallback `Profile`.

## Testing

- Extended `readByMembersFallbackPreservesAgentVerification` to also assert `profile.isAgent` survives the fallback (the property the avatar views actually gate on).
- Full ConvosCore suite: **1215 tests in 173 suites, all passing** (local XMTP Docker stack).
- SwiftLint strict: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783867679&installation_id=128169237&pr_number=1062&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1062&signature=8f6ab1ce88bd15d7c4c08b90574c69044395ca77550649bff30cb761868d6704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isAgent` not being set on fallback-built profiles for read receipt readers
> When `MessagesListProcessor` builds a fallback `Profile` from `memberProfiles` for read-receipt readers, it previously omitted `isAgent`, leaving it at the default value. The fix passes `isAgent: info.isAgent` to the `Profile` initializer in [MessagesListProcessor.swift](https://github.com/xmtplabs/convos-ios/pull/1062/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7). A new assertion in [MessagesListProcessorTests.swift](https://github.com/xmtplabs/convos-ios/pull/1062/files#diff-02e4f56ebdce0ca714f81c9e2a1d074ff74e2ae60e2747c9d74bf3bbf942a213) verifies that agent reader profiles carry `isAgent == true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca0155c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->