### PR TITLE
fix: group photo cached as the agent's profile avatar

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2327,7 +2327,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         }
 
         if isConversationImageDirty, let conversationImage = conversationImage {
-            ImageCache.shared.cacheImage(conversationImage, for: conversation.imageCacheIdentifier, imageFormat: .jpg)
+            // Key by the conversation id, not `imageCacheIdentifier`: before
+            // the image upload persists, that identifier resolves to the other
+            // member's inbox id and would cache this image as their avatar.
+            ImageCache.shared.cacheImage(conversationImage, for: conversation.clientConversationId, imageFormat: .jpg)
             isConversationImageDirty = false
 
             Task { [weak self] in

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -407,8 +407,15 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     ///   - object: The ImageCacheable object this image is for
     /// - Returns: JPEG data ready for upload, or nil if compression fails
     public func prepareForUpload(_ image: UIImage, for object: any ImageCacheable) -> Data? {
-        let identifier = object.imageCacheIdentifier
+        prepareForUpload(image, forIdentifier: object.imageCacheIdentifier)
+    }
 
+    /// Identifier-based variant of `prepareForUpload(_:for:)`. Conversation
+    /// image uploads must pass the conversation's stable id directly:
+    /// `Conversation.imageCacheIdentifier` resolves to the other member's
+    /// inbox id while `imageURL` is nil, which would cache the conversation
+    /// image as that member's profile avatar.
+    public func prepareForUpload(_ image: UIImage, forIdentifier identifier: String) -> Data? {
         // Immediately set the cache so there is no delay showing in the UI
         cache.setObject(image, forKey: identifier as NSString, cost: memoryCost(for: image))
 

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCacheProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCacheProtocol.swift
@@ -25,6 +25,12 @@ public protocol ImageCacheProtocol: AnyObject, Sendable {
     /// Prepare an image for upload by resizing/compressing and caching it
     func prepareForUpload(_ image: ImageType, for object: any ImageCacheable) -> Data?
 
+    /// Prepare an image for upload, caching it under an explicit identifier.
+    /// Use this when the object's `imageCacheIdentifier` depends on mutable
+    /// state and could resolve to a different entity's key (e.g. a conversation
+    /// without a persisted image resolves to the other member's inbox id).
+    func prepareForUpload(_ image: ImageType, forIdentifier identifier: String) -> Data?
+
     /// Cache an image after upload completes, updating URL tracking
     func cacheAfterUpload(_ image: ImageType, for object: any ImageCacheable, url: String)
 

--- a/ConvosCore/Sources/ConvosCore/Image Cache/MockImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/MockImageCache.swift
@@ -23,6 +23,8 @@ public final class MockImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     public func prepareForUpload(_ image: ImageType, for object: any ImageCacheable) -> Data? { nil }
 
+    public func prepareForUpload(_ image: ImageType, forIdentifier identifier: String) -> Data? { nil }
+
     public func cacheAfterUpload(_ image: ImageType, for object: any ImageCacheable, url: String) {}
 
     public func cacheAfterUpload(_ image: ImageType, for identifier: String, url: String) {}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -167,9 +167,13 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
             throw ConversationMetadataError.conversationNotFound(conversationId: conversation.id)
         }
 
+        // Key by the conversation id, not `conversation.imageCacheIdentifier`:
+        // until `imageURL` is persisted that identifier resolves to the other
+        // member's inbox id, which would cache the conversation image as that
+        // member's profile avatar everywhere.
         guard let compressedImageData = ImageCacheContainer.shared.prepareForUpload(
             image,
-            for: conversation
+            forIdentifier: conversation.clientConversationId
         ) else {
             throw ConversationMetadataWriterError.failedImageCompression
         }
@@ -251,11 +255,15 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
             ImageCacheContainer.shared.removeImage(for: oldPublicImageURL)
         }
 
-        // Cache the uploaded image using the new URL-tracking API
-        // Uses prepareForUpload + cacheAfterUpload to avoid double-caching
-        if let cachedImage = ImageType(data: compressedImageData) {
-            ImageCacheContainer.shared.cacheAfterUpload(cachedImage, for: conversation, url: encryptedAssetUrl)
-        }
+        // Cache under the conversation id, matching the prepareForUpload key
+        // above. The `conversation` parameter still has a nil `imageURL`, so
+        // its `imageCacheIdentifier` would resolve to the other member's
+        // inbox id and record the conversation image as their avatar.
+        ImageCacheContainer.shared.cacheAfterUpload(
+            compressedImageData,
+            for: conversation.clientConversationId,
+            url: encryptedAssetUrl
+        )
 
         try await syncInvitePreview(for: updatedConversation)
 


### PR DESCRIPTION
## Summary

In a conversation whose only other joined member is an agent (every agent-builder convo until the first invitee accepts), setting the conversation photo cached that photo under the **agent's inbox id** instead of the conversation id. Profile avatars are deliberately cached app-wide per inbox id and persisted to disk, so the group photo then rendered as the agent's profile avatar everywhere — message bubbles, member list, contact card, other conversations — and survived later member joins.

Root cause: `Conversation.imageCacheIdentifier` resolves to the other member's inbox id whenever `imageURL` is nil (the intentional DM avatar-sharing *read* path), and the conversation-image *write* paths reused it:

- `ConversationMetadataWriter.updateImage` called `prepareForUpload(image, for: conversation)` before the upload, and `cacheAfterUpload(..., for: conversation, ...)` after — the latter with the stale in-memory snapshot whose `imageURL` is still nil, so the mis-keyed write happened deterministically on every first photo set, not just in a race window.
- `ConversationViewModel` made the same mis-keyed optimistic `cacheImage` write on photo edit.

## Changes

- Key all conversation-image cache writes by `clientConversationId`:
  - `ConversationMetadataWriter.updateImage` pre-upload write (new identifier-based `prepareForUpload`) and post-upload write (existing data-based `cacheAfterUpload`, which also drops a needless re-compression)
  - `ConversationViewModel` optimistic cache write
- Add `prepareForUpload(_:forIdentifier:)` to `ImageCacheProtocol`; object-based variant delegates to it; `MockImageCache` conforms.

Read paths are untouched: DM conversation avatars still share the member's avatar cache entry, and the conversation-image reload listener keeps working because hydration re-emits the conversation with `imageURL` set right after the upload persists.

Note: this prevents new poisoning but does not clean entries already on users' disks; those heal only when the agent's real avatar URL drifts in. A one-time cleanup can follow if we want it.

## Test plan

- Full ConvosCore suite against the local XMTP node: 1215 tests in 173 suites, all passing
- `Convos (Dev)` scheme builds
- SwiftLint strict clean on changed files
- Manual repro path: in a convo with just you + an agent and no photo, set a conversation photo → agent's avatar must stay its own (previously became the group photo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783869613&installation_id=128169237&pr_number=1064&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1064&signature=17e5843986559fe07bfe76adc21acf44e1278bb476929e72678a38ac6735fe1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix group photo being cached under the agent's profile avatar identity
> - Group conversation images were being cached under `imageCacheIdentifier`, which resolves to the other member's inbox ID before the image upload persists — causing the group photo to overwrite the agent's profile avatar.
> - Fixes this in both [`ConversationViewModel`](https://github.com/xmtplabs/convos-ios/pull/1064/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) and [`ConversationMetadataWriter`](https://github.com/xmtplabs/convos-ios/pull/1064/files#diff-ce17de6d3ad64e828d2531d31326211c4a7d54f39e9e4e299402b089d206eeaf) by keying all cache operations on `clientConversationId` instead.
> - Adds a new `prepareForUpload(_:forIdentifier:)` API to [`ImageCache`](https://github.com/xmtplabs/convos-ios/pull/1064/files#diff-9c43db5e1255cd76ef671f19b4a4c7a02209590452cefbe49fbee60b9884b12b) and [`ImageCacheProtocol`](https://github.com/xmtplabs/convos-ios/pull/1064/files#diff-2672654a2e138e5119c1edf43f5bf683c097f7a08114f99cc1eb9f9a2510b25a) to support caching under an explicit identifier rather than the object's `imageCacheIdentifier`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3cbcac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->