### PR TITLE
fix: make entire app indicator pill tappable

### DIFF
--- a/Convos/Shared Views/AppIndicatorPill.swift
+++ b/Convos/Shared Views/AppIndicatorPill.swift
@@ -32,6 +32,7 @@ struct AppIndicatorPill: View {
     var body: some View {
         Button(action: action) {
             content
+                .contentShape(.capsule)
         }
         .buttonStyle(.plain)
         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Problem

The app indicator pill in the top bar had a tiny, pixel-precise hit area: taps only registered directly on the avatar image or the title/subtitle text. Tapping the pill's padding, the gap between the avatar and the text, or the glass capsule background did nothing.

## Cause

`AppIndicatorPill` wraps its label in a `Button` with `.buttonStyle(.plain)`, which only hit-tests the label's opaque pixels. The label's internal padding and spacing are transparent, and the glass capsule background is applied outside the button entirely, so none of those regions were tappable.

## Fix

Add `.contentShape(.capsule)` to the button label so the full capsule area responds to taps. Covers both render sites (`MainTabView.sharedTopBar` and `ConversationPresenter`'s app-mode indicator) since they share this component.

## Testing

- SwiftLint strict passes; SwiftFormat clean (pre-commit and pre-push hooks green).
- Test suite not run per Jarod's instruction (one-line view-layer change; ConvosCore is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783874251&installation_id=128169237&pr_number=1069&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1069&signature=bd7a35aa3a6a6f54482f80d366ad285c8bfe186fe677af6123a362f0322b61ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tappable area of `AppIndicatorPill` to match capsule shape
> Adds `.contentShape(.capsule)` to the button label in [AppIndicatorPill.swift](https://github.com/xmtplabs/convos-ios/pull/1069/files#diff-d991987b786537a77bfd3a185a313b63317b66da2d5459a55904d644ef7b1a6b) so the hit-test region matches the visual pill shape. Previously, only parts of the pill responded to taps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c030311.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->