### PR TITLE
Mproberts/profile writer fixes

### DIFF
--- a/Convos/Profile/ProfileSettingsViewModel.swift
+++ b/Convos/Profile/ProfileSettingsViewModel.swift
@@ -148,14 +148,21 @@ class ProfileSettingsViewModel {
         }
         let trimmedName = editingDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedName: String? = trimmedName.isEmpty ? nil : trimmedName
-        let imageData = profileImage?.jpegData(compressionQuality: 1.0)
-        let assetIdentifier = imageData == nil ? nil : profileImageAssetIdentifier
-        try await writer.save(
-            name: resolvedName,
-            imageData: imageData,
-            imageAssetIdentifier: assetIdentifier,
-            metadata: nil
-        )
+
+        // Field-preserving writes instead of a full-row replace. The name comes
+        // straight from the text field (never an un-hydrated value), so it always
+        // applies and preserves the stored image + metadata. The image is only
+        // written when we have one in memory, or when the profile is confirmed
+        // loaded and genuinely has none (a real removal) - never speculatively,
+        // so a save during cold-launch/post-pairing load can't wipe the avatar.
+        try await writer.update(name: resolvedName)
+
+        if let profileImage, let imageData = profileImage.jpegData(compressionQuality: 1.0) {
+            try await writer.update(imageData: imageData, imageAssetIdentifier: profileImageAssetIdentifier)
+        } else if profileImage == nil, await waitForProfileLoad(timeout: 2.0) {
+            try await writer.update(imageData: nil, imageAssetIdentifier: nil)
+        }
+
         markProfileEditorShownIfPopulated()
     }
 

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -828,11 +828,11 @@ extension MessagingService {
                     } else {
                         try DBConversation.fetchOne(db, id: conversationId)?.imageEncryptionKey
                     }
-                    profile = profile.with(
-                        avatar: update.encryptedImage.url,
+                    profile = profile.applyingEncryptedAvatar(
+                        url: update.encryptedImage.url,
                         salt: update.encryptedImage.salt,
                         nonce: update.encryptedImage.nonce,
-                        key: encryptionKey
+                        resolvedKey: encryptionKey
                     )
                 } else {
                     profile = profile.with(avatar: nil, salt: nil, nonce: nil, key: nil)
@@ -840,6 +840,9 @@ extension MessagingService {
 
                 let priorMemberKind = profile.memberKind
                 profile = profile.with(memberKind: update.memberKind.dbMemberKind)
+
+                let profileMetadata = update.profileMetadata
+                profile = profile.with(metadata: profileMetadata.isEmpty ? nil : profileMetadata)
 
                 if profile.isAgent {
                     let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
@@ -853,7 +856,7 @@ extension MessagingService {
                     profile = profile.with(memberKind: priorMemberKind)
                 }
 
-                try ContactsWriter.saveMemberProfileAndMirrorToContactInTransaction(db: db, profile: profile, receivedAt: receivedAt)
+                try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt)
                 try Self.markConversationHasVerifiedAgentIfNeeded(profile: profile, conversationId: conversationId, db: db)
             }
             Log.debug("NSE: Processed ProfileUpdate from \(senderInboxId) in \(conversationId)")
@@ -889,10 +892,6 @@ extension MessagingService {
                         inboxId: inboxId
                     )
 
-                    if existingProfile?.name != nil || existingProfile?.avatar != nil {
-                        continue
-                    }
-
                     var profile = existingProfile ?? DBMemberProfile(
                         conversationId: conversationId,
                         inboxId: inboxId,
@@ -903,16 +902,19 @@ extension MessagingService {
                     profile = profile.with(name: memberProfile.hasName ? memberProfile.name : nil)
 
                     if memberProfile.hasEncryptedImage, memberProfile.encryptedImage.isValid {
-                        profile = profile.with(
-                            avatar: memberProfile.encryptedImage.url,
+                        profile = profile.applyingEncryptedAvatar(
+                            url: memberProfile.encryptedImage.url,
                             salt: memberProfile.encryptedImage.salt,
                             nonce: memberProfile.encryptedImage.nonce,
-                            key: existingProfile?.avatarKey ?? encryptionKey
+                            resolvedKey: existingProfile?.avatarKey ?? encryptionKey
                         )
                     }
 
                     let priorMemberKind = profile.memberKind
                     profile = profile.with(memberKind: memberProfile.memberKind.dbMemberKind)
+
+                    let snapshotMetadata = memberProfile.profileMetadata
+                    profile = profile.with(metadata: snapshotMetadata.isEmpty ? nil : snapshotMetadata)
 
                     if profile.isAgent {
                         let verification = profile.hydrateProfile().verifyCachedAgentAttestation()
@@ -926,7 +928,7 @@ extension MessagingService {
                         profile = profile.with(memberKind: priorMemberKind)
                     }
 
-                    try ContactsWriter.saveMemberProfileAndMirrorToContactInTransaction(db: db, profile: profile, receivedAt: receivedAt)
+                    try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt)
                     try Self.markConversationHasVerifiedAgentIfNeeded(profile: profile, conversationId: conversationId, db: db)
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -928,7 +928,7 @@ extension MessagingService {
                         profile = profile.with(memberKind: priorMemberKind)
                     }
 
-                    try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt)
+                    try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt, source: .snapshotBackfill)
                     try Self.markConversationHasVerifiedAgentIfNeeded(profile: profile, conversationId: conversationId, db: db)
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -25,12 +25,18 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     private let _reactionWriter: any ReactionWriterProtocol
     private let _readReceiptWriter: any ReadReceiptWriterProtocol
     private let _replyWriter: any ReplyMessageWriterProtocol
+    // Injected so tests can hold the exact global-profile writer/repository the
+    // service hands out (the factory methods otherwise return fresh instances).
+    private let _myGlobalProfileWriter: (any MyGlobalProfileWriterProtocol)?
+    private let _myGlobalProfileRepository: (any MyGlobalProfileRepositoryProtocol)?
 
     // MARK: - Initialization
 
     public init(
         sessionStateManager: (any SessionStateManagerProtocol)? = nil,
         myProfileWriter: (any MyProfileWriterProtocol)? = nil,
+        myGlobalProfileWriter: (any MyGlobalProfileWriterProtocol)? = nil,
+        myGlobalProfileRepository: (any MyGlobalProfileRepositoryProtocol)? = nil,
         conversationStateManager: (any ConversationStateManagerProtocol)? = nil,
         conversationConsentWriter: (any ConversationConsentWriterProtocol)? = nil,
         conversationLocalStateWriter: (any ConversationLocalStateWriterProtocol)? = nil,
@@ -44,6 +50,8 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     ) {
         self._sessionStateManager = sessionStateManager ?? MockSessionStateManager()
         self._myProfileWriter = myProfileWriter ?? MockMyProfileWriter()
+        self._myGlobalProfileWriter = myGlobalProfileWriter
+        self._myGlobalProfileRepository = myGlobalProfileRepository
         self._conversationStateManager = conversationStateManager ?? MockConversationStateManager()
         self._conversationConsentWriter = conversationConsentWriter ?? MockConversationConsentWriter()
         self._conversationLocalStateWriter = conversationLocalStateWriter ?? MockConversationLocalStateWriter()
@@ -75,11 +83,11 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     }
 
     public func myGlobalProfileWriter() -> any MyGlobalProfileWriterProtocol {
-        MockMyGlobalProfileWriter()
+        _myGlobalProfileWriter ?? MockMyGlobalProfileWriter()
     }
 
     public func myGlobalProfileRepository() -> any MyGlobalProfileRepositoryProtocol {
-        MockMyGlobalProfileRepository()
+        _myGlobalProfileRepository ?? MockMyGlobalProfileRepository()
     }
 
     public func conversationStateManager() -> any ConversationStateManagerProtocol {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberProfile.swift
@@ -50,6 +50,9 @@ struct DBMemberProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         static let imageSourceContentDigest: Column = Column(CodingKeys.imageSourceContentDigest)
         static let memberKind: Column = Column(CodingKeys.memberKind)
         static let metadata: Column = Column(CodingKeys.metadata)
+        static let profileUpdatedAt: Column = Column(CodingKeys.profileUpdatedAt)
+        static let publishedNameDigest: Column = Column(CodingKeys.publishedNameDigest)
+        static let publishedAvatarDigest: Column = Column(CodingKeys.publishedAvatarDigest)
     }
 
     let conversationId: String
@@ -70,6 +73,23 @@ struct DBMemberProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
     let imageSourceContentDigest: String?
     let memberKind: DBMemberKind?
     let metadata: ProfileMetadata?
+    /// Recency guard for inbound profile writes: the `sentAt` of the most recent
+    /// profile message applied to this row. Inbound applies are dropped when the
+    /// incoming message is older than this (most-recent-wins, mirroring
+    /// `DBContact.profileUpdatedAt`). nil means no message-sourced stamp yet, so
+    /// any inbound write may apply. Local edits stamp this with the wall clock.
+    let profileUpdatedAt: Date?
+    /// Digest of the display name last successfully published (sent as a
+    /// ProfileUpdate to the group) for the local user's own profile in this
+    /// conversation. Activate-sync compares this against the global profile so a
+    /// failed publish (marker stays stale) is retried. nil for other members and
+    /// for never-published rows.
+    let publishedNameDigest: String?
+    /// Digest of the avatar source last successfully published for the local
+    /// user's own profile in this conversation. Compared against
+    /// `DBMyProfile.imageContentDigest`; nil means no avatar was confirmed
+    /// published (or it was confirmed cleared).
+    let publishedAvatarDigest: String?
 
     var isAgent: Bool {
         memberKind?.isAgent ?? false
@@ -91,7 +111,10 @@ struct DBMemberProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         imageSourceAssetIdentifier: String? = nil,
         imageSourceContentDigest: String? = nil,
         memberKind: DBMemberKind? = nil,
-        metadata: ProfileMetadata? = nil
+        metadata: ProfileMetadata? = nil,
+        profileUpdatedAt: Date? = nil,
+        publishedNameDigest: String? = nil,
+        publishedAvatarDigest: String? = nil
     ) {
         self.conversationId = conversationId
         self.inboxId = inboxId
@@ -105,6 +128,9 @@ struct DBMemberProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         self.imageSourceContentDigest = imageSourceContentDigest
         self.memberKind = memberKind
         self.metadata = metadata
+        self.profileUpdatedAt = profileUpdatedAt
+        self.publishedNameDigest = publishedNameDigest
+        self.publishedAvatarDigest = publishedAvatarDigest
     }
 
     static let memberForeignKey: ForeignKey = ForeignKey([Columns.inboxId], to: [DBMember.Columns.inboxId])
@@ -157,7 +183,10 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
     }
 
@@ -168,7 +197,10 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
     }
 
@@ -179,7 +211,10 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
     }
 
@@ -190,7 +225,10 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
     }
 
@@ -201,7 +239,10 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
     }
 
@@ -212,7 +253,10 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
     }
 
@@ -223,8 +267,49 @@ extension DBMemberProfile {
             avatarLastRenewed: avatarLastRenewed,
             imageSourceAssetIdentifier: imageSourceAssetIdentifier,
             imageSourceContentDigest: imageSourceContentDigest,
-            memberKind: memberKind, metadata: metadata
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
         )
+    }
+
+    func with(profileUpdatedAt: Date?) -> DBMemberProfile {
+        .init(
+            conversationId: conversationId, inboxId: inboxId, name: name, avatar: avatar,
+            avatarSalt: avatarSalt, avatarNonce: avatarNonce, avatarKey: avatarKey,
+            avatarLastRenewed: avatarLastRenewed,
+            imageSourceAssetIdentifier: imageSourceAssetIdentifier,
+            imageSourceContentDigest: imageSourceContentDigest,
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
+        )
+    }
+
+    func with(publishedNameDigest: String?, publishedAvatarDigest: String?) -> DBMemberProfile {
+        .init(
+            conversationId: conversationId, inboxId: inboxId, name: name, avatar: avatar,
+            avatarSalt: avatarSalt, avatarNonce: avatarNonce, avatarKey: avatarKey,
+            avatarLastRenewed: avatarLastRenewed,
+            imageSourceAssetIdentifier: imageSourceAssetIdentifier,
+            imageSourceContentDigest: imageSourceContentDigest,
+            memberKind: memberKind, metadata: metadata,
+            profileUpdatedAt: profileUpdatedAt,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
+        )
+    }
+
+    /// Applies an inbound encrypted-avatar reference only when its decryption
+    /// key is resolvable. Persisting the avatar with a nil key would store a row
+    /// the image cache can't decrypt - it renders blank and never self-heals -
+    /// so when the key is missing we leave the existing avatar untouched and let
+    /// a later message (or the conversation-key backfill on sync) supply it.
+    func applyingEncryptedAvatar(url: String, salt: Data, nonce: Data, resolvedKey: Data?) -> DBMemberProfile {
+        guard let resolvedKey else { return self }
+        return with(avatar: url, salt: salt, nonce: nonce, key: resolvedKey)
     }
 
     var hasValidEncryptedAvatar: Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -194,7 +194,7 @@ extension SharedDatabaseMigrator {
 
         migrator.registerMigration("createHandledJoinRequest", migrate: Self.createHandledJoinRequest)
 
-        migrator.registerMigration("addMemberProfileProfileUpdatedAt", migrate: Self.addMemberProfileProfileUpdatedAt)
+        migrator.registerMigration("addMemberProfileUpdatedAt", migrate: Self.addMemberProfileUpdatedAt)
 
         migrator.registerMigration("addMemberProfilePublishedMarkers", migrate: Self.addMemberProfilePublishedMarkers)
 
@@ -222,7 +222,7 @@ extension SharedDatabaseMigrator {
     /// mirroring `contact.profileUpdatedAt`. Nullable with no backfill: legacy
     /// rows start nil (treated as overwritable) and the first inbound profile
     /// message back-fills the stamp.
-    private static func addMemberProfileProfileUpdatedAt(_ db: Database) throws {
+    private static func addMemberProfileUpdatedAt(_ db: Database) throws {
         try db.alter(table: "memberProfile") { t in
             t.add(column: "profileUpdatedAt", .datetime)
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -179,22 +179,7 @@ extension SharedDatabaseMigrator {
         // schema, so an upgrade migrates in place.
         Self.registerAgentTemplateContactMigrations(on: &migrator)
 
-        // Filter set of agent-builder bundle message ids hidden from every
-        // client's chat. Intentionally no foreign key to `conversation`: a
-        // manifest can be processed before its conversation row is stored (the
-        // stream routes supplementals ahead of `conversationWriter.store`, and
-        // catch-up can deliver a manifest before the initial conversation sync
-        // lands); a FK would make those inserts fail and silently drop the hidden
-        // ids, leaving the brief visible. A stray row for an absent conversation
-        // matches nothing and is harmless. Teardown clears the table explicitly
-        // in `SessionManager.deleteAllInboxes` (no cascade).
-        migrator.registerMigration("createBuilderBundleHiddenMessage") { db in
-            try db.create(table: "builder_bundle_hidden_message") { t in
-                t.column("conversationId", .text).notNull()
-                t.column("messageId", .text).notNull()
-                t.primaryKey(["conversationId", "messageId"])
-            }
-        }
+        migrator.registerMigration("createBuilderBundleHiddenMessage", migrate: Self.createBuilderBundleHiddenMessage)
 
         migrator.registerMigration("backfillContactAgentTemplateFieldsFromMemberProfiles",
                                    migrate: Self.backfillContactAgentTemplateFieldsFromMemberProfiles)
@@ -209,7 +194,52 @@ extension SharedDatabaseMigrator {
 
         migrator.registerMigration("createHandledJoinRequest", migrate: Self.createHandledJoinRequest)
 
+        migrator.registerMigration("addMemberProfileProfileUpdatedAt", migrate: Self.addMemberProfileProfileUpdatedAt)
+
+        migrator.registerMigration("addMemberProfilePublishedMarkers", migrate: Self.addMemberProfilePublishedMarkers)
+
         return migrator
+    }
+
+    /// Filter set of agent-builder bundle message ids hidden from every
+    /// client's chat. Intentionally no foreign key to `conversation`: a
+    /// manifest can be processed before its conversation row is stored (the
+    /// stream routes supplementals ahead of `conversationWriter.store`, and
+    /// catch-up can deliver a manifest before the initial conversation sync
+    /// lands); a FK would make those inserts fail and silently drop the hidden
+    /// ids, leaving the brief visible. A stray row for an absent conversation
+    /// matches nothing and is harmless. Teardown clears the table explicitly
+    /// in `SessionManager.deleteAllInboxes` (no cascade).
+    private static func createBuilderBundleHiddenMessage(_ db: Database) throws {
+        try db.create(table: "builder_bundle_hidden_message") { t in
+            t.column("conversationId", .text).notNull()
+            t.column("messageId", .text).notNull()
+            t.primaryKey(["conversationId", "messageId"])
+        }
+    }
+
+    /// Most-recent-wins recency guard for per-conversation member profiles,
+    /// mirroring `contact.profileUpdatedAt`. Nullable with no backfill: legacy
+    /// rows start nil (treated as overwritable) and the first inbound profile
+    /// message back-fills the stamp.
+    private static func addMemberProfileProfileUpdatedAt(_ db: Database) throws {
+        try db.alter(table: "memberProfile") { t in
+            t.add(column: "profileUpdatedAt", .datetime)
+        }
+    }
+
+    /// Confirmed-published markers for the local user's own per-conversation
+    /// profile: the name/avatar digests last successfully sent as a
+    /// ProfileUpdate to the group. Activate-sync compares these (not the local
+    /// row, which is written optimistically before the network publish) so a
+    /// failed publish leaves the marker stale and is retried. Nullable with no
+    /// backfill: legacy rows start nil ("never confirmed published"), so the
+    /// first sync after upgrade re-publishes once and heals prior silent drops.
+    private static func addMemberProfilePublishedMarkers(_ db: Database) throws {
+        try db.alter(table: "memberProfile") { t in
+            t.add(column: "publishedNameDigest", .text)
+            t.add(column: "publishedAvatarDigest", .text)
+        }
     }
 
     /// Ledger of join-request message IDs that already admitted their

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -389,4 +389,39 @@ extension ContactsWriter {
             agentTemplateEmoji: profile.agentTemplateEmoji
         )
     }
+
+    /// Most-recent-wins apply for an inbound member profile (live stream,
+    /// history replay, or push extension). Drops the write when `incomingSentAt`
+    /// is older than the row's stored `profileUpdatedAt`, so a stale or replayed
+    /// message can never clobber newer data. When applied, stamps the row with
+    /// `incomingSentAt`, persists it, and mirrors to `DBContact` in the same
+    /// transaction so the member row and contact row can never diverge.
+    ///
+    /// `incomingSentAt` is the sender's `message.sentAt` (sender clock); this
+    /// accepts sender-clock ordering, identical to the `DBContact` guard in
+    /// `replacingProfile(of:with:)`. Equal-or-newer applies (the equal case is
+    /// the idempotent reprocess of the same message). Returns true when applied,
+    /// false when dropped as stale.
+    @discardableResult
+    static func applyInboundMemberProfileInTransaction(
+        db: Database,
+        profile: DBMemberProfile,
+        incomingSentAt: Date
+    ) throws -> Bool {
+        let stored = try DBMemberProfile.fetchOne(
+            db,
+            conversationId: profile.conversationId,
+            inboxId: profile.inboxId
+        )?.profileUpdatedAt
+        if let stored, incomingSentAt < stored {
+            return false
+        }
+        let stamped = profile.with(profileUpdatedAt: incomingSentAt)
+        try saveMemberProfileAndMirrorToContactInTransaction(
+            db: db,
+            profile: stamped,
+            receivedAt: incomingSentAt
+        )
+        return true
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -391,30 +391,46 @@ extension ContactsWriter {
     }
 
     /// Most-recent-wins apply for an inbound member profile (live stream,
-    /// history replay, or push extension). Drops the write when `incomingSentAt`
-    /// is older than the row's stored `profileUpdatedAt`, so a stale or replayed
-    /// message can never clobber newer data. When applied, stamps the row with
+    /// history replay, or push extension). When applied, stamps the row with
     /// `incomingSentAt`, persists it, and mirrors to `DBContact` in the same
     /// transaction so the member row and contact row can never diverge.
     ///
-    /// `incomingSentAt` is the sender's `message.sentAt` (sender clock); this
-    /// accepts sender-clock ordering, identical to the `DBContact` guard in
-    /// `replacingProfile(of:with:)`. Equal-or-newer applies (the equal case is
-    /// the idempotent reprocess of the same message). Returns true when applied,
-    /// false when dropped as stale.
+    /// The `source` selects how `incomingSentAt` is interpreted:
+    /// - `.authoritativeUpdate` (ProfileUpdate): `incomingSentAt` is the
+    ///   sender's per-member `message.sentAt`, a meaningful recency signal.
+    ///   Drops the write when it is older than the stored `profileUpdatedAt`,
+    ///   so a stale or replayed message can never clobber newer data.
+    ///   Equal-or-newer applies (the equal case is the idempotent reprocess of
+    ///   the same message). This matches the `DBContact` guard in
+    ///   `replacingProfile(of:with:)`.
+    /// - `.snapshotBackfill` (ProfileSnapshot): the snapshot carries a single
+    ///   author-clock `sentAt` for every member, so it is not a valid
+    ///   per-member recency signal. Applies only when the row has no stored
+    ///   `profileUpdatedAt` yet (backfill for a never-seen member); never
+    ///   overwrites a row an authoritative update already stamped.
+    ///
+    /// Returns true when applied, false when dropped.
     @discardableResult
     static func applyInboundMemberProfileInTransaction(
         db: Database,
         profile: DBMemberProfile,
-        incomingSentAt: Date
+        incomingSentAt: Date,
+        source: InboundProfileSource = .authoritativeUpdate
     ) throws -> Bool {
         let stored = try DBMemberProfile.fetchOne(
             db,
             conversationId: profile.conversationId,
             inboxId: profile.inboxId
         )?.profileUpdatedAt
-        if let stored, incomingSentAt < stored {
-            return false
+        switch source {
+        case .authoritativeUpdate:
+            if let stored, incomingSentAt < stored {
+                return false
+            }
+        case .snapshotBackfill:
+            if stored != nil {
+                return false
+            }
         }
         let stamped = profile.with(profileUpdatedAt: incomingSentAt)
         try saveMemberProfileAndMirrorToContactInTransaction(
@@ -424,4 +440,13 @@ extension ContactsWriter {
         )
         return true
     }
+}
+
+/// Distinguishes the wire source of an inbound member profile so the recency
+/// guard can treat a per-member `ProfileUpdate` timestamp as authoritative
+/// while treating a `ProfileSnapshot`'s shared author-clock timestamp as
+/// backfill-only. See `ContactsWriter.applyInboundMemberProfileInTransaction`.
+enum InboundProfileSource {
+    case authoritativeUpdate
+    case snapshotBackfill
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -380,7 +380,28 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             try profile.save(db)
         }
 
+        // Repair member avatars that were stored with a reference but no
+        // decryption key (a profile message processed before this conversation's
+        // imageEncryptionKey was known - e.g. pre-fix rows, or a race during
+        // initial sync). Member avatars are encrypted with the group key, so
+        // stamping it makes them decryptable; without this they render blank.
+        if let key = prepared.dbConversation.imageEncryptionKey {
+            try Self.backfillKeylessMemberAvatars(conversationId: prepared.dbConversation.id, key: key, in: db)
+        }
+
         return saveResult
+    }
+
+    /// Stamps `key` onto member profiles in `conversationId` that have an
+    /// encrypted-avatar reference (url + salt + nonce) but no `avatarKey`.
+    static func backfillKeylessMemberAvatars(conversationId: String, key: Data, in db: Database) throws {
+        try DBMemberProfile
+            .filter(DBMemberProfile.Columns.conversationId == conversationId)
+            .filter(DBMemberProfile.Columns.avatar != nil)
+            .filter(DBMemberProfile.Columns.avatarSalt != nil)
+            .filter(DBMemberProfile.Columns.avatarNonce != nil)
+            .filter(DBMemberProfile.Columns.avatarKey == nil)
+            .updateAll(db, DBMemberProfile.Columns.avatarKey.set(to: key))
     }
 
     /// Clears a persisted removed marker once a synced member list proves the
@@ -1054,8 +1075,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             let conversationId = conversation.id
             let encryptionKey = try? conversation.imageEncryptionKey
 
-            var latestUpdates: [String: ProfileUpdate] = [:]
-            var latestSnapshot: ProfileSnapshot?
+            var latestUpdates: [String: (update: ProfileUpdate, sentAt: Date)] = [:]
+            var latestSnapshot: (snapshot: ProfileSnapshot, sentAt: Date)?
 
             for message in messages {
                 guard let contentType = try? message.encodedContent.type else { continue }
@@ -1064,9 +1085,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                     guard let update = try? ProfileUpdateCodec().decode(content: message.encodedContent) else { continue }
                     let inboxId = message.senderInboxId
                     guard !inboxId.isEmpty, latestUpdates[inboxId] == nil else { continue }
-                    latestUpdates[inboxId] = update
+                    latestUpdates[inboxId] = (update, message.sentAt)
                 } else if contentType == ContentTypeProfileSnapshot, latestSnapshot == nil {
-                    latestSnapshot = try? ProfileSnapshotCodec().decode(content: message.encodedContent)
+                    if let snapshot = try? ProfileSnapshotCodec().decode(content: message.encodedContent) {
+                        latestSnapshot = (snapshot, message.sentAt)
+                    }
                 }
             }
 
@@ -1074,7 +1097,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             let resolvedSnapshot = latestSnapshot
 
             try await databaseWriter.write { db in
-                for (inboxId, update) in resolvedUpdates {
+                for (inboxId, entry) in resolvedUpdates {
+                    let update = entry.update
                     let profileMetadata = update.profileMetadata
                     try Self.applyProfileData(
                         db: db, conversationId: conversationId, inboxId: inboxId,
@@ -1082,17 +1106,15 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                         encryptedImage: update.hasEncryptedImage ? update.encryptedImage : nil,
                         memberKind: update.memberKind.dbMemberKind,
                         metadata: profileMetadata.isEmpty ? nil : profileMetadata,
-                        fallbackEncryptionKey: encryptionKey
+                        fallbackEncryptionKey: encryptionKey,
+                        sentAt: entry.sentAt
                     )
                 }
 
-                if let snapshot = resolvedSnapshot {
-                    for memberProfile in snapshot.profiles {
+                if let snapshotEntry = resolvedSnapshot {
+                    for memberProfile in snapshotEntry.snapshot.profiles {
                         let inboxId = memberProfile.inboxIdString
                         guard !inboxId.isEmpty, resolvedUpdates[inboxId] == nil else { continue }
-
-                        let existing = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
-                        guard existing?.name == nil, existing?.avatar == nil else { continue }
 
                         let snapshotMetadata = memberProfile.profileMetadata
                         try Self.applyProfileData(
@@ -1101,13 +1123,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                             encryptedImage: memberProfile.hasEncryptedImage ? memberProfile.encryptedImage : nil,
                             memberKind: memberProfile.memberKind.dbMemberKind,
                             metadata: snapshotMetadata.isEmpty ? nil : snapshotMetadata,
-                            fallbackEncryptionKey: encryptionKey
+                            fallbackEncryptionKey: encryptionKey,
+                            sentAt: snapshotEntry.sentAt
                         )
                     }
                 }
             }
 
-            let profileCount = latestUpdates.count + (latestSnapshot?.profiles.count ?? 0)
+            let profileCount = latestUpdates.count + (latestSnapshot?.snapshot.profiles.count ?? 0)
             if profileCount > 0 {
                 Log.debug("Processed \(profileCount) profile messages from history for \(conversationId)")
             }
@@ -1124,7 +1147,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         encryptedImage: EncryptedProfileImageRef?,
         memberKind: DBMemberKind?,
         metadata: ProfileMetadata? = nil,
-        fallbackEncryptionKey: Data?
+        fallbackEncryptionKey: Data?,
+        sentAt: Date
     ) throws {
         let member = DBMember(inboxId: inboxId)
         try member.save(db)
@@ -1136,9 +1160,9 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         profile = profile.with(name: name)
 
         if let image = encryptedImage, image.isValid {
-            profile = profile.with(
-                avatar: image.url, salt: image.salt, nonce: image.nonce,
-                key: profile.avatarKey ?? fallbackEncryptionKey
+            profile = profile.applyingEncryptedAvatar(
+                url: image.url, salt: image.salt, nonce: image.nonce,
+                resolvedKey: profile.avatarKey ?? fallbackEncryptionKey
             )
         }
 
@@ -1163,7 +1187,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             profile = profile.with(memberKind: priorMemberKind)
         }
 
-        try profile.save(db)
+        try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: sentAt)
 
         if profile.agentVerification.isConvosAgent,
            let conversation = try DBConversation.fetchOne(db, id: conversationId),

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -1124,7 +1124,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                             memberKind: memberProfile.memberKind.dbMemberKind,
                             metadata: snapshotMetadata.isEmpty ? nil : snapshotMetadata,
                             fallbackEncryptionKey: encryptionKey,
-                            sentAt: snapshotEntry.sentAt
+                            sentAt: snapshotEntry.sentAt,
+                            source: .snapshotBackfill
                         )
                     }
                 }
@@ -1148,7 +1149,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         memberKind: DBMemberKind?,
         metadata: ProfileMetadata? = nil,
         fallbackEncryptionKey: Data?,
-        sentAt: Date
+        sentAt: Date,
+        source: InboundProfileSource = .authoritativeUpdate
     ) throws {
         let member = DBMember(inboxId: inboxId)
         try member.save(db)
@@ -1187,7 +1189,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             profile = profile.with(memberKind: priorMemberKind)
         }
 
-        try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: sentAt)
+        try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: sentAt, source: source)
 
         if profile.agentVerification.isConvosAgent,
            let conversation = try DBConversation.fetchOne(db, id: conversationId),

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import GRDB
 @preconcurrency import XMTPiOS
@@ -27,19 +28,31 @@ enum MyProfileWriterError: Error {
 }
 
 final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
-    private let sessionStateManager: any SessionStateManagerProtocol
+    /// Resolves the live XMTP client + API client + inbox id. Default path
+    /// awaits `SessionStateManager`; the background `ProfileSyncReconciler`
+    /// injects a static context built from the session's already-live client
+    /// (it has no `SessionStateManager`).
+    private let resolveInboxReady: @Sendable () async throws -> InboxReadyResult
     private let databaseWriter: any DatabaseWriter
 
     init(
         sessionStateManager: any SessionStateManagerProtocol,
         databaseWriter: any DatabaseWriter
     ) {
-        self.sessionStateManager = sessionStateManager
+        self.resolveInboxReady = { try await sessionStateManager.waitForInboxReadyResult() }
+        self.databaseWriter = databaseWriter
+    }
+
+    init(
+        databaseWriter: any DatabaseWriter,
+        resolveInboxReady: @escaping @Sendable () async throws -> InboxReadyResult
+    ) {
+        self.resolveInboxReady = resolveInboxReady
         self.databaseWriter = databaseWriter
     }
 
     func update(displayName: String, conversationId: String) async throws {
-        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let inboxReady = try await resolveInboxReady()
         guard let conversation = try await inboxReady.client.conversation(with: conversationId),
               case .group(let group) = conversation else {
             throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
@@ -61,7 +74,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
                 inboxId: inboxId,
                 name: name,
                 avatar: nil
-            )).with(name: name)
+            )).with(name: name).with(profileUpdatedAt: Date())
             try profile.save(db)
             return profile
         }
@@ -83,7 +96,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
     }
 
     func updateAndPublish(metadata: ProfileMetadata?, conversationId: String) async throws {
-        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let inboxReady = try await resolveInboxReady()
         guard let conversation = try await inboxReady.client.conversation(with: conversationId),
               case .group(let group) = conversation else {
             throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
@@ -97,7 +110,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
                 inboxId: inboxId,
                 name: nil,
                 avatar: nil
-            )).with(metadata: metadata?.isEmpty == true ? nil : metadata)
+            )).with(metadata: metadata?.isEmpty == true ? nil : metadata).with(profileUpdatedAt: Date())
             try profile.save(db)
             return profile
         }
@@ -110,7 +123,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
     }
 
     func update(avatar: ImageType?, imageSourceContentDigest: String?, conversationId: String) async throws {
-        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let inboxReady = try await resolveInboxReady()
         guard let conversation = try await inboxReady.client.conversation(with: conversationId),
               case .group(let group) = conversation else {
             throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
@@ -139,6 +152,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
             let updatedProfile = profile
                 .with(avatar: nil, salt: nil, nonce: nil, key: nil)
                 .with(imageSourceContentDigest: nil)
+                .with(profileUpdatedAt: Date())
             try await databaseWriter.write { db in
                 try updatedProfile.save(db)
             }
@@ -183,6 +197,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
                 key: groupKey
             )
             .with(imageSourceContentDigest: imageSourceContentDigest)
+            .with(profileUpdatedAt: Date())
 
         do {
             try await group.updateProfile(updatedProfile)
@@ -203,7 +218,7 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
     }
 
     func syncFromGlobalProfile(conversationId: String) async throws {
-        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let inboxReady = try await resolveInboxReady()
         let inboxId = inboxReady.client.inboxId
 
         let global = try await databaseWriter.read { db in
@@ -217,43 +232,46 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
             try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
         }
 
-        // global.name is already trim/clamp/nil-if-empty normalized by MyGlobalProfileWriter,
-        // so it can be compared to member?.name directly without re-normalizing here.
-        if global.name != member?.name {
+        // Gate on the confirmed-published markers, not the local row. The local
+        // row is written optimistically before the network publish, so comparing
+        // it would treat a failed publish as done and never retry. The markers
+        // are stamped only after a successful send (see sendProfileUpdateThrowing),
+        // so a dropped publish leaves them stale and the next sync re-publishes.
+        // global.name is already trim/clamp/nil-if-empty normalized by MyGlobalProfileWriter.
+        let targetNameDigest = Self.nameDigest(global.name)
+        if member?.publishedNameDigest != targetNameDigest {
             try await update(displayName: global.name ?? "", conversationId: conversationId)
         }
 
         if global.imageData == nil {
-            // Global avatar was cleared. Propagate the removal so the per-conversation avatar
-            // doesn't outlive it. Requires the digest to be cleared too: image bytes that are
-            // merely not rehydrated yet (fresh pairing, mid-hydration launch) keep their
-            // digest, and propagating a "removal" the user never made would strip the avatar
-            // for every other member.
-            if global.imageContentDigest == nil, member?.avatar != nil {
+            // Global avatar was cleared vs merely not rehydrated yet (fresh
+            // pairing keeps the digest without the bytes). Only propagate a
+            // genuine removal, and only if we previously published an avatar.
+            if global.imageContentDigest == nil, member?.publishedAvatarDigest != nil {
                 try await update(
                     avatar: nil,
                     imageSourceContentDigest: nil,
                     conversationId: conversationId
                 )
             }
-        } else {
-            let needsAvatarUpload: Bool
-            if member?.avatar == nil {
-                needsAvatarUpload = true
-            } else {
-                // Compare content digests so the decision is reliable regardless of whether the
-                // photos library returned an asset identifier. nil-vs-something on either side
-                // counts as a change and triggers a re-upload.
-                needsAvatarUpload = member?.imageSourceContentDigest != global.imageContentDigest
-            }
-            if needsAvatarUpload, let imageData = global.imageData, let image = ImageType(data: imageData) {
-                try await update(
-                    avatar: image,
-                    imageSourceContentDigest: global.imageContentDigest,
-                    conversationId: conversationId
-                )
-            }
+        } else if member?.publishedAvatarDigest != global.imageContentDigest,
+                  let imageData = global.imageData,
+                  let image = ImageType(data: imageData) {
+            try await update(
+                avatar: image,
+                imageSourceContentDigest: global.imageContentDigest,
+                conversationId: conversationId
+            )
         }
+    }
+
+    /// Base64 SHA-256 of the display name, or nil for an empty/absent name.
+    /// Used as the published-name marker so activate-sync can compare what was
+    /// published against the global profile without storing the raw name twice.
+    /// Internal so `ProfileSyncReconciler` computes the same target digest.
+    static func nameDigest(_ name: String?) -> String? {
+        guard let name, !name.isEmpty else { return nil }
+        return Data(SHA256.hash(data: Data(name.utf8))).base64EncodedString()
     }
 
     private func sendProfileUpdate(profile: DBMemberProfile, group: XMTPiOS.Group) async {
@@ -290,10 +308,33 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
         }
 
         do {
-            _ = try await group.send(encodedContent: encoded)
+            try await withExponentialBackoffRetry {
+                _ = try await group.send(encodedContent: encoded)
+            }
             Log.debug("Sent ProfileUpdate message for \(profile.inboxId) in \(profile.conversationId)")
         } catch {
             throw MyProfileWriterError.profileUpdatePublishFailed(underlying: error)
+        }
+
+        // Confirmed published: stamp the markers for the local user's own row so
+        // activate-sync's gate stops re-publishing this state, while a future
+        // failed publish (markers left stale) is retried. The send carried the
+        // full current profile, so both name and avatar markers reflect exactly
+        // what reached the network.
+        let publishedName = Self.nameDigest(profile.name)
+        let publishedAvatar = profile.imageSourceContentDigest
+        try await databaseWriter.write { db in
+            guard let row = try DBMemberProfile.fetchOne(
+                db,
+                conversationId: profile.conversationId,
+                inboxId: profile.inboxId
+            ) else {
+                return
+            }
+            try row.with(
+                publishedNameDigest: publishedName,
+                publishedAvatarDigest: publishedAvatar
+            ).save(db)
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -205,7 +205,7 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
                 // Note: `Date()` here rather than the message's `sentAtNs`
                 // because `JoinResult` doesn't carry the original timestamp.
                 // Tracked as a follow-up — see the contacts MVP plan.
-                try ContactsWriter.saveMemberProfileAndMirrorToContactInTransaction(db: db, profile: dbProfile, receivedAt: Date())
+                try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: dbProfile, incomingSentAt: Date())
 
                 if dbProfile.agentVerification.isConvosAgent,
                    let conversation = try DBConversation.fetchOne(db, id: result.conversationId),

--- a/ConvosCore/Sources/ConvosCore/Syncing/ProfileSyncReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/ProfileSyncReconciler.swift
@@ -1,0 +1,162 @@
+import Foundation
+import GRDB
+import os
+import XMTPiOS
+
+/// Re-drives global-profile fan-out so a name/avatar edit reliably reaches
+/// every conversation, even ones never opened and ones whose earlier publish
+/// silently failed.
+///
+/// `MyProfileWriter.syncFromGlobalProfile` only fans out lazily, on a
+/// conversation's `.ready` transition, and records a conversation as synced via
+/// confirmed-published markers (`DBMemberProfile.publishedNameDigest` /
+/// `publishedAvatarDigest`) that advance only after a successful send. This
+/// reconciler observes those markers against `DBMyProfile`:
+///
+/// - On every start / resume it re-drives any conversation whose published
+///   markers don't match the global profile (the app-foreground / network-
+///   reconnect backstop, wired the same way as `ConversationConsentReconciler`).
+/// - Because the observation reads `DBMyProfile`, editing the global profile
+///   re-fires it and sweeps every conversation immediately - no separate
+///   save-time hook needed.
+///
+/// Each target re-runs `syncFromGlobalProfile`, which is idempotent once the
+/// markers match, so the observation converges. A `.ready`-driven sync racing
+/// the reconciler at worst sends one redundant (recency-gated, harmless)
+/// ProfileUpdate.
+///
+/// `@unchecked Sendable` for the same reason as `ConversationConsentReconciler`:
+/// the captured client is thread-safe in practice and the only mutable state
+/// (`observationTask`) is guarded by an unfair lock.
+final class ProfileSyncReconciler: @unchecked Sendable {
+    private let databaseReader: any DatabaseReader
+    private let inboxId: String
+    private let writer: any MyProfileWriterProtocol
+
+    private let observationTask: OSAllocatedUnfairLock<Task<Void, Never>?> = .init(initialState: nil)
+
+    init(
+        databaseReader: any DatabaseReader,
+        databaseWriter: any DatabaseWriter,
+        client: any XMTPClientProvider,
+        apiClient: any ConvosAPIClientProtocol
+    ) {
+        self.databaseReader = databaseReader
+        self.inboxId = client.inboxId
+        // The reconciler runs inside SyncingManager, which has no
+        // SessionStateManager. Bind a writer to the session's already-live
+        // client so it reuses the exact gate + publish + avatar-upload logic.
+        let ready = InboxReadyResult(client: client, apiClient: apiClient)
+        self.writer = MyProfileWriter(databaseWriter: databaseWriter, resolveInboxReady: { ready })
+    }
+
+    /// Begin observing. Safe to call repeatedly - the previous task is
+    /// cancelled and replaced.
+    func start() {
+        observationTask.withLock { existing in
+            existing?.cancel()
+            existing = Task { [weak self] in
+                await self?.observe()
+            }
+        }
+    }
+
+    func stop() {
+        observationTask.withLock { existing in
+            existing?.cancel()
+            existing = nil
+        }
+    }
+
+    /// Upper bound on concurrent in-flight syncs per batch. Each sync is a
+    /// network round-trip (and possibly an avatar upload), so a large mismatch
+    /// set (every conversation, on first launch after the markers migration or
+    /// after a global-profile edit) is processed with a sliding window rather
+    /// than all at once.
+    private static let maxConcurrentSyncs: Int = 6
+
+    private func observe() async {
+        let inboxId = self.inboxId
+        let stream = ValueObservation
+            .tracking { db in
+                try Self.fetchMismatchedConversationIds(db: db, inboxId: inboxId)
+            }
+            // An unrelated write re-emits the observation even when the mismatch
+            // set is unchanged; skip re-driving the network loop when identical.
+            .removeDuplicates()
+            .values(in: databaseReader)
+        do {
+            for try await ids in stream {
+                if Task.isCancelled { return }
+                await reconcileBatch(ids)
+            }
+        } catch {
+            Log.error("ProfileSyncReconciler: stream failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Conversations where the local user's confirmed-published markers don't
+    /// match the global profile. Drafts are excluded (no XMTP group yet). Once a
+    /// sync stamps the markers the row matches and drops out, so the observation
+    /// converges.
+    static func fetchMismatchedConversationIds(db: Database, inboxId: String) throws -> [String] {
+        guard let global = try DBMyProfile
+            .filter(DBMyProfile.Columns.inboxId == inboxId)
+            .fetchOne(db) else {
+            return []
+        }
+        let targetNameDigest = MyProfileWriter.nameDigest(global.name)
+        let globalImageData = global.imageData
+        let globalImageDigest = global.imageContentDigest
+
+        let rows = try DBMemberProfile
+            .filter(DBMemberProfile.Columns.inboxId == inboxId)
+            .fetchAll(db)
+
+        return rows.compactMap { row -> String? in
+            if DBConversation.isDraft(id: row.conversationId) {
+                return nil
+            }
+            let nameMismatch: Bool = row.publishedNameDigest != targetNameDigest
+            let avatarMismatch: Bool
+            if globalImageData == nil {
+                // Cleared (digest also nil) -> a previously published avatar must
+                // be removed. Not-rehydrated (digest present, bytes absent) -> leave.
+                avatarMismatch = globalImageDigest == nil ? (row.publishedAvatarDigest != nil) : false
+            } else {
+                avatarMismatch = row.publishedAvatarDigest != globalImageDigest
+            }
+            return (nameMismatch || avatarMismatch) ? row.conversationId : nil
+        }
+    }
+
+    private func reconcileBatch(_ conversationIds: [String]) async {
+        await withTaskGroup(of: Void.self) { group in
+            var iterator = conversationIds.makeIterator()
+            var inflight = 0
+            while inflight < Self.maxConcurrentSyncs, let id = iterator.next() {
+                group.addTask { [weak self] in await self?.reconcile(id) }
+                inflight += 1
+            }
+            while await group.next() != nil {
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
+                if let id = iterator.next() {
+                    group.addTask { [weak self] in await self?.reconcile(id) }
+                }
+            }
+        }
+    }
+
+    private func reconcile(_ conversationId: String) async {
+        do {
+            try await writer.syncFromGlobalProfile(conversationId: conversationId)
+        } catch {
+            // Markers stay stale on failure, so the next start / resume / global
+            // edit re-drives this conversation.
+            Log.error("ProfileSyncReconciler: sync failed for \(conversationId): \(error.localizedDescription)")
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/ProfileSyncReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/ProfileSyncReconciler.swift
@@ -72,7 +72,9 @@ final class ProfileSyncReconciler: @unchecked Sendable {
     /// network round-trip (and possibly an avatar upload), so a large mismatch
     /// set (every conversation, on first launch after the markers migration or
     /// after a global-profile edit) is processed with a sliding window rather
-    /// than all at once.
+    /// than all at once. Six keeps the backlog draining promptly while bounding
+    /// simultaneous network/upload and battery pressure; it is a pragmatic cap,
+    /// not a measured optimum, and can be tuned if profiling warrants.
     private static let maxConcurrentSyncs: Int = 6
 
     private func observe() async {

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -601,7 +601,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                         profile = profile.with(memberKind: priorMemberKind)
                     }
 
-                    try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt)
+                    try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt, source: .snapshotBackfill)
                     try Self.markConversationHasVerifiedAgentIfNeeded(profile: profile, conversationId: conversationId, db: db)
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -502,11 +502,11 @@ actor StreamProcessor: StreamProcessorProtocol {
                     } else {
                         try DBConversation.fetchOne(db, id: conversationId)?.imageEncryptionKey
                     }
-                    profile = profile.with(
-                        avatar: update.encryptedImage.url,
+                    profile = profile.applyingEncryptedAvatar(
+                        url: update.encryptedImage.url,
                         salt: update.encryptedImage.salt,
                         nonce: update.encryptedImage.nonce,
-                        key: encryptionKey
+                        resolvedKey: encryptionKey
                     )
                 } else {
                     profile = profile.with(avatar: nil, salt: nil, nonce: nil, key: nil)
@@ -530,7 +530,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                     profile = profile.with(memberKind: priorMemberKind)
                 }
 
-                try ContactsWriter.saveMemberProfileAndMirrorToContactInTransaction(db: db, profile: profile, receivedAt: receivedAt)
+                try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt)
                 try Self.markConversationHasVerifiedAgentIfNeeded(profile: profile, conversationId: conversationId, db: db)
             }
             Log.debug("Processed ProfileUpdate from \(senderInboxId) in \(conversationId)")
@@ -565,10 +565,6 @@ actor StreamProcessor: StreamProcessorProtocol {
                         inboxId: inboxId
                     )
 
-                    if existingProfile?.name != nil || existingProfile?.avatar != nil {
-                        continue
-                    }
-
                     var profile = existingProfile ?? DBMemberProfile(
                         conversationId: conversationId,
                         inboxId: inboxId,
@@ -579,11 +575,11 @@ actor StreamProcessor: StreamProcessorProtocol {
                     profile = profile.with(name: memberProfile.hasName ? memberProfile.name : nil)
 
                     if memberProfile.hasEncryptedImage, memberProfile.encryptedImage.isValid {
-                        profile = profile.with(
-                            avatar: memberProfile.encryptedImage.url,
+                        profile = profile.applyingEncryptedAvatar(
+                            url: memberProfile.encryptedImage.url,
                             salt: memberProfile.encryptedImage.salt,
                             nonce: memberProfile.encryptedImage.nonce,
-                            key: existingProfile?.avatarKey ?? encryptionKey
+                            resolvedKey: existingProfile?.avatarKey ?? encryptionKey
                         )
                     }
 
@@ -605,7 +601,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                         profile = profile.with(memberKind: priorMemberKind)
                     }
 
-                    try ContactsWriter.saveMemberProfileAndMirrorToContactInTransaction(db: db, profile: profile, receivedAt: receivedAt)
+                    try ContactsWriter.applyInboundMemberProfileInTransaction(db: db, profile: profile, incomingSentAt: receivedAt)
                     try Self.markConversationHasVerifiedAgentIfNeeded(profile: profile, conversationId: conversationId, db: db)
                 }
             }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -136,6 +136,11 @@ actor SyncingManager: SyncingManagerProtocol {
     /// start because it captures the live XMTP client.
     private var consentReconciler: ConversationConsentReconciler?
 
+    /// Re-drives global-profile fan-out so name/avatar edits reliably reach
+    /// every conversation (and retries silently-failed publishes). Reconstructed
+    /// per session start because it captures the live XMTP + API clients.
+    private var profileReconciler: ProfileSyncReconciler?
+
     /// Populates the agent-template read-through cache for template-backed
     /// agent contacts. Reconstructed per start because it captures the
     /// live API client.
@@ -214,6 +219,7 @@ actor SyncingManager: SyncingManagerProtocol {
     deinit {
         // Clean up tasks
         consentReconciler?.stop()
+        profileReconciler?.stop()
         agentTemplateCacheCoordinator?.stop()
         syncTask?.cancel()
         notificationTask?.cancel()
@@ -455,6 +461,7 @@ actor SyncingManager: SyncingManagerProtocol {
         }
 
         restartConsentReconciler(client: client)
+        restartProfileReconciler(client: client, apiClient: apiClient)
         restartAgentTemplateCacheCoordinator(apiClient: apiClient)
 
         // Wait for streams to enter their async iteration loops before proceeding.
@@ -656,19 +663,6 @@ actor SyncingManager: SyncingManagerProtocol {
     }
 
     /// Signals that the message stream has entered its async iteration loop.
-    private func signalMessageStreamReady() {
-        messageStreamReadyContinuation?.yield()
-        messageStreamReadyContinuation?.finish()
-        messageStreamReadyContinuation = nil
-    }
-
-    /// Signals that the conversation stream has entered its async iteration loop.
-    private func signalConversationStreamReady() {
-        conversationStreamReadyContinuation?.yield()
-        conversationStreamReadyContinuation?.finish()
-        conversationStreamReadyContinuation = nil
-    }
-
     private func handlePause() async throws {
         guard case .ready(let params) = _state else {
             Log.warning("Cannot pause - not in ready state")
@@ -720,6 +714,7 @@ actor SyncingManager: SyncingManagerProtocol {
         }
 
         restartConsentReconciler(client: params.client)
+        restartProfileReconciler(client: params.client, apiClient: params.apiClient)
         restartAgentTemplateCacheCoordinator(apiClient: params.apiClient)
 
         // Wait for streams to subscribe before transitioning to ready
@@ -973,6 +968,22 @@ actor SyncingManager: SyncingManagerProtocol {
     }
 }
 
+extension SyncingManager {
+    /// Signals that the message stream has entered its async iteration loop.
+    fileprivate func signalMessageStreamReady() {
+        messageStreamReadyContinuation?.yield()
+        messageStreamReadyContinuation?.finish()
+        messageStreamReadyContinuation = nil
+    }
+
+    /// Signals that the conversation stream has entered its async iteration loop.
+    fileprivate func signalConversationStreamReady() {
+        conversationStreamReadyContinuation?.yield()
+        conversationStreamReadyContinuation?.finish()
+        conversationStreamReadyContinuation = nil
+    }
+}
+
 // MARK: - Mutation
 
 extension SyncingManager {
@@ -1081,20 +1092,6 @@ extension SyncingManager {
         await runMessageBatch(client: client, since: since)
         return acceptedCount
     }
-
-    private enum Constant {
-        /// How often the temporary agent-join poll checks for unprocessed
-        /// join requests.
-        static let agentJoinPollInterval: TimeInterval = 5
-        /// How long the poll keeps checking after an agents/join call. The
-        /// agent backend gives up after about two minutes; poll a bit past
-        /// that so the tail end of the window is still observable.
-        static let agentJoinPollWindow: TimeInterval = 150
-        /// Back-overlap applied when advancing the poll cursor so messages
-        /// that land while a sync pass is in flight aren't skipped by the
-        /// next tick.
-        static let agentJoinPollCursorOverlap: TimeInterval = 5
-    }
 }
 
 extension SyncingManager {
@@ -1114,12 +1111,18 @@ extension SyncingManager {
         notificationObservers.append(activeConversationObserver)
         installPushTokenObserver()
     }
+}
 
-    /// Stop and clear the session-scoped observers (consent reconciler and
-    /// agent-template cache coordinator) on pause / teardown.
+// Session-scoped observer lifecycle (consent + profile reconcilers,
+// agent-template cache). Grouped in an extension to keep the main actor body
+// under the type-length limit.
+extension SyncingManager {
+    /// Stop and clear the session-scoped observers on pause / teardown.
     fileprivate func stopSessionScopedObservers() {
         consentReconciler?.stop()
         consentReconciler = nil
+        profileReconciler?.stop()
+        profileReconciler = nil
         agentTemplateCacheCoordinator?.stop()
         agentTemplateCacheCoordinator = nil
     }
@@ -1128,13 +1131,18 @@ extension SyncingManager {
     /// on every start / resume - the previous instance is stopped first.
     fileprivate func restartConsentReconciler(client: AnyClientProvider) {
         consentReconciler?.stop()
-        let reconciler = ConversationConsentReconciler(
-            databaseReader: databaseReader,
-            databaseWriter: databaseWriter,
-            client: client
-        )
+        let reconciler = ConversationConsentReconciler(databaseReader: databaseReader, databaseWriter: databaseWriter, client: client)
         reconciler.start()
         consentReconciler = reconciler
+    }
+
+    /// (Re)start the profile-sync reconciler with the live clients. Safe to call
+    /// on every start / resume - the previous instance is stopped first.
+    fileprivate func restartProfileReconciler(client: AnyClientProvider, apiClient: any ConvosAPIClientProtocol) {
+        profileReconciler?.stop()
+        let reconciler = ProfileSyncReconciler(databaseReader: databaseReader, databaseWriter: databaseWriter, client: client, apiClient: apiClient)
+        reconciler.start()
+        profileReconciler = reconciler
     }
 
     /// (Re)start the agent-template cache coordinator with the live API
@@ -1142,13 +1150,23 @@ extension SyncingManager {
     /// is stopped first.
     fileprivate func restartAgentTemplateCacheCoordinator(apiClient: any ConvosAPIClientProtocol) {
         agentTemplateCacheCoordinator?.stop()
-        let coordinator = AgentTemplateCacheCoordinator(
-            databaseReader: databaseReader,
-            apiClient: apiClient,
-            cacheWriter: AgentTemplateCacheWriter(databaseWriter: databaseWriter)
-        )
+        let coordinator = AgentTemplateCacheCoordinator(databaseReader: databaseReader, apiClient: apiClient, cacheWriter: AgentTemplateCacheWriter(databaseWriter: databaseWriter))
         coordinator.start()
         agentTemplateCacheCoordinator = coordinator
+    }
+
+    private enum Constant {
+        /// How often the temporary agent-join poll checks for unprocessed
+        /// join requests.
+        static let agentJoinPollInterval: TimeInterval = 5
+        /// How long the poll keeps checking after an agents/join call. The
+        /// agent backend gives up after about two minutes; poll a bit past
+        /// that so the tail end of the window is still observable.
+        static let agentJoinPollWindow: TimeInterval = 150
+        /// Back-overlap applied when advancing the poll cursor so messages
+        /// that land while a sync pass is in flight aren't skipped by the
+        /// next tick.
+        static let agentJoinPollCursorOverlap: TimeInterval = 5
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/DBMemberProfileWithHelpersTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DBMemberProfileWithHelpersTests.swift
@@ -15,6 +15,8 @@ struct DBMemberProfileWithHelpersTests {
         "verified": .bool(true)
     ]
 
+    private static let baseProfileUpdatedAt: Date = Date(timeIntervalSince1970: 2_000)
+
     private static func base() -> DBMemberProfile {
         DBMemberProfile(
             conversationId: "convo-1",
@@ -28,7 +30,8 @@ struct DBMemberProfileWithHelpersTests {
             imageSourceAssetIdentifier: "asset-old",
             imageSourceContentDigest: "digest-old",
             memberKind: nil,
-            metadata: baseMetadata
+            metadata: baseMetadata,
+            profileUpdatedAt: baseProfileUpdatedAt
         )
     }
 
@@ -113,6 +116,44 @@ struct DBMemberProfileWithHelpersTests {
     @Test("with(avatarLastRenewed:) preserves metadata")
     func withAvatarLastRenewedPreservesMetadata() {
         let updated = Self.base().with(avatarLastRenewed: Date(timeIntervalSince1970: 9_999))
+        #expect(updated.metadata == Self.baseMetadata)
+    }
+
+    /// Every field-preserving `with(...)` helper must copy `profileUpdatedAt`
+    /// forward. The recency guard in `ContactsWriter.applyInboundMemberProfileInTransaction`
+    /// relies on this: a helper that dropped the stamp would reset the row to
+    /// "overwritable", reopening the out-of-order clobber the guard prevents.
+    @Test("every with(...) helper preserves profileUpdatedAt")
+    func allWithHelpersPreserveProfileUpdatedAt() {
+        let stamp = Self.baseProfileUpdatedAt
+        #expect(Self.base().with(name: "Bob").profileUpdatedAt == stamp)
+        #expect(Self.base().with(name: nil).profileUpdatedAt == stamp)
+        #expect(Self.base().with(avatar: "https://example.com/x.enc").profileUpdatedAt == stamp)
+        #expect(Self.base().with(
+            avatar: "https://example.com/x.enc",
+            salt: Data(repeating: 0x10, count: 32),
+            nonce: Data(repeating: 0x11, count: 12),
+            key: Data(repeating: 0x12, count: 32)
+        ).profileUpdatedAt == stamp)
+        #expect(Self.base().with(avatarLastRenewed: Date(timeIntervalSince1970: 9_999)).profileUpdatedAt == stamp)
+        #expect(Self.base().with(imageSourceContentDigest: "digest-new").profileUpdatedAt == stamp)
+        #expect(Self.base().with(memberKind: .agent).profileUpdatedAt == stamp)
+        #expect(Self.base().with(metadata: nil).profileUpdatedAt == stamp)
+    }
+
+    @Test("with(profileUpdatedAt:) sets the stamp and preserves other fields")
+    func withProfileUpdatedAtSetsStamp() {
+        let newStamp = Date(timeIntervalSince1970: 5_000)
+        let updated = Self.base().with(profileUpdatedAt: newStamp)
+        #expect(updated.profileUpdatedAt == newStamp)
+        #expect(updated.name == "Alice")
+        #expect(updated.metadata == Self.baseMetadata)
+    }
+
+    @Test("with(profileUpdatedAt: nil) clears the stamp")
+    func withNilProfileUpdatedAtClearsStamp() {
+        let updated = Self.base().with(profileUpdatedAt: nil)
+        #expect(updated.profileUpdatedAt == nil)
         #expect(updated.metadata == Self.baseMetadata)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/MemberProfileAvatarKeyTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberProfileAvatarKeyTests.swift
@@ -1,0 +1,125 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Covers the fix for blank avatars caused by persisting an encrypted-avatar
+/// reference without its decryption key: the `applyingEncryptedAvatar` guard
+/// (never write a keyless avatar) and the `backfillKeylessMemberAvatars` repair
+/// (stamp the group key onto pre-existing keyless rows once it's known).
+@Suite("Member profile avatar key handling", .serialized)
+struct MemberProfileAvatarKeyTests {
+    private static func base() -> DBMemberProfile {
+        DBMemberProfile(conversationId: "c1", inboxId: "inbox-1", name: "Alice", avatar: nil)
+    }
+
+    // MARK: - applyingEncryptedAvatar guard
+
+    @Test("nil key leaves the existing avatar untouched (no keyless write)")
+    func nilKeySkips() {
+        let existing = Self.base().with(
+            avatar: "https://example.com/old.enc",
+            salt: Data(repeating: 0x01, count: 32),
+            nonce: Data(repeating: 0x02, count: 12),
+            key: Data(repeating: 0x03, count: 32)
+        )
+        let result = existing.applyingEncryptedAvatar(
+            url: "https://example.com/new.enc",
+            salt: Data(repeating: 0x10, count: 32),
+            nonce: Data(repeating: 0x11, count: 12),
+            resolvedKey: nil
+        )
+        // Unchanged: the prior (decryptable) avatar is preserved rather than
+        // replaced by a keyless one.
+        #expect(result.avatar == "https://example.com/old.enc")
+        #expect(result.avatarKey == Data(repeating: 0x03, count: 32))
+    }
+
+    @Test("resolved key applies the new encrypted avatar")
+    func presentKeyApplies() {
+        let result = Self.base().applyingEncryptedAvatar(
+            url: "https://example.com/new.enc",
+            salt: Data(repeating: 0x10, count: 32),
+            nonce: Data(repeating: 0x11, count: 12),
+            resolvedKey: Data(repeating: 0x12, count: 32)
+        )
+        #expect(result.avatar == "https://example.com/new.enc")
+        #expect(result.avatarKey == Data(repeating: 0x12, count: 32))
+        #expect(result.hasValidEncryptedAvatar)
+    }
+
+    // MARK: - backfillKeylessMemberAvatars repair
+
+    private static func seedConversation(db: Database, id: String) throws {
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: "inbox-self",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(timeIntervalSince1970: 1_000),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db, onConflict: .ignore)
+    }
+
+    private static func seedMember(db: Database, inboxId: String, _ profile: DBMemberProfile) throws {
+        try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        try profile.save(db)
+    }
+
+    @Test("backfill stamps the key onto keyless avatars, leaves others alone")
+    func backfillRepairsKeylessRows() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let groupKey = Data(repeating: 0xAB, count: 32)
+        let salt = Data(repeating: 0x01, count: 32)
+        let nonce = Data(repeating: 0x02, count: 12)
+
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "c1")
+            // Keyless avatar (the bug): url + salt + nonce, no key.
+            try Self.seedMember(db: db, inboxId: "keyless", DBMemberProfile(
+                conversationId: "c1", inboxId: "keyless", name: nil,
+                avatar: "https://example.com/a.enc", avatarSalt: salt, avatarNonce: nonce, avatarKey: nil
+            ))
+            // Already-keyed avatar: must not be touched.
+            try Self.seedMember(db: db, inboxId: "keyed", DBMemberProfile(
+                conversationId: "c1", inboxId: "keyed", name: nil,
+                avatar: "https://example.com/b.enc", avatarSalt: salt, avatarNonce: nonce,
+                avatarKey: Data(repeating: 0xCD, count: 32)
+            ))
+            // No avatar at all: must not gain a phantom key.
+            try Self.seedMember(db: db, inboxId: "noavatar", DBMemberProfile(
+                conversationId: "c1", inboxId: "noavatar", name: "Bob", avatar: nil
+            ))
+
+            try ConversationWriter.backfillKeylessMemberAvatars(conversationId: "c1", key: groupKey, in: db)
+        }
+
+        try dbManager.dbReader.read { db in
+            let keyless = try DBMemberProfile.fetchOne(db, conversationId: "c1", inboxId: "keyless")
+            #expect(keyless?.avatarKey == groupKey)
+            #expect(keyless?.hasValidEncryptedAvatar == true)
+
+            let keyed = try DBMemberProfile.fetchOne(db, conversationId: "c1", inboxId: "keyed")
+            #expect(keyed?.avatarKey == Data(repeating: 0xCD, count: 32))
+
+            let noavatar = try DBMemberProfile.fetchOne(db, conversationId: "c1", inboxId: "noavatar")
+            #expect(noavatar?.avatarKey == nil)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MemberProfileRecencyTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberProfileRecencyTests.swift
@@ -1,0 +1,180 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Covers the most-recent-wins recency guard on `DBMemberProfile`
+/// (`ContactsWriter.applyInboundMemberProfileInTransaction`). The bug this
+/// guards against: an out-of-order or replayed older profile message
+/// overwriting newer per-conversation profile data, and the member row
+/// diverging from the mirrored contact row (which already had a recency guard).
+@Suite("Member profile recency guard", .serialized)
+struct MemberProfileRecencyTests {
+    private static let convoId: String = "convo-1"
+    private static let selfInboxId: String = "inbox-self"
+    private static let otherInboxId: String = "inbox-other"
+
+    private static let t0: Date = Date(timeIntervalSince1970: 1_000)
+    private static let t1: Date = Date(timeIntervalSince1970: 2_000)
+    private static let t2: Date = Date(timeIntervalSince1970: 3_000)
+    private static let t3: Date = Date(timeIntervalSince1970: 4_000)
+
+    /// Seeds the FK prerequisites (member + conversation) and an existing
+    /// contact row stamped at `t0` so the mirror has a target to update.
+    private static func seed(db: Database, withContact: Bool = true) throws {
+        try DBMember(inboxId: otherInboxId).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: convoId,
+            clientConversationId: "client-\(convoId)",
+            inviteTag: "tag-\(convoId)",
+            creatorId: selfInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: t0,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db, onConflict: .ignore)
+
+        if withContact {
+            try ContactsWriter.upsertContactInTransaction(
+                db: db,
+                inboxId: otherInboxId,
+                addedViaConversationId: convoId,
+                profile: ContactProfileSnapshot(displayName: "seed", profileUpdatedAt: t0)
+            )
+        }
+    }
+
+    private static func inbound(name: String) -> DBMemberProfile {
+        DBMemberProfile(conversationId: Self.convoId, inboxId: Self.otherInboxId, name: name, avatar: nil)
+    }
+
+    private static func memberName(_ db: Database) throws -> String? {
+        try DBMemberProfile.fetchOne(db, conversationId: convoId, inboxId: otherInboxId)?.name
+    }
+
+    private static func contactName(_ db: Database) throws -> String? {
+        try DBContact.fetchOne(db, key: otherInboxId)?.displayName
+    }
+
+    @Test("older inbound is dropped; member stays newer and matches contact")
+    func olderInboundDropped() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+
+            let appliedNewer = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-2"), incomingSentAt: Self.t2
+            )
+            #expect(appliedNewer)
+            #expect(try Self.memberName(db) == "Bravo-2")
+            #expect(try Self.contactName(db) == "Bravo-2")
+
+            // Replay an older update after the newer one.
+            let appliedOlder = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-1"), incomingSentAt: Self.t1
+            )
+            #expect(appliedOlder == false)
+            // Member must not revert, and must still agree with the contact row.
+            #expect(try Self.memberName(db) == "Bravo-2")
+            #expect(try Self.contactName(db) == "Bravo-2")
+        }
+    }
+
+    @Test("newer inbound updates an already-populated row")
+    func newerInboundUpdates() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+
+            _ = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-2"), incomingSentAt: Self.t2
+            )
+            let applied = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-3"), incomingSentAt: Self.t3
+            )
+            #expect(applied)
+            #expect(try Self.memberName(db) == "Bravo-3")
+            #expect(try Self.contactName(db) == "Bravo-3")
+        }
+    }
+
+    @Test("nil stored stamp accepts any timestamped inbound")
+    func nilStoredStampAccepts() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+            // Placeholder row with no recency stamp (mirrors saveMembers / appData fill).
+            try DBMemberProfile(conversationId: Self.convoId, inboxId: Self.otherInboxId, name: nil, avatar: nil)
+                .insert(db, onConflict: .ignore)
+
+            let applied = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-1"), incomingSentAt: Self.t1
+            )
+            #expect(applied)
+            #expect(try Self.memberName(db) == "Bravo-1")
+        }
+    }
+
+    @Test("equal timestamp applies (idempotent reprocess)")
+    func equalTimestampApplies() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+            _ = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-2"), incomingSentAt: Self.t2
+            )
+            let applied = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-2b"), incomingSentAt: Self.t2
+            )
+            #expect(applied)
+            #expect(try Self.memberName(db) == "Bravo-2b")
+        }
+    }
+
+    @Test("a local edit stamped now is not clobbered by a stale echo")
+    func localEditBeatsStaleEcho() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+            // Simulate a local write: row stamped at t3 (the user's own edit).
+            try DBMemberProfile(conversationId: Self.convoId, inboxId: Self.otherInboxId, name: "Local", avatar: nil)
+                .with(profileUpdatedAt: Self.t3)
+                .save(db)
+
+            // An older inbound echo (sent before the local edit) must be dropped.
+            let applied = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Echo"), incomingSentAt: Self.t2
+            )
+            #expect(applied == false)
+            #expect(try Self.memberName(db) == "Local")
+        }
+    }
+
+    @Test("mirror no-ops when there is no contact row (no auto-add)")
+    func noContactRowIsNoOp() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db, withContact: false)
+            let applied = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Bravo-2"), incomingSentAt: Self.t2
+            )
+            #expect(applied)
+            #expect(try Self.memberName(db) == "Bravo-2")
+            #expect(try DBContact.fetchOne(db, key: Self.otherInboxId) == nil)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MemberProfileRecencyTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberProfileRecencyTests.swift
@@ -164,6 +164,46 @@ struct MemberProfileRecencyTests {
         }
     }
 
+    @Test("snapshot backfill populates a row with no recency stamp")
+    func snapshotBackfillPopulatesUnstamped() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+            // Placeholder row with no recency stamp (never received a ProfileUpdate).
+            try DBMemberProfile(conversationId: Self.convoId, inboxId: Self.otherInboxId, name: nil, avatar: nil)
+                .insert(db, onConflict: .ignore)
+
+            let applied = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Snap"), incomingSentAt: Self.t2, source: .snapshotBackfill
+            )
+            #expect(applied)
+            #expect(try Self.memberName(db) == "Snap")
+        }
+    }
+
+    @Test("snapshot backfill does not clobber a row an update already stamped, even when newer")
+    func snapshotBackfillDoesNotClobberStamped() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seed(db: db)
+
+            // An authoritative ProfileUpdate lands first and stamps the row at t1.
+            let update = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "Update"), incomingSentAt: Self.t1
+            )
+            #expect(update)
+
+            // A snapshot carries a later author-clock t2, but its per-member data
+            // is not a valid recency signal; it must not overwrite the update.
+            let snapshot = try ContactsWriter.applyInboundMemberProfileInTransaction(
+                db: db, profile: Self.inbound(name: "StaleSnap"), incomingSentAt: Self.t2, source: .snapshotBackfill
+            )
+            #expect(snapshot == false)
+            #expect(try Self.memberName(db) == "Update")
+            #expect(try Self.contactName(db) == "Update")
+        }
+    }
+
     @Test("mirror no-ops when there is no contact row (no auto-add)")
     func noContactRowIsNoOp() throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileSyncReconcilerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileSyncReconcilerTests.swift
@@ -1,0 +1,167 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Covers `ProfileSyncReconciler.fetchMismatchedConversationIds` - the
+/// observation query that decides which conversations still need their global
+/// profile re-published. The reconciler re-drives exactly these, so the gate
+/// must converge (return empty once the published markers match the global
+/// profile) and must ignore drafts and other members.
+@Suite("ProfileSyncReconciler mismatch query", .serialized)
+struct ProfileSyncReconcilerTests {
+    private static let selfInboxId: String = "inbox-self"
+    private static let otherInboxId: String = "inbox-other"
+
+    private static func mismatched(_ reader: any DatabaseReader) throws -> [String] {
+        try reader.read { db in
+            try ProfileSyncReconciler.fetchMismatchedConversationIds(db: db, inboxId: selfInboxId)
+        }
+    }
+
+    private static func seedConversation(db: Database, id: String) throws {
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: selfInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(timeIntervalSince1970: 1_000),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db, onConflict: .ignore)
+    }
+
+    private static func seedGlobal(db: Database, name: String?, imageData: Data?, imageDigest: String?) throws {
+        try DBMyProfile(
+            inboxId: selfInboxId,
+            name: name,
+            imageData: imageData,
+            imageAssetIdentifier: nil,
+            imageContentDigest: imageDigest,
+            metadata: nil,
+            updatedAt: Date(timeIntervalSince1970: 2_000)
+        ).save(db)
+    }
+
+    private static func seedSelfMember(
+        db: Database,
+        conversationId: String,
+        publishedNameDigest: String?,
+        publishedAvatarDigest: String?
+    ) throws {
+        try DBMember(inboxId: selfInboxId).save(db, onConflict: .ignore)
+        try DBMemberProfile(
+            conversationId: conversationId,
+            inboxId: selfInboxId,
+            name: nil,
+            avatar: nil,
+            publishedNameDigest: publishedNameDigest,
+            publishedAvatarDigest: publishedAvatarDigest
+        ).save(db)
+    }
+
+    @Test("name not yet published is a mismatch; matching digest converges")
+    func nameGate() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let nameDigest = MyProfileWriter.nameDigest("Alice")
+
+        try dbManager.dbWriter.write { db in
+            try Self.seedGlobal(db: db, name: "Alice", imageData: nil, imageDigest: nil)
+            try Self.seedConversation(db: db, id: "c1")
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nil, publishedAvatarDigest: nil)
+        }
+        let beforeIds = try Self.mismatched(dbManager.dbReader)
+        #expect(beforeIds == ["c1"])
+
+        // Mark it published with the matching digest -> converges to empty.
+        try dbManager.dbWriter.write { db in
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nameDigest, publishedAvatarDigest: nil)
+        }
+        let afterIds = try Self.mismatched(dbManager.dbReader)
+        #expect(afterIds.isEmpty)
+    }
+
+    @Test("avatar present but unpublished is a mismatch")
+    func avatarGate() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let nameDigest = MyProfileWriter.nameDigest("Alice")
+        try dbManager.dbWriter.write { db in
+            try Self.seedGlobal(db: db, name: "Alice", imageData: Data([0x1, 0x2]), imageDigest: "X")
+            try Self.seedConversation(db: db, id: "c1")
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nameDigest, publishedAvatarDigest: nil)
+        }
+        #expect(try Self.mismatched(dbManager.dbReader) == ["c1"])
+
+        try dbManager.dbWriter.write { db in
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nameDigest, publishedAvatarDigest: "X")
+        }
+        #expect(try Self.mismatched(dbManager.dbReader).isEmpty)
+    }
+
+    @Test("not-rehydrated avatar (digest set, bytes absent) is not a mismatch")
+    func notRehydratedAvatarIsNoMismatch() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let nameDigest = MyProfileWriter.nameDigest("Alice")
+        try dbManager.dbWriter.write { db in
+            // Paired-device shape: digest present but no image bytes.
+            try Self.seedGlobal(db: db, name: "Alice", imageData: nil, imageDigest: "X")
+            try Self.seedConversation(db: db, id: "c1")
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nameDigest, publishedAvatarDigest: nil)
+        }
+        #expect(try Self.mismatched(dbManager.dbReader).isEmpty)
+    }
+
+    @Test("cleared global avatar requires un-publishing a previously published avatar")
+    func clearedAvatarGate() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let nameDigest = MyProfileWriter.nameDigest("Alice")
+        try dbManager.dbWriter.write { db in
+            try Self.seedGlobal(db: db, name: "Alice", imageData: nil, imageDigest: nil)
+            try Self.seedConversation(db: db, id: "c1")
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nameDigest, publishedAvatarDigest: "X")
+        }
+        #expect(try Self.mismatched(dbManager.dbReader) == ["c1"])
+    }
+
+    @Test("drafts and other members are ignored")
+    func ignoresDraftsAndOtherMembers() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let draftId = DBConversation.generateDraftConversationId()
+        try dbManager.dbWriter.write { db in
+            try Self.seedGlobal(db: db, name: "Alice", imageData: nil, imageDigest: nil)
+            // Draft conversation with an unpublished self member -> ignored.
+            try Self.seedConversation(db: db, id: draftId)
+            try Self.seedSelfMember(db: db, conversationId: draftId, publishedNameDigest: nil, publishedAvatarDigest: nil)
+            // Another member's row in a real conversation -> ignored (not self).
+            try Self.seedConversation(db: db, id: "c1")
+            try DBMember(inboxId: Self.otherInboxId).save(db, onConflict: .ignore)
+            try DBMemberProfile(conversationId: "c1", inboxId: Self.otherInboxId, name: nil, avatar: nil).save(db)
+        }
+        #expect(try Self.mismatched(dbManager.dbReader).isEmpty)
+    }
+
+    @Test("no global profile yields no targets")
+    func noGlobalProfile() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "c1")
+            try Self.seedSelfMember(db: db, conversationId: "c1", publishedNameDigest: nil, publishedAvatarDigest: nil)
+        }
+        #expect(try Self.mismatched(dbManager.dbReader).isEmpty)
+    }
+}

--- a/ConvosTests/ProfileSettingsViewModelTests.swift
+++ b/ConvosTests/ProfileSettingsViewModelTests.swift
@@ -1,5 +1,6 @@
 @testable import Convos
 import ConvosCore
+import UIKit
 import XCTest
 
 /// Regression coverage for the race condition where setting a profile in
@@ -64,5 +65,49 @@ final class ProfileSettingsViewModelTests: XCTestCase {
             UserDefaults.standard.bool(forKey: "hasShownProfileEditor"),
             "Whitespace-only names should be treated as empty"
         )
+    }
+
+    /// Regression: editing only the name must not wipe the stored avatar or
+    /// global metadata. The old full-row `save(... metadata: nil)` replaced
+    /// every field, so a name edit dropped the avatar (when unhydrated) and
+    /// always nulled metadata. The field-preserving `update(...)` path keeps them.
+    func testSaveAndAwaitPreservesAvatarAndMetadataOnNameOnlyEdit() async throws {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2))
+        let image = renderer.image { ctx in
+            UIColor.red.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+        }
+        let imageData = try XCTUnwrap(image.jpegData(compressionQuality: 1.0))
+        let metadata: ProfileMetadata = ["emoji": .string("🎯")]
+        let initial = MyProfile(
+            inboxId: "inbox-1",
+            name: "Old Name",
+            imageData: imageData,
+            imageAssetIdentifier: nil,
+            imageContentDigest: nil,
+            metadata: metadata,
+            updatedAt: Date()
+        )
+        let writer = MockMyGlobalProfileWriter(stored: initial)
+        let repository = MockMyGlobalProfileRepository(initial: initial)
+        let session = MockInboxesService(
+            mockMessagingService: MockMessagingService(
+                myGlobalProfileWriter: writer,
+                myGlobalProfileRepository: repository
+            )
+        )
+
+        let viewModel = ProfileSettingsViewModel.shared
+        viewModel.rebind(session: session)
+        // bindInternal's synchronous fast path applies the loaded profile.
+        XCTAssertEqual(viewModel.editingDisplayName, "Old Name")
+        XCTAssertNotNil(viewModel.profileImage)
+
+        viewModel.editingDisplayName = "New Name"
+        try await viewModel.saveAndAwait()
+
+        XCTAssertEqual(writer.stored?.name, "New Name")
+        XCTAssertNotNil(writer.stored?.imageData, "avatar must survive a name-only edit")
+        XCTAssertEqual(writer.stored?.metadata, metadata, "metadata must survive a name-only edit")
     }
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784416120&installation_id=128169237&pr_number=1088&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1088&signature=6e5d7a0a9f9b9622eac6e150be918af956b994da4e56f9a93ffca91aca5a79b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix member profile sync to enforce most-recent-wins ordering and retry failed publishes
> - Adds `profileUpdatedAt`, `publishedNameDigest`, and `publishedAvatarDigest` columns to the `memberProfile` table via two new migrations in [`SharedDatabaseMigrator.swift`](https://github.com/xmtplabs/convos-ios/pull/1088/files#diff-1d28d03ee0fb38381b6052060082c7561fa8ccc71fda470214d763f53a4414df).
> - Replaces `saveMemberProfileAndMirrorToContactInTransaction` with `applyInboundMemberProfileInTransaction` across all inbound profile processing paths; the new method drops stale writes where `incomingSentAt` is older than the stored `profileUpdatedAt`.
> - Adds `ProfileSyncReconciler`, a background observer that compares published name/avatar digest markers on `DBMemberProfile` against the global profile and re-drives sync for mismatched conversations (up to 6 concurrent), started on session start/resume via `SyncingManager`.
> - Fixes `MyProfileWriter.syncFromGlobalProfile` to gate republishing on confirmed-published digest markers rather than raw local fields, so failed publishes are retried and successful ones are not redundantly resent.
> - Fixes `ProfileSettingsViewModel.saveAndAwait` so a name-only edit no longer clears the stored avatar or metadata.
> - Removes the early-continue guard that skipped profile snapshot processing when an existing profile already had a name or avatar, in both `StreamProcessor` and the NSE push handler.
> - Risk: all existing `memberProfile` rows will have `profileUpdatedAt = NULL` after migration, so any inbound profile message will apply until a timestamp is established.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3642099. 12 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->