### PR TITLE
fix(credits): version the useRealBackend UserDefaults key to orphan stale overrides

### DIFF
--- a/Convos/Config/Dev.xcconfig
+++ b/Convos/Config/Dev.xcconfig
@@ -5,7 +5,9 @@ CONFIG_FILE = config.dev.json
 DEVELOPMENT_TEAM = FY4NZR34Z3
 
 // Swift compiler flags - define DEBUG for conditional compilation (if needed for dev/testflight)
-// Note: SWIFT_ACTIVE_COMPILATION_CONDITIONS propagates to Swift Package dependencies
+// Note: this does not propagate to Swift Package dependencies (e.g. ConvosCore) - Xcode builds
+// packages in their release configuration unless the app configuration is literally named "Debug",
+// so #if DEBUG inside packages stays inactive in Dev/Local builds.
 // Comment out the line below if you don't want DEBUG in TestFlight builds
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
 

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServices.swift
@@ -77,6 +77,13 @@ public enum CreditsServices {
     }
 
     enum Constant {
-        static let useRealBackendKey: String = "creditsServices.useRealBackend"
+        /// Versioned key (v2): the original `creditsServices.useRealBackend`
+        /// key accumulated stale writes during the eras when the setter
+        /// persisted but the gate ignored the stored value (see the doc
+        /// comment on `resolveUseRealBackend`). Those stale off values would
+        /// have silently flipped TestFlight testers to mock credits once the
+        /// gate started honoring them. The old key is intentionally never
+        /// read - only deliberate toggles made after the fix persist under v2.
+        static let useRealBackendKey: String = "creditsServices.useRealBackend.v2"
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/CreditsServicesUseRealBackendTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CreditsServicesUseRealBackendTests.swift
@@ -50,4 +50,15 @@ struct CreditsServicesUseRealBackendTests {
             defaults: defaults
         ) == true)
     }
+
+    @Test("a value stored under the legacy (pre-v2) key is ignored")
+    func legacyKeyValueIsIgnored() {
+        let defaults = Self.makeDefaults()
+        // Stale writes from the eras when the gate ignored the stored value
+        // live under the old key; the v2 key must orphan them.
+        let legacyKey = "creditsServices.useRealBackend"
+        #expect(CreditsServices.Constant.useRealBackendKey != legacyKey)
+        defaults.set(false, forKey: legacyKey)
+        #expect(CreditsServices.resolveUseRealBackend(environment: .tests, defaults: defaults) == true)
+    }
 }


### PR DESCRIPTION
## The landmine

#1059 fixed the `useRealBackend` debug toggle by making the stored `creditsServices.useRealBackend` UserDefaults value effective at runtime in non-production builds. Correct fix — but it arms a leftover: the **setter persisted in every historical era**, while for months the **gate ignored the stored value** (#963 wrapped the read in `#if DEBUG` inside ConvosCore, which is dead code there: Xcode compiles SPM packages in their release configuration unless the app configuration is literally named "Debug", and ours are Local/Dev/Release).

During that window, testers flipping the visibly-broken toggle (it snapped back to ON) silently wrote stale `false` values into the `org.convos.ios-preview` defaults. TestFlight builds run the Dev environment, so the **first TF build containing #1059 would honor those stale writes and silently flip testers to mock credits** — an invisible behavior change for the whole dev-TF cohort.

## The fix: version the key

- Gate and setter now use `creditsServices.useRealBackend.v2`. The old key is never read — all pre-#1059 writes were made while reads ignored them, so they are stale by definition. Only deliberate toggles made after the fix persist.
- No behavior change for anyone who never touched the toggle (default stays ON / real backend; production still short-circuits to real before reading defaults).
- Also corrects the Dev.xcconfig comment claiming `SWIFT_ACTIVE_COMPILATION_CONDITIONS` propagates to Swift Package dependencies — it doesn't, which is exactly why the `#if DEBUG` era was broken.

## Tests

- The four #1059 resolution tests now exercise the v2 key (they reference the constant).
- New test: a `false` stored under the legacy `creditsServices.useRealBackend` key is ignored, and the active key differs from the legacy one.

Should land **before the next git tag** so the first post-#1059 TestFlight build ships with it.

Refs #1059.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872510&installation_id=128169237&pr_number=1067&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1067&signature=0a7570d87df9c3867d09049327116143a1c3e06850359b6b9b03491e42f3c88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Version the `useRealBackend` UserDefaults key to orphan stale overrides
> - Changes the persisted key in [`CreditsServices.swift`](https://github.com/xmtplabs/convos-ios/pull/1067/files#diff-de36dd1a671eccaa8a1060406f4496ff259d7c6fa4e5367dd24b1dbc4c6aebe7) from `creditsServices.useRealBackend` to `creditsServices.useRealBackend.v2`, so any value stored under the old key is silently ignored.
> - Adds a test asserting that legacy key values are ignored and that `resolveUseRealBackend` defaults to `true` in the test environment unless the v2 key is explicitly set.
> - Also clarifies in [`Dev.xcconfig`](https://github.com/xmtplabs/convos-ios/pull/1067/files#diff-360320fdadbb6289c797f90a6868b0e3a2a78449a1a57f939fdc817002557224) that `SWIFT_ACTIVE_COMPILATION_CONDITIONS` does not propagate to Swift Package dependencies unless the configuration is literally named `Debug`.
> - Behavioral Change: devices with a previously stored `false` override will revert to using the real backend until the new key is explicitly set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fecae9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->