### PR TITLE
Builder cards: keep one card per Make and clear stale full-bleed adjacency

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListProcessor.swift
@@ -85,26 +85,42 @@ public final class MessagesListProcessor: Sendable {
         return rebuilt
     }
 
-    /// Group build messages into runs of entries adjacent in the message stream.
-    /// One Make sends its prompt + attachment bundle back to back, so they form a
-    /// single run (and a single card); separate Make events split by other
-    /// messages form separate runs and render separate cards.
+    /// Group build messages into runs. One Make sends its prompt + attachment
+    /// bundle back to back, so they form a single run (and a single card);
+    /// separate Make events split by other visible messages form separate runs
+    /// and render separate cards. Rows that never render their own list item
+    /// (silent updates, connection invocations) don't break a run -- one
+    /// landing between the bundle's publishes must not turn one Make into two
+    /// cards.
     private static func buildRuns(in rawMessages: [AnyMessage], buildMessageIds: Set<String>) -> [[AnyMessage]] {
         guard !buildMessageIds.isEmpty else { return [] }
         var runs: [[AnyMessage]] = []
         var current: [AnyMessage] = []
-        var lastIndex: Int?
-        for (index, message) in rawMessages.enumerated() where buildMessageIds.contains(message.messageId) {
-            if let last = lastIndex, index == last + 1 {
+        var visibleRowSinceLastBuildRow: Bool = false
+        for message in rawMessages {
+            if buildMessageIds.contains(message.messageId) {
+                if visibleRowSinceLastBuildRow, !current.isEmpty {
+                    runs.append(current)
+                    current = []
+                }
                 current.append(message)
-            } else {
-                if !current.isEmpty { runs.append(current) }
-                current = [message]
+                visibleRowSinceLastBuildRow = false
+            } else if rendersOwnListRow(message.content) {
+                visibleRowSinceLastBuildRow = true
             }
-            lastIndex = index
         }
         if !current.isEmpty { runs.append(current) }
         return runs
+    }
+
+    /// Whether a message produces its own row in the list. Mirrors the two
+    /// silent paths in `processMessages`: contents hidden by
+    /// `showsInMessagesList`, and connection invocations, which the grouping
+    /// loop skips outright.
+    private static func rendersOwnListRow(_ content: MessageContent) -> Bool {
+        guard content.showsInMessagesList else { return false }
+        if case .connectionInvocation = content { return false }
+        return true
     }
 
     /// The `AgentBuilderConnection` raw values captured in a creator's local
@@ -302,6 +318,7 @@ public final class MessagesListProcessor: Sendable {
             items = insertingContactCard(in: items, agent: agent)
         }
 
+        items = reconcilingFullBleedAdjacency(in: items)
         return clearingDuplicatedLastGroupFlags(in: items)
     }
 
@@ -761,6 +778,34 @@ private extension MessagesListProcessor {
                 } else {
                     seenLastBeforeOtherMembers = true
                 }
+            }
+            if changed { items[index] = .messages(group) }
+        }
+        return items
+    }
+
+    /// The full-bleed adjacency pass runs before the card splices, so a group
+    /// can keep a flag from a full-bleed neighbor that was swallowed or
+    /// replaced by a card row -- rendering hairline padding against a
+    /// non-media row. Clear any flag whose neighbor is no longer a full-bleed
+    /// group (clear-only: a group never gains hairline treatment here).
+    static func reconcilingFullBleedAdjacency(
+        in baseItems: [MessagesListItemType]
+    ) -> [MessagesListItemType] {
+        var items: [MessagesListItemType] = baseItems
+        for index in items.indices {
+            guard case .messages(var group) = items[index],
+                  group.adjacentToFullBleedAbove || group.adjacentToFullBleedBelow else { continue }
+            let fullBleedAbove: Bool = index > 0 && items[index - 1].isFullBleedAttachmentGroup
+            let fullBleedBelow: Bool = index < items.count - 1 && items[index + 1].isFullBleedAttachmentGroup
+            var changed: Bool = false
+            if group.adjacentToFullBleedAbove, !fullBleedAbove {
+                group.adjacentToFullBleedAbove = false
+                changed = true
+            }
+            if group.adjacentToFullBleedBelow, !fullBleedBelow {
+                group.adjacentToFullBleedBelow = false
+                changed = true
             }
             if changed { items[index] = .messages(group) }
         }

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListProcessorTests.swift
@@ -2064,3 +2064,71 @@ extension MessagesListProcessorPendingBuilderCardTests {
         #expect(flagged.first?.messages.map(\.messageId) == ["second"])
     }
 }
+
+private func makeConnectionInvocation(
+    id: String = UUID().uuidString,
+    sender: ConversationMember = otherUser,
+    date: Date = Date()
+) -> AnyMessage {
+    .message(Message(
+        id: id,
+        sender: sender,
+        source: .incoming,
+        status: .published,
+        content: .connectionInvocation(summary: ConnectionEventSummary(
+            text: "read calendar events",
+            outcome: .success,
+            icon: .calendar
+        )),
+        date: date,
+        reactions: []
+    ), .existing)
+}
+
+extension MessagesListProcessorAgentBuilderCardTests {
+    @Test("An invocation row landing between the bundle's publishes keeps one card")
+    func invisibleRowBetweenBundlePublishesKeepsOneCard() {
+        let now = Date()
+        // The bundle's attachment and prompt rows publish back to back, but a
+        // connection invocation (which never renders its own row) lands
+        // between them. One Make must still render one card, not an
+        // attachments-only card plus a prompt-only card.
+        let messages = [
+            makeAttachment(id: "b-att", sender: currentUser, date: now),
+            makeConnectionInvocation(id: "invoke", date: now.addingTimeInterval(1)),
+            makeMessage(id: "b-text", sender: currentUser, text: "Track the fog", date: now.addingTimeInterval(2)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-att", "b-text"]
+        )
+        let cards = builderCards(from: result)
+        #expect(cards.count == 1)
+        #expect(cards.first?.prompt == "Track the fog")
+        #expect(cards.first?.attachments.count == 1)
+    }
+
+    @Test("Replacing a full-bleed bundle row with the card clears the neighbor's hairline adjacency")
+    func swallowedFullBleedBundleClearsStaleAdjacency() {
+        let now = Date()
+        // A full-bleed photo sits directly above the bundle's full-bleed
+        // attachment row, so the adjacency pass marks the pair before the
+        // bundle rows are replaced by the card. The photo must not keep
+        // hairline padding against the card row.
+        let messages = [
+            makeAttachment(id: "photo", sender: otherUser, date: now),
+            makeAttachment(id: "b-att", sender: currentUser, date: now.addingTimeInterval(5)),
+            makeMessage(id: "b-text", sender: currentUser, text: "Track the fog", date: now.addingTimeInterval(6)),
+        ]
+        let result = MessagesListProcessor.process(
+            messages,
+            hiddenBundleMessageIds: ["b-att", "b-text"]
+        )
+        #expect(builderCards(from: result).count == 1)
+        let photoGroup = groups(from: result).first { group in
+            group.messages.contains { $0.messageId == "photo" }
+        }
+        #expect(photoGroup != nil)
+        #expect(photoGroup?.adjacentToFullBleedBelow == false)
+    }
+}


### PR DESCRIPTION
Follow-up to #1057, fixing the two pre-existing nits its review surfaced in the builder-card reconstruction path.

## 1. Invisible rows no longer split one Make into two cards

`buildRuns` grouped a Make's prompt + attachment rows by raw-index adjacency. A row that never renders its own list item — a silent metadata update or a `.connectionInvocation` — landing in the gap between the bundle's two publishes split the run, so one Make rendered **two** cards: an attachments-only card and a prompt-only card. (Creator's latest build was immune via the `ownsSummary` swallow; recipients and older builds were not.)

Runs now break only on rows that actually render, via a `rendersOwnListRow` check mirroring the two silent paths in `processMessages`. Separate Makes split by visible messages still render separate cards (existing `multipleBuildRuns` test unchanged).

## 2. Stale hairline padding after a bundle row is swallowed/replaced

The full-bleed adjacency pass runs before the card splices, so a full-bleed photo group neighboring the bundle's full-bleed attachment row kept `adjacentToFullBleedBelow` after that row was swallowed or replaced by the card — rendering hairline padding against a non-media row.

A clear-only `reconcilingFullBleedAdjacency` sweep now runs after all splicing (run cards, summary card, contact card), clearing any adjacency flag whose neighbor is no longer a full-bleed group. This generalizes the manual clearing `insertingContactCard` already did for its own splice. Clear-only by design: groups never *gain* hairline treatment from post-splice adjacency.

## Tests

Two regression tests, both verified to fail on the previous code with the exact symptoms:
- `invisibleRowBetweenBundlePublishesKeepsOneCard` — failed with `cards.count → 2` and a blank-prompt first card
- `swallowedFullBleedBundleClearsStaleAdjacency` — failed with `adjacentToFullBleedBelow → true`

Full ConvosCore suite passes: 1217 tests in 173 suites. SwiftLint strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783867756&installation_id=128169237&pr_number=1063&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1063&signature=fb5f5962d7aba80c72e1d9060e65483570e387b902fca40a7f9c15a85ea94de5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix builder card deduplication and stale full-bleed adjacency flags after card insertion
> - `buildRuns` in [`MessagesListProcessor`](https://github.com/xmtplabs/convos-ios/pull/1063/files#diff-c32ba383ca53d832eed02dc83f3d0a9546aad74da5c5919555079a4fc07383d7) no longer splits runs on invisible rows (e.g. silent updates, connection invocations); only rows that render in the list break a run, ensuring one card is produced per Make bundle.
> - A new `reconcilingFullBleedAdjacency` pass clears stale `adjacentToFullBleedAbove/Below` flags on message groups whose neighbors are no longer full-bleed after a card row is spliced in.
> - The reconciliation pass runs before `clearingDuplicatedLastGroupFlags` in the main `process` function.
> - Two new tests cover these cases: an invisible row between bundle publishes and a swallowed full-bleed bundle neighbor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b97228f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->