### PR TITLE
fix(notifications): exclude removed members from push notification title

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -473,11 +473,26 @@ extension MessagingService {
         currentInboxId: String
     ) async throws -> Int {
         try await databaseReader.read { db in
-            try DBMemberProfile
-                .filter(DBMemberProfile.Columns.conversationId == conversationId)
-                .filter(DBMemberProfile.Columns.inboxId != currentInboxId)
-                .fetchCount(db)
+            try Self.otherMemberCount(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId
+            )
         }
+    }
+
+    /// Counts the conversation's current members excluding the current user,
+    /// gated on `DBConversationMember` so a removed member's orphaned profile
+    /// no longer inflates the count that drives sender-name prefixing.
+    static func otherMemberCount(
+        db: Database,
+        conversationId: String,
+        currentInboxId: String
+    ) throws -> Int {
+        try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .filter(DBConversationMember.Columns.inboxId != currentInboxId)
+            .fetchCount(db)
     }
 
     private func buildNotificationBody(
@@ -999,60 +1014,89 @@ extension MessagingService {
         currentInboxId: String
     ) async throws -> String {
         try await databaseReader.read { db in
-            guard let conversation = try DBConversation.fetchOne(db, key: conversationId) else {
-                return "Untitled"
-            }
-
-            if let name = conversation.name, !name.isEmpty {
-                return name
-            }
-
-            let memberProfiles = try DBMemberProfile
-                .filter(DBMemberProfile.Columns.conversationId == conversationId)
-                .filter(DBMemberProfile.Columns.inboxId != currentInboxId)
-                .fetchAll(db)
-
-            if memberProfiles.isEmpty {
-                return "New Convo"
-            }
-
-            // Resolve each member like `Profile.formattedNamesString(memberNameOverride:)`:
-            // the contact's display name (the user's global profile snapshot
-            // for this inbox) wins over the per-conversation profile name.
-            // Unnamed members are bucketed by agent vs. human so the rendered
-            // title matches: anonymous agents read as "Agent" / "Agents",
-            // anonymous humans as "Somebody" / "Somebodies".
-            let resolved: [(name: String?, isAgent: Bool)] = try memberProfiles.map { (profile: DBMemberProfile) -> (name: String?, isAgent: Bool) in
-                if let contactName = try ContactsRepository.contactNameInTransaction(db: db, inboxId: profile.inboxId) {
-                    return (contactName, profile.isAgent)
-                }
-                if let name = profile.name, !name.isEmpty {
-                    return (name, profile.isAgent)
-                }
-                return (nil, profile.isAgent)
-            }
-            let namedProfiles: [String] = resolved.compactMap { $0.name }.sorted()
-            let anonymousAgentCount: Int = resolved.filter { $0.name == nil && $0.isAgent }.count
-            let anonymousHumanCount: Int = resolved.filter { $0.name == nil && !$0.isAgent }.count
-
-            var allNames = namedProfiles
-            if anonymousAgentCount == 1 {
-                allNames.append("Agent")
-            } else if anonymousAgentCount > 1 {
-                allNames.append("Agents")
-            }
-            if anonymousHumanCount == 1 {
-                allNames.append("Somebody")
-            } else if anonymousHumanCount > 1 {
-                allNames.append("Somebodies")
-            }
-
-            if allNames.isEmpty {
-                return "Untitled"
-            }
-
-            return allNames.joined(separator: ", ")
+            try Self.computedDisplayName(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId
+            )
         }
+    }
+
+    /// Builds the group notification title from the conversation's current
+    /// members. Current membership is read through `DBConversationMember` so a
+    /// removed member's orphaned `DBMemberProfile` row no longer feeds the
+    /// title; this mirrors the in-app header, which hydrates from
+    /// `DBConversationMember` as well. Per-member name resolution still goes
+    /// through `ContactsRepository` then the per-conversation profile name.
+    static func computedDisplayName(
+        db: Database,
+        conversationId: String,
+        currentInboxId: String
+    ) throws -> String {
+        guard let conversation = try DBConversation.fetchOne(db, key: conversationId) else {
+            return "Untitled"
+        }
+
+        if let name = conversation.name, !name.isEmpty {
+            return name
+        }
+
+        let currentMemberInboxIds = try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .filter(DBConversationMember.Columns.inboxId != currentInboxId)
+            .fetchAll(db)
+            .map(\.inboxId)
+
+        if currentMemberInboxIds.isEmpty {
+            return "New Convo"
+        }
+
+        let memberProfiles = try DBMemberProfile.fetchAll(
+            db,
+            conversationId: conversationId,
+            inboxIds: currentMemberInboxIds
+        )
+
+        if memberProfiles.isEmpty {
+            return "New Convo"
+        }
+
+        // Resolve each member like `Profile.formattedNamesString(memberNameOverride:)`:
+        // the contact's display name (the user's global profile snapshot
+        // for this inbox) wins over the per-conversation profile name.
+        // Unnamed members are bucketed by agent vs. human so the rendered
+        // title matches: anonymous agents read as "Agent" / "Agents",
+        // anonymous humans as "Somebody" / "Somebodies".
+        let resolved: [(name: String?, isAgent: Bool)] = try memberProfiles.map { (profile: DBMemberProfile) -> (name: String?, isAgent: Bool) in
+            if let contactName = try ContactsRepository.contactNameInTransaction(db: db, inboxId: profile.inboxId) {
+                return (contactName, profile.isAgent)
+            }
+            if let name = profile.name, !name.isEmpty {
+                return (name, profile.isAgent)
+            }
+            return (nil, profile.isAgent)
+        }
+        let namedProfiles: [String] = resolved.compactMap { $0.name }.sorted()
+        let anonymousAgentCount: Int = resolved.filter { $0.name == nil && $0.isAgent }.count
+        let anonymousHumanCount: Int = resolved.filter { $0.name == nil && !$0.isAgent }.count
+
+        var allNames = namedProfiles
+        if anonymousAgentCount == 1 {
+            allNames.append("Agent")
+        } else if anonymousAgentCount > 1 {
+            allNames.append("Agents")
+        }
+        if anonymousHumanCount == 1 {
+            allNames.append("Somebody")
+        } else if anonymousHumanCount > 1 {
+            allNames.append("Somebodies")
+        }
+
+        if allNames.isEmpty {
+            return "Untitled"
+        }
+
+        return allNames.joined(separator: ", ")
     }
 
     private func getMemberDisplayName(

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -344,10 +344,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             let count: Int = try DBConversationMember
                 .filter(DBConversationMember.Columns.conversationId == convoId)
                 .fetchCount(db)
-            let hasAgent: Bool = try DBMemberProfile
-                .filter(DBMemberProfile.Columns.conversationId == convoId)
-                .filter(DBMemberProfile.Columns.memberKind != nil)
-                .fetchCount(db) > 0
+            let hasAgent: Bool = try Self.hasCurrentAgentMember(db: db, conversationId: convoId)
             return (count, hasAgent)
         }) ?? (0, false)
         await actions.sentMessage(

--- a/ConvosCore/Tests/ConvosCoreTests/NotificationTitleMembershipTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/NotificationTitleMembershipTests.swift
@@ -1,0 +1,139 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("Notification title excludes removed members")
+struct NotificationTitleMembershipTests {
+    private let conversationId: String = "conversation-1"
+    private let currentInboxId: String = "current-user"
+    private let presentInboxId: String = "present-member"
+    private let orphanInboxId: String = "removed-member"
+
+    private func seedConversation(db: Database) throws {
+        for inboxId in [currentInboxId, presentInboxId, orphanInboxId] {
+            try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        }
+        try DBConversation(
+            id: conversationId,
+            clientConversationId: "client-\(conversationId)",
+            inviteTag: "invite-tag-\(conversationId)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+        ).insert(db)
+    }
+
+    private func seedMemberProfile(db: Database, inboxId: String, name: String?, memberKind: DBMemberKind? = nil) throws {
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            name: name,
+            avatar: nil,
+            memberKind: memberKind
+        ).insert(db)
+    }
+
+    private func seedConversationMember(db: Database, inboxId: String, role: MemberRole) throws {
+        try DBConversationMember(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            role: role,
+            consent: .allowed,
+            createdAt: Date(),
+            invitedByInboxId: nil
+        ).insert(db)
+    }
+
+    /// Seeds a conversation with the current user plus one present member and
+    /// one orphan member. The orphan keeps a `DBMemberProfile` row (as a real
+    /// removal leaves behind for historical sender attribution) but has no
+    /// `DBConversationMember` row, reproducing the stale-title bug.
+    private func seedRemovedMemberScenario(db: Database) throws {
+        try seedConversation(db: db)
+
+        try seedMemberProfile(db: db, inboxId: currentInboxId, name: "Me")
+        try seedMemberProfile(db: db, inboxId: presentInboxId, name: "Kai")
+        try seedMemberProfile(db: db, inboxId: orphanInboxId, name: "Berry Bowl Bliss", memberKind: .agent)
+
+        try seedConversationMember(db: db, inboxId: currentInboxId, role: .superAdmin)
+        try seedConversationMember(db: db, inboxId: presentInboxId, role: .member)
+    }
+
+    @Test("Computed title excludes a removed member whose profile is orphaned")
+    func computedTitleExcludesOrphanProfile() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedRemovedMemberScenario(db: db)
+        }
+        let title = try dbManager.dbReader.read { db in
+            try MessagingService.computedDisplayName(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId
+            )
+        }
+        #expect(title == "Kai")
+    }
+
+    @Test("Other-member count is gated on current membership, not profiles")
+    func otherMemberCountExcludesOrphanProfile() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedRemovedMemberScenario(db: db)
+        }
+        let count = try dbManager.dbReader.read { db in
+            try MessagingService.otherMemberCount(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId
+            )
+        }
+        #expect(count == 1)
+    }
+
+    @Test("Present members are unaffected by the membership gate")
+    func presentMembersStillResolve() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try seedConversation(db: db)
+            try seedMemberProfile(db: db, inboxId: currentInboxId, name: "Me")
+            try seedMemberProfile(db: db, inboxId: presentInboxId, name: "Kai")
+            try seedMemberProfile(db: db, inboxId: orphanInboxId, name: "Ada")
+            try seedConversationMember(db: db, inboxId: currentInboxId, role: .superAdmin)
+            try seedConversationMember(db: db, inboxId: presentInboxId, role: .member)
+            try seedConversationMember(db: db, inboxId: orphanInboxId, role: .member)
+        }
+        let result = try dbManager.dbReader.read { db -> (String, Int) in
+            let title = try MessagingService.computedDisplayName(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId
+            )
+            let count = try MessagingService.otherMemberCount(
+                db: db,
+                conversationId: conversationId,
+                currentInboxId: currentInboxId
+            )
+            return (title, count)
+        }
+        #expect(result.0 == "Ada, Kai")
+        #expect(result.1 == 2)
+    }
+}


### PR DESCRIPTION
## Symptom

Shane reported that a removed group member kept showing up in the **push notification title**: the agent "Berry Bowl Bliss" lingered in `"Berry Bowl Bliss, Kai"` after being removed, even though the in-app conversation header correctly showed only `"Kai"`.

## Root cause

The Notification Service Extension built the group title from a **direct `DBMemberProfile` query** (by `conversationId`, filtered only `inboxId != currentInboxId`) with **no join to current membership**.

Member removal prunes only the `DBConversationMember` row; it deliberately leaves `DBMemberProfile` intact. So the removed member's orphaned profile kept feeding the NSE title. The in-app header is correct because it hydrates members through `DBConversationMember`.

This was a systemic staleness bug: it hit human members too, not just agents, and it did **not** self-heal because the source data (`DBMemberProfile`) was never re-derived from membership.

## The fix (query-side membership join; profiles untouched)

`ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift`
- `getComputedDisplayName` now reads **current members through `DBConversationMember`** (excluding `currentInboxId`), then fetches the matching `DBMemberProfile` rows for name resolution. Per-member name resolution (ContactsRepository -> per-conversation profile name fallback) is unchanged - only the member **set** source changed. Extracted into a testable `static computedDisplayName(db:conversationId:currentInboxId:)` seam mirroring the existing `notificationMemberDisplayName`.
- `getOtherMemberCount` is now membership-gated the same way (counts current `DBConversationMember` rows excluding the current user), extracted to `static otherMemberCount(...)`.

`ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift`
- Aligned `hasAgent` in `emitSentMessage` to the existing membership-gated `Self.hasCurrentAgentMember(db:conversationId:)` helper. Behavior-preserving for present members: a present agent has both a `DBConversationMember` row and an agent `DBMemberProfile`, and `DBMemberKind.isAgent` is always true (so the old `memberKind != nil` predicate equals the agent predicate). Only orphaned removed agents change - which is the same staleness bug.

This **heals existing stale titles** on the next notification with no data migration.

## Scope

Fixes all `getComputedDisplayName` notification paths (welcome/join notifications and group message notifications) plus the `hasAgent` metric on the send path.

## Why we did NOT delete `DBMemberProfile`

`DBMemberProfile` is still needed for **historical sender attribution** in message history (rendering past messages from members who later left). The fix is query-side only; removal/reconciliation deletion logic is untouched.

## Test

Added `ConvosCore/Tests/ConvosCoreTests/NotificationTitleMembershipTests.swift` - pure GRDB, **Docker-free**:
- Seeds a conversation with the current user, one present member (with a `DBConversationMember` row), and one orphan member (profile but **no** `DBConversationMember` row).
- Asserts the computed title excludes the orphan (`"Kai"`, not `"Berry Bowl Bliss, Kai"`) and the other-member count is `1`.
- A third case confirms present members and the multi-member sort path are unaffected.

3 tests, all pass in ~0.06s with no Docker.

## Test status: local vs CI

- `swift build --package-path ConvosCore`: passed locally.
- `NotificationTitleMembershipTests`: passed locally (Docker-free).
- Full suite: **not run locally** (most of it requires the shared Docker XMTP node, which is left untouched for other sessions). The full suite runs on CI.

## Lint

`swiftlint --strict` and `swiftformat --lint` clean on changed files; pre-commit and pre-push hooks passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784280387&installation_id=128169237&pr_number=1080&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1080&signature=cff9d5dae209f2b5130a449eba922fd8d1d5365aacfbd1bf1971bb9e5f2b7a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude removed members from push notification title and member count
> - Rewrites `computedDisplayName` in [MessagingService+PushNotifications.swift](https://github.com/xmtplabs/convos-ios/pull/1080/files#diff-e3600c561fc30fca5b793ab019a6c9384b2f81973531eff39d65eba919fddf4b) to build group notification titles from `DBConversationMember` (current members) instead of `DBMemberProfile`, so removed members with orphaned profile rows no longer appear in the title.
> - Adds a new `otherMemberCount` helper that similarly gates counts on current membership rather than profile rows.
> - Updates `OutgoingMessageWriter` to use `hasCurrentAgentMember` when reporting the `hasAssistant` metric, consistent with the same membership-first approach.
> - Adds `NotificationTitleMembershipTests` to verify that removed members are excluded from display names and counts while present members resolve correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e444f69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->