### PR TITLE
test: integration coverage for the denied-only consent gate

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -440,6 +440,89 @@ struct InviteCoordinatorIntegrationTests {
         )
     }
 
+    /// Only an explicit .denied consent (delete, block, and explode all
+    /// write it) is reported to the joiner. The reply's reason carries the
+    /// consent state so telemetry can tell denials from sync gaps.
+    @Test("Join into a .denied group sends one consent_not_allowed error")
+    func deniedConsentSendsConsentError() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let coordinator = makeCoordinator()
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group)
+        let invite = try await coordinator.createInvite(for: group, client: creatorClient)
+        // The creator deletes the conversation after the invite went out.
+        try await group.updateConsentState(state: .denied)
+
+        _ = try await coordinator.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        _ = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+
+        let errors = try await joinErrors(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(errors.count == 1, "A join into a denied group sends exactly one error reply")
+        #expect(errors.first?.errorType == .consentNotAllowed)
+        #expect(errors.first?.reason?.contains("denied") == true)
+
+        let memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(!memberInboxIds.contains(joinerClient.inboxID), "Joiner must not be added to a denied group")
+    }
+
+    /// .unknown consent means this installation has no consent record for
+    /// the group (paired and restored installations start that way for the
+    /// user's own groups), not that the creator declined. The join must
+    /// proceed - the invite signature already proves this inbox authored
+    /// the invite - and no error reply may be sent.
+    @Test("Join into an .unknown-consent group proceeds without an error")
+    func unknownConsentProceedsWithoutError() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let coordinator = makeCoordinator()
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await coordinator.revokeInvites(for: group)
+        let invite = try await coordinator.createInvite(for: group, client: creatorClient)
+        // Simulate a paired or restored installation that has the group but
+        // no consent record for it yet.
+        try await group.updateConsentState(state: .unknown)
+
+        _ = try await coordinator.sendJoinRequest(for: invite.signedInvite, client: joinerClient)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let outcomes = await coordinator.processJoinRequestOutcomes(since: nil, client: creatorClient)
+
+        #expect(
+            outcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id },
+            "An .unknown consent state must not block the join"
+        )
+        let memberInboxIds = try await group.members.map(\.inboxId)
+        #expect(memberInboxIds.contains(joinerClient.inboxID), "Joiner must be added when consent is .unknown")
+
+        let errorCount = try await joinErrorCount(inDmWith: joinerClient.inboxID, client: creatorClient)
+        #expect(errorCount == 0, "An .unknown consent state must not send an error reply")
+    }
+
+    private func joinErrors(inDmWith peerInboxId: String, client: Client) async throws -> [InviteJoinError] {
+        let dm = try await client.conversations.findOrCreateDm(with: peerInboxId)
+        let messages = try await dm.messages()
+        return messages.compactMap { (message: DecodedMessage) -> InviteJoinError? in
+            guard let contentType = try? message.encodedContent.type,
+                  contentType == ContentTypeInviteJoinError else { return nil }
+            return try? message.content() as InviteJoinError
+        }
+    }
+
     private func joinErrorCount(inDmWith peerInboxId: String, client: Client) async throws -> Int {
         try await messageCount(ofType: ContentTypeInviteJoinError, inDmWith: peerInboxId, client: client)
     }

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -391,6 +391,28 @@ public final class InviteCoordinator: @unchecked Sendable {
         }
     }
 
+    /// Whether the creator's consent state on the invited group should reject
+    /// an otherwise-valid join request.
+    ///
+    /// Only `.denied` is a real denial - the creator deleted, blocked, or
+    /// exploded the conversation (all three write `.denied`). `.unknown` is
+    /// not a denial: it means this particular installation has no consent
+    /// record for the group yet. A secondary device or a fresh reinstall of
+    /// the creator's inbox arrives at `.unknown` until libxmtp device sync
+    /// delivers the record, and `resolveInvitedGroup` itself pulls the group
+    /// down via `syncConversations()` in exactly that case, guaranteeing an
+    /// `.unknown` read. Rejecting `.unknown` told joiners a perfectly valid
+    /// invite "no longer exists" whenever a non-primary installation answered
+    /// first, so it is treated as allowed here.
+    static func shouldRejectJoin(for consent: ConsentState) -> Bool {
+        switch consent {
+        case .denied:
+            return true
+        case .allowed, .unknown:
+            return false
+        }
+    }
+
     private func resolveInvitedGroup(
         conversationId: String,
         request: JoinRequest,
@@ -438,8 +460,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             delegate?.coordinator(self, didRejectJoinRequest: request, error: .processingFailed)
             return .stop(benignFailure(request, error: .processingFailed))
         }
-        guard consent == .allowed else {
-            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state '\(consent)' is not .allowed")
+        if Self.shouldRejectJoin(for: consent) {
+            Log.warning("Rejecting join for \(conversationId) (inviteTag: \(request.signedInvite.invitePayload.tag)): consent state is '\(consent)'")
             await sendJoinError(
                 .consentNotAllowed,
                 reason: "creator consent state is '\(consent)'",

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -419,6 +419,27 @@ struct JoinRequestProcessingTests {
         #expect(decoded.userFacingMessage == "This conversation is no longer available")
     }
 
+    // MARK: - Consent Rejection Rule
+
+    @Test("Allowed consent does not reject a join")
+    func allowedConsentDoesNotReject() {
+        #expect(!InviteCoordinator.shouldRejectJoin(for: .allowed))
+    }
+
+    @Test("Denied consent rejects a join")
+    func deniedConsentRejects() {
+        #expect(InviteCoordinator.shouldRejectJoin(for: .denied))
+    }
+
+    @Test("Unknown consent does not reject a join")
+    func unknownConsentDoesNotReject() {
+        // `.unknown` means this installation has no consent record for the
+        // group yet (secondary device, fresh reinstall), not that the
+        // creator denied the conversation. It must not trigger
+        // consent_not_allowed for an otherwise-valid invite.
+        #expect(!InviteCoordinator.shouldRejectJoin(for: .unknown))
+    }
+
     // MARK: - Date Extension
 
     @Test("Date nanoseconds conversion")


### PR DESCRIPTION
Stacked on #1072. Adds end-to-end integration coverage (local XMTP node) for the consent gate it introduces, exercising the full join-request flow rather than the `shouldRejectJoin` unit rule alone.

## What's covered

- **`.denied` group → exactly one `consent_not_allowed` error.** Creates a group, issues an invite, flips consent to `.denied` (what delete, block, and explode all write), and asserts the joiner gets exactly one error reply with `errorType == .consentNotAllowed` and a reason carrying `'denied'` — the string Herald telemetry facets on — and is not added to the group.
- **`.unknown` group → join proceeds, no error.** Simulates a paired/restored installation that has the group but no consent record for it (the state #1072 stops rejecting): the joiner is added and no error reply is sent.

## Why

The Datadog `reason`-field data showed `consent_not_allowed` is 99.5% of real join failures (368 distinct DMs over 30 days). These tests pin both halves of the new gate: real denials still answer the joiner (so it isn't left hanging), and consent-record sync gaps no longer kill valid joins.

## Testing

- `swift test --package-path ConvosCore --filter InviteCoordinatorIntegrationTests` — 9/9 passed
- Full suites on this tree: ConvosInvites 180/180, ConvosCore 1281/1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783895168&installation_id=128169237&pr_number=1074&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1074&signature=6058055ac7bb3cc7459cb174d808586dd7a6319724c953836273d691c919d3d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `InviteCoordinator` to allow join requests when consent is `.unknown`
> - Adds `InviteCoordinator.shouldRejectJoin(for:)` in [`InviteCoordinator.swift`](https://github.com/xmtplabs/convos-ios/pull/1074/files#diff-87d55c5ffa790402965a59c8132ef0a34a6485257304dd2f6de696c14cf22917) to centralize consent-gate logic: only `.denied` rejects; `.allowed` and `.unknown` proceed.
> - Updates `processJoinRequest` to call `shouldRejectJoin` instead of requiring `consent == .allowed`, so joins no longer fail when no local consent record exists (`.unknown`).
> - Adds unit tests in [`JoinRequestProcessingTests.swift`](https://github.com/xmtplabs/convos-ios/pull/1074/files#diff-1d96b6c0047ae16444a399efc32c21ed9a9be94998a5b70eb83bd9fdf9764cc2) and integration tests in [`InviteCoordinatorIntegrationTests.swift`](https://github.com/xmtplabs/convos-ios/pull/1074/files#diff-93d77f6f0ad34d3eb607a79da30273e314c6d0aa539ec463e4043165ba444c76) covering denied, allowed, and unknown consent paths.
> - Behavioral Change: previously, `.unknown` consent caused a `consent_not_allowed` error reply and blocked the joiner; now it permits the join.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b79ff73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->