### PR TITLE
Default templates to unlisted on create

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/AgentTemplateGenerationModels.swift
+++ b/ConvosCore/Sources/ConvosCore/API/AgentTemplateGenerationModels.swift
@@ -44,12 +44,19 @@ public extension ConvosAPI {
         /// byte-identical and dedupe against a stored `[]`.
         public let connections: [String]?
         public let clientDeviceId: String?
+        /// Publish visibility for the generated template, a top-level envelope
+        /// field alongside `source`. The app submits `"unlisted"` (templates
+        /// built in-app are private to the build flow, not surfaced in any public
+        /// directory), matching the website create flow. Always encoded; when the
+        /// field is absent the backend defaults to a listed/public template.
+        public let publishStatus: String
 
-        public init(source: String, inputs: Inputs, connections: [String]? = nil, clientDeviceId: String?) {
+        public init(source: String, inputs: Inputs, connections: [String]? = nil, clientDeviceId: String?, publishStatus: String) {
             self.source = source
             self.inputs = inputs
             self.connections = connections
             self.clientDeviceId = clientDeviceId
+            self.publishStatus = publishStatus
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -953,7 +953,8 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
                 source: source,
                 inputs: .init(text: text, attachments: attachments.isEmpty ? nil : attachments),
                 connections: connections.isEmpty ? nil : connections,
-                clientDeviceId: clientDeviceId
+                clientDeviceId: clientDeviceId,
+                publishStatus: "unlisted"
             )
         )
         request.httpBody = body


### PR DESCRIPTION
Fix the missing share button on the agent profile screen. Agents didn't have their URL set, clients now directly drive the create endpoint, they needed to properly set the publish status. Publish status was defaulting to draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784548799&installation_id=128169237&pr_number=1091&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1091&signature=6194657297841674f1cc009649279cdbfcff7d37f86899295549cd4f91ec2eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default agent template publish status to 'unlisted' on create
> Adds `publishStatus` to `AgentTemplateGenerationRequest` and hardcodes the value to `"unlisted"` when calling `createAgentTemplateGeneration`, so newly created templates are unlisted by default rather than publicly visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 989d2aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->