### PR TITLE
Use "made you a thing" copy when an agent sends an html file

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -446,14 +446,12 @@ extension MessagingService {
             conversationId: conversationId,
             currentInboxId: currentInboxId
         )
-        let shouldShowSenderName = otherMemberCount > 1
-
         let body = try await buildNotificationBody(
             encodedContentType: encodedContentType,
             decodedMessage: decodedMessage,
             conversationId: conversationId,
             senderName: senderName,
-            shouldShowSenderName: shouldShowSenderName
+            otherMemberCount: otherMemberCount
         )
 
         guard let body else {
@@ -487,8 +485,9 @@ extension MessagingService {
         decodedMessage: DecodedMessage,
         conversationId: String,
         senderName: String,
-        shouldShowSenderName: Bool
+        otherMemberCount: Int
     ) async throws -> String? {
+        let shouldShowSenderName = otherMemberCount > 1
         switch encodedContentType {
         case ContentTypeText:
             let content = try decodedMessage.content() as Any
@@ -521,11 +520,67 @@ extension MessagingService {
             return nil
 
         case ContentTypeRemoteAttachment, ContentTypeMultiRemoteAttachment:
+            if let agentBody = try await agentMadeThingNotificationBody(
+                decodedMessage: decodedMessage,
+                conversationId: conversationId,
+                senderName: senderName,
+                otherMemberCount: otherMemberCount
+            ) {
+                return agentBody
+            }
             let attachmentText = try attachmentNotificationText(for: decodedMessage)
             return shouldShowSenderName ? "\(senderName) sent \(attachmentText)" : "sent \(attachmentText)"
 
         default:
             return nil
+        }
+    }
+
+    /// Returns the bespoke notification body for an agent sending a single
+    /// html file ("made you a thing" / "made a thing for the group"), or nil
+    /// when the message should use the generic attachment copy.
+    private func agentMadeThingNotificationBody(
+        decodedMessage: DecodedMessage,
+        conversationId: String,
+        senderName: String,
+        otherMemberCount: Int
+    ) async throws -> String? {
+        guard isHtmlFilename(try singleAttachmentFilename(for: decodedMessage)) else {
+            return nil
+        }
+        guard try await isMemberAgent(
+            inboxId: decodedMessage.senderInboxId,
+            conversationId: conversationId
+        ) else {
+            return nil
+        }
+        return otherMemberCount > 1
+            ? "\(senderName) made a thing for the group"
+            : "\(senderName) made you a thing"
+    }
+
+    private func singleAttachmentFilename(for decodedMessage: DecodedMessage) throws -> String? {
+        let content = try decodedMessage.content() as Any
+        if let attachment = content as? RemoteAttachment {
+            return attachment.filename
+        }
+        if let attachments = content as? [RemoteAttachment], attachments.count == 1 {
+            return attachments.first?.filename
+        }
+        return nil
+    }
+
+    private func isHtmlFilename(_ filename: String?) -> Bool {
+        guard let filename else { return false }
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return false }
+        return utType.conforms(to: .html)
+    }
+
+    private func isMemberAgent(inboxId: String, conversationId: String) async throws -> Bool {
+        try await databaseReader.read { db in
+            let profile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
+            return profile?.isAgent ?? false
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -36,11 +36,14 @@ extension DBLastMessageWithSource {
         case .original:
             switch contentType {
             case .attachments:
-                if shouldShowSenderName {
-                    text = "\(senderName) sent \(attachmentsString)"
-                } else {
-                    text = "sent \(attachmentsString)"
-                }
+                text = Self.attachmentsPreviewText(
+                    senderName: senderName,
+                    senderIsAgent: !isCurrentUser && senderProfile?.memberProfile.isAgent == true,
+                    attachmentUrls: attachmentUrls,
+                    attachmentsString: attachmentsString,
+                    otherMemberCount: otherMemberCount,
+                    shouldShowSenderName: shouldShowSenderName
+                )
             case .text:
                 if shouldShowSenderName {
                     text = "\(senderName): \(self.text ?? "")"
@@ -155,6 +158,33 @@ extension DBLastMessageWithSource {
         if isCurrentUser { return "You" }
         if let name = profile?.name, !name.isEmpty { return name }
         return profile?.isAgent == true ? "Agent" : "Somebody"
+    }
+
+    /// Builds the preview line for an attachment message. An agent sending a
+    /// single html file gets bespoke copy ("made you a thing" / "made a thing
+    /// for the group") instead of the generic "sent <filename>" line.
+    static func attachmentsPreviewText(
+        senderName: String,
+        senderIsAgent: Bool,
+        attachmentUrls: [String],
+        attachmentsString: String,
+        otherMemberCount: Int,
+        shouldShowSenderName: Bool
+    ) -> String {
+        if senderIsAgent, isSingleHtmlAttachment(attachmentUrls) {
+            return otherMemberCount > 1
+                ? "\(senderName) made a thing for the group"
+                : "\(senderName) made you a thing"
+        }
+        return shouldShowSenderName ? "\(senderName) sent \(attachmentsString)" : "sent \(attachmentsString)"
+    }
+
+    private static func isSingleHtmlAttachment(_ attachmentUrls: [String]) -> Bool {
+        guard attachmentUrls.count == 1, let url = attachmentUrls.first else { return false }
+        guard let filename = classifyAttachment(url).filename else { return false }
+        let ext = (filename as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty, let utType = UTType(filenameExtension: ext) else { return false }
+        return utType.conforms(to: .html)
     }
 
     static func attachmentsPreviewString(attachmentUrls: [String], count: Int) -> String {

--- a/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VideoMessageTests.swift
@@ -232,6 +232,87 @@ struct VideoMessageTests {
         #expect(result == "a photo")
     }
 
+    // MARK: - Agent Html Attachment Preview
+
+    @Test("Agent sending an html file with only the current user shows 'made you a thing'")
+    func testAgentHtmlPreviewOneOnOne() {
+        let result = DBLastMessageWithSource.attachmentsPreviewText(
+            senderName: "Robo",
+            senderIsAgent: true,
+            attachmentUrls: [makeHtmlJSON()],
+            attachmentsString: "thing.html",
+            otherMemberCount: 1,
+            shouldShowSenderName: false
+        )
+        #expect(result == "Robo made you a thing")
+    }
+
+    @Test("Agent sending an html file to a group shows 'made a thing for the group'")
+    func testAgentHtmlPreviewGroup() {
+        let result = DBLastMessageWithSource.attachmentsPreviewText(
+            senderName: "Robo",
+            senderIsAgent: true,
+            attachmentUrls: [makeHtmlJSON()],
+            attachmentsString: "thing.html",
+            otherMemberCount: 3,
+            shouldShowSenderName: true
+        )
+        #expect(result == "Robo made a thing for the group")
+    }
+
+    @Test("Non-agent sending an html file keeps the generic copy")
+    func testNonAgentHtmlPreview() {
+        let result = DBLastMessageWithSource.attachmentsPreviewText(
+            senderName: "Somebody",
+            senderIsAgent: false,
+            attachmentUrls: [makeHtmlJSON()],
+            attachmentsString: "thing.html",
+            otherMemberCount: 1,
+            shouldShowSenderName: false
+        )
+        #expect(result == "sent thing.html")
+    }
+
+    @Test("Agent sending a non-html file keeps the generic copy")
+    func testAgentNonHtmlPreview() {
+        let result = DBLastMessageWithSource.attachmentsPreviewText(
+            senderName: "Robo",
+            senderIsAgent: true,
+            attachmentUrls: [makeVideoJSON()],
+            attachmentsString: "a video",
+            otherMemberCount: 1,
+            shouldShowSenderName: false
+        )
+        #expect(result == "sent a video")
+    }
+
+    @Test("Agent sending multiple attachments keeps the generic copy")
+    func testAgentMultipleAttachmentsPreview() {
+        let htmlJSON = makeHtmlJSON()
+        let result = DBLastMessageWithSource.attachmentsPreviewText(
+            senderName: "Robo",
+            senderIsAgent: true,
+            attachmentUrls: [htmlJSON, htmlJSON],
+            attachmentsString: "2 attachments",
+            otherMemberCount: 1,
+            shouldShowSenderName: false
+        )
+        #expect(result == "sent 2 attachments")
+    }
+
+    private func makeHtmlJSON() -> String {
+        let stored = StoredRemoteAttachment(
+            url: "https://example.com/thing.enc",
+            contentDigest: "abc",
+            secret: Data("s".utf8),
+            salt: Data("s".utf8),
+            nonce: Data("n".utf8),
+            filename: "thing.html",
+            mimeType: "text/html"
+        )
+        return (try? stored.toJSON()) ?? ""
+    }
+
     private func makePhotoJSON() -> String {
         let stored = StoredRemoteAttachment(
             url: "https://example.com/photo.enc",


### PR DESCRIPTION
## Summary

When an agent sends an html file, the conversation list preview and push notification previously read `sent <filename>.html` / `<sender> sent a file`. Both now use:

- **"<agent display name> made you a thing"** when the agent is the only other member besides the current user
- **"<agent display name> made a thing for the group"** when the conversation has additional members

## Changes

- `DBMessage+MessagePreview.swift`: the attachment preview case routes through a new `attachmentsPreviewText` helper that detects an agent sender with a single html attachment (via `UTType`, so `.htm` counts too) and picks the copy off the other-member count. Human senders, multi-attachment messages, and replies keep the existing copy.
- `MessagingService+PushNotifications.swift`: `buildNotificationBody` applies the same copy for remote-attachment content when the sender's member profile `isAgent` and the payload is a single html file. The agent name resolves through the existing notification display-name path (contact name -> profile name -> "Agent").
- `VideoMessageTests.swift`: 5 new tests covering both phrasings and the non-agent / non-html / multi-attachment fallbacks.

## Testing

- `swift build --package-path ConvosCore` passes
- SwiftLint strict passes on changed files
- Full ConvosCore suite: 1284 tests in 178 suites passed against the local Docker stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783894589&installation_id=128169237&pr_number=1073&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1073&signature=26cdd75337ae34dd55fa8edbb794f26f4b34950464be1940c04b3fc59a54b6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'made you a thing' notification and preview copy when an agent sends an HTML file
> - When an agent sends a single HTML attachment, push notification bodies and message previews now read `<senderName> made you a thing` (1:1) or `<senderName> made a thing for the group` (group) instead of the generic 'sent <attachment>' copy.
> - HTML detection uses `UTType` conformance checks; agent status is verified via a `DBMemberProfile` database lookup in [`MessagingService`](https://github.com/xmtplabs/convos-ios/pull/1073/files#diff-e3600c561fc30fca5b793ab019a6c9384b2f81973531eff39d65eba919fddf4b) and an `isAgent` flag in [`DBMessage+MessagePreview`](https://github.com/xmtplabs/convos-ios/pull/1073/files#diff-d3e6bc13d59fe4e0d21f30113e0b756b6ce497672ffcb3141af165d59424981e).
> - All non-qualifying cases (non-agent sender, non-HTML file, multiple attachments) retain existing copy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5209fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->