### PR TITLE
chore(renovate): auto-merge libxmtp minor and patch bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,12 @@
       "allowedVersions": "/^ios-\\d+\\.\\d+\\.\\d+-nightly\\.\\d{8}\\.[a-f0-9]+$/",
       "commitMessageTopic": "libxmtp",
       "commitMessageExtra": "to {{newValue}}"
+    },
+    {
+      "matchPackageNames": ["https://github.com/xmtp/libxmtp"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
Auto-merge libxmtp minor and patch updates once required status checks pass.

- Adds a package rule with `matchUpdateTypes: ["minor", "patch"]` -> `automerge: true` + `platformAutomerge: true` for the libxmtp dep.
- Patch covers the daily nightly build-segment bumps (e.g. `ios-4.11.0-nightly.YYYYMMDD.<sha>`); minor covers `4.10 -> 4.11` style nightly bumps.
- Gating: `platformAutomerge` waits on the `dev` ruleset's required checks (Unit Tests, SwiftLint, Run KeychainIdentityStore Tests) before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784138673&installation_id=128169237&pr_number=1078&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1078&signature=84aacb4bf1a7912a685eba2e805a9ffb6f655047c87f445b1402ea14b5594b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable auto-merge for minor and patch updates to `libxmtp`
> Adds a package rule to [renovate.json](https://github.com/xmtplabs/convos-ios/pull/1078/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) that enables platform-level automerge for minor and patch updates to `https://github.com/xmtp/libxmtp`, reducing manual review overhead for routine dependency bumps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 189574d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->