### PR TITLE
fix(invites): only reject join with consent_not_allowed on denied conversations

### DIFF
--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -391,6 +391,28 @@ public final class InviteCoordinator: @unchecked Sendable {
         }
     }
 
+    /// Whether the creator's consent state on the invited group should reject
+    /// an otherwise-valid join request.
+    ///
+    /// Only `.denied` is a real denial - the creator deleted, blocked, or
+    /// exploded the conversation (all three write `.denied`). `.unknown` is
+    /// not a denial: it means this particular installation has no consent
+    /// record for the group yet. A secondary device or a fresh reinstall of
+    /// the creator's inbox arrives at `.unknown` until libxmtp device sync
+    /// delivers the record, and `resolveInvitedGroup` itself pulls the group
+    /// down via `syncConversations()` in exactly that case, guaranteeing an
+    /// `.unknown` read. Rejecting `.unknown` told joiners a perfectly valid
+    /// invite "no longer exists" whenever a non-primary installation answered
+    /// first, so it is treated as allowed here.
+    static func shouldRejectJoin(for consent: ConsentState) -> Bool {
+        switch consent {
+        case .denied:
+            return true
+        case .allowed, .unknown:
+            return false
+        }
+    }
+
     private func resolveInvitedGroup(
         conversationId: String,
         request: JoinRequest,
@@ -438,8 +460,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
             return .stop(benignFailure(request, error: .processingFailed))
         }
-        guard consent == .allowed else {
-            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state '\(consent)' is not .allowed")
+        if Self.shouldRejectJoin(for: consent) {
+            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state is '\(consent)'")
             await sendJoinError(
                 .consentNotAllowed,
                 reason: "creator consent state is '\(consent)'",

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -419,6 +419,27 @@ struct JoinRequestProcessingTests {
         #expect(decoded.userFacingMessage == "This conversation is no longer available")
     }
 
+    // MARK: - Consent Rejection Rule
+
+    @Test("Allowed consent does not reject a join")
+    func allowedConsentDoesNotReject() {
+        #expect(!InviteCoordinator.shouldRejectJoin(for: .allowed))
+    }
+
+    @Test("Denied consent rejects a join")
+    func deniedConsentRejects() {
+        #expect(InviteCoordinator.shouldRejectJoin(for: .denied))
+    }
+
+    @Test("Unknown consent does not reject a join")
+    func unknownConsentDoesNotReject() {
+        // `.unknown` means this installation has no consent record for the
+        // group yet (secondary device, fresh reinstall), not that the
+        // creator denied the conversation. It must not trigger
+        // consent_not_allowed for an otherwise-valid invite.
+        #expect(!InviteCoordinator.shouldRejectJoin(for: .unknown))
+    }
+
     // MARK: - Date Extension
 
     @Test("Date nanoseconds conversion")


### PR DESCRIPTION
## Problem

Humans and agents joining a group via a valid invite link were receiving `InviteJoinError` messages with `errorType: consent_not_allowed`, telling them the conversation "no longer exists" with no retry.

## Root cause

The invite creator's client rejects a join request with `consent_not_allowed` whenever the invited group's XMTP consent state isn't `.allowed` (`InviteCoordinator.resolveInvitedGroup`). That guard also fired on **`.unknown`**, which is not a denial — it means the responding installation has no consent record for the group yet.

In libxmtp, consent is written `.allowed` only on the installation that *created* the group. On a secondary device or a fresh reinstall of the creator's inbox, the group arrives `.unknown` until device sync delivers the consent record (async, best-effort). `resolveInvitedGroup` even self-induces this state: it calls `syncConversations()` to pull the group down for exactly the secondary-install case, then immediately reads `.unknown` consent and rejects.

Since identity now syncs across devices via iCloud Keychain (and survives reinstalls while the libxmtp DB does not), join-request DMs fan out to **every** installation of the creator's inbox, and any of them can answer first. A reinstalled phone, an iPad, or an old device could reply `consent_not_allowed` for a conversation that is perfectly valid on the primary device. The joiner treats the first error reply as terminal.

Other consent gates in the codebase already exempt this case (`StreamProcessor.shouldProcessConversation` skips the gate for self-created groups; `ConversationConsentReconciler` only touches contact-created conversations), but this guard did not.

## Fix

Only `.denied` is a real denial — delete, block, and explode all write `.denied`. Extract the decision into a pure, unit-tested `InviteCoordinator.shouldRejectJoin(for:)` that rejects only on `.denied` and treats `.unknown` like `.allowed`. The `consentState()`-throw path (transient local read failure) is unchanged.

## Tests

Added three unit tests covering the rule (`.allowed` → no reject, `.denied` → reject, `.unknown` → no reject).

- `swift test --package-path ConvosInvites`: **180/180 pass** (3 new)
- SwiftLint: 0 violations
- SwiftFormat: 0 files require formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `InviteCoordinator` to only reject joins on denied consent, not unknown consent
> Previously, `resolveInvitedGroup` rejected join requests whenever the creator's consent state was not explicitly `allowed`, which incorrectly treated `unknown` (no local record) as a denial. Now only a `denied` consent state triggers rejection with a `consent_not_allowed` error. A new `shouldRejectJoin` static helper in [InviteCoordinator.swift](https://github.com/xmtplabs/convos-ios/pull/1072/files#diff-87d55c5ffa790402965a59c8132ef0a34a6485257304dd2f6de696c14cf22917) encodes this logic, covered by three new tests in [JoinRequestProcessingTests.swift](https://github.com/xmtplabs/convos-ios/pull/1072/files#diff-1d96b6c0047ae16444a399efc32c21ed9a9be94998a5b70eb83bd9fdf9764cc2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7954590.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->