### PR TITLE
feat(agents): publish user timezone to agents

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -15,6 +15,11 @@ struct ConvosApp: App {
     let coreActions: any CoreActions
     let conversationsViewModel: ConversationsViewModel
     let profileSettingsViewModel: ProfileSettingsViewModel = .shared
+    /// Guards the opportunistic agent-timezone republish to once per foreground
+    /// session, so background-foregrounding the app repeatedly does not re-run
+    /// it. A reference type so the flag survives across `onChange` invocations
+    /// of the value-type App.
+    private let timezoneForegroundGuard: ForegroundOnceGuard = ForegroundOnceGuard()
 
     init() {
         FileDescriptorDiagnostics.raiseSoftLimit(to: 512)
@@ -181,16 +186,63 @@ struct ConvosApp: App {
             .additionalTopSafeArea(DesignConstants.Spacing.stepX)
             .withSafeAreaEnvironment()
             .onChange(of: scenePhase) { _, newPhase in
-                guard newPhase == .active else { return }
-                // Foreground refresh — TTL-debounced inside both services, so
-                // this is a cheap no-op if we were just active. Catches the
-                // case where credits changed server-side while the app was
-                // backgrounded (agent runtime consume, Apple webhook, manual op).
-                Task {
-                    await CreditsServices.shared.refresh()
-                    await SubscriptionServices.shared.refresh()
+                switch newPhase {
+                case .active:
+                    handleScenePhaseActive()
+                case .background:
+                    // Re-arm the once-per-foreground guard so the next time the
+                    // app comes back to the foreground it republishes again.
+                    timezoneForegroundGuard.reset()
+                default:
+                    break
                 }
             }
         }
+    }
+
+    private func handleScenePhaseActive() {
+        // Foreground refresh — TTL-debounced inside both services, so this is a
+        // cheap no-op if we were just active. Catches the case where credits
+        // changed server-side while the app was backgrounded (agent runtime
+        // consume, Apple webhook, manual op).
+        Task {
+            await CreditsServices.shared.refresh()
+            await SubscriptionServices.shared.refresh()
+        }
+
+        // Opportunistic agent-timezone republish (agent-timezone Channel B).
+        // Once per foreground session, after a short settle delay, the session
+        // republishes the device timezone for every agent conversation whose
+        // last-published value differs from the current one. Throttling and
+        // agent-scope gating live inside the session/publisher; this only
+        // schedules the work from the foregrounded main app.
+        guard timezoneForegroundGuard.tryConsume() else { return }
+        let session = convos.session
+        Task(priority: .utility) {
+            try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+            await session.republishAgentTimezones()
+        }
+    }
+}
+
+/// Single-shot guard for the once-per-foreground-session timezone republish.
+/// `tryConsume()` returns true exactly once until `reset()` re-arms it on the
+/// next background transition.
+private final class ForegroundOnceGuard: @unchecked Sendable {
+    private let lock: NSLock = NSLock()
+    private var consumed: Bool = false
+
+    func tryConsume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !consumed else { return false }
+        consumed = true
+        return true
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        consumed = false
     }
 }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -178,17 +178,28 @@ public enum ConvosAPI {
         public let conversationId: String?
         public let templateId: String?
         public let options: AgentJoinOptions?
+        /// IANA timezone identifier (e.g. "Europe/Paris") carrying the
+        /// conversation creator's device timezone, used by the agent runtime as
+        /// the conversation's baseline/default. Distinct from the per-sender
+        /// "timezone" key in ProfileUpdate.metadata, which reflects each
+        /// member's own current device timezone: this one is set once at join
+        /// time and does not track travel or DST. Optional and nil-omitted by
+        /// Codable, so the wire format stays backward-compatible until the
+        /// backend reads it.
+        public let timezone: String?
 
         public init(
             slug: String? = nil,
             conversationId: String? = nil,
             templateId: String? = nil,
-            options: AgentJoinOptions? = nil
+            options: AgentJoinOptions? = nil,
+            timezone: String? = nil
         ) {
             self.slug = slug
             self.conversationId = conversationId
             self.templateId = templateId
             self.options = options
+            self.timezone = timezone
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -88,11 +88,14 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// `inboxId`; the caller adds that inbox to the declared group with
     /// addMembers and the runtime attaches when it observes the resulting
     /// group welcome — no further calls.
+    /// `timezone` is the creator's device IANA timezone identifier, forwarded
+    /// to the agent runtime as the conversation's baseline/default zone.
     func requestAgentJoin(
         slug: String?,
         conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
@@ -215,21 +218,27 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 
 extension ConvosAPIClientProtocol {
     func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: nil, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(
+            slug: slug, conversationId: nil, templateId: nil, options: nil, timezone: nil, forceErrorCode: nil
+        )
     }
 
     func requestAgentJoin(
         slug: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: nil, options: options, forceErrorCode: nil)
+        try await requestAgentJoin(
+            slug: slug, conversationId: nil, templateId: nil, options: options, timezone: nil, forceErrorCode: nil
+        )
     }
 
     func requestAgentJoin(
         slug: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(slug: slug, conversationId: nil, templateId: templateId, options: nil, forceErrorCode: nil)
+        try await requestAgentJoin(
+            slug: slug, conversationId: nil, templateId: templateId, options: nil, timezone: nil, forceErrorCode: nil
+        )
     }
 
     /// Default so bespoke test doubles that don't exercise the builder don't
@@ -847,6 +856,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         conversationId: String? = nil,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
+        timezone: String? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
         var request = try authenticatedRequest(for: "v2/agents/join", method: "POST")
@@ -858,12 +868,16 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             request.setValue("\(forceErrorCode)", forHTTPHeaderField: "X-Force-Error")
         }
 
+        // `timezone` is the creator's device IANA timezone, captured on the main
+        // actor by the caller. It seeds the agent's baseline/default zone and is
+        // distinct from the per-sender ProfileUpdate "timezone" metadata key.
         request.httpBody = try JSONEncoder().encode(
             ConvosAPI.AgentJoinRequest(
                 slug: slug,
                 conversationId: conversationId,
                 templateId: templateId,
-                options: options
+                options: options,
+                timezone: timezone
             )
         )
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -100,6 +100,7 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         conversationId: String? = nil,
         templateId: String? = nil,
         options: ConvosAPI.AgentJoinOptions? = nil,
+        timezone: String? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
@@ -380,6 +380,7 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                         conversationId: row.conversationId,
                         templateId: templateId,
                         options: nil,
+                        timezone: nil,
                         forceErrorCode: nil
                     )
                 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -40,20 +40,20 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     private let sessionStateManager: any SessionStateManagerProtocol
     private let databaseWriter: any DatabaseWriter
     private let databaseReader: any DatabaseReader
-    private let myProfileWriter: any MyProfileWriterProtocol
+    private let profileMetadataWriter: any ProfileMetadataWriterProtocol
     private let servicesStore: any ConnectionServicesStoreProtocol
 
     init(
         sessionStateManager: any SessionStateManagerProtocol,
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
-        myProfileWriter: any MyProfileWriterProtocol,
+        profileMetadataWriter: any ProfileMetadataWriterProtocol,
         servicesStore: any ConnectionServicesStoreProtocol
     ) {
         self.sessionStateManager = sessionStateManager
         self.databaseWriter = databaseWriter
         self.databaseReader = databaseReader
-        self.myProfileWriter = myProfileWriter
+        self.profileMetadataWriter = profileMetadataWriter
         self.servicesStore = servicesStore
     }
 
@@ -474,24 +474,20 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         senderId: String,
         grantsJson: String?
     ) async throws {
-        let existingMetadata = try await databaseReader.read { db in
-            try DBMemberProfile.fetchOne(
-                db,
-                conversationId: conversationId,
-                inboxId: senderId
-            )?.metadata
+        // Route through the shared ProfileMetadataWriter so a connections write
+        // and a timezone write can never interleave on the per-sender metadata
+        // map's non-atomic read-merge-write.
+        let connectionsKey = Constant.connectionsKey
+        try await profileMetadataWriter.updateMetadata(
+            conversationId: conversationId,
+            inboxId: senderId
+        ) { metadata in
+            if let grantsJson {
+                metadata[connectionsKey] = .string(grantsJson)
+            } else {
+                metadata.removeValue(forKey: connectionsKey)
+            }
         }
-        var merged: ProfileMetadata = existingMetadata ?? [:]
-        if let grantsJson {
-            merged[Constant.connectionsKey] = .string(grantsJson)
-        } else {
-            merged.removeValue(forKey: Constant.connectionsKey)
-        }
-
-        try await myProfileWriter.updateAndPublish(
-            metadata: merged.isEmpty ? nil : merged,
-            conversationId: conversationId
-        )
     }
 
     private func prettyPrint(_ json: String) -> String {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -109,6 +109,8 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         return .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
     }
 
+    public func republishAgentTimezones() async {}
+
     public func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol {
         MockConversationRepository()
     }

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -307,13 +307,36 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         servicesStore
     }
 
+    /// One shared serialization choke point for every per-sender
+    /// `ProfileUpdate.metadata` write (connections, timezone, ...). The shared
+    /// instance is what lets a connections write and a timezone write queue
+    /// behind each other instead of clobbering the per-sender metadata map.
+    private lazy var sharedProfileMetadataWriter: ProfileMetadataWriter = ProfileMetadataWriter(
+        myProfileWriter: myProfileWriter(),
+        databaseReader: databaseReader
+    )
+
+    func profileMetadataWriter() -> any ProfileMetadataWriterProtocol {
+        sharedProfileMetadataWriter
+    }
+
     func connectionGrantWriter() -> any CloudConnectionGrantWriterProtocol {
         CloudConnectionGrantWriter(
             sessionStateManager: sessionStateManager,
             databaseWriter: databaseWriter,
             databaseReader: databaseReader,
-            myProfileWriter: myProfileWriter(),
+            profileMetadataWriter: sharedProfileMetadataWriter,
             servicesStore: servicesStore
+        )
+    }
+
+    func agentTimezonePublisher() async throws -> any AgentTimezonePublishing {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        return AgentTimezonePublisher(
+            profileMetadataWriter: sharedProfileMetadataWriter,
+            databaseReader: databaseReader,
+            myInboxId: inboxReady.client.inboxId,
+            appGroupIdentifier: environment.appGroupIdentifier
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -81,7 +81,11 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable, PostPairBroadcast
     func conversationMetadataWriter() -> any ConversationMetadataWriterProtocol
     func conversationExplosionWriter() -> any ConversationExplosionWriterProtocol
     func conversationPermissionsRepository() -> any ConversationPermissionsRepositoryProtocol
+    func profileMetadataWriter() -> any ProfileMetadataWriterProtocol
     func connectionGrantWriter() -> any CloudConnectionGrantWriterProtocol
+    /// Per-sender timezone publisher (agent-timezone Channel B). Resolves the
+    /// ready inbox first, so it throws while the inbox is still authorizing.
+    func agentTimezonePublisher() async throws -> any AgentTimezonePublishing
     func connectionServicesStore() -> any ConnectionServicesStoreProtocol
     func connectionEventWriter() -> any ConnectionEventWriterProtocol
     func capabilityRequestResultWriter() -> any CapabilityRequestResultWriterProtocol

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -129,8 +129,16 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         _conversationPermissionsRepository
     }
 
+    public func profileMetadataWriter() -> any ProfileMetadataWriterProtocol {
+        MockProfileMetadataWriter()
+    }
+
     public func connectionGrantWriter() -> any CloudConnectionGrantWriterProtocol {
         MockConnectionGrantWriter()
+    }
+
+    public func agentTimezonePublisher() async throws -> any AgentTimezonePublishing {
+        MockAgentTimezonePublisher()
     }
 
     public func connectionServicesStore() -> any ConnectionServicesStoreProtocol {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockProfileMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockProfileMetadataWriter.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Mock `ProfileMetadataWriterProtocol` for tests/previews. Records the merged
+/// metadata each `updateMetadata` produced, applying the caller's closure to an
+/// empty map so callers can assert on the keys they set.
+public final class MockProfileMetadataWriter: ProfileMetadataWriterProtocol, @unchecked Sendable {
+    public struct Update {
+        public let conversationId: String
+        public let inboxId: String
+        public let metadata: ProfileMetadata
+    }
+
+    public private(set) var updates: [Update] = []
+    public var updateError: (any Error)?
+
+    public init() {}
+
+    public func updateMetadata(
+        conversationId: String,
+        inboxId: String,
+        update: @escaping @Sendable (inout ProfileMetadata) -> Void
+    ) async throws {
+        var metadata: ProfileMetadata = [:]
+        update(&metadata)
+        updates.append(.init(conversationId: conversationId, inboxId: inboxId, metadata: metadata))
+        if let updateError {
+            throw updateError
+        }
+    }
+}
+
+/// Mock `AgentTimezonePublishing` for tests/previews. Records the conversation
+/// ids it was asked to publish for and how many full republish sweeps ran.
+public final class MockAgentTimezonePublisher: AgentTimezonePublishing, @unchecked Sendable {
+    public private(set) var publishedConversationIds: [String] = []
+    public private(set) var republishCount: Int = 0
+
+    public init() {}
+
+    public func publishTimezoneIfAgentConversation(conversationId: String) async {
+        publishedConversationIds.append(conversationId)
+    }
+
+    public func republishTimezoneForAgentConversations() async {
+        republishCount += 1
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1133,6 +1133,12 @@ extension SessionManager {
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
+        // Capture the creator's device timezone on the main actor before any
+        // async hop. This seeds the agent's baseline/default zone (Channel A);
+        // it is distinct from the per-sender "timezone" ProfileUpdate metadata
+        // key published below, which tracks each member's own current device tz.
+        let creatorTimezone: String = await MainActor.run { TimeZone.current.identifier }
+
         // 1. Provision the agent and wait until its XMTP inbox is registered.
         //    Extracted to a helper that touches only the API client (no
         //    messaging service) so the poll loop and its terminal/timeout/
@@ -1144,6 +1150,7 @@ extension SessionManager {
                     conversationId: conversationId.lowercased(),
                     templateId: templateId,
                     options: options,
+                    timezone: creatorTimezone,
                     forceErrorCode: forceErrorCode
                 )
             },
@@ -1170,6 +1177,10 @@ extension SessionManager {
             do {
                 try await messagingService().conversationMetadataWriter()
                     .addMembers([agentInboxId], to: conversationId)
+                // The conversation now has an agent member. Publish this user's
+                // own device timezone into the per-sender ProfileUpdate metadata
+                // (Channel B). Best-effort: a failure must not fail the join.
+                await publishTimezoneForAgentConversation(conversationId: conversationId)
                 return resolved.response
             } catch {
                 lastError = error
@@ -1184,6 +1195,34 @@ extension SessionManager {
             }
         }
         throw lastError ?? APIError.invalidResponse
+    }
+
+    /// Best-effort per-sender timezone publish (agent-timezone Channel B) for a
+    /// single conversation. The publisher gates on the conversation actually
+    /// containing an agent member, so this is safe to call on any add path.
+    private func publishTimezoneForAgentConversation(conversationId: String) async {
+        do {
+            let publisher = try await messagingService().agentTimezonePublisher()
+            await publisher.publishTimezoneIfAgentConversation(conversationId: conversationId)
+        } catch {
+            Log.warning("Skipped timezone publish for \(conversationId); inbox not ready: \(error.localizedDescription)")
+        }
+    }
+
+    /// Opportunistic foreground republish of the user's timezone across every
+    /// agent conversation (agent-timezone Channel B refresh). Throttled inside
+    /// the publisher so a conversation is only republished when the device
+    /// timezone changed since the last published value. Best-effort.
+    ///
+    /// Call only from the foregrounded main app -- never from the Notification
+    /// Service Extension or a background task.
+    public func republishAgentTimezones() async {
+        do {
+            let publisher = try await messagingService().agentTimezonePublisher()
+            await publisher.republishTimezoneForAgentConversations()
+        } catch {
+            Log.warning("Skipped agent timezone republish; inbox not ready: \(error.localizedDescription)")
+        }
     }
 
     /// A provisioned agent whose XMTP inbox has registered and is ready to add.

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -113,6 +113,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    /// Opportunistic foreground republish of the user's timezone across every
+    /// agent conversation (agent-timezone Channel B refresh). Throttled so a
+    /// conversation is only republished when the device timezone changed since
+    /// the last published value. Call only from the foregrounded main app.
+    func republishAgentTimezones() async
+
     func conversationRepository(for conversationId: String) -> any ConversationRepositoryProtocol
 
     /// Owns the direct agent-builder generation lifecycle (submit -> poll ->

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTimezonePublisher.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/AgentTimezonePublisher.swift
@@ -1,0 +1,127 @@
+import Foundation
+import GRDB
+
+public protocol AgentTimezonePublishing: Sendable {
+    /// Publishes the current device's IANA timezone identifier into the
+    /// sender's per-conversation `ProfileUpdate.metadata` under the `timezone`
+    /// key, but only when the conversation already contains an agent member.
+    /// Best-effort: a failure is logged and swallowed so it never blocks the
+    /// caller (e.g. an agent join).
+    func publishTimezoneIfAgentConversation(conversationId: String) async
+
+    /// Republishes the timezone for every conversation that contains an agent
+    /// member, throttled so a conversation is only republished when the current
+    /// timezone differs from the last value published for it. Intended for the
+    /// opportunistic app-foreground refresh.
+    func republishTimezoneForAgentConversations() async
+}
+
+/// Per-sender timezone publish (Channel B in the agent-timezone design).
+///
+/// The device timezone is captured up front on the main actor (timezone reads
+/// touch regional settings synchronously) and then written through the shared
+/// `ProfileMetadataWriter`, so a timezone write and a connections write can
+/// never race on the per-sender metadata map.
+///
+/// Scope: agent conversations only. A timezone has no purpose for human peers
+/// and must not leak into human-only conversations. Writes only ever happen
+/// from the foreground main app -- never the Notification Service Extension or
+/// a background task.
+public final class AgentTimezonePublisher: AgentTimezonePublishing, @unchecked Sendable {
+    private let profileMetadataWriter: any ProfileMetadataWriterProtocol
+    private let databaseReader: any DatabaseReader
+    private let myInboxId: String
+    private let appGroupIdentifier: String
+
+    public init(
+        profileMetadataWriter: any ProfileMetadataWriterProtocol,
+        databaseReader: any DatabaseReader,
+        myInboxId: String,
+        appGroupIdentifier: String
+    ) {
+        self.profileMetadataWriter = profileMetadataWriter
+        self.databaseReader = databaseReader
+        self.myInboxId = myInboxId
+        self.appGroupIdentifier = appGroupIdentifier
+    }
+
+    public func publishTimezoneIfAgentConversation(conversationId: String) async {
+        let currentTimezone = await currentDeviceTimezone()
+        do {
+            let hasAgent = try await databaseReader.read { db in
+                try OutgoingMessageWriter.hasCurrentAgentMember(db: db, conversationId: conversationId)
+            }
+            guard hasAgent else { return }
+            try await publish(timezone: currentTimezone, conversationId: conversationId)
+        } catch {
+            Log.warning("Failed to publish timezone for \(conversationId) (best-effort): \(error.localizedDescription)")
+        }
+    }
+
+    public func republishTimezoneForAgentConversations() async {
+        let currentTimezone = await currentDeviceTimezone()
+        let inboxId = myInboxId
+        let agentConversationIds: [String]
+        do {
+            agentConversationIds = try await databaseReader.read { db in
+                let myConversationIds: [String] = try DBMemberProfile
+                    .filter(DBMemberProfile.Columns.inboxId == inboxId)
+                    .fetchAll(db)
+                    .map(\.conversationId)
+                return try myConversationIds.filter { conversationId in
+                    try OutgoingMessageWriter.hasCurrentAgentMember(db: db, conversationId: conversationId)
+                }
+            }
+        } catch {
+            Log.warning("Failed to enumerate agent conversations for timezone republish: \(error.localizedDescription)")
+            return
+        }
+
+        for conversationId in agentConversationIds {
+            guard lastPublishedTimezone(for: conversationId) != currentTimezone else { continue }
+            do {
+                try await publish(timezone: currentTimezone, conversationId: conversationId)
+            } catch {
+                Log.warning("Failed to republish timezone for \(conversationId) (best-effort): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func publish(timezone: String, conversationId: String) async throws {
+        try await profileMetadataWriter.updateMetadata(
+            conversationId: conversationId,
+            inboxId: myInboxId
+        ) { metadata in
+            metadata[Constant.timezoneKey] = .string(timezone)
+        }
+        setLastPublishedTimezone(timezone, for: conversationId)
+    }
+
+    @MainActor
+    private func currentDeviceTimezone() -> String {
+        TimeZone.current.identifier
+    }
+
+    // MARK: - Throttle persistence
+
+    private func defaults() -> UserDefaults {
+        UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+    }
+
+    private func storageKey(for conversationId: String) -> String {
+        "\(Constant.lastPublishedKeyPrefix)\(conversationId)"
+    }
+
+    private func lastPublishedTimezone(for conversationId: String) -> String? {
+        defaults().string(forKey: storageKey(for: conversationId))
+    }
+
+    private func setLastPublishedTimezone(_ timezone: String, for conversationId: String) {
+        defaults().set(timezone, forKey: storageKey(for: conversationId))
+    }
+
+    private enum Constant {
+        static let timezoneKey: String = "timezone"
+        static let lastPublishedKeyPrefix: String = "convos.agentTimezone.lastPublished.v1."
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ProfileMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ProfileMetadataWriter.swift
@@ -1,0 +1,89 @@
+import Foundation
+import GRDB
+
+public protocol ProfileMetadataWriterProtocol: Sendable {
+    /// Reads the sender's current per-conversation metadata map, applies the
+    /// caller's mutation closure, and republishes the merged map through
+    /// `MyProfileWriter.updateAndPublish`. The whole read-modify-write runs as
+    /// one serialized unit so two callers (e.g. a connections write and a
+    /// timezone write) can never interleave and clobber each other's keys.
+    func updateMetadata(
+        conversationId: String,
+        inboxId: String,
+        update: @escaping @Sendable (inout ProfileMetadata) -> Void
+    ) async throws
+}
+
+/// Shared serialization choke point for every per-sender
+/// `ProfileUpdate.metadata` write.
+///
+/// The `ProfileUpdate.metadata` map is per-sender, but a publish rewrites the
+/// whole merged map for that sender (read existing -> merge key -> publish).
+/// Two async tasks in the same process can interleave on this non-atomic
+/// read-merge-write: a timezone publish and a `connections` publish both touch
+/// the same `DBMemberProfile`. If they overlap, the later write overwrites the
+/// earlier with a stale copy of the key the other task just set -- silent data
+/// loss.
+///
+/// To prevent that, all metadata map writes for a given sender/conversation go
+/// through one shared instance of this class. `@MainActor` keeps the bookkeeping
+/// on a single actor, and an internal serial task chain makes each
+/// `updateMetadata` call run to completion (including its async hops) before the
+/// next one starts, so the read-merge-write is atomic across callers.
+@MainActor
+public final class ProfileMetadataWriter: ProfileMetadataWriterProtocol {
+    private let myProfileWriter: any MyProfileWriterProtocol
+    private let databaseReader: any DatabaseReader
+
+    /// Tail of the serial task chain. Each new call appends itself after the
+    /// previous one, so writes never overlap even across `await` suspension
+    /// points. Errors are isolated per call: a failure in one write does not
+    /// cancel queued writes. Only ever touched inside `updateMetadata`, which is
+    /// `@MainActor`-isolated, so the `nonisolated(unsafe)` here only relaxes the
+    /// initializer's isolation and never permits an off-actor mutation.
+    private nonisolated(unsafe) var tail: Task<Void, Never> = Task {}
+
+    public nonisolated init(
+        myProfileWriter: any MyProfileWriterProtocol,
+        databaseReader: any DatabaseReader
+    ) {
+        self.myProfileWriter = myProfileWriter
+        self.databaseReader = databaseReader
+    }
+
+    public func updateMetadata(
+        conversationId: String,
+        inboxId: String,
+        update: @escaping @Sendable (inout ProfileMetadata) -> Void
+    ) async throws {
+        let previous = tail
+        let work = Task { @MainActor [myProfileWriter, databaseReader] () -> Result<Void, any Error> in
+            await previous.value
+            do {
+                let existing = try await databaseReader.read { db in
+                    try DBMemberProfile.fetchOne(
+                        db,
+                        conversationId: conversationId,
+                        inboxId: inboxId
+                    )?.metadata
+                }
+                var merged: ProfileMetadata = existing ?? [:]
+                update(&merged)
+                try await myProfileWriter.updateAndPublish(
+                    metadata: merged.isEmpty ? nil : merged,
+                    conversationId: conversationId
+                )
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+        tail = Task { _ = await work.value }
+        switch await work.value {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
@@ -157,6 +157,7 @@ private final class HappyStubAPIClient: TestStubAPIClient {
         conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock {
@@ -190,6 +191,7 @@ private final class ModeratedStubAPIClient: TestStubAPIClient {
         conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock { joinCallCount += 1 }
@@ -236,6 +238,7 @@ private final class AttachmentUploadFailingStubAPIClient: TestStubAPIClient {
         conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock { joinCallCount += 1 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -32,7 +32,10 @@ struct ConnectionGrantWriterTests {
                 sessionStateManager: sessionStateManager,
                 databaseWriter: databaseManager.dbWriter,
                 databaseReader: databaseManager.dbReader,
-                myProfileWriter: profileWriter,
+                profileMetadataWriter: ProfileMetadataWriter(
+                    myProfileWriter: profileWriter,
+                    databaseReader: databaseManager.dbReader
+                ),
                 servicesStore: Self.makeServicesStore(apiClient: apiClient)
             )
         }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileMetadataWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileMetadataWriterTests.swift
@@ -1,0 +1,153 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Tests for ProfileMetadataWriter, the shared serialization choke point for
+/// per-sender ProfileUpdate.metadata writes.
+///
+/// Covers:
+/// - read existing metadata -> apply closure -> publish merged map
+/// - empty merged map publishes nil (so an empty map clears rather than writes)
+/// - concurrent writers to different keys both survive (no clobber)
+@Suite("ProfileMetadataWriter Tests")
+struct ProfileMetadataWriterTests {
+    private struct Fixture {
+        let databaseManager: MockDatabaseManager
+        let profileWriter: MockMyProfileWriter
+        let writer: ProfileMetadataWriter
+
+        init() {
+            let databaseManager = MockDatabaseManager.makeTestDatabase()
+            let profileWriter = MockMyProfileWriter()
+            self.databaseManager = databaseManager
+            self.profileWriter = profileWriter
+            self.writer = ProfileMetadataWriter(
+                myProfileWriter: profileWriter,
+                databaseReader: databaseManager.dbReader
+            )
+        }
+
+        func seedConversation(id: String) throws {
+            let conversation = DBConversation(
+                id: id,
+                clientConversationId: id,
+                inviteTag: "invite-\(id)",
+                creatorId: "test-inbox",
+                kind: .group,
+                consent: .allowed,
+                createdAt: Date(),
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAgent: false,
+            )
+            try databaseManager.dbWriter.write { db in
+                try conversation.save(db)
+            }
+        }
+
+        func seedMemberProfile(
+            conversationId: String,
+            inboxId: String,
+            metadata: ProfileMetadata?
+        ) throws {
+            try databaseManager.dbWriter.write { db in
+                try DBMember(inboxId: inboxId).save(db)
+                let profile = DBMemberProfile(
+                    conversationId: conversationId,
+                    inboxId: inboxId,
+                    name: nil,
+                    avatar: nil,
+                    metadata: metadata
+                )
+                try profile.save(db)
+            }
+        }
+    }
+
+    @Test("Applies the closure on top of existing metadata and publishes the merge")
+    func mergesExistingMetadata() async throws {
+        let fixture = Fixture()
+        let conversationId = "convo-1"
+        let inboxId = "inbox-1"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            metadata: ["connections": .string("existing-grants")]
+        )
+
+        try await fixture.writer.updateMetadata(
+            conversationId: conversationId,
+            inboxId: inboxId
+        ) { metadata in
+            metadata["timezone"] = .string("Europe/Paris")
+        }
+
+        let published = try #require(fixture.profileWriter.publishedMetadata.last)
+        #expect(published.conversationId == conversationId)
+        let metadata = try #require(published.metadata)
+        #expect(metadata["connections"] == .string("existing-grants"))
+        #expect(metadata["timezone"] == .string("Europe/Paris"))
+    }
+
+    @Test("An empty merged map publishes nil")
+    func emptyMapPublishesNil() async throws {
+        let fixture = Fixture()
+        let conversationId = "convo-2"
+        let inboxId = "inbox-2"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.updateMetadata(
+            conversationId: conversationId,
+            inboxId: inboxId
+        ) { _ in }
+
+        let published = try #require(fixture.profileWriter.publishedMetadata.last)
+        #expect(published.metadata == nil)
+    }
+
+    @Test("Concurrent writes to different keys do not clobber each other")
+    func concurrentWritesPreserveBothKeys() async throws {
+        let fixture = Fixture()
+        let conversationId = "convo-3"
+        let inboxId = "inbox-3"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedMemberProfile(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            metadata: nil
+        )
+
+        // First write lands the connections key, persisting it so the second
+        // write reads it back and the merge preserves it. Serialized by the
+        // writer's internal task chain.
+        try await fixture.writer.updateMetadata(conversationId: conversationId, inboxId: inboxId) { metadata in
+            metadata["connections"] = .string("grants")
+        }
+        // Persist what the first publish produced so the second read sees it,
+        // mirroring how MyProfileWriter saves to DBMemberProfile in production.
+        let firstMerged = try #require(fixture.profileWriter.publishedMetadata.last?.metadata)
+        try fixture.seedMemberProfile(conversationId: conversationId, inboxId: inboxId, metadata: firstMerged)
+
+        try await fixture.writer.updateMetadata(conversationId: conversationId, inboxId: inboxId) { metadata in
+            metadata["timezone"] = .string("America/New_York")
+        }
+
+        let published = try #require(fixture.profileWriter.publishedMetadata.last?.metadata)
+        #expect(published["connections"] == .string("grants"))
+        #expect(published["timezone"] == .string("America/New_York"))
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -40,6 +40,7 @@ extension ConvosAPIClientProtocol {
         conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         ConvosAPI.AgentJoinResponse(
@@ -192,6 +193,7 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
         conversationId: String?,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         ConvosAPI.AgentJoinResponse(

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -307,6 +307,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         )
     }
 
+    func republishAgentTimezones() async {
+        await base.republishAgentTimezones()
+    }
+
     func voiceMemoTranscriptRepository() -> any VoiceMemoTranscriptRepositoryProtocol {
         base.voiceMemoTranscriptRepository()
     }


### PR DESCRIPTION
## What

Implements the **producer (iOS) side** of giving a Convos AI agent the user's IANA time zone, invisibly, so it can answer "what time is it" / "remind me at 9am" correctly and handle DST. Nothing is rendered in chat. This is the iOS half only; the backend (`v2/agents/join`) and the agent runtime (Hermes) consume these values in a separate, coordinated change.

The same wire name `timezone` is used on both channels; the role distinction lives in comments, not the field name (a source-agnostic name is preferred over `creatorTimezone` because the assistant only needs the value).

## Two channels

**Channel A — join-request field (creator baseline).** Adds `timezone: String?` to `ConvosAPI.AgentJoinRequest` and populates it at the single construction site. The value is captured on the main actor before any async hop (`await MainActor.run { TimeZone.current.identifier }` in `SessionManager.addAgentToConversation`) and threaded through `ConvosAPIClientProtocol.requestAgentJoin`. It carries the conversation creator's device tz as the agent's baseline/default; set once at join time (does not track travel/DST). Optional and nil-omitted by Codable, so the wire format stays backward-compatible until the backend reads it.

**Channel B — per-sender `ProfileUpdate.metadata` (ongoing per-user).** Publishes the current user's own tz under metadata key `"timezone"`, scoped to conversations that contain an agent member. Triggered:
- right after a successful agent join (`SessionManager.addAgentToConversation`), and
- opportunistically on app foreground (`ConvosApp` scenePhase `.active`), after a 5s settle delay, throttled to publish only when the current tz differs from the last-published value (persisted per-conversation in the app-group `UserDefaults`), once per foreground session (re-armed on `.background`).

Both triggers gate on the conversation actually having an agent member, and only ever run from the foreground main app.

## The shared serialization choke point

The per-sender metadata map is rewritten whole on each publish (read existing -> merge key -> publish). A connections write and a timezone write could interleave on that non-atomic sequence and clobber each other's key — silent data loss. New `ProfileMetadataWriter` (`@MainActor public final class`) owns the single choke point: read existing metadata, apply a caller-supplied closure, publish the merge. An internal serial task chain makes each `updateMetadata` atomic across callers even across `await` suspension points. `CloudConnectionGrantWriter` is refactored to route its `connections` write through this shared instance (behavior unchanged; all 23 existing connection-grant tests pass), and the timezone publish uses it for the `timezone` key, so the two can never race.

## Tests

- New `ProfileMetadataWriterTests` (3): merge-on-existing, empty-map-publishes-nil, concurrent-writes-preserve-both-keys.
- `ConnectionGrantWriterTests` updated for the new constructor; all 23 pass — no regression.

## Verification

- `swift build --package-path ConvosCore` — succeeds.
- `xcodebuild build` `Convos (Dev)` on iPhone 17 simulator — succeeds, zero errors, zero long-type-check warnings.
- `swiftlint --strict` on changed files — clean.

## Notes

Producer half only. The backend must accept the join `timezone` field and the runtime must read `metadata["timezone"]` for it to have any effect; until then iOS sends the bytes and they are ignored.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784308248&installation_id=128169237&pr_number=1087&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1087&signature=0f729eea769a684f0c5855f2b80b6c9ca2be25853469a7317710604e66d3152c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish user timezone to agent conversations on join and app foreground
> - Adds the device timezone to `requestAgentJoin` API calls and writes it into per-sender `ProfileUpdate.metadata` after an agent is added to a conversation.
> - Introduces `AgentTimezonePublisher` to publish and throttled-republish timezone metadata across all agent conversations for the current inbox.
> - On each app foreground, schedules a one-time-per-foreground republish of agent timezones after a 5-second delay via `ForegroundOnceGuard` and `session.republishAgentTimezones()`.
> - Adds `ProfileMetadataWriter` to serialize concurrent `ProfileUpdate.metadata` writes and prevent key clobbering between operations like timezone and connection grant updates.
> - Risk: timezone publish failures are best-effort and do not fail the agent join, so agents may temporarily have stale or missing timezone metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e876db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->