### PR TITLE
feat(debug): curated prod debug menu (Tier-1)

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -64,6 +64,10 @@ struct AppSettingsView: View {
     @Environment(\.dismiss) private var dismiss: DismissAction
     @State private var navState: AppSettingsNavigatorImpl = .init()
     @State private var navigator: AppSettingsCollector?
+    @State private var versionTapCount: Int = 0
+    @State private var lastVersionTapAt: Date?
+    @State private var showingEnableDebugConfirmation: Bool = false
+    @State private var prodDebugMenuEnabled: Bool = DebugMenuGate.showsProdDebugMenu(for: ConfigManager.shared.currentEnvironment)
 
     private func ensureNavigator() {
         guard navigator == nil else { return }
@@ -320,16 +324,34 @@ struct AppSettingsView: View {
 
     @ViewBuilder
     private var linksSection: some View {
+        let environment: AppEnvironment = ConfigManager.shared.currentEnvironment
+        let showsFullMenu: Bool = DebugMenuGate.showsFullDebugMenu(for: environment)
         Section {
             privacyTermsRow
             sendFeedbackRow
-            if !ConfigManager.shared.currentEnvironment.isProduction {
+            if showsFullMenu {
                 debugRow
+            } else if prodDebugMenuEnabled {
+                prodDebugRow
             }
         } footer: {
             linksFooter
         }
         .listRowSeparatorTint(.colorBorderSubtle)
+        .confirmationDialog(
+            "Enable debug menu?",
+            isPresented: $showingEnableDebugConfirmation,
+            titleVisibility: .visible
+        ) {
+            let enableAction = {
+                DebugMenuFlagStore.enable()
+                prodDebugMenuEnabled = true
+            }
+            Button("Enable", action: enableAction)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Reveals on-device diagnostics for this account. You can turn it off any time from the debug menu.")
+        }
     }
 
     @ViewBuilder
@@ -363,14 +385,47 @@ struct AppSettingsView: View {
     }
 
     @ViewBuilder
+    private var prodDebugRow: some View {
+        NavigationLink {
+            ProdDebugMenuView(environment: ConfigManager.shared.currentEnvironment, session: session)
+        } label: {
+            Text("Debug menu")
+        }
+        .foregroundStyle(.colorTextPrimary)
+        .accessibilityIdentifier("prod-debug-menu-row")
+    }
+
+    @ViewBuilder
     private var linksFooter: some View {
         HStack {
             Text("Made in the open by XMTP Labs")
             Spacer()
-            Text("v\(Bundle.appVersion)")
-                .foregroundStyle(.colorTextTertiary)
+            let versionTapAction = { handleVersionTapped() }
+            Button(action: versionTapAction) {
+                Text("v\(Bundle.appVersion)")
+                    .foregroundStyle(.colorTextTertiary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("settings-version-label")
         }
         .foregroundStyle(.colorTextSecondary)
+    }
+
+    private func handleVersionTapped() {
+        let environment: AppEnvironment = ConfigManager.shared.currentEnvironment
+        // Non-production already shows the full debug menu, so the easter-egg
+        // gesture only matters in production where the curated menu is opt-in.
+        guard environment.isProduction, !prodDebugMenuEnabled else { return }
+        let now = Date()
+        if let lastTap = lastVersionTapAt, now.timeIntervalSince(lastTap) > Constant.versionTapWindow {
+            versionTapCount = 0
+        }
+        lastVersionTapAt = now
+        versionTapCount += 1
+        if versionTapCount >= Constant.versionTapThreshold {
+            versionTapCount = 0
+            showingEnableDebugConfirmation = true
+        }
     }
 
     @ViewBuilder
@@ -419,6 +474,11 @@ struct AppSettingsView: View {
     private func openExternalURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         openURL(url)
+    }
+
+    private enum Constant {
+        static let versionTapThreshold: Int = 7
+        static let versionTapWindow: TimeInterval = 3
     }
 }
 

--- a/Convos/Debug View/DebugMenuFlagStore.swift
+++ b/Convos/Debug View/DebugMenuFlagStore.swift
@@ -1,0 +1,35 @@
+import ConvosCore
+import Foundation
+
+/// Persistent on/off flag for the curated prod debug menu.
+///
+/// Stored in plain `UserDefaults.standard` (main app only; the Notification
+/// Service Extension does not need it). The flag is OFF by default and stays
+/// enabled until the user explicitly turns it off -- there is no auto-expiry
+/// and no cold-launch clear.
+///
+/// In production the getter returns `false` unless the flag is explicitly set,
+/// mirroring the defensive posture of `FeatureFlags.isDebugInjectorEnabled`:
+/// a stray UserDefaults value leaking in from a non-prod build with the same
+/// bundle id can never silently enable the menu.
+enum DebugMenuFlagStore {
+    static func isEnabled() -> Bool {
+        UserDefaults.standard.bool(forKey: Constant.enabledKey)
+    }
+
+    static func enable() {
+        UserDefaults.standard.set(true, forKey: Constant.enabledKey)
+    }
+
+    static func disable() {
+        UserDefaults.standard.set(false, forKey: Constant.enabledKey)
+    }
+
+    static func setEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: Constant.enabledKey)
+    }
+
+    private enum Constant {
+        static let enabledKey: String = "convos.debugMenu.enabled.v1"
+    }
+}

--- a/Convos/Debug View/DebugMenuGate.swift
+++ b/Convos/Debug View/DebugMenuGate.swift
@@ -1,0 +1,33 @@
+import ConvosCore
+import Foundation
+
+/// Runtime gate deciding whether a debug menu is reachable.
+///
+/// The codebase prefers runtime gates over `#if DEBUG` because `#if DEBUG`
+/// does not propagate into the ConvosCore SPM package, so environment-based
+/// runtime checks are the established convention here.
+///
+/// - Non-production environments keep the full debug experience unconditionally.
+/// - Production exposes only the curated `ProdDebugMenuView`, and only when the
+///   persistent `DebugMenuFlagStore` toggle has been explicitly enabled.
+enum DebugMenuGate {
+    /// True when the full (non-prod) debug section should be shown.
+    static func showsFullDebugMenu(for environment: AppEnvironment) -> Bool {
+        !environment.isProduction
+    }
+
+    /// True when the curated prod debug menu should be reachable. In
+    /// production this requires the explicit opt-in toggle; in non-prod it is
+    /// always available alongside the full menu.
+    static func showsProdDebugMenu(for environment: AppEnvironment) -> Bool {
+        if !environment.isProduction { return true }
+        return DebugMenuFlagStore.isEnabled()
+    }
+
+    /// True when the app-wide "debug mode ON" indicator should be visible.
+    /// Only meaningful in production, where the menu is opt-in; in non-prod the
+    /// debug menu is always present so the indicator would be noise.
+    static func showsDebugModeIndicator(for environment: AppEnvironment) -> Bool {
+        environment.isProduction && DebugMenuFlagStore.isEnabled()
+    }
+}

--- a/Convos/Debug View/DebugModeIndicator.swift
+++ b/Convos/Debug View/DebugModeIndicator.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Always-visible chip shown while the curated prod debug menu is enabled, so a
+/// user (or a support agent reviewing a screen recording) can always tell the
+/// device is in an elevated-diagnostics state. Rendered app-wide from the root
+/// container; it does not gate any data on its own.
+struct DebugModeIndicator: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            HStack(spacing: 6) {
+                Image(systemName: "ladybug.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("Debug mode ON")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color.orange)
+            )
+            .padding(.bottom, 8)
+            .accessibilityIdentifier("debug-mode-indicator")
+            .accessibilityLabel("Debug mode is on")
+        }
+        .allowsHitTesting(false)
+        .ignoresSafeArea(.keyboard)
+    }
+}
+
+#Preview {
+    DebugModeIndicator()
+}

--- a/Convos/Debug View/DebugRevealableValueRow.swift
+++ b/Convos/Debug View/DebugRevealableValueRow.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import UIKit
+
+/// A read-only row for a sensitive identity correlator (eth address, accountId,
+/// inboxId, installation id, APNs token). The value is masked by default; a tap
+/// reveals the full value in monospace, and an explicit copy button places it on
+/// the clipboard. Masking-by-default plus explicit reveal is the accepted
+/// control for surfacing these correlators in production.
+struct DebugRevealableValueRow: View {
+    let label: String
+    let value: String?
+
+    @State private var isRevealed: Bool = false
+    @State private var didCopy: Bool = false
+
+    private var displayValue: String {
+        guard let value, !value.isEmpty else { return "(none)" }
+        if isRevealed { return value }
+        return Self.masked(value)
+    }
+
+    private var hasValue: Bool {
+        guard let value else { return false }
+        return !value.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .foregroundStyle(.colorTextPrimary)
+            HStack(spacing: 8) {
+                let toggleReveal = {
+                    guard hasValue else { return }
+                    isRevealed.toggle()
+                }
+                Button(action: toggleReveal) {
+                    Text(displayValue)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(isRevealed ? nil : 1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                .buttonStyle(.plain)
+                .disabled(!hasValue)
+
+                let copyValue: () -> Void = {
+                    guard let value, !value.isEmpty else { return }
+                    UIPasteboard.general.string = value
+                    didCopy = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 1_500_000_000)
+                        didCopy = false
+                    }
+                }
+                Button(action: copyValue) {
+                    Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!hasValue)
+            }
+        }
+    }
+
+    private static func masked(_ value: String) -> String {
+        guard value.count > 10 else { return String(repeating: "•", count: value.count) }
+        let prefix = value.prefix(6)
+        let suffix = value.suffix(4)
+        return "\(prefix)…\(suffix)"
+    }
+}

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -1,0 +1,316 @@
+import ConvosCore
+import ConvosCoreiOS
+import SwiftUI
+import UserNotifications
+
+// Module overview -- prod debug menu entry points
+//
+// This is the curated, read-only, own-account subset of the debug tools that
+// is safe to reach in a production build. It is deliberately NOT the full
+// `DebugViewSection`, which interleaves Tier-2 mutating / other-users'-data
+// controls.
+//
+// Reachable from:
+// - App Settings links group, after the version-tap gesture enables the
+//   persistent toggle (see `AppSettingsView`). In production this is the only
+//   debug surface.
+// - Non-production builds continue to show the full `DebugViewSection`
+//   unchanged via the existing environment gate; this curated view is the
+//   prod-only surface.
+//
+// Hard rules enforced here:
+// - No mutating controls (no "Request Now", no "Register Device Again", no
+//   purchase / change-plan CTAs, no mock-credit toggles).
+// - The live `BackendAuthProbe` (JWT minter) is never imported or instantiated
+//   here. The identity readout uses `DeviceIdentitySnapshot`, which is
+//   network-free and carries no JWT.
+// - Sensitive correlators (eth address, accountId, inboxId, installation ids,
+//   APNs token) are masked by default with explicit tap-to-reveal + copy.
+struct ProdDebugMenuView: View {
+    let environment: AppEnvironment
+    let session: any SessionManagerProtocol
+
+    @State private var notificationAuthStatus: UNAuthorizationStatus = .notDetermined
+    @State private var notificationAuthGranted: Bool = false
+    @State private var apnsToken: String = ""
+    @State private var logStorageInfo: DebugLogExporter.LogStorageInfo?
+    @State private var exportedLogsURL: URL?
+    @State private var isExportingLogs: Bool = false
+    @State private var identity: DeviceIdentitySnapshot?
+    @State private var installations: InstallationsSnapshot?
+    @State private var debugModeEnabled: Bool = DebugMenuFlagStore.isEnabled()
+    @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
+    @State private var currentSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
+
+    var body: some View {
+        List {
+            debugModeSection
+            buildSection
+            identitySection
+            subscriptionSection
+            pushSection
+            featureFlagsSection
+            logsSection
+        }
+        .scrollContentBackground(.hidden)
+        .background(.colorBackgroundRaisedSecondary)
+        .navigationTitle("Debug menu")
+        .navigationBarTitleDisplayMode(.inline)
+        .onReceive(CreditsServices.shared.balancePublisher) { creditBalance = $0 }
+        .onReceive(SubscriptionServices.shared.subscriptionPublisher) { currentSubscription = $0 }
+        .task {
+            await loadDiagnostics()
+        }
+    }
+
+    // MARK: - Debug mode toggle
+
+    @ViewBuilder
+    private var debugModeSection: some View {
+        Section {
+            Toggle("Debug mode", isOn: $debugModeEnabled)
+                .onChange(of: debugModeEnabled) { _, newValue in
+                    DebugMenuFlagStore.setEnabled(newValue)
+                }
+        } footer: {
+            Text("Turn this off to hide the debug menu and clear the on-screen indicator.")
+        }
+    }
+
+    // MARK: - Build / environment
+
+    @ViewBuilder
+    private var buildSection: some View {
+        let bundleId: String = Bundle.main.bundleIdentifier ?? "Unknown"
+        let buildNumber: String = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        let environmentName: String = environment.name.capitalized
+        Section("Build") {
+            labeledRow("Version", Bundle.appVersion)
+            labeledRow("Build", buildNumber)
+            labeledRow("Bundle ID", bundleId)
+            labeledRow("Environment", environmentName)
+        }
+    }
+
+    // MARK: - Identity (Tier 1, network-free, no JWT)
+
+    @ViewBuilder
+    private var identitySection: some View {
+        let siwe: SIWEConfiguration = environment.siweConfiguration
+        Section("Identity") {
+            DebugRevealableValueRow(label: "ETH address", value: identity?.ethAddress)
+            DebugRevealableValueRow(label: "Account ID", value: identity?.accountId)
+            DebugRevealableValueRow(label: "Inbox ID", value: identity?.inboxId ?? installations?.inboxId)
+            DebugRevealableValueRow(label: "Installation ID", value: installations?.currentInstallationId)
+            peerInstallationsRows
+            labeledRow("SIWE domain", siwe.domain)
+            labeledRow("SIWE URI", siwe.uri)
+            labeledRow("SIWE chain ID", "\(siwe.chainId)")
+        }
+    }
+
+    @ViewBuilder
+    private var peerInstallationsRows: some View {
+        let currentId: String? = installations?.currentInstallationId
+        let peers: [InstallationInfo] = installations?.installations.filter { $0.id != currentId } ?? []
+        ForEach(peers, id: \.id) { (peer: InstallationInfo) in
+            DebugRevealableValueRow(label: "Peer installation", value: peer.id)
+        }
+    }
+
+    // MARK: - Subscription & credits (Tier 1, read-only)
+
+    @ViewBuilder
+    private var subscriptionSection: some View {
+        Section("Subscription & Credits") {
+            labeledRow("Plan", subscriptionPlanText)
+            labeledRow("Status", subscriptionStatusText)
+            if let subscription = currentSubscription {
+                labeledRow("Product ID", subscription.productId)
+                labeledRow("Period", subscription.period == .monthly ? "Monthly" : "Annual")
+                labeledRow("Renews", subscription.willRenew ? "Yes" : "No")
+                labeledRow("In trial", subscription.isInTrial ? "Yes" : "No")
+                labeledRow("Period end", Self.dateText(subscription.currentPeriodEnd))
+            }
+            creditRows
+        }
+    }
+
+    @ViewBuilder
+    private var creditRows: some View {
+        if let balance = creditBalance {
+            labeledRow("Credits", "\(balance.balance) / \(balance.monthlyGrant)")
+            labeledRow("Grant used", "\(balance.monthlyGrantUsed)")
+            labeledRow("Period", balance.periodLabel)
+            labeledRow("Next refresh", Self.dateText(balance.nextRefreshAt))
+        } else {
+            labeledRow("Credits", "(unavailable)")
+        }
+    }
+
+    // MARK: - Push diagnostics (Tier 1, masked token, no mutating buttons)
+
+    @ViewBuilder
+    private var pushSection: some View {
+        let apnsEnv: String = environment.apnsEnvironment.rawValue
+        Section("Push") {
+            labeledRow("Auth status", Self.authStatusText(notificationAuthStatus))
+            labeledRow("Authorized", notificationAuthGranted ? "Yes" : "No")
+            labeledRow("APNs environment", apnsEnv)
+            DebugRevealableValueRow(label: "APNs token", value: apnsToken.isEmpty ? nil : apnsToken)
+        }
+    }
+
+    // MARK: - Feature flags (display only)
+
+    @ViewBuilder
+    private var featureFlagsSection: some View {
+        let injectorEnabled: Bool = FeatureFlags.shared.isDebugInjectorEnabled
+        Section("Feature flags") {
+            labeledRow("Debug injector", injectorEnabled ? "On" : "Off")
+        }
+    }
+
+    // MARK: - Logs (read-only export, already ships in prod)
+
+    @ViewBuilder
+    private var logsSection: some View {
+        Section("Logs") {
+            HStack {
+                Text("Log storage")
+                    .foregroundStyle(.colorTextPrimary)
+                Spacer()
+                if let info = logStorageInfo {
+                    Text(info.formattedTotalSize)
+                        .foregroundStyle(.colorTextSecondary)
+                } else {
+                    ProgressView()
+                }
+            }
+            logExportRow
+        }
+    }
+
+    @ViewBuilder
+    private var logExportRow: some View {
+        if let url = exportedLogsURL {
+            ShareLink(item: url) {
+                HStack {
+                    Text("Share logs")
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer()
+                    Image(systemName: "square.and.arrow.up")
+                        .foregroundStyle(.colorTextSecondary)
+                }
+            }
+            .buttonStyle(.plain)
+        } else {
+            let exportAction: () -> Void = {
+                Task { await prepareExportedLogs() }
+            }
+            Button(action: exportAction) {
+                HStack {
+                    Text("Export logs")
+                        .foregroundStyle(.colorTextPrimary)
+                    Spacer()
+                    if isExportingLogs { ProgressView() }
+                }
+            }
+            .disabled(isExportingLogs)
+        }
+    }
+
+    // MARK: - Shared rows
+
+    @ViewBuilder
+    private func labeledRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(label)
+                .foregroundStyle(.colorTextPrimary)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - Derived text
+
+    private var subscriptionPlanText: String {
+        guard let subscription = currentSubscription else { return "Free" }
+        let name: String = SubscriptionCopy.displayName(for: subscription.tier)
+        return subscription.isInTrial ? "\(name) trial" : name
+    }
+
+    private var subscriptionStatusText: String {
+        guard let subscription = currentSubscription else { return "No subscription" }
+        switch subscription.status {
+        case .trial: return "Trial"
+        case .active: return "Active"
+        case .grace: return "Grace"
+        case .billingRetry: return "Billing retry"
+        case .expired: return "Expired"
+        case .revoked: return "Revoked"
+        }
+    }
+
+    // MARK: - Loading
+
+    private func loadDiagnostics() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        notificationAuthStatus = settings.authorizationStatus
+        notificationAuthGranted = settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional
+        apnsToken = PushNotificationRegistrar.token ?? ""
+        logStorageInfo = DebugLogExporter.getStorageInfo(environment: environment)
+
+        let store = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
+        identity = await DeviceIdentitySnapshot.current(identityStore: store)
+
+        do {
+            installations = try await session.messagingService().installationsSnapshot(refreshFromNetwork: false)
+        } catch {
+            Log.warning("ProdDebugMenuView: failed to read installations: \(error)")
+        }
+    }
+
+    private func prepareExportedLogs() async {
+        guard !isExportingLogs else { return }
+        isExportingLogs = true
+        defer { isExportingLogs = false }
+        let environment = environment
+        let url = await Task.detached { () -> URL? in
+            do {
+                return try DebugLogExporter.exportAllLogs(environment: environment)
+            } catch {
+                Log.error("ProdDebugMenuView: failed to export logs: \(error.localizedDescription)")
+                return nil
+            }
+        }.value
+        exportedLogsURL = url
+    }
+
+    private static func authStatusText(_ status: UNAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined: return "notDetermined"
+        case .denied: return "denied"
+        case .authorized: return "authorized"
+        case .provisional: return "provisional"
+        case .ephemeral: return "ephemeral"
+        @unknown default: return "unknown"
+        }
+    }
+
+    private static func dateText(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProdDebugMenuView(environment: .tests, session: MockInboxesService())
+    }
+}

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -59,6 +59,12 @@ struct MainTabView: View {
     /// past the top. While hidden, a compact "add agent" button takes its
     /// place in the nav bar.
     @State private var isBuilderBarRevealed: Bool = true
+    /// Whether the app-wide "debug mode ON" indicator is shown. Only true in
+    /// production when the curated debug menu's persistent toggle is enabled;
+    /// refreshed when the UserDefaults-backed flag changes.
+    @State private var debugModeIndicatorVisible: Bool = DebugMenuGate.showsDebugModeIndicator(
+        for: ConfigManager.shared.currentEnvironment
+    )
     /// Latest scroll content offset from each tab's primary scroll view.
     /// Tracked per-tab so swapping tabs can re-evaluate the builder bar
     /// state against the new tab's scroll position immediately, instead
@@ -1038,11 +1044,22 @@ extension MainTabView {
             tabView
 
             sharedAppIndicatorOverlay
+
+            if debugModeIndicatorVisible {
+                DebugModeIndicator()
+                    .zIndex(1001)
+            }
         }
         .animation(.smooth(duration: 0.35), value: isConversationSelected)
         .animation(.smooth(duration: 0.35), value: isEmptyChatsCTAActive)
         .onChange(of: thingsPushedItems) { _, newItems in
             syncThingsPushedConvoVM(with: newItems)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            refreshDebugModeIndicator()
+        }
+        .onAppear {
+            refreshDebugModeIndicator()
         }
         .onReceive(SubscriptionServices.shared.subscriptionPublisher) { newSubscription in
             userSubscription = newSubscription
@@ -1054,6 +1071,14 @@ extension MainTabView {
             handleConversationNotificationTapped()
         }
         .modifier(mainTabSheetsModifier)
+    }
+
+    private func refreshDebugModeIndicator() {
+        let environment: AppEnvironment = ConfigManager.shared.currentEnvironment
+        let shouldShow: Bool = DebugMenuGate.showsDebugModeIndicator(for: environment)
+        if debugModeIndicatorVisible != shouldShow {
+            debugModeIndicatorVisible = shouldShow
+        }
     }
 
     var metricsObserversModifier: MetricsObservers {

--- a/ConvosCore/Sources/ConvosCore/Auth/SIWE/DeviceIdentitySnapshot.swift
+++ b/ConvosCore/Sources/ConvosCore/Auth/SIWE/DeviceIdentitySnapshot.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Network-free, JWT-free snapshot of this device's own static identity
+/// correlators, read directly from the keychain. Intended for the curated
+/// prod debug menu's read-only Identity view.
+///
+/// This deliberately does not carry the SIWE JWT and never makes a network
+/// call. It is the Tier-1 counterpart to `BackendAuthProbe.currentStatus`:
+/// the prod-reachable identity surface reads only on-device, static values
+/// and must never depend on the live token-minting probe. Keep it free of
+/// any `BackendAuthProbe` reference so the prod menu cannot reach the
+/// JWT-minting path.
+public struct DeviceIdentitySnapshot: Sendable {
+    /// Checksummed EIP-55 ethereum address, nil if there is no on-device identity.
+    public let ethAddress: String?
+    /// Backend-assigned accountId cached in the keychain, nil if absent.
+    public let accountId: String?
+    /// The XMTP inbox id for this device's identity.
+    public let inboxId: String?
+    /// The libxmtp client id (installation-scoped) for this identity.
+    public let clientId: String?
+
+    public init(
+        ethAddress: String?,
+        accountId: String?,
+        inboxId: String?,
+        clientId: String?
+    ) {
+        self.ethAddress = ethAddress
+        self.accountId = accountId
+        self.inboxId = inboxId
+        self.clientId = clientId
+    }
+
+    /// Reads the static identity from the keychain. No network, no JWT.
+    public static func current(
+        identityStore: any KeychainIdentityStoreProtocol
+    ) async -> DeviceIdentitySnapshot {
+        let identity: KeychainIdentity?
+        identity = try? await identityStore.load()
+        guard let identity else {
+            return DeviceIdentitySnapshot(ethAddress: nil, accountId: nil, inboxId: nil, clientId: nil)
+        }
+        let address = EthereumAddress.toChecksummed(identity.keys.privateKey.identity.identifier)
+        let keychain = KeychainService()
+        let deviceId = DeviceInfo.deviceIdentifier
+        let accountSlot = KeychainAccount.siweAccountId(deviceId: deviceId, address: address)
+        let rawAccountId: String?
+        if let loaded = try? keychain.retrieveString(account: accountSlot) {
+            rawAccountId = loaded
+        } else {
+            rawAccountId = nil
+        }
+        let cachedAccountId: String? = (rawAccountId?.isEmpty == true) ? nil : rawAccountId
+        return DeviceIdentitySnapshot(
+            ethAddress: address,
+            accountId: cachedAccountId,
+            inboxId: identity.inboxId,
+            clientId: identity.clientId
+        )
+    }
+}


### PR DESCRIPTION
## What

Adds a curated, read-only, own-account debug menu reachable in production builds, plus the gate and activation that guard it.

### Gate + toggle
- `DebugMenuFlagStore` persists a single on/off flag in plain `UserDefaults.standard` (main-app only; the Notification Service Extension does not need it). Off by default, stays on until explicitly turned off, no auto-expiry. In production the getter returns false unless explicitly set, mirroring the defensive posture of `FeatureFlags.isDebugInjectorEnabled`.
- `DebugMenuGate` decides reachability: non-production keeps the full existing debug menu unchanged; production exposes only the curated view, and only when the toggle is enabled.

### Activation (version-tap)
- Tapping the bundle-version label in App Settings 7 times within a short window reveals an "Enable debug menu?" confirmation; confirming enables the persistent toggle and surfaces a "Debug menu" row in the same Settings group as the existing debug section. The gesture only does anything in production (non-prod already shows the full menu).

### Curated `ProdDebugMenuView` (Tier-1 only)
- Subscription & Credits: read-only readout (plan, status, product id, period, renew/trial flags, period end, credit balance / grant / next refresh). No purchase or change-plan CTAs, no mock-credit toggles.
- Push diagnostics: auth status, authorized, APNs environment, and the APNs token masked by default with explicit tap-to-reveal + copy. No mutating buttons (no "Request Now" / "Register Again").
- Read-only SIWE identity: eth address, accountId, inboxId, current + peer installation ids, SIWE config (domain/uri/chainId), and build/env. Backed by a new network-free `DeviceIdentitySnapshot` reader in ConvosCore that reads only on-device keychain values. It does not import or instantiate the live `BackendAuthProbe` and carries no JWT.
- Baseline: build/bundle/version/environment, feature-flag readout (display only), log storage size + log export (export already ships in prod), and the enable/disable toggle.
- Sensitive correlators are masked by default with tap-to-reveal + copy.

### App-wide indicator
- A persistent "Debug mode ON" chip renders from the root container (`MainTabView`) whenever the production toggle is enabled, so the elevated-diagnostics state is always visible.

## Out of scope (stays DEBUG-only, not exposed)
Sensitive and mutating tools remain gated to non-production builds and are not reachable from this prod surface. The live token-minting probe in particular is never referenced by the prod menu.

## Build / lint
- Local build: `Convos (Dev)` scheme compiled clean for the iOS Simulator (BUILD SUCCEEDED) with the project's warnings-as-errors and 100ms type-check budget in effect. ConvosCore also builds via SwiftPM.
- SwiftLint `--strict` passes on all changed files (pre-commit and pre-push hooks green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784296463&installation_id=128169237&pr_number=1085&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1085&signature=d69d496904f65bed66785271009829cae7eb05cb393fe5452e6947c547d560f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add curated production debug menu behind a 7-tap version label easter egg
> - Tapping the version label 7 times within 3 seconds in production presents a confirmation dialog; on confirmation, a persistent `UserDefaults` flag ([DebugMenuFlagStore](https://github.com/xmtplabs/convos-ios/pull/1085/files#diff-76b165f6c7f8a6dc74d6d372fd9546bf455348dd3f1da67dcd117f1a1bcfbb50)) is set and a "Debug menu" row appears in App Settings.
> - The new [ProdDebugMenuView](https://github.com/xmtplabs/convos-ios/pull/1085/files#diff-815af3105d8d852a87268252db30020c7003096279ca94a9c908613d1bb26cef) exposes build info, on-device identity (via [DeviceIdentitySnapshot](https://github.com/xmtplabs/convos-ios/pull/1085/files#diff-99e18d360dd652331ff868be0e4005a5df41af483d52a70ef1761af65aca0d98)), subscription/credits status, push diagnostics, feature flags, and log export — all read-only and without network/JWT calls.
> - A persistent [DebugModeIndicator](https://github.com/xmtplabs/convos-ios/pull/1085/files#diff-6d0c9e1b393e1c6457e2556eaa87d92c2f7ea7adc3b002dc06cd030bd1579cdd) capsule overlays the root [MainTabView](https://github.com/xmtplabs/convos-ios/pull/1085/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67) when production debug mode is enabled, refreshing on `UserDefaults` changes.
> - Sensitive values in the menu are masked by default with tap-to-reveal and clipboard copy via [DebugRevealableValueRow](https://github.com/xmtplabs/convos-ios/pull/1085/files#diff-f276513f9979c8db92a7716c13a016ee71cbd1d2e1ea833156d3f6ab81b7981f).
> - Non-production builds continue to show the full debug menu unconditionally with no behavior change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40be092.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->