### PR TITLE
fix: stop the hidden app indicator from eating taps during its removal transition

### DIFF
--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -562,7 +562,7 @@ struct MainTabView: View {
         .padding(.top, safeAreaInsets.top)
         .padding(.leading, leadingAppIndicatorPadding)
         .padding(.trailing, DesignConstants.Spacing.step3x)
-        .transition(.blurReplace)
+        .transition(.blurReplace.combined(with: .hitTestGate))
     }
 
     private var leadingAppIndicatorPadding: CGFloat {
@@ -616,7 +616,7 @@ struct MainTabView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, safeAreaInsets.top)
         .padding(.horizontal, DesignConstants.Spacing.step3x)
-        .transition(.blurReplace)
+        .transition(.blurReplace.combined(with: .hitTestGate))
         // Keep the lifted indicator's coordinator current: unlike the
         // committed-conversation coordinator (updated by ConversationPresenter),
         // ConversationIndicatorWrapper doesn't, so its quick-editor focus would

--- a/Convos/Shared Views/AdaptiveAppIndicator.swift
+++ b/Convos/Shared Views/AdaptiveAppIndicator.swift
@@ -18,6 +18,24 @@ enum AdaptiveAppIndicatorMode {
     case conversation
 }
 
+/// Disables hit testing whenever the view is not at the identity phase.
+/// Combined with `.blurReplace` at the top-bar indicator transition sites:
+/// SwiftUI keeps a removal-transitioning view tappable for its full bounds
+/// while it fades (hit testing ignores rendered pixels), so without this
+/// the invisible pill keeps eating taps near the top bar for the duration
+/// of the removal animation - e.g. opening app settings from a pushed
+/// contact detail. `allowsHitTesting` is not animatable, so it flips off
+/// the moment the removal starts.
+struct HitTestGateTransition: Transition {
+    func body(content: Content, phase: TransitionPhase) -> some View {
+        content.allowsHitTesting(phase == .identity)
+    }
+}
+
+extension Transition where Self == HitTestGateTransition {
+    static var hitTestGate: HitTestGateTransition { HitTestGateTransition() }
+}
+
 /// Subtitle for [[AppIndicatorPill]]. Either a plain string (typically the
 /// active subscription tier name) or an SF Symbol — currently used to
 /// surface depleted credit balance as a bolt icon in colorLava.

--- a/Convos/Shared Views/ConversationPresenter.swift
+++ b/Convos/Shared Views/ConversationPresenter.swift
@@ -194,7 +194,7 @@ struct ConversationPresenter<Content: View>: View {
         )
         .padding(.top, indicatorTopInset)
         .padding(.leading, indicatorLeadingInset)
-        .transition(.blurReplace)
+        .transition(.blurReplace.combined(with: .hitTestGate))
     }
 
     @ViewBuilder
@@ -212,7 +212,7 @@ struct ConversationPresenter<Content: View>: View {
         .padding(.top, indicatorTopInset)
         .padding(.horizontal, DesignConstants.Spacing.step3x)
         .padding(.leading, indicatorLeadingInset)
-        .transition(.blurReplace)
+        .transition(.blurReplace.combined(with: .hitTestGate))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Problem

On the Contacts tab, tapping into a contact and then tapping near the top-leading area (anywhere but exactly on the `<` back button) opened App Settings — as if the (hidden) app indicator pill had been tapped.

## Root cause

`MainTabView.sharedAppIndicatorOverlay` removes the pill with `.transition(.blurReplace)` driven by a bouncy spring. SwiftUI keeps a removal-transitioning view hit-testable for its **full bounds** for the entire removal animation (hit testing ignores rendered pixels), so for roughly a second after the push the invisible pill still owned the top-leading tap region. The same window exists for the pill ↔ centered-conversation-indicator morphs. Verified on simulator that this reproduces with and without #1069's `contentShape` — it predates that change; the bounds-based hit test was always there.

## Fix

Add `HitTestGateTransition` (a `Transition` whose body applies `.allowsHitTesting(phase == .identity)`) and combine it with `.blurReplace` at the four indicator transition sites (shared overlay pill + centered indicator in `MainTabView`, conversation + app indicator in `ConversationPresenter`). `allowsHitTesting` is not animatable, so it flips off the moment the removal starts while blur/opacity animate exactly as before.

## Verification (simulator, idb-driven taps)

- Contacts push, tap old pill area at 0.3s / 0.6s after push: App Settings no longer opens (reproduced reliably before the fix)
- Conversation push and agent-builder open, tap old pill area mid-morph: nothing opens
- Visible pill: avatar/text tap and capsule dead-zone tap both open App Settings (#1069 behavior preserved)
- Centered conversation indicator still morphs into place and opens conversation info after settle
- `swift test --package-path ConvosCore`: 1281 tests in 178 suites passed
- SwiftLint/SwiftFormat clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783897875&installation_id=128169237&pr_number=1075&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1075&signature=4dbe7ef7e9f5930255192be084d0445805657fb41a97153f281d9cc40c807239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix app and conversation indicator overlays eating taps during removal transitions
> Adds a `HitTestGateTransition` in [AdaptiveAppIndicator.swift](https://github.com/xmtplabs/convos-ios/pull/1075/files#diff-5b908fec04ebcf67307574a5d36035c0a93ea0b1cdf0e9f6c74590430646691c) that disables hit testing on a view unless it is at the identity transition phase. This transition is combined with `blurReplace` on the leading app-indicator and centered conversation-indicator overlays in [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/1075/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) and [ConversationPresenter.swift](https://github.com/xmtplabs/convos-ios/pull/1075/files#diff-b43cd7da077f6223cf5e0d1281de02cd00c32eb7b922b573c843b347811dec97), so taps are blocked while those overlays are animating in or out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dadf0ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->