### PR TITLE
fix(settings): lowercase the v in the version label

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -367,7 +367,7 @@ struct AppSettingsView: View {
         HStack {
             Text("Made in the open by XMTP Labs")
             Spacer()
-            Text("V\(Bundle.appVersion)")
+            Text("v\(Bundle.appVersion)")
                 .foregroundStyle(.colorTextTertiary)
         }
         .foregroundStyle(.colorTextSecondary)


### PR DESCRIPTION
Changes `"V\(Bundle.appVersion)"` to `"v\(Bundle.appVersion)"` in `Convos/App Settings/AppSettingsView.swift` line 370, so the Settings footer displays "v2.0" instead of "V2.0". Small typography fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784292039&installation_id=128169237&pr_number=1084&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1084&signature=af42911d28cd10ef5984315beb3d980d1e1652c9ad10ed0c8b23cd30497fba1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lowercase the version prefix 'v' in `AppSettingsView` footer
> Changes the version label in [AppSettingsView.swift](https://github.com/xmtplabs/convos-ios/pull/1084/files#diff-30e98d39613710cf0f912b477ed30a8638995959caa9cb2e9facdc10e1c3f8b9) from `V` to `v` to match standard version string formatting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39465b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->