### PR TITLE
fix: deleting a verifying conversation no longer resurrects it

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -174,6 +174,14 @@ extension MessagingService {
             do {
                 let dbConversation = try await storeConversation(newGroup.group, inboxId: client.inboxId)
 
+                // The user deleted this conversation while the invite was
+                // still verifying -- it arrived denied and is filtered out
+                // of the list, so don't announce it.
+                guard dbConversation.consent != .denied else {
+                    Log.info("Suppressing welcome notification for denied conversation \(dbConversation.id)")
+                    return .droppedMessage
+                }
+
                 let displayName = (try? await getComputedDisplayName(
                     conversationId: dbConversation.id,
                     currentInboxId: client.inboxId
@@ -187,6 +195,9 @@ extension MessagingService {
                 )
             } catch {
                 Log.error("Failed to store conversation in NSE: \(error.localizedDescription)")
+                if await isLocallyDeniedInvite(group: newGroup.group) {
+                    return .droppedMessage
+                }
                 return .init(
                     title: newGroup.conversationName.orUntitled,
                     body: "Your invite was verified",
@@ -901,6 +912,29 @@ extension MessagingService {
             coreActions: coreActions
         )
         return try await conversationWriter.storeWithLatestMessages(conversation: conversation, inboxId: inboxId)
+    }
+
+    /// True when the local DB carries a denial for this group -- either its
+    /// own row or a deleted pending-invite draft sharing its invite tag
+    /// (the draft survives when storing the arriving group fails). Used to
+    /// suppress notifications for conversations the user deleted.
+    private func isLocallyDeniedInvite(group: XMTPiOS.Group) async -> Bool {
+        let groupId = group.id
+        let inviteTag = (try? group.inviteTag) ?? ""
+        let denied = try? await databaseReader.read { db in
+            var request = DBConversation
+                .filter(DBConversation.Columns.consent == Consent.denied)
+            if inviteTag.isEmpty {
+                request = request.filter(DBConversation.Columns.id == groupId)
+            } else {
+                request = request.filter(
+                    DBConversation.Columns.id == groupId
+                        || DBConversation.Columns.inviteTag == inviteTag
+                )
+            }
+            return try request.fetchOne(db) != nil
+        }
+        return denied ?? false
     }
 
     // MARK: - Computed Display Name

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift
@@ -39,11 +39,43 @@ class ConversationConsentWriter: ConversationConsentWriterProtocol, @unchecked S
     }
 
     func delete(conversation: Conversation) async throws {
+        let targetId = try await resolveDeletionTarget(for: conversation.id)
+
+        // A pending-invite draft ("verifying") has no XMTP group yet, so a
+        // network consent update would throw conversationNotFound before the
+        // local denial was written and the conversation would pop back into
+        // the list. Persist the denial locally only; ConversationWriter
+        // carries it onto the real group if the invite is later approved.
+        guard !DBConversation.isDraft(id: targetId) else {
+            try await persistDeniedConsent(conversationId: targetId)
+            return
+        }
+
         let client = try await sessionStateManager.waitForInboxReadyResult().client
-        try await client.update(consent: .denied, for: conversation.id)
+        try await client.update(consent: .denied, for: targetId)
+        try await persistDeniedConsent(conversationId: targetId)
+    }
+
+    /// A pending invite can resolve while the delete is in flight: the real
+    /// group's row replaces the draft row but keeps the draft id as its
+    /// clientConversationId. Re-target the delete at the real row in that
+    /// case, otherwise the denial would silently hit a row that no longer
+    /// exists and the conversation would stay visible.
+    private func resolveDeletionTarget(for conversationId: String) async throws -> String {
+        guard DBConversation.isDraft(id: conversationId) else { return conversationId }
+        let resolvedId = try await databaseWriter.read { db in
+            try DBConversation
+                .filter(DBConversation.Columns.clientConversationId == conversationId)
+                .select(DBConversation.Columns.id, as: String.self)
+                .fetchOne(db)
+        }
+        return resolvedId ?? conversationId
+    }
+
+    private func persistDeniedConsent(conversationId: String) async throws {
         try await databaseWriter.write { db in
             guard let localConversation = try DBConversation
-                .filter(DBConversation.Columns.id == conversation.id)
+                .filter(DBConversation.Columns.id == conversationId)
                 .fetchOne(db) else {
                 return
             }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -259,6 +259,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         clientConversationId: String? = nil
     ) async throws -> PreparedConversation {
         try await conversation.sync()
+        try await denyConsentIfInviteWasLocallyDeleted(for: conversation)
         let metadata = try await extractConversationMetadata(from: conversation)
         let members = try await conversation.members
         let dbMembers = members.map { $0.dbRepresentation(conversationId: conversation.id) }
@@ -275,6 +276,52 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             dbMembers: dbMembers,
             memberProfiles: memberProfiles
         )
+    }
+
+    /// Completes the denial carry-forward when `saveConversation`'s
+    /// invite-tag branch inherited .denied from the replaced row (a delete
+    /// that landed between prepare and persist, which the prepare-time check
+    /// below could not see). Pushing the denial into the XMTP consent state
+    /// keeps later syncs from reading allowed consent and resurrecting the
+    /// row. Best effort: the local row is already denied, and the push is a
+    /// local libxmtp write that effectively only fails if the database does.
+    private func pushCarriedForwardDenialIfNeeded(
+        saveResult: ConversationSaveResult,
+        group: XMTPiOS.Group
+    ) async {
+        guard saveResult.deniedConsentCarriedForward else { return }
+        do {
+            try await group.updateConsentState(state: .denied)
+            Log.info("Pushed carried-forward denial to XMTP for conversation \(group.id)")
+        } catch {
+            Log.error("Failed pushing carried-forward denial for \(group.id): \(error)")
+        }
+    }
+
+    /// Deleting a pending-invite draft ("verifying") can only flip the local
+    /// row to denied -- no XMTP group exists yet to deny. When the invite is
+    /// later approved and the real group arrives, carry that denial onto the
+    /// group before its row is built: pushing .denied into the XMTP consent
+    /// state means the persisted row and inbound stream filtering agree the
+    /// conversation stays deleted, and the denial propagates to other
+    /// installations via consent-record sync (they may show the conversation
+    /// transiently until that sync lands). Throws on failure so the group is
+    /// not persisted as allowed with the denial lost.
+    private func denyConsentIfInviteWasLocallyDeleted(for conversation: XMTPiOS.Group) async throws {
+        let inviteTag = try conversation.inviteTag
+        guard !inviteTag.isEmpty else { return }
+        guard try conversation.consentState() != .denied else { return }
+        let conversationId = conversation.id
+        let hasDeniedRowMatchingTag = try await databaseWriter.read { db in
+            try DBConversation
+                .filter(DBConversation.Columns.inviteTag == inviteTag)
+                .filter(DBConversation.Columns.id != conversationId)
+                .filter(DBConversation.Columns.consent == Consent.denied)
+                .fetchOne(db) != nil
+        }
+        guard hasDeniedRowMatchingTag else { return }
+        Log.info("Carrying local denial onto arriving group \(conversationId) whose invite tag matches a deleted conversation")
+        try await conversation.updateConsentState(state: .denied)
     }
 
     /// Synchronous, transaction-scoped. Call inside `databaseWriter.write { db in ... }`.
@@ -382,6 +429,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         saveResult: ConversationSaveResult,
         group: XMTPiOS.Group
     ) async {
+        await pushCarriedForwardDenialIfNeeded(saveResult: saveResult, group: group)
         enqueueContactSyncForNetworkChange(conversationId: prepared.dbConversation.id)
         prefetchEncryptedImages(profiles: prepared.memberProfiles, group: group)
         prefetchEncryptedGroupImage(
@@ -478,6 +526,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let saveResult = try await databaseWriter.write { [self] db in
             try persist(prepared, in: db)
         }
+
+        await pushCarriedForwardDenialIfNeeded(saveResult: saveResult, group: conversation)
 
         // Network-driven member commit just landed (initial conversation
         // arrival or refresh-with-new-members). Fire the contact-sync
@@ -632,6 +682,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let clientConversationId: String
         let oldImageURL: String?
         let preservedInviteTag: String?
+        /// True when the invite-tag replacement branch inherited .denied
+        /// from the row it replaced. Callers holding the XMTP group must
+        /// then push the denial into the XMTP consent state, which the
+        /// prepare-time check could not have done (the deleting write
+        /// landed after prepare ran).
+        let deniedConsentCarriedForward: Bool
     }
 
     /// Returns the actual clientConversationId used (may differ from input if a local draft exists),
@@ -646,6 +702,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let actualClientConversationId: String
         let oldImageURL: String?
         let preservedInviteTag: String?
+        let deniedConsentCarriedForward: Bool
 
         // Fetch current conversation state inside the transaction to avoid race conditions
         // with concurrent asset renewal that might update imageLastRenewed
@@ -723,6 +780,19 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             if localConversation.isUnused {
                 conversationToSave = conversationToSave.with(isUnused: true)
             }
+            // The row being replaced was deleted by the user (a denied
+            // pending-invite draft). The replacement must not resurrect it.
+            // `prepare` already pushes the denial into the XMTP consent
+            // state; this transactional check covers a delete landing
+            // between prepare and persist. In that race the incoming
+            // consent is still allowed, so the carried-forward denial is
+            // surfaced in the save result for callers to push to XMTP.
+            if localConversation.consent == .denied {
+                deniedConsentCarriedForward = conversationToSave.consent != .denied
+                conversationToSave = conversationToSave.with(consent: .denied)
+            } else {
+                deniedConsentCarriedForward = false
+            }
             // This row is replacing `localConversation`, so its sticky-on
             // agent flag must carry forward.
             let mergedHasAgentByTag: Bool = localConversation.hasHadVerifiedAgent || conversationToSave.hasHadVerifiedAgent
@@ -739,10 +809,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             )
             firstTimeSeeingConversationExpired = updateOutcome.firstTimeSeeingConversationExpired
             actualClientConversationId = updateOutcome.actualClientConversationId
+            deniedConsentCarriedForward = false
         } else {
             try conversationToSave.save(db)
             firstTimeSeeingConversationExpired = conversationToSave.isExpired
             actualClientConversationId = conversationToSave.clientConversationId
+            deniedConsentCarriedForward = false
         }
 
         if firstTimeSeeingConversationExpired {
@@ -752,7 +824,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         return ConversationSaveResult(
             clientConversationId: actualClientConversationId,
             oldImageURL: oldImageURL,
-            preservedInviteTag: preservedInviteTag
+            preservedInviteTag: preservedInviteTag,
+            deniedConsentCarriedForward: deniedConsentCarriedForward
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -200,13 +200,21 @@ actor StreamProcessor: StreamProcessorProtocol {
 
         let perfStart = CFAbsoluteTimeGetCurrent()
         Log.info("Syncing conversation: \(conversation.id)")
-        try await conversationWriter.storeWithLatestMessages(
+        let storedConversation = try await conversationWriter.storeWithLatestMessages(
             conversation: conversation,
             inboxId: params.client.inboxId,
             clientConversationId: clientConversationId
         )
         let perfElapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - perfStart) * 1000)
         Log.info("[PERF] conversation.sync: \(perfElapsed)ms id=\(conversation.id)")
+
+        // The user deleted this conversation while its invite was still
+        // verifying -- it arrived denied and stays hidden, so skip the
+        // profile snapshot and don't subscribe its push topic.
+        guard storedConversation.consent != .denied else {
+            Log.info("Skipping post-store side effects for denied conversation \(conversation.id)")
+            return
+        }
 
         if creatorInboxId == params.client.inboxId {
             await sendInitialProfileSnapshot(group: conversation)

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
@@ -46,6 +46,107 @@ struct ConversationConsentWriterDeleteTests {
         #expect(stored == nil)
     }
 
+    @Test("delete(conversation:) on a pending-invite draft writes the local denial without contacting XMTP")
+    func deleteDraftWritesLocalDenialWithoutXMTP() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let draftId = "draft-verifying-1"
+        try seedAllowedConversation(in: dbManager.dbWriter, conversationId: draftId)
+
+        // A pending-invite draft has no XMTP group to deny, so the writer
+        // must not touch the network path at all. A session manager that
+        // cannot vend a client proves the draft branch never asks for one --
+        // before the draft-aware fix this delete threw and the local denial
+        // was never written, so the conversation popped back into the list.
+        let writer = ConversationConsentWriter(
+            sessionStateManager: InboxUnavailableSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+
+        try await writer.delete(conversation: .mock(id: draftId))
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: draftId)
+        }
+        #expect(stored?.consent == .denied)
+    }
+
+    @Test("delete(conversation:) with a stale draft id re-targets the row that replaced the draft")
+    func deleteStaleDraftIdRetargetsReplacementRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        // The invite resolved while the delete was in flight: the draft row
+        // is gone and the real group's row kept the draft id as its sticky
+        // clientConversationId.
+        let draftId = "draft-resolved-1"
+        let realId = "real-group-resolved-1"
+        try seedAllowedConversation(
+            in: dbManager.dbWriter,
+            conversationId: realId,
+            clientConversationId: draftId
+        )
+
+        let writer = ConversationConsentWriter(
+            sessionStateManager: MockSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+
+        try await writer.delete(conversation: .mock(id: draftId))
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: realId)
+        }
+        #expect(stored?.consent == .denied)
+    }
+
+    @Test("delete(conversation:) with a stale draft id uses the networked denial for the replacement row")
+    func deleteStaleDraftIdRequiresClientForReplacementRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let draftId = "draft-resolved-2"
+        let realId = "real-group-resolved-2"
+        try seedAllowedConversation(
+            in: dbManager.dbWriter,
+            conversationId: realId,
+            clientConversationId: draftId
+        )
+
+        // Once the draft resolved to a real group, the denial must go
+        // through XMTP -- an unavailable inbox has to fail the delete
+        // instead of silently denying only the local row.
+        let writer = ConversationConsentWriter(
+            sessionStateManager: InboxUnavailableSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await writer.delete(conversation: .mock(id: draftId))
+        }
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: realId)
+        }
+        #expect(stored?.consent == .allowed)
+    }
+
+    @Test("delete(conversation:) on a real conversation still requires the XMTP client")
+    func deleteRealConversationStillRequiresClient() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let conversationId = "conv-real-1"
+        try seedAllowedConversation(in: dbManager.dbWriter, conversationId: conversationId)
+
+        let writer = ConversationConsentWriter(
+            sessionStateManager: InboxUnavailableSessionStateManager(),
+            databaseWriter: dbManager.dbWriter
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await writer.delete(conversation: .mock(id: conversationId))
+        }
+
+        let stored = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: conversationId)
+        }
+        #expect(stored?.consent == .allowed)
+    }
+
     @Test("After delete, a fetch filtered on [.allowed] no longer returns the row")
     func repositoryFilterExcludesDeniedRow() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
@@ -78,14 +179,40 @@ struct ConversationConsentWriterDeleteTests {
 
 // MARK: - Helpers
 
+/// Session manager whose inbox never becomes ready. Used to prove a code
+/// path completes without ever needing the XMTP client.
+private final class InboxUnavailableSessionStateManager: SessionStateManagerProtocol, @unchecked Sendable {
+    struct InboxUnavailableError: Error {}
+
+    var currentState: SessionStateMachine.State = .idle
+    var isSyncReady: Bool { false }
+
+    func waitForInboxReadyResult() async throws -> InboxReadyResult {
+        throw InboxUnavailableError()
+    }
+
+    func waitForDeletionComplete() async {}
+    func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async {}
+    func setTypingIndicatorHandler(_ handler: @escaping @Sendable (String, String, Bool) -> Void) async {}
+    func requestDiscovery() async {}
+    func startAgentJoinRequestPolling() async {}
+    func addObserver(_ observer: SessionStateObserver) {}
+    func removeObserver(_ observer: SessionStateObserver) {}
+
+    func observeState(_ handler: @escaping (SessionStateMachine.State) -> Void) -> StateObserverHandle {
+        StateObserverHandle(observer: ClosureStateObserver(handler: handler), manager: self)
+    }
+}
+
 private func seedAllowedConversation(
     in writer: any DatabaseWriter,
-    conversationId: String
+    conversationId: String,
+    clientConversationId: String? = nil
 ) throws {
     try writer.write { db in
         try DBConversation(
             id: conversationId,
-            clientConversationId: "client-\(conversationId)",
+            clientConversationId: clientConversationId ?? "client-\(conversationId)",
             inviteTag: "invite-\(conversationId)",
             creatorId: "inbox-1",
             kind: .group,

--- a/ConvosCore/Tests/ConvosCoreTests/DeletedPendingInviteTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DeletedPendingInviteTests.swift
@@ -1,0 +1,215 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+import XMTPiOS
+
+/// Coverage for the denial carry-forward that keeps a deleted
+/// pending-invite ("verifying") conversation deleted once the invite is
+/// approved. Deleting a draft can only flip the local row to `.denied`
+/// (no XMTP group exists yet to deny). When the real group later arrives
+/// it replaces that row by invite-tag match and must inherit the denial
+/// instead of resurrecting the conversation in the list.
+@Suite("Deleted pending-invite denial carry-forward", .serialized)
+struct DeletedPendingInviteTests {
+    private enum TestError: Error {
+        case missingClients
+    }
+
+    @Test("persist() carries .denied from the replaced draft row onto the arriving group")
+    func persistInheritsDenialFromDeletedDraft() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let inviteTag = "tag-denied-draft"
+        let draftId = "draft-deleted-1"
+        try seedConversation(in: dbManager.dbWriter, id: draftId, inviteTag: inviteTag, consent: .denied)
+
+        let writer = ConversationWriter(
+            identityStore: MockKeychainIdentityStore(),
+            databaseWriter: dbManager.dbWriter,
+            messageWriter: MockIncomingMessageWriter()
+        )
+
+        let incoming = makeDBConversation(id: "real-group-1", inviteTag: inviteTag, consent: .allowed)
+        let prepared = ConversationWriter.PreparedConversation(
+            dbConversation: incoming,
+            dbMembers: [],
+            memberProfiles: []
+        )
+        let saveResult = try await dbManager.dbWriter.write { db in
+            try writer.persist(prepared, in: db)
+        }
+        // The inherited denial is surfaced so the caller pushes it into the
+        // XMTP consent state (the prepare-time check missed this delete).
+        #expect(saveResult.deniedConsentCarriedForward)
+
+        let real = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: "real-group-1")
+        }
+        #expect(real?.consent == .denied)
+
+        let draft = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: draftId)
+        }
+        #expect(draft == nil)
+    }
+
+    @Test("persist() keeps the incoming consent when the matching draft was not deleted")
+    func persistKeepsConsentForLiveDraft() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let inviteTag = "tag-live-draft"
+        let draftId = "draft-live-1"
+        try seedConversation(in: dbManager.dbWriter, id: draftId, inviteTag: inviteTag, consent: .allowed)
+
+        let writer = ConversationWriter(
+            identityStore: MockKeychainIdentityStore(),
+            databaseWriter: dbManager.dbWriter,
+            messageWriter: MockIncomingMessageWriter()
+        )
+
+        let incoming = makeDBConversation(id: "real-group-2", inviteTag: inviteTag, consent: .allowed)
+        let prepared = ConversationWriter.PreparedConversation(
+            dbConversation: incoming,
+            dbMembers: [],
+            memberProfiles: []
+        )
+        let saveResult = try await dbManager.dbWriter.write { db in
+            try writer.persist(prepared, in: db)
+        }
+        #expect(!saveResult.deniedConsentCarriedForward)
+
+        let real = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: "real-group-2")
+        }
+        #expect(real?.consent == .allowed)
+    }
+
+    @Test("store() denies the arriving XMTP group when its invite tag matches a deleted local conversation")
+    func storeDeniesArrivingGroupMatchingDeletedInvite() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB,
+              let clientIdA = fixtures.clientIdA else {
+            throw TestError.missingClients
+        }
+
+        let inboxIdA = clientA.inboxID
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdA, clientId: clientIdA, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxId],
+            name: "Test Group",
+            imageUrl: "",
+            description: ""
+        )
+        try await group.ensureInviteTag()
+        let inviteTag = try group.inviteTag
+        #expect(!inviteTag.isEmpty)
+
+        // The user deleted the conversation while it was still "verifying":
+        // only the local draft row carries the denial.
+        let draftId = "draft-deleted-2"
+        try seedConversation(
+            in: fixtures.databaseManager.dbWriter,
+            id: draftId,
+            inviteTag: inviteTag,
+            consent: .denied
+        )
+
+        let writer = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: MockIncomingMessageWriter()
+        )
+        _ = try await writer.store(conversation: group, inboxId: inboxIdA)
+
+        let groupId = group.id
+        let stored = try await fixtures.databaseManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: groupId)
+        }
+        #expect(stored?.consent == .denied)
+
+        // The denial must reach the XMTP consent state too, so inbound
+        // stream filtering and later syncs keep agreeing the conversation
+        // stays deleted.
+        #expect(try group.consentState() == .denied)
+
+        let draft = try await fixtures.databaseManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, id: draftId)
+        }
+        #expect(draft == nil)
+
+        try? await fixtures.cleanup()
+    }
+}
+
+// MARK: - Helpers
+
+private func seedConversation(
+    in writer: any DatabaseWriter,
+    id: String,
+    inviteTag: String,
+    consent: Consent
+) throws {
+    try writer.write { db in
+        try DBMember(inboxId: "inbox-creator").save(db)
+        try DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: inviteTag,
+            creatorId: "inbox-creator",
+            kind: .group,
+            consent: consent,
+            createdAt: Date(),
+            name: "Verifying",
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+        ).insert(db)
+    }
+}
+
+private func makeDBConversation(
+    id: String,
+    inviteTag: String,
+    consent: Consent
+) -> DBConversation {
+    DBConversation(
+        id: id,
+        clientConversationId: id,
+        inviteTag: inviteTag,
+        creatorId: "inbox-creator",
+        kind: .group,
+        consent: consent,
+        createdAt: Date(),
+        name: "Arrived",
+        description: nil,
+        imageURLString: nil,
+        publicImageURLString: nil,
+        includeInfoInPublicPreview: false,
+        expiresAt: nil,
+        debugInfo: .empty,
+        isLocked: false,
+        imageSalt: nil,
+        imageNonce: nil,
+        imageEncryptionKey: nil,
+        conversationEmoji: nil,
+        imageLastRenewed: nil,
+        isUnused: false,
+        hasHadVerifiedAgent: false,
+    )
+}


### PR DESCRIPTION
## Problem

Deleting a conversation in "verifying" state (a pending-invite draft awaiting inviter approval) made it pop right back into the conversations list — and even if it had stayed hidden, it would have been resurrected when the inviter approved the invite.

Two root causes:

1. **Immediate reappearance**: `ConversationConsentWriter.delete` set XMTP consent before the local write. A verifying conversation's id is a local draft id (`draft-<UUID>`) with no XMTP group behind it, so the consent call threw `conversationNotFound`, the local denial never landed, and `ConversationsViewModel.leave`'s catch block rolled back the optimistic hide.
2. **Resurrection on approval**: when the real group arrives it is auto-allowed (an outgoing join request exists) and `saveConversation` replaces the draft row by invite-tag match using the group's XMTP consent — wiping any local denial.

## Fix

- **Draft-aware delete** (`ConversationConsentWriter`): drafts persist the denial locally and skip the doomed network call. If the invite resolved while the delete was in flight, the delete re-targets the replacement row (found via its sticky `clientConversationId`) and denies the real group through XMTP.
- **Denial carry-forward** (`ConversationWriter`): `prepare()` pushes `.denied` into the arriving group's XMTP consent state when its invite tag matches a locally denied row, before the row is built — so the persisted row, inbound stream filtering, and consent-record sync all keep the conversation deleted. A transactional backstop in `saveConversation`'s invite-tag branch covers a delete landing between prepare and persist, and both persist paths push that carried-forward denial to XMTP afterwards.
- **User-facing gates**: `StreamProcessor` no longer subscribes the push topic (or sends the profile snapshot) for a denied arrival, and the NSE welcome path suppresses the "Your invite was verified" notification when the stored conversation is denied.

## Known limitations (pre-existing semantics, noted by review)

- A second installation of the same inbox has no draft row, so it may show the conversation transiently until the consent-record denial syncs over — matching existing cross-device delete behavior.
- Re-tapping the invite link before approval revives the draft (intentional rejoin). Re-tapping after approval opens the still-denied conversation without re-allowing it; this matches the existing behavior for deleted real conversations and is left for a follow-up.
- A group arriving with lost invite-tag metadata bypasses the tag match (existing `[MetadataDebug]` self-heal territory).

## Testing

- 4 new unit tests in `ConversationConsentWriterDeleteTests` (draft denial without XMTP, stale-draft-id re-targeting, networked-path enforcement) and a new `DeletedPendingInviteTests` suite (persist-level carry-forward + flag, and a live-XMTP integration test where a denied draft denies the arriving real group end-to-end).
- Full ConvosCore suite: 1222 tests / 174 suites pass against the local Docker XMTP node. SwiftLint strict clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783870601&installation_id=128169237&pr_number=1066&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1066&signature=a14182707be9964d790b34ded05a1b4295f79938ff5f9f08663e06423b36ac38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix deleted verifying conversations from being resurrected on arrival
> - When a pending-invite (draft) conversation is deleted, consent is now persisted locally as `.denied` without a network call; if a real row later replaces the draft via `inviteTag`, the denial is carried forward to the replacement.
> - `ConversationWriter` checks for a locally denied draft matching the arriving group's `inviteTag` and pushes a `.denied` consent state to the XMTP group before and after persistence.
> - `MessagingService.handlePushNotification` suppresses welcome notifications for conversations whose stored `DBConversation` has `consent == .denied`, and drops the notification entirely when the invite is locally denied.
> - `StreamProcessor` skips post-store side effects (profile snapshot, push topic subscription) for denied conversations.
> - Risk: deletion of a draft conversation now skips the network consent update; only replacements resolved via `clientConversationId` trigger the remote denial.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d99093.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->