### PR TITLE
Fix white flash when inline video player replaces the thumbnail

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -730,6 +730,7 @@ private struct AttachmentPlaceholder: View {
     @ViewBuilder
     private func inlineVideoView(player: AVPlayer) -> some View {
         InlineVideoPlayerView(player: player)
+            .background { videoThumbnailUnderlay }
             .scaleEffect(showBlurOverlay ? 1.65 : 1.0)
             .blur(radius: showBlurOverlay ? blurRadius : 0)
             .overlay(alignment: .top) {
@@ -747,6 +748,18 @@ private struct AttachmentPlaceholder: View {
             .compositingGroup()
             .modifier(MediaBoxLayout())
             .animation(.easeOut(duration: 0.25), value: showBlurOverlay)
+    }
+
+    // An AVPlayerLayer renders nothing until its first frame is decoded, so
+    // keeping the thumbnail underneath avoids a white flash when the player
+    // replaces the thumbnail view.
+    @ViewBuilder
+    private var videoThumbnailUnderlay: some View {
+        if let image = loadedImage {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Problem

Opening a conversation containing a video message flashes a white box with a play button for ~150ms before the video's first frame appears (also reproduces when re-entering the conversation).

## Root cause

`AttachmentPlaceholder.contentGroup` shows the video's thumbnail while loading, but swaps it out for `InlineVideoPlayerView` the moment the `AVPlayer` is assigned. An `AVPlayerLayer` renders nothing until it decodes its first frame, so for that window the layer is transparent and the white app background shows through where the thumbnail used to be.

## Fix

Keep the thumbnail layered underneath the player view (`.background { videoThumbnailUnderlay }`). The transparent player layer reveals the thumbnail instead of white, and the first decoded frame covers it seamlessly. The load path applies the thumbnail before the player is created, so the underlay is always populated when the player mounts.

## Testing

- `Convos (Dev)` builds clean in the worktree
- Full ConvosCore suite: 1279 tests in 178 suites, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thumbnail underlay to inline video player to prevent white flash before first frame
> Renders the loaded image thumbnail as a background layer beneath the AVPlayer in `AttachmentPlaceholder.inlineVideoView`, eliminating the white flash that appears before the first video frame is decoded. A new `videoThumbnailUnderlay` computed view in [MessagesGroupItemView.swift](https://github.com/xmtplabs/convos-ios/pull/1071/files#diff-34b33cae925fe553d357af97d04319b8de2de329c1903afe72c915e36aa98774) handles the conditional rendering when a thumbnail is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 531cfd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->