### PR TITLE
fix(invites): dedupe join requests by message ID so removing a member sticks

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1114,6 +1114,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                 GroupUpdatedCodec(),
                 ExplodeSettingsCodec(),
                 InviteJoinErrorCodec(),
+                InviteJoinHandledCodec(),
                 ProfileUpdateCodec(),
                 ProfileSnapshotCodec(),
                 JoinRequestCodec(),

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBHandledJoinRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBHandledJoinRequest.swift
@@ -1,0 +1,16 @@
+import Foundation
+import GRDB
+
+/// A join-request message that already admitted its sender to a group.
+/// Keyed by XMTP message ID; see `DatabaseHandledJoinRequestStore`.
+struct DBHandledJoinRequest: FetchableRecord, PersistableRecord, Codable, Hashable {
+    static let databaseTableName: String = "handledJoinRequest"
+
+    enum Columns {
+        static let messageId: Column = Column(CodingKeys.messageId)
+        static let handledAt: Column = Column(CodingKeys.handledAt)
+    }
+
+    let messageId: String
+    let handledAt: Date
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -207,7 +207,20 @@ extension SharedDatabaseMigrator {
 
         migrator.registerMigration("addConnectionGrantBundleScope", migrate: Self.addConnectionGrantBundleScope)
 
+        migrator.registerMigration("createHandledJoinRequest", migrate: Self.createHandledJoinRequest)
+
         return migrator
+    }
+
+    /// Ledger of join-request message IDs that already admitted their
+    /// sender, shared with the notification service extension. Keyed by
+    /// message ID so revalidation passes cannot re-add a member the user
+    /// removed; see `DatabaseHandledJoinRequestStore`.
+    private static func createHandledJoinRequest(_ db: Database) throws {
+        try db.create(table: "handledJoinRequest") { t in
+            t.column("messageId", .text).notNull().primaryKey()
+            t.column("handledAt", .datetime).notNull()
+        }
     }
 
     /// Persisted "the local user was removed from this conversation" marker.

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -221,6 +221,11 @@ extension SharedDatabaseMigrator {
             t.column("messageId", .text).notNull().primaryKey()
             t.column("handledAt", .datetime).notNull()
         }
+        try db.create(
+            index: "handledJoinRequest_handledAt",
+            on: "handledJoinRequest",
+            columns: ["handledAt"]
+        )
     }
 
     /// Persisted "the local user was removed from this conversation" marker.

--- a/ConvosCore/Sources/ConvosCore/Syncing/DatabaseHandledJoinRequestStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/DatabaseHandledJoinRequestStore.swift
@@ -28,11 +28,13 @@ final class DatabaseHandledJoinRequestStore: HandledJoinRequestStoreProtocol, Se
     }
 
     func markHandled(messageId: String) async {
+        let now = Date()
+        let retentionCutoff = now.addingTimeInterval(-Constant.retention)
         do {
             try await databaseWriter.write { db in
-                try DBHandledJoinRequest(messageId: messageId, handledAt: Date()).save(db)
+                try DBHandledJoinRequest(messageId: messageId, handledAt: now).save(db)
                 try DBHandledJoinRequest
-                    .filter(DBHandledJoinRequest.Columns.handledAt < Date().addingTimeInterval(-Constant.retention))
+                    .filter(DBHandledJoinRequest.Columns.handledAt < retentionCutoff)
                     .deleteAll(db)
             }
         } catch {

--- a/ConvosCore/Sources/ConvosCore/Syncing/DatabaseHandledJoinRequestStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/DatabaseHandledJoinRequestStore.swift
@@ -1,0 +1,49 @@
+import ConvosInvites
+import Foundation
+import GRDB
+
+/// GRDB-backed handled-join-request ledger, shared between the app and the
+/// notification service extension through the app-group database. Survives
+/// across processing passes (`SyncingManager` builds a fresh
+/// `InviteJoinRequestsManager` per batch) so an already-honored join request
+/// stays inert even after its sender is removed from the group.
+final class DatabaseHandledJoinRequestStore: HandledJoinRequestStoreProtocol, Sendable {
+    private let databaseWriter: any DatabaseWriter
+
+    init(databaseWriter: any DatabaseWriter) {
+        self.databaseWriter = databaseWriter
+    }
+
+    func isHandled(messageId: String) async -> Bool {
+        do {
+            return try await databaseWriter.read { db in
+                try DBHandledJoinRequest.filter(key: messageId).fetchOne(db) != nil
+            }
+        } catch {
+            // On a read failure fall back to the coordinator's
+            // membership-based dedupe instead of dropping the request.
+            Log.error("Reading handled join request \(messageId) failed: \(error)")
+            return false
+        }
+    }
+
+    func markHandled(messageId: String) async {
+        do {
+            try await databaseWriter.write { db in
+                try DBHandledJoinRequest(messageId: messageId, handledAt: Date()).save(db)
+                try DBHandledJoinRequest
+                    .filter(DBHandledJoinRequest.Columns.handledAt < Date().addingTimeInterval(-Constant.retention))
+                    .deleteAll(db)
+            }
+        } catch {
+            Log.error("Persisting handled join request \(messageId) failed: \(error)")
+        }
+    }
+
+    private enum Constant {
+        /// How long handled-request rows are kept. Catch-up passes look back
+        /// at most 24 hours (`InviteJoinRequestsManager.maxCatchUpWindow`),
+        /// so rows older than this can never be revalidated.
+        static let retention: TimeInterval = 30 * 24 * 60 * 60
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -85,7 +85,8 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
 
     init(identityStore: any KeychainIdentityStoreProtocol,
          databaseWriter: any DatabaseWriter,
-         tagStorage: any InviteTagStorageProtocol = ProtobufInviteTagStorage()) {
+         tagStorage: any InviteTagStorageProtocol = ProtobufInviteTagStorage(),
+         handledRequestStore: (any HandledJoinRequestStoreProtocol)? = nil) {
         self.databaseWriter = databaseWriter
         self.coordinator = InviteCoordinator(
             privateKeyProvider: { inboxId in
@@ -94,7 +95,11 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
                 }
                 return identity.keys.privateKey.secp256K1.bytes
             },
-            tagStorage: tagStorage
+            tagStorage: tagStorage,
+            // The persistent ledger is what keeps an already-honored join
+            // request inert across passes and processes; every production
+            // caller funnels through this default.
+            handledRequestStore: handledRequestStore ?? DatabaseHandledJoinRequestStore(databaseWriter: databaseWriter)
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/DatabaseHandledJoinRequestStoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DatabaseHandledJoinRequestStoreTests.swift
@@ -1,0 +1,57 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("DatabaseHandledJoinRequestStore")
+struct DatabaseHandledJoinRequestStoreTests {
+    private func makeDatabase() throws -> DatabaseQueue {
+        let dbQueue = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: dbQueue)
+        return dbQueue
+    }
+
+    @Test("Marked message IDs are reported handled; unmarked are not")
+    func marksAndReadsBack() async throws {
+        let store = DatabaseHandledJoinRequestStore(databaseWriter: try makeDatabase())
+
+        #expect(await store.isHandled(messageId: "msg-1") == false)
+
+        await store.markHandled(messageId: "msg-1")
+
+        #expect(await store.isHandled(messageId: "msg-1"))
+        #expect(await store.isHandled(messageId: "msg-2") == false)
+    }
+
+    @Test("Marking the same message twice is idempotent")
+    func markingIsIdempotent() async throws {
+        let database = try makeDatabase()
+        let store = DatabaseHandledJoinRequestStore(databaseWriter: database)
+
+        await store.markHandled(messageId: "msg-1")
+        await store.markHandled(messageId: "msg-1")
+
+        let count = try await database.read { db in
+            try DBHandledJoinRequest.fetchCount(db)
+        }
+        #expect(count == 1)
+    }
+
+    @Test("Rows past retention are pruned on write")
+    func prunesExpiredRows() async throws {
+        let database = try makeDatabase()
+        let store = DatabaseHandledJoinRequestStore(databaseWriter: database)
+
+        try await database.write { db in
+            try DBHandledJoinRequest(
+                messageId: "msg-old",
+                handledAt: Date().addingTimeInterval(-31 * 24 * 60 * 60)
+            ).save(db)
+        }
+
+        await store.markHandled(messageId: "msg-new")
+
+        #expect(await store.isHandled(messageId: "msg-old") == false)
+        #expect(await store.isHandled(messageId: "msg-new"))
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -381,6 +381,65 @@ struct InviteCoordinatorIntegrationTests {
         #expect(memberInboxIds.contains(joinerClient.inboxID))
     }
 
+    /// Isolates the ledger layer: a text-only joiner (pre-typed build) gets
+    /// no marker because of the cross-version gate, so the per-device
+    /// ledger alone must keep the honored request inert after removal -
+    /// and a fresh text request must still rejoin.
+    @Test("Text-only joiner: ledger alone keeps a replayed request inert; a fresh request rejoins")
+    func textOnlyJoinerLedgerCoversReplay() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let key = creatorInviteKey
+        let coordinator = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group)
+        let invite = try await coordinator.createInvite(for: group, client: creatorClient)
+
+        // Text-only request, the pre-typed (2.0.0 and earlier) wire format.
+        let dm = try await joinerClient.conversations.findOrCreateDm(with: creatorClient.inboxID)
+        _ = try await dm.send(content: invite.slug)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let firstOutcomes = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
+        #expect(try await joinHandledMarkerCount(inDmWith: joinerClient.inboxID, client: creatorClient) == 0)
+
+        try await group.removeMembers(inboxIds: [joinerClient.inboxID])
+
+        let replayOutcomes = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(
+            replayOutcomes.compactMap(\.joinResult).isEmpty,
+            "The ledger alone must keep a text-only joiner's honored request inert"
+        )
+        var memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(!memberInboxIds.contains(joinerClient.inboxID), "Removed member must stay removed")
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        _ = try await dm.send(content: invite.slug)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let rejoinOutcomes = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(
+            rejoinOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id },
+            "A fresh text-only join request must be honored"
+        )
+        memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(memberInboxIds.contains(joinerClient.inboxID))
+        #expect(
+            try await joinHandledMarkerCount(inDmWith: joinerClient.inboxID, client: creatorClient) == 0,
+            "Text-only joins must never produce a marker, including on rejoin"
+        )
+    }
+
     private func joinErrorCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {
         try await messageCount(ofType: ContentTypeInviteJoinError, inDmWith: peerInboxId, client: client)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -225,6 +225,73 @@ struct InviteCoordinatorIntegrationTests {
         #expect(errorCount == 2, "A retried join request gets its own error reply")
     }
 
+    /// Regression test for removed agents instantly rejoining: join-request
+    /// DMs are durable, and batch catch-up / the agent-join poll revalidate
+    /// them after the member list changes. Before the handled-request ledger,
+    /// the only dedupe was "is the joiner currently a member", so removing
+    /// the member made the already-honored request actionable again and the
+    /// next pass silently re-added them. The ledger keys on message ID:
+    /// the replayed request stays inert, while a fresh request with the same
+    /// invite still joins (removal is not a block).
+    @Test("Replayed join request does not re-add a removed member; a fresh request does")
+    func replayedJoinRequestStaysInertAfterRemoval() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        // One ledger shared by two coordinator instances, mirroring how
+        // production passes build a fresh coordinator per batch around the
+        // shared database-backed store.
+        let ledger = InMemoryHandledJoinRequestStore()
+        let key = creatorInviteKey
+        let firstPass = InviteCoordinator(privateKeyProvider: { _ in key }, handledRequestStore: ledger)
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await firstPass.revokeInvites(for: group)
+        let invite = try await firstPass.createInvite(for: group, client: creatorClient)
+
+        _ = try await firstPass.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let firstOutcomes = await firstPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
+
+        try await group.removeMembers(inboxIds: [joinerClient.inboxID])
+        var memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(!memberInboxIds.contains(joinerClient.inboxID))
+
+        // Revalidate the full DM history, as batch catch-up and the
+        // agent-join poll do after the removal.
+        let secondPass = InviteCoordinator(privateKeyProvider: { _ in key }, handledRequestStore: ledger)
+        let replayOutcomes = await secondPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(
+            replayOutcomes.compactMap(\.joinResult).isEmpty,
+            "Revalidating an already-honored join request must not re-add the removed member"
+        )
+        memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(
+            !memberInboxIds.contains(joinerClient.inboxID),
+            "Removed member must stay removed after revalidation passes"
+        )
+
+        // Removal is not a block: a fresh join request with the same valid
+        // invite is a new attempt and joins again.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        _ = try await secondPass.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let rejoinOutcomes = await secondPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(
+            rejoinOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id },
+            "A fresh join request from a removed member must be honored"
+        )
+        memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(memberInboxIds.contains(joinerClient.inboxID), "Fresh request re-adds the removed member")
+    }
+
     private func joinErrorCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {
         let dm = try await client.conversations.findOrCreateDm(with: peerInboxId)
         let messages = try await dm.messages()

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -328,6 +328,16 @@ struct InviteCoordinatorIntegrationTests {
         let firstOutcomes = await firstInstallation.processJoinRequestOutcomes(since: nil, client: creatorClient)
         #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
 
+        // The marker is now the newest DM message on the joiner's side. The
+        // outgoing-join-request check must still see the joiner's request
+        // through it, or the newly joined group never gets its consent bump
+        // and stays hidden from the joiner's feed.
+        _ = try await joinerClient.conversations.syncAllConversations(consentStates: nil)
+        let joinerGroups = try await joinerClient.conversations.listGroups()
+        let joinerGroup = try #require(joinerGroups.first { $0.id == group.id })
+        let stillOutgoing = try await firstInstallation.hasOutgoingJoinRequest(for: joinerGroup, client: joinerClient)
+        #expect(stillOutgoing, "Creator bookkeeping in the DM must not hide the joiner's outgoing join request")
+
         try await group.removeMembers(inboxIds: [joinerClient.inboxID])
 
         // Empty ledger, same DM history: only the marker can dedupe here.

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -29,6 +29,7 @@ struct InviteCoordinatorIntegrationTests {
                 TextCodec(),
                 JoinRequestCodec(),
                 InviteJoinErrorCodec(),
+                InviteJoinHandledCodec(),
             ],
             dbEncryptionKey: dbKey,
             dbDirectory: tmpDir.path
@@ -290,6 +291,70 @@ struct InviteCoordinatorIntegrationTests {
         )
         memberInboxIds = try await group.members.map(\.inboxId)
         #expect(memberInboxIds.contains(joinerClient.inboxID), "Fresh request re-adds the removed member")
+    }
+
+    /// The handled-request ledger is per-device; the cross-installation
+    /// guarantee comes from the `invite_join_handled` marker the creator
+    /// sends in the join DM after honoring a request. A coordinator with a
+    /// fresh, empty ledger (simulating a paired device or reinstall that
+    /// shares DM history but not the local database) must still treat the
+    /// honored request - including the text copy of Herald's typed+text
+    /// pair - as inert after the member is removed, while a fresh request
+    /// with the same invite still joins.
+    @Test("Handled marker keeps a replayed request inert for an installation with an empty ledger")
+    func handledMarkerCoversInstallationsWithoutLedger() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let key = creatorInviteKey
+        let firstInstallation = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await firstInstallation.revokeInvites(for: group)
+        let invite = try await firstInstallation.createInvite(for: group, client: creatorClient)
+
+        // Herald-style typed + text pair.
+        let dm = try await firstInstallation.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+        _ = try await dm.send(content: invite.slug)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let firstOutcomes = await firstInstallation.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
+
+        try await group.removeMembers(inboxIds: [joinerClient.inboxID])
+
+        // Empty ledger, same DM history: only the marker can dedupe here.
+        let otherInstallation = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+        let replayOutcomes = await otherInstallation.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(
+            replayOutcomes.compactMap(\.joinResult).isEmpty,
+            "The handled marker must keep both copies of the honored request inert without a local ledger"
+        )
+        var memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(!memberInboxIds.contains(joinerClient.inboxID), "Removed member must stay removed")
+
+        // A fresh request postdates the marker and must still join.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        _ = try await otherInstallation.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let rejoinOutcomes = await otherInstallation.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(
+            rejoinOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id },
+            "A fresh join request sent after the marker must be honored"
+        )
+        memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(memberInboxIds.contains(joinerClient.inboxID))
     }
 
     private func joinErrorCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -143,6 +143,14 @@ struct InviteCoordinatorIntegrationTests {
 
         let memberInboxIds = try await group.members.map(\.inboxId)
         #expect(memberInboxIds.contains(joinerClient.inboxID), "Text-slug joiner must be added to the group")
+
+        // Cross-version guard: pre-typed builds (2.0.0 and earlier) require
+        // their join request to be the DM's literal last message for
+        // `hasOutgoingJoinRequest`, so a text-only join must not get a
+        // handled marker - creator bookkeeping would break their consent
+        // bump for the newly joined group.
+        let markerCount = try await joinHandledMarkerCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(markerCount == 0, "Text-only joiners must not receive a handled marker")
     }
 
     /// Herald sends a typed join_request plus a plain-text slug copy. A
@@ -328,6 +336,12 @@ struct InviteCoordinatorIntegrationTests {
         let firstOutcomes = await firstInstallation.processJoinRequestOutcomes(since: nil, client: creatorClient)
         #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
 
+        // The typed copy in the pair marks the joiner as typed-capable, so
+        // the marker must be sent even though the newer text copy is the
+        // honored message.
+        let markerCount = try await joinHandledMarkerCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(markerCount == 1, "A typed-capable join must produce exactly one handled marker")
+
         // The marker is now the newest DM message on the joiner's side. The
         // outgoing-join-request check must still see the joiner's request
         // through it, or the newly joined group never gets its consent bump
@@ -368,11 +382,23 @@ struct InviteCoordinatorIntegrationTests {
     }
 
     private func joinErrorCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {
+        try await messageCount(ofType: ContentTypeInviteJoinError, inDmWith: peerInboxId, client: client)
+    }
+
+    private func joinHandledMarkerCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {
+        try await messageCount(ofType: ContentTypeInviteJoinHandled, inDmWith: peerInboxId, client: client)
+    }
+
+    private func messageCount(
+        ofType expectedType: ContentTypeID,
+        inDmWith peerInboxId: String,
+        client: Client
+    ) async throws -> Int {
         let dm = try await client.conversations.findOrCreateDm(with: peerInboxId)
         let messages = try await dm.messages()
         return messages.filter { message in
             guard let contentType = try? message.encodedContent.type else { return false }
-            return contentType == ContentTypeInviteJoinError
+            return contentType == expectedType
         }.count
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -154,6 +154,7 @@ class TestFixtures {
                 GroupUpdatedCodec(),
                 ExplodeSettingsCodec(),
                 InviteJoinErrorCodec(),
+                InviteJoinHandledCodec(),
                 ProfileUpdateCodec(),
                 ProfileSnapshotCodec(),
                 JoinRequestCodec(),

--- a/ConvosInvites/Sources/ConvosInvites/ContentTypes/InviteJoinHandledCodec.swift
+++ b/ConvosInvites/Sources/ConvosInvites/ContentTypes/InviteJoinHandledCodec.swift
@@ -1,0 +1,60 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+public let ContentTypeInviteJoinHandled = ContentTypeID(
+    authorityID: "convos.org",
+    typeID: "invite_join_handled",
+    versionMajor: 1,
+    versionMinor: 0
+)
+
+public enum InviteJoinHandledCodecError: Error, LocalizedError {
+    case emptyContent
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyContent:
+            return "InviteJoinHandled content is empty"
+        }
+    }
+}
+
+public struct InviteJoinHandledCodec: ContentCodec {
+    public typealias T = InviteJoinHandled
+
+    public var contentType: ContentTypeID = ContentTypeInviteJoinHandled
+
+    public init() {}
+
+    public func encode(content: InviteJoinHandled) throws -> EncodedContent {
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeInviteJoinHandled
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encodedContent.content = try encoder.encode(content)
+
+        return encodedContent
+    }
+
+    public func decode(content: EncodedContent) throws -> InviteJoinHandled {
+        guard !content.content.isEmpty else {
+            throw InviteJoinHandledCodecError.emptyContent
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        return try decoder.decode(InviteJoinHandled.self, from: content.content)
+    }
+
+    public func fallback(content: InviteJoinHandled) throws -> String? {
+        // Creator-side bookkeeping; joiners and older clients have nothing
+        // to show for it.
+        nil
+    }
+
+    public func shouldPush(content: InviteJoinHandled) throws -> Bool {
+        false
+    }
+}

--- a/ConvosInvites/Sources/ConvosInvites/HandledJoinRequestStore.swift
+++ b/ConvosInvites/Sources/ConvosInvites/HandledJoinRequestStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// MARK: - Handled Join Request Store Protocol
+
+/// Ledger of join-request messages that have already admitted their sender.
+///
+/// Join-request DMs are durable, and several paths (message stream, batch
+/// catch-up, the agent-join poll, the notification service extension) can
+/// revalidate the same message long after it was first honored. Group
+/// membership alone cannot dedupe those passes: once the creator removes
+/// the member, the old request looks actionable again and silently re-adds
+/// someone the user just removed. Keying handled requests by message ID
+/// makes each request admit its sender at most once. Removal is not a
+/// block - a removed member can rejoin with the same invite by sending a
+/// fresh join request, which carries a new message ID.
+public protocol HandledJoinRequestStoreProtocol: Sendable {
+    /// Whether this join-request message already admitted its sender.
+    func isHandled(messageId: String) async -> Bool
+
+    /// Record that this join-request message admitted its sender, or was
+    /// observed already satisfied (sender in the group).
+    func markHandled(messageId: String) async
+}
+
+// MARK: - Default Implementation
+
+/// In-memory store, suitable for tests and single-pass tools. Apps should
+/// inject a persistent implementation so the ledger survives across
+/// processing passes and across processes (app and notification service
+/// extension).
+public actor InMemoryHandledJoinRequestStore: HandledJoinRequestStoreProtocol {
+    private var handledMessageIds: Set<String> = []
+
+    public init() {}
+
+    public func isHandled(messageId: String) async -> Bool {
+        handledMessageIds.contains(messageId)
+    }
+
+    public func markHandled(messageId: String) async {
+        handledMessageIds.insert(messageId)
+    }
+}

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -499,10 +499,15 @@ public final class InviteCoordinator: @unchecked Sendable {
         // worse, a spurious error DM back to a joiner that already joined.
         // Mark the request handled so it stays inert if the member is later
         // removed; this also retires requests honored before the ledger
-        // existed, and the text copy of a typed+text pair.
+        // existed, and the text copy of a typed+text pair. Send the marker
+        // too: a join honored before the marker shipped (or whose marker
+        // send failed) is otherwise invisible to other installations, and
+        // reaching this branch means no marker covers the request yet (the
+        // marker check above would have returned first).
         if let memberInboxIds = try? await group.members.map(\.inboxId),
            memberInboxIds.contains(request.joinerInboxId) {
             await handledRequestStore.markHandled(messageId: request.messageId)
+            await sendJoinHandledMarker(for: request, client: client)
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
                 joinerInboxId: request.joinerInboxId
@@ -557,31 +562,8 @@ public final class InviteCoordinator: @unchecked Sendable {
 
         if let dm = try? await client.findConversation(conversationId: request.dmConversationId) {
             try? await dm.updateConsentState(state: .allowed)
-            // Best-effort cross-installation marker; the local ledger and
-            // the membership check still dedupe if the send fails. Gated on
-            // the joiner having sent a typed request: pre-typed builds
-            // (2.0.0 and earlier) require their join request to be the DM's
-            // literal last message for `hasOutgoingJoinRequest`, and a
-            // creator-sent marker displacing it would break their consent
-            // bump for the newly joined group. Typed sends ship in the same
-            // release as the windowed check, so a typed request proves the
-            // joiner tolerates creator bookkeeping in the DM. Herald always
-            // sends a typed copy (even though its newer text copy is
-            // usually the one honored), so agent joins keep full marker
-            // protection.
-            if await Self.joinerSendsTypedRequests(in: dm, joinerInboxId: request.joinerInboxId) {
-                let handled = InviteJoinHandled(
-                    inviteTag: signedInvite.invitePayload.tag,
-                    handledMessageId: request.messageId,
-                    timestamp: Date()
-                )
-                let codec = InviteJoinHandledCodec()
-                _ = try? await dm.send(
-                    content: handled,
-                    options: .init(contentType: codec.contentType)
-                )
-            }
         }
+        await sendJoinHandledMarker(for: request, client: client)
 
         let result = JoinResult(
             conversationId: conversationId,
@@ -623,33 +605,19 @@ public final class InviteCoordinator: @unchecked Sendable {
             return true
         }
 
-        // Cross-installation dedupe: markers another installation sent for
-        // already-honored requests. A relevant marker is always sent after
-        // the request it covers, so anchoring the fetch at the oldest
-        // candidate's send time bounds the scan without a recency window
-        // that a chatty DM could push markers out of.
-        var markers: [JoinHandledMarker] = []
-        if let oldestCandidateSentAt = candidates.map(\.sentAt).min(),
-           let recent = try? await dm.messages(afterNs: oldestCandidateSentAt.nanosecondsSince1970 - 1) {
-            markers = Self.joinHandledMarkers(in: recent, creatorInboxId: client.inviteInboxId)
-        }
-
         var firstBenignFailure: JoinRequestDMOutcome?
         var handledOutcome: JoinRequestDMOutcome?
         for message in candidates {
             // An already-honored request is inert, but it must not end the
             // scan: the same DM can carry a fresh join request from a member
-            // who was removed and is rejoining with the same invite.
+            // who was removed and is rejoining with the same invite, or a
+            // pending request for a different group. The ledger pre-check is
+            // safe without verification because only verified, honored
+            // requests are ever written to it; marker-based suppression
+            // happens inside processMessageOutcome after signature
+            // verification, so tampered slugs still reach the malicious
+            // detection and DM blocking path.
             if await handledRequestStore.isHandled(messageId: message.id) {
-                handledOutcome = handledOutcome ?? .alreadyMember(
-                    dmConversationId: dm.id,
-                    joinerInboxId: message.senderInboxId
-                )
-                continue
-            }
-            if let tag = Self.inviteTag(from: message),
-               markers.contains(where: { $0.tag == tag && $0.sentAt >= message.sentAt }) {
-                await handledRequestStore.markHandled(messageId: message.id)
                 handledOutcome = handledOutcome ?? .alreadyMember(
                     dmConversationId: dm.id,
                     joinerInboxId: message.senderInboxId
@@ -664,7 +632,8 @@ public final class InviteCoordinator: @unchecked Sendable {
                 try? await dm.updateConsentState(state: .allowed)
                 return outcome
             case .alreadyMember:
-                return outcome
+                handledOutcome = handledOutcome ?? outcome
+                continue
             case .malicious:
                 return outcome
             case .benignFailure:
@@ -792,6 +761,36 @@ public final class InviteCoordinator: @unchecked Sendable {
             .contains { $0.tag == tag && $0.sentAt >= requestSentAt }
     }
 
+    /// Best-effort cross-installation marker; the local ledger and the
+    /// membership check still dedupe if the send fails. Gated on the joiner
+    /// having sent a typed request: pre-typed builds (2.0.0 and earlier)
+    /// require their join request to be the DM's literal last message for
+    /// `hasOutgoingJoinRequest`, and a creator-sent marker displacing it
+    /// would break their consent bump for the newly joined group. Typed
+    /// sends ship in the same release as the windowed check, so a typed
+    /// request proves the joiner tolerates creator bookkeeping in the DM.
+    /// Herald always sends a typed copy (even though its newer text copy is
+    /// usually the one honored), so agent joins keep full marker protection.
+    private func sendJoinHandledMarker(
+        for request: JoinRequest,
+        client: any InviteClientProvider
+    ) async {
+        guard let dm = try? await client.findConversation(conversationId: request.dmConversationId),
+              await Self.joinerSendsTypedRequests(in: dm, joinerInboxId: request.joinerInboxId) else {
+            return
+        }
+        let handled = InviteJoinHandled(
+            inviteTag: request.signedInvite.invitePayload.tag,
+            handledMessageId: request.messageId,
+            timestamp: Date()
+        )
+        let codec = InviteJoinHandledCodec()
+        _ = try? await dm.send(
+            content: handled,
+            options: .init(contentType: codec.contentType)
+        )
+    }
+
     /// Whether the joiner has sent a typed join request in this DM. False
     /// (including on a failed fetch) suppresses the handled marker, which
     /// degrades safely: no marker means no cross-installation dedupe for
@@ -829,21 +828,6 @@ public final class InviteCoordinator: @unchecked Sendable {
             markers.append(JoinHandledMarker(tag: marker.inviteTag, sentAt: message.sentAt))
         }
         return markers
-    }
-
-    /// Invite tag of a join-request candidate, from either the typed
-    /// content or a plain-text slug. Lighter-weight parse than
-    /// `processMessageOutcome` for the marker comparison in `processDm`.
-    private static func inviteTag(from message: XMTPiOS.DecodedMessage) -> String? {
-        let slug: String
-        if let joinRequest: JoinRequestContent = try? message.content() {
-            slug = joinRequest.inviteSlug
-        } else if let text: String = try? message.content() {
-            slug = text
-        } else {
-            return nil
-        }
-        return (try? SignedInvite.fromURLSafeSlug(slug))?.invitePayload.tag
     }
 
     private enum Constant {

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -263,6 +263,21 @@ public final class InviteCoordinator: @unchecked Sendable {
         _ request: JoinRequest,
         client: any InviteClientProvider
     ) async -> JoinRequestDMOutcome {
+        // A join-request message admits its sender at most once. Checked
+        // before any validation so a replayed request (stream duplicate,
+        // catch-up, agent-join poll) does neither crypto work nor sends a
+        // stale error reply if the group's state has since changed.
+        // Membership alone cannot dedupe: after the creator removes the
+        // member, the already-honored request would look actionable again.
+        // Removal is not a block - a removed member rejoins by sending a
+        // fresh request (new message ID) with the same invite.
+        if await handledRequestStore.isHandled(messageId: request.messageId) {
+            return .alreadyMember(
+                dmConversationId: request.dmConversationId,
+                joinerInboxId: request.joinerInboxId
+            )
+        }
+
         let conversationId: String
         switch await validateInviteAndDecryptConversationId(request, client: client) {
         case .proceed(let value):
@@ -457,19 +472,6 @@ public final class InviteCoordinator: @unchecked Sendable {
     ) async -> JoinRequestDMOutcome {
         let signedInvite = request.signedInvite
 
-        // A join-request message admits its sender at most once. Membership
-        // alone cannot dedupe revalidation passes: after the creator removes
-        // the member, the already-honored request would look actionable
-        // again and silently re-add them. Removal is not a block - a removed
-        // member rejoins by sending a fresh request (new message ID) with
-        // the same invite.
-        if await handledRequestStore.isHandled(messageId: request.messageId) {
-            return .alreadyMember(
-                dmConversationId: request.dmConversationId,
-                joinerInboxId: request.joinerInboxId
-            )
-        }
-
         // The ledger is per-device; the DM marker is the cross-installation
         // signal. Another installation of this inbox (paired device, prior
         // install) may have honored this request and recorded it in the DM,
@@ -610,10 +612,13 @@ public final class InviteCoordinator: @unchecked Sendable {
         }
 
         // Cross-installation dedupe: markers another installation sent for
-        // already-honored requests. Fetched once per DM and compared per
-        // candidate by invite tag and send order.
+        // already-honored requests. A relevant marker is always sent after
+        // the request it covers, so anchoring the fetch at the oldest
+        // candidate's send time bounds the scan without a recency window
+        // that a chatty DM could push markers out of.
         var markers: [JoinHandledMarker] = []
-        if !candidates.isEmpty, let recent = try? await dm.messages(limit: Constant.dedupeScanLimit) {
+        if let oldestCandidateSentAt = candidates.map(\.sentAt).min(),
+           let recent = try? await dm.messages(afterNs: oldestCandidateSentAt.nanosecondsSince1970 - 1) {
             markers = Self.joinHandledMarkers(in: recent, creatorInboxId: client.inviteInboxId)
         }
 
@@ -729,7 +734,7 @@ public final class InviteCoordinator: @unchecked Sendable {
         in dm: XMTPiOS.Conversation,
         client: any InviteClientProvider
     ) async -> Bool {
-        guard let messages = try? await dm.messages(limit: Constant.dedupeScanLimit) else {
+        guard let messages = try? await dm.messages(limit: Constant.joinErrorDedupeScanLimit) else {
             return false
         }
         let codec = InviteJoinErrorCodec()
@@ -765,8 +770,10 @@ public final class InviteCoordinator: @unchecked Sendable {
         dmConversationId: String,
         client: any InviteClientProvider
     ) async -> Bool {
+        // A covering marker is always sent after the request, so fetching
+        // from the request's send time is precise and naturally bounded.
         guard let dm = try? await client.findConversation(conversationId: dmConversationId),
-              let messages = try? await dm.messages(limit: Constant.dedupeScanLimit) else {
+              let messages = try? await dm.messages(afterNs: requestSentAt.nanosecondsSince1970 - 1) else {
             return false
         }
         return Self.joinHandledMarkers(in: messages, creatorInboxId: client.inviteInboxId)
@@ -809,10 +816,11 @@ public final class InviteCoordinator: @unchecked Sendable {
 
     private enum Constant {
         /// How many recent DM messages to scan when checking whether an
-        /// error reply or handled marker for an invite tag was already
-        /// sent. Join-request DMs carry very little traffic, so a small
-        /// window is plenty.
-        static let dedupeScanLimit: Int = 50
+        /// error reply for an invite tag was already sent. Join-request DMs
+        /// carry very little traffic, so a small window is plenty. If a DM
+        /// somehow accumulates more than this between a request and its
+        /// revalidation, the worst case is one duplicate error reply.
+        static let joinErrorDedupeScanLimit: Int = 50
         /// Underlying error descriptions (libxmtp, keychain) can be very
         /// long; cap the diagnostic reason so error replies stay small.
         static let joinErrorReasonMaxLength: Int = 500
@@ -846,24 +854,43 @@ extension Date {
 // MARK: - Dm Extension
 
 extension XMTPiOS.Dm {
+    /// Most recent signed invite the client sent in this DM, scanning a
+    /// small window of recent messages rather than only the literal last
+    /// one. The creator appends bookkeeping to the DM (invite_join_handled
+    /// markers, error replies), so on the joiner's side the join request is
+    /// often no longer the final message - requiring that would make
+    /// `hasOutgoingJoinRequest` go false the moment a join is honored,
+    /// which breaks the consent bump for the newly arrived group.
     func lastMessageAsSignedInvite(sentBy clientInboxId: String) async -> SignedInvite? {
-        guard let lastMessage = try? await self.lastMessage(),
-              lastMessage.senderInboxId == clientInboxId,
-              let contentType = try? lastMessage.encodedContent.type else {
+        guard let messages = try? await self.messages(limit: Constant.outgoingInviteScanLimit) else {
             return nil
         }
 
-        let slug: String
-        if contentType == ContentTypeJoinRequest,
-           let joinRequest: JoinRequestContent = try? lastMessage.content() {
-            slug = joinRequest.inviteSlug
-        } else if contentType == ContentTypeText,
-                  let text: String = try? lastMessage.content() {
-            slug = text
-        } else {
-            return nil
-        }
+        for message in messages where message.senderInboxId == clientInboxId {
+            guard let contentType = try? message.encodedContent.type else { continue }
 
-        return try? SignedInvite.fromURLSafeSlug(slug)
+            let slug: String
+            if contentType == ContentTypeJoinRequest,
+               let joinRequest: JoinRequestContent = try? message.content() {
+                slug = joinRequest.inviteSlug
+            } else if contentType == ContentTypeText,
+                      let text: String = try? message.content() {
+                slug = text
+            } else {
+                continue
+            }
+
+            if let invite = try? SignedInvite.fromURLSafeSlug(slug) {
+                return invite
+            }
+        }
+        return nil
+    }
+
+    private enum Constant {
+        /// Window for finding the client's most recent join request among
+        /// interleaved creator bookkeeping. Join DMs carry very little
+        /// traffic, so a handful of messages is plenty.
+        static let outgoingInviteScanLimit: Int = 10
     }
 }

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -558,17 +558,29 @@ public final class InviteCoordinator: @unchecked Sendable {
         if let dm = try? await client.findConversation(conversationId: request.dmConversationId) {
             try? await dm.updateConsentState(state: .allowed)
             // Best-effort cross-installation marker; the local ledger and
-            // the membership check still dedupe if the send fails.
-            let handled = InviteJoinHandled(
-                inviteTag: signedInvite.invitePayload.tag,
-                handledMessageId: request.messageId,
-                timestamp: Date()
-            )
-            let codec = InviteJoinHandledCodec()
-            _ = try? await dm.send(
-                content: handled,
-                options: .init(contentType: codec.contentType)
-            )
+            // the membership check still dedupe if the send fails. Gated on
+            // the joiner having sent a typed request: pre-typed builds
+            // (2.0.0 and earlier) require their join request to be the DM's
+            // literal last message for `hasOutgoingJoinRequest`, and a
+            // creator-sent marker displacing it would break their consent
+            // bump for the newly joined group. Typed sends ship in the same
+            // release as the windowed check, so a typed request proves the
+            // joiner tolerates creator bookkeeping in the DM. Herald always
+            // sends a typed copy (even though its newer text copy is
+            // usually the one honored), so agent joins keep full marker
+            // protection.
+            if await Self.joinerSendsTypedRequests(in: dm, joinerInboxId: request.joinerInboxId) {
+                let handled = InviteJoinHandled(
+                    inviteTag: signedInvite.invitePayload.tag,
+                    handledMessageId: request.messageId,
+                    timestamp: Date()
+                )
+                let codec = InviteJoinHandledCodec()
+                _ = try? await dm.send(
+                    content: handled,
+                    options: .init(contentType: codec.contentType)
+                )
+            }
         }
 
         let result = JoinResult(
@@ -780,6 +792,26 @@ public final class InviteCoordinator: @unchecked Sendable {
             .contains { $0.tag == tag && $0.sentAt >= requestSentAt }
     }
 
+    /// Whether the joiner has sent a typed join request in this DM. False
+    /// (including on a failed fetch) suppresses the handled marker, which
+    /// degrades safely: no marker means no cross-installation dedupe for
+    /// this join, never a broken joiner.
+    private static func joinerSendsTypedRequests(
+        in dm: XMTPiOS.Conversation,
+        joinerInboxId: String
+    ) async -> Bool {
+        guard let messages = try? await dm.messages(limit: Constant.typedCapabilityScanLimit) else {
+            return false
+        }
+        return messages.contains { message in
+            guard message.senderInboxId == joinerInboxId,
+                  let contentType = try? message.encodedContent.type else {
+                return false
+            }
+            return contentType == ContentTypeJoinRequest
+        }
+    }
+
     /// Markers are only trusted from the creator's own inbox; a joiner
     /// cannot forge one to suppress (or fake) an acceptance.
     private static func joinHandledMarkers(
@@ -821,6 +853,11 @@ public final class InviteCoordinator: @unchecked Sendable {
         /// somehow accumulates more than this between a request and its
         /// revalidation, the worst case is one duplicate error reply.
         static let joinErrorDedupeScanLimit: Int = 50
+        /// Window for spotting a typed join request from the joiner when
+        /// deciding whether to send the handled marker. The typed copy sits
+        /// next to the honored request, so a small window suffices; missing
+        /// it only skips the marker, which degrades safely.
+        static let typedCapabilityScanLimit: Int = 20
         /// Underlying error descriptions (libxmtp, keychain) can be very
         /// long; cap the diagnostic reason so error replies stay small.
         static let joinErrorReasonMaxLength: Int = 500

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -470,6 +470,24 @@ public final class InviteCoordinator: @unchecked Sendable {
             )
         }
 
+        // The ledger is per-device; the DM marker is the cross-installation
+        // signal. Another installation of this inbox (paired device, prior
+        // install) may have honored this request and recorded it in the DM,
+        // which syncs everywhere the ledger does not.
+        if let requestSentAt = request.sentAt,
+           await hasJoinHandledMarker(
+               forTag: signedInvite.invitePayload.tag,
+               since: requestSentAt,
+               dmConversationId: request.dmConversationId,
+               client: client
+           ) {
+            await handledRequestStore.markHandled(messageId: request.messageId)
+            return .alreadyMember(
+                dmConversationId: request.dmConversationId,
+                joinerInboxId: request.joinerInboxId
+            )
+        }
+
         try? await group.sync()
 
         // Multiple processing paths (message stream, batch catch-up, and the
@@ -537,6 +555,18 @@ public final class InviteCoordinator: @unchecked Sendable {
 
         if let dm = try? await client.findConversation(conversationId: request.dmConversationId) {
             try? await dm.updateConsentState(state: .allowed)
+            // Best-effort cross-installation marker; the local ledger and
+            // the membership check still dedupe if the send fails.
+            let handled = InviteJoinHandled(
+                inviteTag: signedInvite.invitePayload.tag,
+                handledMessageId: request.messageId,
+                timestamp: Date()
+            )
+            let codec = InviteJoinHandledCodec()
+            _ = try? await dm.send(
+                content: handled,
+                options: .init(contentType: codec.contentType)
+            )
         }
 
         let result = JoinResult(
@@ -579,6 +609,14 @@ public final class InviteCoordinator: @unchecked Sendable {
             return true
         }
 
+        // Cross-installation dedupe: markers another installation sent for
+        // already-honored requests. Fetched once per DM and compared per
+        // candidate by invite tag and send order.
+        var markers: [JoinHandledMarker] = []
+        if !candidates.isEmpty, let recent = try? await dm.messages(limit: Constant.dedupeScanLimit) {
+            markers = Self.joinHandledMarkers(in: recent, creatorInboxId: client.inviteInboxId)
+        }
+
         var firstBenignFailure: JoinRequestDMOutcome?
         var handledOutcome: JoinRequestDMOutcome?
         for message in candidates {
@@ -586,6 +624,15 @@ public final class InviteCoordinator: @unchecked Sendable {
             // scan: the same DM can carry a fresh join request from a member
             // who was removed and is rejoining with the same invite.
             if await handledRequestStore.isHandled(messageId: message.id) {
+                handledOutcome = handledOutcome ?? .alreadyMember(
+                    dmConversationId: dm.id,
+                    joinerInboxId: message.senderInboxId
+                )
+                continue
+            }
+            if let tag = Self.inviteTag(from: message),
+               markers.contains(where: { $0.tag == tag && $0.sentAt >= message.sentAt }) {
+                await handledRequestStore.markHandled(messageId: message.id)
                 handledOutcome = handledOutcome ?? .alreadyMember(
                     dmConversationId: dm.id,
                     joinerInboxId: message.senderInboxId
@@ -682,7 +729,7 @@ public final class InviteCoordinator: @unchecked Sendable {
         in dm: XMTPiOS.Conversation,
         client: any InviteClientProvider
     ) async -> Bool {
-        guard let messages = try? await dm.messages(limit: Constant.joinErrorDedupeScanLimit) else {
+        guard let messages = try? await dm.messages(limit: Constant.dedupeScanLimit) else {
             return false
         }
         let codec = InviteJoinErrorCodec()
@@ -702,11 +749,70 @@ public final class InviteCoordinator: @unchecked Sendable {
         return false
     }
 
+    private struct JoinHandledMarker {
+        let tag: String
+        let sentAt: Date
+    }
+
+    /// Whether a creator-sent `invite_join_handled` marker covers a request
+    /// for `tag` sent at `requestSentAt`. Mirrors `hasAlreadySentJoinError`:
+    /// the marker dedupes per attempt (tag plus send order), so the text
+    /// copy of a typed+text pair is covered by the typed copy's marker,
+    /// while a fresh request sent after the marker is not.
+    private func hasJoinHandledMarker(
+        forTag tag: String,
+        since requestSentAt: Date,
+        dmConversationId: String,
+        client: any InviteClientProvider
+    ) async -> Bool {
+        guard let dm = try? await client.findConversation(conversationId: dmConversationId),
+              let messages = try? await dm.messages(limit: Constant.dedupeScanLimit) else {
+            return false
+        }
+        return Self.joinHandledMarkers(in: messages, creatorInboxId: client.inviteInboxId)
+            .contains { $0.tag == tag && $0.sentAt >= requestSentAt }
+    }
+
+    /// Markers are only trusted from the creator's own inbox; a joiner
+    /// cannot forge one to suppress (or fake) an acceptance.
+    private static func joinHandledMarkers(
+        in messages: [XMTPiOS.DecodedMessage],
+        creatorInboxId: String
+    ) -> [JoinHandledMarker] {
+        let codec = InviteJoinHandledCodec()
+        var markers: [JoinHandledMarker] = []
+        for message in messages where message.senderInboxId == creatorInboxId {
+            guard let contentType = try? message.encodedContent.type,
+                  contentType == ContentTypeInviteJoinHandled,
+                  let marker = try? codec.decode(content: message.encodedContent) else {
+                continue
+            }
+            markers.append(JoinHandledMarker(tag: marker.inviteTag, sentAt: message.sentAt))
+        }
+        return markers
+    }
+
+    /// Invite tag of a join-request candidate, from either the typed
+    /// content or a plain-text slug. Lighter-weight parse than
+    /// `processMessageOutcome` for the marker comparison in `processDm`.
+    private static func inviteTag(from message: XMTPiOS.DecodedMessage) -> String? {
+        let slug: String
+        if let joinRequest: JoinRequestContent = try? message.content() {
+            slug = joinRequest.inviteSlug
+        } else if let text: String = try? message.content() {
+            slug = text
+        } else {
+            return nil
+        }
+        return (try? SignedInvite.fromURLSafeSlug(slug))?.invitePayload.tag
+    }
+
     private enum Constant {
         /// How many recent DM messages to scan when checking whether an
-        /// error reply for an invite tag was already sent. Join-request DMs
-        /// carry very little traffic, so a small window is plenty.
-        static let joinErrorDedupeScanLimit: Int = 50
+        /// error reply or handled marker for an invite tag was already
+        /// sent. Join-request DMs carry very little traffic, so a small
+        /// window is plenty.
+        static let dedupeScanLimit: Int = 50
         /// Underlying error descriptions (libxmtp, keychain) can be very
         /// long; cap the diagnostic reason so error replies stay small.
         static let joinErrorReasonMaxLength: Int = 500

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -46,6 +46,7 @@ public extension InviteCoordinatorDelegate {
 public final class InviteCoordinator: @unchecked Sendable {
     private let privateKeyProvider: PrivateKeyProvider
     private let tagStorage: any InviteTagStorageProtocol
+    private let handledRequestStore: any HandledJoinRequestStoreProtocol
 
     public weak var delegate: (any InviteCoordinatorDelegate)? {
         get { lock.withLock { _delegate } }
@@ -57,10 +58,12 @@ public final class InviteCoordinator: @unchecked Sendable {
 
     public init(
         privateKeyProvider: @escaping PrivateKeyProvider,
-        tagStorage: any InviteTagStorageProtocol = ProtobufInviteTagStorage()
+        tagStorage: any InviteTagStorageProtocol = ProtobufInviteTagStorage(),
+        handledRequestStore: any HandledJoinRequestStoreProtocol = InMemoryHandledJoinRequestStore()
     ) {
         self.privateKeyProvider = privateKeyProvider
         self.tagStorage = tagStorage
+        self.handledRequestStore = handledRequestStore
     }
 
     // MARK: - Invite Creation
@@ -454,6 +457,19 @@ public final class InviteCoordinator: @unchecked Sendable {
     ) async -> JoinRequestDMOutcome {
         let signedInvite = request.signedInvite
 
+        // A join-request message admits its sender at most once. Membership
+        // alone cannot dedupe revalidation passes: after the creator removes
+        // the member, the already-honored request would look actionable
+        // again and silently re-add them. Removal is not a block - a removed
+        // member rejoins by sending a fresh request (new message ID) with
+        // the same invite.
+        if await handledRequestStore.isHandled(messageId: request.messageId) {
+            return .alreadyMember(
+                dmConversationId: request.dmConversationId,
+                joinerInboxId: request.joinerInboxId
+            )
+        }
+
         try? await group.sync()
 
         // Multiple processing paths (message stream, batch catch-up, and the
@@ -461,8 +477,12 @@ public final class InviteCoordinator: @unchecked Sendable {
         // If the joiner is already in the group, a previous pass handled it -
         // skip the re-add so we don't send duplicate profile snapshots or,
         // worse, a spurious error DM back to a joiner that already joined.
+        // Mark the request handled so it stays inert if the member is later
+        // removed; this also retires requests honored before the ledger
+        // existed, and the text copy of a typed+text pair.
         if let memberInboxIds = try? await group.members.map(\.inboxId),
            memberInboxIds.contains(request.joinerInboxId) {
+            await handledRequestStore.markHandled(messageId: request.messageId)
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
                 joinerInboxId: request.joinerInboxId
@@ -513,6 +533,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             return benignFailure(request, error: .addMemberFailed)
         }
 
+        await handledRequestStore.markHandled(messageId: request.messageId)
+
         if let dm = try? await client.findConversation(conversationId: request.dmConversationId) {
             try? await dm.updateConsentState(state: .allowed)
         }
@@ -558,7 +580,18 @@ public final class InviteCoordinator: @unchecked Sendable {
         }
 
         var firstBenignFailure: JoinRequestDMOutcome?
+        var handledOutcome: JoinRequestDMOutcome?
         for message in candidates {
+            // An already-honored request is inert, but it must not end the
+            // scan: the same DM can carry a fresh join request from a member
+            // who was removed and is rejoining with the same invite.
+            if await handledRequestStore.isHandled(messageId: message.id) {
+                handledOutcome = handledOutcome ?? .alreadyMember(
+                    dmConversationId: dm.id,
+                    joinerInboxId: message.senderInboxId
+                )
+                continue
+            }
             let outcome = await processMessageOutcome(message, client: client)
             switch outcome {
             case .noJoinRequest:
@@ -575,7 +608,7 @@ public final class InviteCoordinator: @unchecked Sendable {
                 continue
             }
         }
-        return firstBenignFailure ?? .noJoinRequest
+        return firstBenignFailure ?? handledOutcome ?? .noJoinRequest
     }
 
     private func benignFailure(

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -156,10 +156,12 @@ public struct JoinResult: Sendable {
 /// - `malicious`: Signature verification failed in a way that indicates
 ///   tampering. The DM is denied and the device unsubscribes from its
 ///   topic so it can no longer wake the inbox.
-/// - `alreadyMember`: The request decoded and verified, but the joiner is
-///   already in the group - another processing path (stream vs batch vs
-///   poll) handled this request first. No re-add, no snapshot, no error
-///   DM; the DM stays subscribed like `accepted`.
+/// - `alreadyMember`: The request needs no action - either the joiner is
+///   already in the group, or this exact message already admitted them
+///   once (handled-request ledger) and they may have since been removed.
+///   Another processing path (stream vs batch vs poll) handled this
+///   request first. No re-add, no snapshot, no error DM; the DM stays
+///   subscribed like `accepted`.
 /// - `noJoinRequest`: The message was not a join-request candidate.
 public enum JoinRequestDMOutcome: Sendable {
     case accepted(JoinResult, dmConversationId: String)

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -299,6 +299,35 @@ extension InviteJoinErrorType: Codable {
     }
 }
 
+/// Marker the creator sends in the join DM after honoring a join request.
+///
+/// The local handled-request ledger only covers one device. Other
+/// installations of the creator's inbox (paired devices, reinstalls)
+/// revalidate the same DM history, and without a shared signal an
+/// already-honored request would look actionable to them again once the
+/// member is removed. The DM syncs to every installation, so the marker
+/// is checked the same way error replies are deduped: a request is
+/// handled when a creator-sent marker for the same invite tag exists at
+/// or after the request's send time. That retires the text copy of a
+/// typed+text pair too, while a fresh request after a removal (newer
+/// than any marker) stays actionable - removal is not a block.
+public struct InviteJoinHandled: Codable, Equatable, Sendable {
+    public let inviteTag: String
+
+    /// Message ID of the join request that was honored. Informational:
+    /// suppression compares invite tag and send order, not message IDs,
+    /// so duplicate copies of the same attempt are covered.
+    public let handledMessageId: String
+
+    public let timestamp: Date
+
+    public init(inviteTag: String, handledMessageId: String, timestamp: Date) {
+        self.inviteTag = inviteTag
+        self.handledMessageId = handledMessageId
+        self.timestamp = timestamp
+    }
+}
+
 /// Error feedback sent to a joiner when their request fails
 public struct InviteJoinError: Codable, Equatable, Sendable {
     public let errorType: InviteJoinErrorType

--- a/ConvosInvites/Tests/ConvosInvitesTests/ContentTypes/InviteJoinHandledCodecTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/ContentTypes/InviteJoinHandledCodecTests.swift
@@ -1,0 +1,89 @@
+@testable import ConvosInvites
+import Foundation
+import Testing
+import XMTPiOS
+
+@Suite("InviteJoinHandled Codec Tests")
+struct InviteJoinHandledCodecTests {
+    let codec: InviteJoinHandledCodec = InviteJoinHandledCodec()
+
+    @Test("Codec content type matches expected value")
+    func codecContentType() {
+        let expectedType = ContentTypeID(
+            authorityID: "convos.org",
+            typeID: "invite_join_handled",
+            versionMajor: 1,
+            versionMinor: 0
+        )
+        #expect(codec.contentType == expectedType)
+        #expect(codec.contentType == ContentTypeInviteJoinHandled)
+    }
+
+    @Test("Codec does not push notifications")
+    func codecShouldNotPush() throws {
+        #expect(try codec.shouldPush(content: InviteJoinHandled(
+            inviteTag: "test-tag",
+            handledMessageId: "msg-1",
+            timestamp: Date()
+        )) == false)
+    }
+
+    @Test("Fallback is nil - markers are creator-side bookkeeping")
+    func fallbackIsNil() throws {
+        let handled = InviteJoinHandled(
+            inviteTag: "test-tag",
+            handledMessageId: "msg-1",
+            timestamp: Date()
+        )
+        #expect(try codec.fallback(content: handled) == nil)
+    }
+
+    @Test("Encode and decode round-trips all fields")
+    func encodeDecodeRoundTrip() throws {
+        let original = InviteJoinHandled(
+            inviteTag: "invite-abc",
+            handledMessageId: "message-123",
+            timestamp: Date()
+        )
+
+        let encodedContent = try codec.encode(content: original)
+        let decoded: InviteJoinHandled = try codec.decode(content: encodedContent)
+
+        #expect(decoded.inviteTag == "invite-abc")
+        #expect(decoded.handledMessageId == "message-123")
+        #expect(abs(decoded.timestamp.timeIntervalSince(original.timestamp)) < 1.0)
+    }
+
+    @Test("Decode empty content throws")
+    func decodeEmptyContentThrows() {
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeInviteJoinHandled
+        encodedContent.content = Data()
+
+        #expect(throws: Error.self) {
+            _ = try codec.decode(content: encodedContent) as InviteJoinHandled
+        }
+    }
+
+    @Test("Decode malformed JSON throws")
+    func decodeMalformedJSONThrows() {
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeInviteJoinHandled
+        encodedContent.content = Data("not valid json".utf8)
+
+        #expect(throws: Error.self) {
+            _ = try codec.decode(content: encodedContent) as InviteJoinHandled
+        }
+    }
+
+    @Test("InviteJoinHandled Equatable conformance")
+    func equatableConformance() {
+        let timestamp = Date()
+        let first = InviteJoinHandled(inviteTag: "tag", handledMessageId: "msg-1", timestamp: timestamp)
+        let second = InviteJoinHandled(inviteTag: "tag", handledMessageId: "msg-1", timestamp: timestamp)
+        let third = InviteJoinHandled(inviteTag: "tag", handledMessageId: "msg-2", timestamp: timestamp)
+
+        #expect(first == second)
+        #expect(first != third)
+    }
+}


### PR DESCRIPTION
## Problem

Removing an agent (or any invited member) from a conversation could re-add them within seconds.

Join-request DMs are durable, and several paths revalidate them after the member list changes: the live message stream, batch catch-up (`runInviteBatch`, up to 24h lookback), the 150s agent-join poll, and the notification service extension. The only dedupe in `InviteCoordinator.addJoinerToGroup` was **"is the joiner currently a member"** - so the moment a member was removed, their already-honored join request looked actionable again, and the next revalidation pass silently called `addMembers` with the still-valid invite. For agents this presented as the agent instantly rejoining after removal (the convos-assistants runtime never re-requests - herald-lite sends one join request and explicitly does not retry; the replay was entirely creator-side).

## Fix

A **handled-request ledger keyed by message ID**: a join-request message admits its sender at most once.

- `ConvosInvites`: new `HandledJoinRequestStoreProtocol` (+ in-memory default). `InviteCoordinator` consults the ledger before adding, marks the message after a successful add, and also marks when a pass observes the joiner already in the group (retires the herald typed+text duplicate and requests honored before the ledger existed).
- `processDm` skips ledger-handled candidates without ending the scan, so a fresh re-join request in the same DM still gets processed.
- `ConvosCore`: `DatabaseHandledJoinRequestStore` persists the ledger in the shared app-group database (app + NSE, fresh manager per batch), with 30-day pruning. Wired as the default in `InviteJoinRequestsManager`.

**Removal is not a block**: a removed member can rejoin with the same valid invite by sending a fresh join request (new message ID).

## Tests

- New integration test (local XMTP node): honored request replayed after removal stays inert; a fresh request from the removed member is honored again.
- Unit tests for the GRDB store (read-back, idempotent mark, retention pruning).
- Full suites pass: ConvosCore 1260 tests / ConvosInvites 170 tests. SwiftLint clean.

## Possible follow-ups (not in this PR)

- A second device/installation of the same inbox keeps its own ledger; an in-band handled marker or invite-tag rotation would extend the guarantee across installations.
- Notify convos-assistants on removal (herald exposes `leaveConversation`/`deleteAgent`) so removed agent instances tear down instead of lingering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783870380&installation_id=128169237&pr_number=1065&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1065&signature=2dca80c69ee69dc78b0db16d70c63341943046108e49e5af3883fb4d57db367d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dedupe join requests by message ID to prevent removed members from being re-added
> - Adds a `handledJoinRequest` DB table and `DatabaseHandledJoinRequestStore` to persist handled join-request message IDs with a 30-day retention window, so deduplication survives app restarts.
> - Introduces a new `invite_join_handled` content type and `InviteJoinHandledCodec`; after honoring a join request, the creator posts a marker to the DM so other installations can skip reprocessing.
> - `InviteCoordinator.processJoinRequest` now checks the ledger first and treats already-handled message IDs as `alreadyMember` without repeating crypto work or sending duplicate error replies.
> - The DM scan loop no longer exits on the first `alreadyMember` result, continuing to find actionable requests while still reporting `alreadyMember` if nothing else applies.
> - Handled markers are only sent when the joiner has demonstrated typed-client capability, preserving compatibility with text-only (pre-typed) clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f58aec7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->