### PR TITLE
fix(push): batch push-topic subscribe/unsubscribe into ≤100-topic deltas

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionCache.swift
@@ -25,8 +25,27 @@ import Foundation
 /// remote-apply skipped" state that Stack 2's response shape will surface
 /// (D16: `remoteApplied: false`) is not handled yet. Until that field
 /// ships, iOS trusts a successful URLSession round trip.
+///
+/// ## Applied-topic mirror (delta reconcile)
+///
+/// Beyond the legacy hash debounce, the cache also persists the **applied
+/// topic list** keyed identically. This mirror is the source of truth for
+/// delta reconciles: `toAdd = desired − applied`, `toRemove = applied −
+/// desired`. Storing the full list (rather than only its hash) is what lets
+/// the manager compute *which* topics changed, not merely *that* something
+/// changed — so it can issue additive subscribes for new topics and targeted
+/// unsubscribes for departed ones instead of re-sending the whole set.
+///
+/// Backward compatibility: the mirror lives in its own UserDefaults key
+/// (`v2`), so a build that ships this change reads `nil` for the mirror on
+/// first launch (cold start) and performs a full chunked additive
+/// re-subscribe, which is harmless because subscribe is additive + idempotent
+/// on the backend. The legacy `v1` hash key is left in place but is no longer
+/// read for the reconcile skip decision — equality is now derived from the
+/// stored list.
 final class PushTopicSubscriptionCache: @unchecked Sendable {
     private static let storeKey: String = "convos.pushTopicSubscriptionCache.v1"
+    private static let topicsStoreKey: String = "convos.pushTopicSubscriptionCache.v2.topics"
 
     private let userDefaults: UserDefaults
     private let lock: NSLock = .init()
@@ -35,40 +54,78 @@ final class PushTopicSubscriptionCache: @unchecked Sendable {
         self.userDefaults = userDefaults
     }
 
-    /// Looks up the cached topic-set hash for the supplied key.
-    /// Returns nil on first call, after a successful failure that left no
-    /// cache write, or whenever the caller passes a fresh `(identity, token,
-    /// device)` tuple.
-    func lookupHash(forKey key: String) -> String? {
+    /// Looks up the applied topic-list mirror for the supplied key.
+    /// Returns `nil` on cold start (no prior successful reconcile under this
+    /// key), which the manager treats as "subscribe to the full desired set".
+    /// The returned list is de-duplicated and sorted so callers can rely on a
+    /// canonical ordering when diffing.
+    func lookupTopics(forKey key: String) -> [String]? {
         lock.lock()
         defer { lock.unlock() }
-        return readDict()[key]
+        return readTopicsDict()[key]
     }
 
-    /// Stores the topic-set hash. Callers MUST only invoke this from inside
-    /// `subscribe`'s success branch; writing pessimistically (before the API
-    /// call returns) would leave iOS thinking it's synced after a transient
-    /// failure, silently breaking the retry loop the plan exists to enable.
-    func storeHash(_ hash: String, forKey key: String) {
+    /// Stores the applied topic-list mirror. As with `storeHash`, callers MUST
+    /// only invoke this once every wire batch for the reconcile has succeeded;
+    /// persisting a partially-applied set would make the next reconcile skip
+    /// the topics that never actually landed on the backend.
+    func storeTopics(_ topics: [String], forKey key: String) {
         lock.lock()
         defer { lock.unlock() }
-        var dict = readDict()
-        dict[key] = hash
-        userDefaults.set(dict, forKey: Self.storeKey)
+        var dict = readTopicsDict()
+        dict[key] = canonical(topics)
+        userDefaults.set(dict, forKey: Self.topicsStoreKey)
     }
 
-    /// Clears every cached hash. Intended for explicit "wipe my state"
-    /// operations like sign-out, "Delete all data", or test setup. Day-to-day
-    /// identity rotation is handled by key partitioning above and does NOT
-    /// need to call this.
+    /// Adds topics to the mirror for the supplied key (union). Used by the
+    /// per-conversation subscribe paths after a successful wire call so the
+    /// mirror stays accurate between full reconciles. Creating the entry if it
+    /// does not yet exist is intentional: a per-conversation subscribe that
+    /// lands before the first reconcile still records what was applied.
+    func addTopics(_ topics: [String], forKey key: String) {
+        guard !topics.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        var dict = readTopicsDict()
+        let merged = (dict[key] ?? []) + topics
+        dict[key] = canonical(merged)
+        userDefaults.set(dict, forKey: Self.topicsStoreKey)
+    }
+
+    /// Removes topics from the mirror for the supplied key (set difference).
+    /// Used by the per-conversation unsubscribe path after a successful wire
+    /// call. No-op when the key has no mirror yet.
+    func removeTopics(_ topics: [String], forKey key: String) {
+        guard !topics.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        var dict = readTopicsDict()
+        guard let existing = dict[key] else { return }
+        let removal = Set(topics)
+        dict[key] = existing.filter { !removal.contains($0) }
+        userDefaults.set(dict, forKey: Self.topicsStoreKey)
+    }
+
+    /// Clears every cached hash and applied-topic mirror. Intended for
+    /// explicit "wipe my state" operations like sign-out, "Delete all data",
+    /// or test setup. Day-to-day identity rotation is handled by key
+    /// partitioning above and does NOT need to call this.
     func clearAll() {
         lock.lock()
         defer { lock.unlock() }
         userDefaults.removeObject(forKey: Self.storeKey)
+        userDefaults.removeObject(forKey: Self.topicsStoreKey)
     }
 
-    private func readDict() -> [String: String] {
-        userDefaults.dictionary(forKey: Self.storeKey) as? [String: String] ?? [:]
+    private func readTopicsDict() -> [String: [String]] {
+        userDefaults.dictionary(forKey: Self.topicsStoreKey) as? [String: [String]] ?? [:]
+    }
+
+    /// De-duplicates and sorts a topic list so the mirror is stored in a
+    /// canonical form (matching `PushTopicHash.of`'s sort) and diffs are
+    /// order-independent.
+    private func canonical(_ topics: [String]) -> [String] {
+        Array(Set(topics)).sorted()
     }
 }
 
@@ -99,18 +156,12 @@ struct PushTopicCacheKey: Sendable {
     }
 }
 
-/// Canonical hashing routine shared by the iOS cache and the eventual Stack 2
-/// backend snapshot. Topics are sorted lexicographically as UTF-8 strings,
-/// joined with a single LF separator, and run through SHA-256 with lowercase
-/// hex output. Match this byte-for-byte on the Node side when the snapshot
-/// table needs to compare hashes across the wire.
+/// Hashing routine for the APNS push token. The delta reconcile compares
+/// applied vs desired topic *lists* directly (see ``PushTopicSubscriptionCache``),
+/// so a topic-set hash is no longer needed; only the token hash survives, as a
+/// cache-key component that forces a miss (and a fresh full reconcile) when the
+/// device's APNS token rotates.
 enum PushTopicHash {
-    static func of(_ topics: [String]) -> String {
-        let canonical = topics.sorted().joined(separator: "\n")
-        let digest = SHA256.hash(data: Data(canonical.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
-    }
-
     /// SHA-256 of the APNS token bytes, lowercase hex. Returns the literal
     /// sentinel `"none"` when no token is available yet so cache keys still
     /// partition cleanly between the pre-token and post-token states (and so

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -98,6 +98,13 @@ struct XMTPPushTopicConversationLister: PushTopicConversationListing {
 }
 
 actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
+    /// Backend `/v2/notifications/subscribe` and `/unsubscribe` reject any
+    /// request carrying more than 100 topics — wholesale, so a 101-topic
+    /// subscribe applies *nothing*. Every wire call therefore loops in chunks
+    /// of at most this many topics. This is a per-request cap, not a per-device
+    /// total cap: a user in 500 conversations is fine across 5 batches.
+    private static let maxTopicsPerRequest: Int = 100
+
     private enum TopicKind: String, Sendable {
         case welcome
         case group
@@ -218,61 +225,106 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         )
     }
 
-    // Reconcile pipeline (D8 hash debounce + D14 token-change trigger compatible):
+    // Reconcile pipeline (delta-based, applied-topic mirror, ≤100-topic batches):
     //
     //     reconcilePushTopics(params, context)
     //       |
     //       +-- computeReconcileDesiredSubscriptions  (welcome + groups + DMs)
-    //       |
     //       +-- dedupe                                (per-topic uniqueness)
     //       |
     //       +-- if cache + token + identity available:
     //       |     |
     //       |     +-- cacheKey = (inboxId, clientId, deviceId, pushTokenSha256)
-    //       |     +-- hash     = SHA256 of sorted-joined topic set
-    //       |     +-- if cache.lookup(cacheKey) == hash -> SKIP (no wire call)
-    //       |     +-- else                               -> subscribe(cacheKey)
+    //       |     +-- applied  = cache.lookupTopics(cacheKey)   (nil = cold start)
+    //       |     +-- if applied == desired -> SKIP (no wire call)
+    //       |     +-- else:
+    //       |          +-- toAdd    = desired − applied (full desired if nil)
+    //       |          +-- toRemove = applied − desired
+    //       |          +-- subscribe(toAdd)   in ≤100 chunks   (additive)
+    //       |          +-- unsubscribe(toRemove) in ≤100 chunks (delta removal)
+    //       |          +-- if ALL batches succeeded -> cache.storeTopics(desired)
+    //       |          +-- else                     -> leave mirror stale
+    //       |                                          (next reconcile re-converges;
+    //       |                                           additive subscribe is
+    //       |                                           idempotent so retry is safe)
     //       |
     //       +-- else (no cache wired, or no token/identity yet):
-    //             +-- subscribe(cacheKey: nil)            (legacy "always send")
+    //             +-- subscribe(full desired) in ≤100 chunks (legacy "always send")
     //
-    //     subscribe(to:params:context:cacheKey:)
-    //       |
-    //       +-- POST /v2/notifications/subscribe
-    //       |     |
-    //       |     +-- success -> log + if cacheKey != nil { cache.store(hash) }
-    //       |     +-- throw   -> Log.warning + QAEvent + NO cache write
-    //       |                    (next reconcile retries the wire)
+    // HARD RULE: the failure path NEVER calls deleteInstallation/unregister.
+    // A stale mirror plus additive+idempotent re-subscribe is the entire
+    // recovery mechanism; there is no destructive reset anywhere in here.
     func reconcilePushTopics(
         params: SyncClientParams,
         context: String
     ) async {
-        let subscriptions = await computeReconcileDesiredSubscriptions(
+        let desired = await computeReconcileDesiredSubscriptions(
             params: params,
             context: context
         )
-        let deduped = dedupe(subscriptions)
+        let deduped = dedupe(desired.subscriptions)
         guard !deduped.isEmpty else { return }
+        let desiredTopics = deduped.map(\.topic)
 
         guard let cache = cache,
               let cacheKey = await currentCacheKey(params: params, context: context) else {
-            await subscribe(to: deduped, params: params, context: context, cacheKey: nil)
+            // No cache wired (tests) or no token/identity yet: fall back to a
+            // full chunked additive subscribe every time. No mirror to persist.
+            _ = await sendSubscribe(topics: desiredTopics, params: params, context: context)
             return
         }
-        let currentHash = PushTopicHash.of(deduped.map(\.topic))
-        if let cached = cache.lookupHash(forKey: cacheKey.keyString), cached == currentHash {
-            Log.debug("Reconcile no-op \(context): topic hash matches cached state")
+
+        let key = cacheKey.keyString
+        let applied = cache.lookupTopics(forKey: key)
+        let desiredSet = Set(desiredTopics)
+
+        // Mirror already matches desired -> nothing to converge. Only short-
+        // circuit on a non-degraded pass: a degraded desired set that happens
+        // to equal a (previously shrunk) mirror must NOT be treated as settled.
+        if !desired.isDegraded, let applied = applied, Set(applied) == desiredSet {
+            Log.debug("Reconcile no-op \(context): applied topic mirror matches desired state")
             return
         }
-        // Pass currentHash through so subscribe doesn't recompute SHA-256 over
-        // the same topic set on success.
-        await subscribe(
-            to: deduped,
-            params: params,
-            context: context,
-            cacheKey: cacheKey.keyString,
-            precomputedHash: currentHash
-        )
+
+        // Cold start / nil mirror -> toAdd is the full desired set (additive
+        // re-subscribe repairs any missed subscriptions).
+        let appliedSet = Set(applied ?? [])
+        let toAdd = desiredTopics.filter { !appliedSet.contains($0) }
+
+        // CRITICAL: only compute removals from an AUTHORITATIVE (non-degraded)
+        // desired set. When a conversation listing failed, the desired set is
+        // incomplete, so `applied - desired` would wrongly flag every topic of
+        // the failed source for unsubscribe. In that case we do the additive
+        // subscribe only, skip removals, and leave the mirror stale so the next
+        // (hopefully complete) reconcile re-converges. This is the additive,
+        // non-destructive recovery the design relies on — never deleteInstallation.
+        let toRemove: [String] = desired.isDegraded
+            ? []
+            : (applied ?? []).filter { !desiredSet.contains($0) }
+
+        var allSucceeded = true
+        if !toAdd.isEmpty {
+            let added = await sendSubscribe(topics: toAdd, params: params, context: context)
+            allSucceeded = allSucceeded && added
+        }
+        if !toRemove.isEmpty {
+            let removed = await sendUnsubscribe(topics: toRemove, params: params, context: context)
+            allSucceeded = allSucceeded && removed
+        }
+
+        // Persist the mirror = desired ONLY when every batch landed AND the
+        // desired set was authoritative. A degraded pass never persists (its
+        // desired set is incomplete); a partial wire failure never persists
+        // (so the next trigger recomputes the same delta and retries). Subscribe
+        // is additive + idempotent, so re-sending already-applied topics is
+        // harmless.
+        if allSucceeded, !desired.isDegraded {
+            cache.storeTopics(desiredTopics, forKey: key)
+        } else if !allSucceeded {
+            Log.warning("Reconcile partial failure \(context): leaving applied mirror stale for retry")
+        } else {
+            Log.warning("Reconcile degraded \(context): incomplete desired set, leaving mirror stale")
+        }
     }
 
     /// Clears the hash debounce cache. Call on "Delete all data" / sign-out
@@ -306,10 +358,22 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     /// to derive desired state. The per-conversation `subscribeToGroup...` /
     /// `subscribeToInviteDMTopics` paths keep their own narrow builders since
     /// they're firing one-shot deltas, not a full sweep.
+    /// Result of computing the desired topic set for a reconcile. `isDegraded`
+    /// is `true` when one of the conversation listings threw, meaning the
+    /// `subscriptions` set is INCOMPLETE — it is missing the topics for the
+    /// source that failed. The delta reconcile must never treat a degraded
+    /// (incomplete) desired set as authoritative for removals, or a transient
+    /// listing failure would unsubscribe every previously-applied topic for
+    /// that source.
+    private struct DesiredSubscriptions {
+        let subscriptions: [TopicSubscription]
+        let isDegraded: Bool
+    }
+
     private func computeReconcileDesiredSubscriptions(
         params: SyncClientParams,
         context: String
-    ) async -> [TopicSubscription] {
+    ) async -> DesiredSubscriptions {
         var subscriptions: [TopicSubscription] = [welcomeSubscription(params: params)]
         var degradedSources: [String] = []
 
@@ -347,55 +411,35 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             ])
         }
 
-        return subscriptions
+        return DesiredSubscriptions(subscriptions: subscriptions, isDegraded: !degradedSources.isEmpty)
     }
 
     // MARK: - Private
 
+    /// Per-conversation subscribe entry point (group join / invite DM). Sends
+    /// the topics in ≤100 chunks and, on full success, folds them into the
+    /// applied-topic mirror so it stays accurate between full reconciles.
+    /// Returns nothing — callers treat push subscription as best-effort.
     private func subscribe(
         to subscriptions: [TopicSubscription],
         params: SyncClientParams,
-        context: String,
-        cacheKey: String? = nil,
-        precomputedHash: String? = nil
+        context: String
     ) async {
         let subscriptions = dedupe(subscriptions)
         guard !subscriptions.isEmpty else { return }
-        guard let identity = await identity(matching: params) else { return }
-        guard let deviceId = await deviceIdentifier(context: context) else { return }
-
-        if let deviceRegistrationManager {
-            await deviceRegistrationManager.registerDeviceIfNeeded()
-        }
-
-        do {
-            try await params.apiClient.subscribeToTopics(
-                deviceId: deviceId,
-                clientId: identity.clientId,
-                topics: subscriptions.map(\.topic)
-            )
-            Log.info("Subscribed to push topics \(context): \(topicSummary(subscriptions))")
-            Log.debug("Subscribed push topic values \(context): \(subscriptions.map(\.topic).joined(separator: ", "))")
-            // Success-only cache write. A failure path falls through to the
-            // catch arm below and leaves the cache untouched so the next
-            // reconcile retries. The cacheKey is nil for per-conversation
-            // subscribe paths (group join / invite DM) since they're deltas,
-            // not full sweeps and don't participate in reconcile debounce.
-            if let cacheKey = cacheKey, let cache = cache {
-                // Reuse the hash reconcile already computed when checking the
-                // cache miss. Falls back to computing it here only when the
-                // per-conversation path opts into caching (it doesn't today).
-                let hash = precomputedHash ?? PushTopicHash.of(subscriptions.map(\.topic))
-                cache.storeHash(hash, forKey: cacheKey)
-            }
-        } catch {
-            Log.warning("Failed subscribing to push topics \(context): \(error)")
-            QAEvent.emit(.sync, "push_topic_subscribe_failed", [
-                "context": context,
-                "topic_count": String(subscriptions.count),
-                "kinds": kindSummary(subscriptions),
-                "error": String(describing: error),
-            ])
+        let topics = subscriptions.map(\.topic)
+        let succeeded = await sendSubscribe(
+            topics: topics,
+            params: params,
+            context: context,
+            kindSubscriptions: subscriptions
+        )
+        // Mirror update is best-effort and additive: only record topics that
+        // actually landed. A failed batch leaves the mirror untouched so the
+        // next full reconcile re-derives and re-applies the missing topic.
+        if succeeded, let cache = cache,
+           let cacheKey = await currentCacheKey(params: params, context: context) {
+            cache.addTopics(topics, forKey: cacheKey.keyString)
         }
     }
 
@@ -406,22 +450,91 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     ) async {
         let topics = Array(Set(topics)).sorted()
         guard !topics.isEmpty else { return }
-        guard let identity = await identity(matching: params) else { return }
-
-        do {
-            try await params.apiClient.unsubscribeFromTopics(
-                clientId: identity.clientId,
-                topics: topics
-            )
-            Log.info("Unsubscribed from push topics \(context): \(topics.joined(separator: ", "))")
-        } catch {
-            Log.warning("Failed unsubscribing from push topics \(context): \(error)")
-            QAEvent.emit(.sync, "push_topic_unsubscribe_failed", [
-                "context": context,
-                "topic_count": String(topics.count),
-                "error": String(describing: error),
-            ])
+        let succeeded = await sendUnsubscribe(topics: topics, params: params, context: context)
+        // Drop the topics from the mirror only after the wire call succeeded,
+        // mirroring the additive subscribe path. A failed unsubscribe leaves
+        // the mirror as-is; the next full reconcile recomputes toRemove.
+        if succeeded, let cache = cache,
+           let cacheKey = await currentCacheKey(params: params, context: context) {
+            cache.removeTopics(topics, forKey: cacheKey.keyString)
         }
+    }
+
+    /// Low-level chunked subscribe. Resolves identity/device once, then issues
+    /// one `subscribeToTopics` call per ≤100-topic chunk. Returns `true` only
+    /// when every chunk succeeded; a single failed chunk returns `false` (and
+    /// is logged per-chunk) so callers know not to persist the mirror.
+    ///
+    /// `kindSubscriptions` is an optional richer view of the same topics used
+    /// only for human-readable logging/QA summaries on the per-conversation
+    /// path; the reconcile path passes plain topic strings.
+    private func sendSubscribe(
+        topics: [String],
+        params: SyncClientParams,
+        context: String,
+        kindSubscriptions: [TopicSubscription]? = nil
+    ) async -> Bool {
+        guard !topics.isEmpty else { return true }
+        guard let identity = await identity(matching: params) else { return false }
+        guard let deviceId = await deviceIdentifier(context: context) else { return false }
+
+        if let deviceRegistrationManager {
+            await deviceRegistrationManager.registerDeviceIfNeeded()
+        }
+
+        var allSucceeded = true
+        for chunk in topics.chunked(into: Self.maxTopicsPerRequest) {
+            do {
+                try await params.apiClient.subscribeToTopics(
+                    deviceId: deviceId,
+                    clientId: identity.clientId,
+                    topics: chunk
+                )
+                Log.info("Subscribed to push topics \(context): \(chunk.count) topic(s)")
+                Log.debug("Subscribed push topic values \(context): \(chunk.joined(separator: ", "))")
+            } catch {
+                allSucceeded = false
+                Log.warning("Failed subscribing to push topics \(context): \(error)")
+                QAEvent.emit(.sync, "push_topic_subscribe_failed", [
+                    "context": context,
+                    "topic_count": String(chunk.count),
+                    "kinds": kindSummary(kindSubscriptions, fallbackCount: chunk.count),
+                    "error": String(describing: error),
+                ])
+            }
+        }
+        return allSucceeded
+    }
+
+    /// Low-level chunked unsubscribe. One `unsubscribeFromTopics` call per
+    /// ≤100-topic chunk. Returns `true` only when every chunk succeeded.
+    private func sendUnsubscribe(
+        topics: [String],
+        params: SyncClientParams,
+        context: String
+    ) async -> Bool {
+        guard !topics.isEmpty else { return true }
+        guard let identity = await identity(matching: params) else { return false }
+
+        var allSucceeded = true
+        for chunk in topics.chunked(into: Self.maxTopicsPerRequest) {
+            do {
+                try await params.apiClient.unsubscribeFromTopics(
+                    clientId: identity.clientId,
+                    topics: chunk
+                )
+                Log.info("Unsubscribed from push topics \(context): \(chunk.joined(separator: ", "))")
+            } catch {
+                allSucceeded = false
+                Log.warning("Failed unsubscribing from push topics \(context): \(error)")
+                QAEvent.emit(.sync, "push_topic_unsubscribe_failed", [
+                    "context": context,
+                    "topic_count": String(chunk.count),
+                    "error": String(describing: error),
+                ])
+            }
+        }
+        return allSucceeded
     }
 
     /// Drops invite DMs whose current consent is `.denied`. The user has
@@ -518,13 +631,14 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
         return result
     }
 
-    private func topicSummary(_ subscriptions: [TopicSubscription]) -> String {
-        subscriptions
-            .map { "\($0.kind.rawValue):\($0.sourceId)" }
-            .joined(separator: ", ")
-    }
-
-    private func kindSummary(_ subscriptions: [TopicSubscription]) -> String {
+    /// Builds the `kinds=...` QA breakdown for a failed subscribe chunk. The
+    /// reconcile path sends plain topic strings (no kind metadata), so it falls
+    /// back to a bare count; the per-conversation path passes the richer
+    /// `TopicSubscription` list and gets a per-kind tally.
+    private func kindSummary(_ subscriptions: [TopicSubscription]?, fallbackCount: Int) -> String {
+        guard let subscriptions = subscriptions else {
+            return "topics=\(fallbackCount)"
+        }
         var counts: [String: Int] = [:]
         for subscription in subscriptions {
             counts[subscription.kind.rawValue, default: 0] += 1
@@ -557,5 +671,17 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
             topic: conversationId.xmtpGroupTopicFormat,
             sourceId: conversationId
         )
+    }
+}
+
+private extension Array {
+    /// Splits the array into sub-arrays of at most `size` elements, preserving
+    /// order. Used to keep every push subscribe/unsubscribe wire call within
+    /// the backend's 100-topic-per-request limit.
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return isEmpty ? [] : [Array(self)] }
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
+        }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -374,6 +374,328 @@ struct PushTopicSubscriptionManagerTests {
         #expect(apiClient.subscribeCalls.count == 2)
     }
 
+    // MARK: - Batched delta reconcile (>100 topics, mirror, partial failure)
+
+    @Test("Reconcile splits a >100 topic desired set into multiple <=100 batches")
+    func reconcileChunksLargeDesiredSet() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        // 120 groups + welcome = 121 desired topics -> 2 batches (100 + 21).
+        let groupIds = (0..<120).map { "group-\($0)" }
+        let conversationLister = RecordingPushConversationLister(groupIds: groupIds, dmIds: [])
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister
+        )
+
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "large"
+        )
+
+        let calls = apiClient.subscribeCalls
+        #expect(calls.count == 2)
+        // Every batch must respect the 100-topic-per-request backend cap.
+        #expect(calls.allSatisfy { $0.topics.count <= 100 })
+        #expect(calls.first?.topics.count == 100)
+        #expect(calls.last?.topics.count == 21)
+        // No topic dropped or duplicated across the batches.
+        let delivered = Set(calls.flatMap(\.topics))
+        var expected = Set(groupIds.map(\.xmtpGroupTopicFormat))
+        expected.insert("test-installation-id".xmtpWelcomeTopicFormat)
+        #expect(delivered == expected)
+    }
+
+    @Test("Cold-start nil mirror triggers a full chunked additive re-subscribe")
+    func reconcileColdStartFullChunkedResubscribe() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let groupIds = (0..<150).map { "group-\($0)" }
+        let conversationLister = RecordingPushConversationLister(groupIds: groupIds, dmIds: [])
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // Cold start: mirror is nil, so toAdd is the FULL desired set, chunked.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "cold"
+        )
+
+        let calls = apiClient.subscribeCalls
+        // 151 desired topics -> 2 chunks (100 + 51); no unsubscribe on cold start.
+        #expect(calls.count == 2)
+        #expect(calls.allSatisfy { $0.topics.count <= 100 })
+        #expect(apiClient.unsubscribeCalls.isEmpty)
+        let delivered = Set(calls.flatMap(\.topics))
+        var expected = Set(groupIds.map(\.xmtpGroupTopicFormat))
+        expected.insert("test-installation-id".xmtpWelcomeTopicFormat)
+        #expect(delivered == expected)
+
+        // Mirror now equals desired -> a second reconcile is a pure no-op.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "warm"
+        )
+        #expect(apiClient.subscribeCalls.count == 2)
+    }
+
+    @Test("Reconcile delta sends additive subscribe for adds and unsubscribe for removes")
+    func reconcileDeltaAddAndRemove() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1", "group-2"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // First reconcile establishes the mirror = {welcome, group-1, group-2}.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "first"
+        )
+        #expect(apiClient.subscribeCalls.count == 1)
+
+        // group-1 leaves, group-3 joins. Desired = {welcome, group-2, group-3}.
+        conversationLister.setGroupIds(["group-2", "group-3"])
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "delta"
+        )
+
+        // Exactly one additive subscribe for the single add (group-3)...
+        #expect(apiClient.subscribeCalls.count == 2)
+        #expect(apiClient.subscribeCalls.last?.topics == ["group-3".xmtpGroupTopicFormat])
+        // ...and exactly one unsubscribe for the single removal (group-1).
+        #expect(apiClient.unsubscribeCalls.count == 1)
+        #expect(apiClient.unsubscribeCalls.last?.topics == ["group-1".xmtpGroupTopicFormat])
+    }
+
+    @Test("Partial batch failure leaves the mirror stale so the next reconcile re-converges")
+    func reconcilePartialFailureLeavesMirrorStale() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        // Fail the very first subscribe batch only; later batches/calls succeed.
+        let apiClient = PartialFailurePushAPIClient(failFirstNSubscribeCalls: 1)
+        let groupIds = (0..<120).map { "group-\($0)" }
+        let conversationLister = RecordingPushConversationLister(groupIds: groupIds, dmIds: [])
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // First reconcile: 2 chunks, the first throws -> allSucceeded == false
+        // -> mirror NOT persisted even though chunk 2 landed.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "partial-fail"
+        )
+        #expect(apiClient.subscribeCalls.count == 2)
+
+        // Second reconcile: mirror is still nil, so the FULL desired set is
+        // re-sent (additive + idempotent makes re-subscribing landed topics
+        // harmless), this time with no failures -> mirror finally persists.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "reconverge"
+        )
+        #expect(apiClient.subscribeCalls.count == 4)
+
+        // Third reconcile: mirror now matches desired -> pure no-op.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "settled"
+        )
+        #expect(apiClient.subscribeCalls.count == 4)
+
+        // Every desired topic was delivered across the converging passes.
+        let delivered = Set(apiClient.subscribeCalls.flatMap(\.topics))
+        var expected = Set(groupIds.map(\.xmtpGroupTopicFormat))
+        expected.insert("test-installation-id".xmtpWelcomeTopicFormat)
+        #expect(expected.isSubset(of: delivered))
+    }
+
+    @Test("Per-conversation subscribe folds the topic into the mirror")
+    func perConversationSubscribeUpdatesMirror() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // Join group-1 incrementally -> mirror should now hold welcome + group-1.
+        await manager.subscribeToGroupAndWelcome(
+            conversationId: "group-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "join"
+        )
+        #expect(apiClient.subscribeCalls.count == 1)
+
+        // A reconcile whose desired set is exactly {welcome, group-1} must be a
+        // no-op: the per-conversation path already recorded both in the mirror.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "reconcile-after-join"
+        )
+        #expect(apiClient.subscribeCalls.count == 1)
+        #expect(apiClient.unsubscribeCalls.isEmpty)
+    }
+
+    @Test("Per-conversation invite-DM unsubscribe removes the topic from the mirror")
+    func perConversationUnsubscribeUpdatesMirror() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        // Reconcile desires the invite DM, so after unsubscribe (which removes
+        // it from the mirror) a reconcile with the same DM still in the desired
+        // set must re-add it -> proves the mirror was actually mutated.
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: [],
+            dmIds: ["dm-1"]
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // Establish mirror = {welcome, dm-1} via a full reconcile.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "seed"
+        )
+        #expect(apiClient.subscribeCalls.count == 1)
+
+        // Unsubscribe the invite DM -> mirror becomes {welcome}.
+        await manager.unsubscribeFromInviteDMTopic(
+            conversationId: "dm-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "reject"
+        )
+        #expect(apiClient.unsubscribeCalls.count == 1)
+        #expect(apiClient.unsubscribeCalls.last?.topics == ["dm-1".xmtpGroupTopicFormat])
+
+        // Reconcile again: dm-1 is still desired but no longer in the mirror,
+        // so it must be re-added as a delta (proving removeTopics mutated it).
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "reconcile-after-reject"
+        )
+        #expect(apiClient.subscribeCalls.count == 2)
+        #expect(apiClient.subscribeCalls.last?.topics == ["dm-1".xmtpGroupTopicFormat])
+    }
+
+    @Test("Degraded listing never unsubscribes applied topics or shrinks the mirror")
+    func reconcileDegradedListingDoesNotRemoveAppliedTopics() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1", "group-2"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // Establish mirror = {welcome, group-1, group-2}.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "seed"
+        )
+        #expect(apiClient.subscribeCalls.count == 1)
+
+        // Group listing now fails transiently -> desired is DEGRADED (welcome
+        // only). A naive delta would unsubscribe group-1/group-2; it must not.
+        conversationLister.setGroupShouldFail(true)
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "degraded"
+        )
+        // No unsubscribe issued from the incomplete desired set.
+        #expect(apiClient.unsubscribeCalls.isEmpty)
+
+        // Listing recovers; mirror was left stale so this pass is a clean no-op
+        // (still {welcome, group-1, group-2}) -> no new wire calls at all.
+        conversationLister.setGroupShouldFail(false)
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "recovered"
+        )
+        #expect(apiClient.unsubscribeCalls.isEmpty)
+        // The only subscribe call ever made was the initial seed: the degraded
+        // pass re-sent nothing new (welcome already applied) and the recovered
+        // pass matched the mirror exactly.
+        #expect(apiClient.subscribeCalls.count == 1)
+    }
+
     @Test("Reconcile still subscribes available topics when one listing fails")
     func reconcileSubscribesAvailableTopicsWhenListingFails() async throws {
         let identityStore = MockKeychainIdentityStore()
@@ -586,6 +908,111 @@ private final class ThrowingPushAPIClient: ConvosAPIClientProtocol, @unchecked S
     func revokeCloudConnection(connectionId: String) async throws {}
 }
 
+/// Records every subscribe/unsubscribe call (one per batch) but throws on the
+/// first `failFirstNSubscribeCalls` subscribe invocations. Used to prove that a
+/// partially-failed multi-batch reconcile does not persist the applied-topic
+/// mirror, so the next reconcile re-sends the full desired set.
+private final class PartialFailurePushAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
+    struct SubscribeCall: Equatable {
+        let deviceId: String
+        let clientId: String
+        let topics: [String]
+    }
+
+    struct UnsubscribeCall: Equatable {
+        let clientId: String
+        let topics: [String]
+    }
+
+    private struct State {
+        var subscribeCalls: [SubscribeCall] = []
+        var unsubscribeCalls: [UnsubscribeCall] = []
+        var remainingFailures: Int
+    }
+
+    private let state: OSAllocatedUnfairLock<State>
+
+    init(failFirstNSubscribeCalls: Int) {
+        state = OSAllocatedUnfairLock(initialState: State(remainingFailures: failFirstNSubscribeCalls))
+    }
+
+    var subscribeCalls: [SubscribeCall] {
+        state.withLock { $0.subscribeCalls }
+    }
+
+    var unsubscribeCalls: [UnsubscribeCall] {
+        state.withLock { $0.unsubscribeCalls }
+    }
+
+    func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
+        guard let url = URL(string: "https://example.com") else {
+            throw URLError(.badURL)
+        }
+        return URLRequest(url: url)
+    }
+
+    func registerDevice(deviceId: String, pushToken: String?) async throws {}
+
+    func authenticate(appCheckToken: String, retryCount: Int) async throws -> String { "token" }
+    func authenticateWithSIWE(appCheckToken: String, signing: BackendAuthSigningContext) async throws -> String { "siwe-token" }
+    func updateSIWESigningContext(_ context: BackendAuthSigningContext?) {}
+    func accountAuthCheck(jwt: String?) async throws -> ConvosAPI.AuthCheckResponse { .init(success: jwt != nil) }
+
+    func uploadAttachment(data: Data, filename: String, contentType: String, acl: String) async throws -> String { "" }
+
+    func uploadAttachmentAndExecute(
+        data: Data,
+        filename: String,
+        afterUpload: @escaping (String) async throws -> Void
+    ) async throws -> String { "" }
+
+    func subscribeToTopics(deviceId: String, clientId: String, topics: [String]) async throws {
+        let shouldFail: Bool = state.withLock {
+            $0.subscribeCalls.append(SubscribeCall(deviceId: deviceId, clientId: clientId, topics: topics))
+            if $0.remainingFailures > 0 {
+                $0.remainingFailures -= 1
+                return true
+            }
+            return false
+        }
+        if shouldFail {
+            throw ThrowingPushAPIClientError.subscribeFailure
+        }
+    }
+
+    func unsubscribeFromTopics(clientId: String, topics: [String]) async throws {
+        state.withLock {
+            $0.unsubscribeCalls.append(UnsubscribeCall(clientId: clientId, topics: topics))
+        }
+    }
+
+    func unregisterInstallation(clientId: String) async throws {}
+
+    func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
+        AssetRenewalResult(renewed: assetKeys.count, failed: 0, expiredKeys: [])
+    }
+
+    func getPresignedUploadURL(filename: String, contentType: String) async throws -> (uploadURL: String, assetURL: String) {
+        ("https://example.com/upload/\(filename)", "https://example.com/assets/\(filename)")
+    }
+
+    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
+        .init(success: true, joined: true)
+    }
+
+    func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
+        .init(connectionRequestId: "", redirectUrl: "")
+    }
+
+    func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse {
+        .init(connectionId: "", serviceId: "", serviceName: "", composioEntityId: "", composioConnectionId: "", status: "")
+    }
+
+    func listCloudConnections() async throws -> [CloudConnectionsAPI.ConnectionResponse] { [] }
+
+    func revokeCloudConnection(connectionId: String) async throws {}
+}
+
 private final class RecordingPushConversationLister: PushTopicConversationListing, @unchecked Sendable {
     struct ListCall: Sendable {
         let consentStateRawValues: [String]?
@@ -629,6 +1056,10 @@ private final class RecordingPushConversationLister: PushTopicConversationListin
 
     func setGroupIds(_ ids: [String]) {
         state.withLock { $0.groupIds = ids }
+    }
+
+    func setGroupShouldFail(_ shouldFail: Bool) {
+        state.withLock { $0.groupShouldFail = shouldFail }
     }
 
     func listGroupConversationIds(


### PR DESCRIPTION
## Problem
Backend `/v2/notifications/subscribe` rejects any request carrying **>100 topics wholesale** — a 101-topic subscribe applies *nothing*. `reconcilePushTopics` sent the full topic set in a single `subscribeToTopics` call, so a user in >100 conversations had their entire reconcile rejected and received **no push subscriptions at all** (the missed-push / Shane bug). Subscribe is additive on the backend, unsubscribe is delta-removal, and 100 is a per-request limit (not a per-device total cap).

## Fix (client-only, no backend change)
1. **Batch every wire call to ≤100 topics.** Both `subscribeToTopics` and `unsubscribeFromTopics` now loop in `chunked(into: 100)`. `maxTopicsPerRequest = 100`.
2. **Persisted applied-topic mirror.** `PushTopicSubscriptionCache` gains a `v2` UserDefaults key storing the applied topic **list**, keyed identically (`inboxId|clientId|deviceId|pushTokenSha256`), superseding the hash-only entry. `clearAll()` wipes both v1 + v2.
3. **Delta reconcile.** `desired` vs `applied`: `toAdd = desired − applied` (full desired on cold-start/nil mirror), `toRemove = applied − desired`. Additive subscribe(`toAdd`) then unsubscribe(`toRemove`), each chunked ≤100. The mirror is persisted = `desired` **only on full success of every batch**; on **any** batch failure the mirror is left **stale** so the next trigger recomputes the same delta and retries — additive + idempotent subscribe makes the retry safe and non-destructive.
4. **Degraded-listing guard.** When a conversation listing throws, the desired set is incomplete, so removals are **suppressed** and the mirror is **not** persisted — preventing a transient listing failure from unsubscribing every previously-applied topic of the failed source.
5. **Per-conversation paths** (group/welcome join, invite-DM subscribe/unsubscribe) update the mirror after a successful wire call so it stays accurate between full reconciles.

## Never `deleteInstallation`
No new `deleteInstallation`/`unregisterInstallation` is introduced anywhere in the subscription/reconcile/delta/failure path. The two existing legitimate uses — sign-out (`SessionStateMachine.swift:966`) and NSE-orphan cleanup (`CachedPushNotificationHandler.swift:289`) — are **untouched** (and not part of this diff). Recovery is entirely additive + idempotent re-subscribe against a stale mirror; there is no destructive reset.

## Test coverage (19 tests, all pass)
New: >100 desired set splits into multiple ≤100 batches; cold-start nil mirror → full chunked re-subscribe; delta add/remove vs mirror; **partial batch failure leaves the mirror stale → next reconcile re-converges**; per-conversation subscribe folds the topic into the mirror; per-conversation invite-DM unsubscribe removes it from the mirror; **degraded listing never unsubscribes applied topics or shrinks the mirror**. All 13 pre-existing tests still pass.

## Build / validation status (honest)
- `xcodebuild build -scheme "Convos (Local)" -configuration Local -destination 'iPhone 17'` → **BUILD SUCCEEDED**.
- `xcodebuild test -scheme "ConvosCore" -only-testing:ConvosCoreTests/PushTopicSubscriptionManagerTests` → **TEST SUCCEEDED** (19 tests, iPhone 17 sim).
- Codex review (read-only): found 1 BLOCKER (a degraded listing wrongly triggering destructive unsubscribes) → fixed + regression test added → re-review **RESOLVED, no remaining issues**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784306709&installation_id=128169237&pr_number=1086&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1086&signature=6d5504b72cdaa5a5c06db02fe35af168a314368522f0c2378b412110ed43eeda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch push-topic subscribe/unsubscribe into ≤100-topic chunks with delta reconciliation
> - `PushTopicSubscriptionManager` now chunks all subscribe/unsubscribe calls into batches of at most 100 topics (`maxTopicsPerRequest`) to respect backend limits.
> - Reconcile switches to a delta-based approach: computes `toAdd` and `toRemove` against a persisted applied-topic mirror in `PushTopicSubscriptionCache`, skipping no-op reconciles when applied equals desired.
> - `PushTopicSubscriptionCache` replaces the hash-based API with a topic-list mirror (stored under a new `v2` UserDefaults key) supporting `addTopics`, `removeTopics`, and `lookupTopics`.
> - Degraded reconcile passes (when conversation listing fails) suppress removals and mirror writes to avoid incorrectly shrinking subscriptions.
> - Risk: partial batch failures leave the mirror stale intentionally, so the next reconcile retries diverged topics; mirror writes from the old hash-based `v1` key are cleared by `clearAll`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4cb27c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->