### PR TITLE
fix(local-stack): guard_port no longer kills `make up` on a fresh stack

### DIFF
--- a/dev/local-stack/stack.sh
+++ b/dev/local-stack/stack.sh
@@ -88,7 +88,11 @@ svc_running() {
 guard_port() {
   local port="$1" name="$2" dir="$3" pid cmd
   svc_running "$name" "$dir" && return 0
-  pid="$(lsof -tnP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1)"
+  # lsof exits non-zero when nothing is listening (the common case on a fresh
+  # stack before the service starts); under set -euo pipefail that would
+  # propagate out of the command substitution and kill the script before the
+  # emptiness guard. Same `|| true` pattern the key/token lookups below use.
+  pid="$(lsof -tnP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -1)" || true
   [[ -z "$pid" ]] && return 0
   cmd="$(ps -o command= -p "$pid" 2>/dev/null | head -c 140)"
   die "port ${port} is held by a foreign process (pid ${pid}: ${cmd}) — it would shadow ${name} and answer health checks with stale state. Kill it (kill ${pid}) and re-run."


### PR DESCRIPTION
## Problem

`guard_port()` in `dev/local-stack/stack.sh` assigns `pid` from `lsof ... | head -1` under `set -euo pipefail`. `lsof` exits non-zero when nothing is listening on the port — the normal case on the **first `make up` of a fresh stack**, before the service has started. That non-zero status propagates out of the command substitution and `set -e` kills the script *before* the `[[ -z "$pid" ]] && return 0` emptiness guard runs.

Symptom: a fresh `make up` dies right after `==> infra (Postgres + MinIO)` with `make: *** [up] Error 1`, even though Postgres and MinIO both come up healthy — the script never reaches the backend start. The bug stays hidden once a service is already running, because `svc_running` short-circuits before the `lsof` line, which is why it doesn't reproduce on a stack that's already been up once.

## Fix

Append `|| true` so an empty `lsof` result degrades to the emptiness guard instead of aborting the script — the same pattern the key/token lookups further down in this file already use (see the comment above `disable_app_check`).

One line; no behavior change when a foreign process *is* holding the port (the `die` path still fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783925555&installation_id=128169237&pr_number=1076&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1076&signature=966864a12db9624b1610d233a69225c41bab295944d618ca882be60c1d7bdb7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `guard_port` in local-stack to not exit on fresh stack with no listeners
> In [stack.sh](https://github.com/xmtplabs/convos-ios/pull/1076/files#diff-ac74f42213bfd94cd92c5951d64ae7013a7155b648d52d642d4c25b01dfb3bd5), `guard_port` uses `lsof` to find a listening process, but under `set -euo pipefail`, `lsof` exits non-zero when no process is listening, killing the script before the empty-pid check runs. Appending `|| true` to the `lsof` assignment lets the script proceed to the empty-pid check and return normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3989668.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->