### PR TITLE
fix(credits): show "agent lost power" only for agents you own (stop mislabeling others' agents)

### DIFF
--- a/Convos/Conversation Detail/ConversationMemberView.swift
+++ b/Convos/Conversation Detail/ConversationMemberView.swift
@@ -67,7 +67,13 @@ struct ConversationMemberView: View {
     }
 
     private var shouldShowOutOfCredits: Bool {
+        // `creditsBalance.isDepleted` is the LOCAL viewer's wallet, so this
+        // "No power" row is only correct for agents the viewer OWNS. On a
+        // non-owned agent's card it would wrongly attribute depletion to that
+        // agent. Gate on ownership (same fix as the in-stream cell); non-owners
+        // see nothing until a backend per-agent power signal exists.
         guard member.isAgent,
+              viewModel.conversation.creator.isCurrentUser,
               !ConfigManager.shared.currentEnvironment.isProduction,
               let creditsBalance else { return false }
         return creditsBalance.isDepleted

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -899,9 +899,15 @@ extension MessagesViewController {
             }
         }
 
-        if creditsDepleted, let agentMember = conversation.members.first(where: { $0.isAgent }) {
+        // Only surface the per-agent "lost power" cell for agents the viewer
+        // OWNS. `creditsDepleted` reflects the LOCAL viewer's wallet, which is
+        // only the right signal for the viewer's own agents - for someone
+        // else's funded agent it would mislabel a working agent as depleted.
+        // Gating on `isCurrentUserCreator` keeps the wallet check correct;
+        // non-owners see nothing until a backend per-agent power signal exists.
+        let isCurrentUserCreator: Bool = conversation.creator.isCurrentUser
+        if creditsDepleted, isCurrentUserCreator, let agentMember = conversation.members.first(where: { $0.isAgent }) {
             let agentInboxId = agentMember.profile.inboxId
-            let isCurrentUserCreator: Bool = conversation.creator.isCurrentUser
             if let lastAgentIndex = cells.lastIndex(where: {
                 if case .messages(let group) = $0 { return group.sender.profile.inboxId == agentInboxId }
                 return false


### PR DESCRIPTION
## Problem

The per-agent "[agent] lost power" surface (`AgentLostPowerStatus`, the in-stream `.agentOutOfCredits` cell at `MessagesViewController.swift`, and the member-card "No power" row in `ConversationMemberView`) was gated only on `creditsDepleted` — the **local viewer's** wallet (`CreditsServices.shared.currentBalance?.isDepleted`). Because `ConversationMember` carries no power/owner field and ownership was never checked, a viewer who is out of credits saw **every** agent — including other people's funded, fully-working agents — labeled "lost power."

## Fix (minimal, ownership gate)

Gate the per-agent "lost power" surfaces on `conversation.creator.isCurrentUser`, in addition to `creditsDepleted`, so they only show for agents the viewer **owns** — where the viewer's wallet *is* the owner's wallet, making the depletion signal actually correct. For agents the viewer does not own, show nothing (missing info beats wrong info). Copy text is intentionally unchanged.

**Surfaces gated:**
- `MessagesViewController.swift` — in-stream `.agentOutOfCredits` cell.
- `ConversationMemberView.swift` `shouldShowOutOfCredits` — the member-card "No power" row (attributed to a specific agent's card).

**Surface left unchanged:**
- `ConversationsView.swift` `toolbarStatusLabel` — the home pill is a genuine **viewer-self** account-status indicator ("No power"/"Plus"/"Basic"), not attributed to any agent, so it correctly reflects the viewer's own wallet.

## Build

`xcodebuild build -scheme "Convos (Local)" -configuration Local -destination 'platform=iOS Simulator,name=iPhone 17 Pro,arch=arm64' ONLY_ACTIVE_ARCH=YES` → **BUILD SUCCEEDED**. SwiftFormat + SwiftLint pre-commit checks pass.

## Follow-up (tracked separately)

The full fix is a backend **per-agent owner-power signal** so non-owners can also see genuinely-depleted agents (rather than nothing). This PR is the minimal correctness fix; the owner-attributed copy rewording and the backend signal are separate work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784737023&installation_id=128169237&pr_number=1093&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1093&signature=20672077784b18affc018927bc8d1e1d0b21f5e1953ad5743ccae9655330dbc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'agent lost power' indicator only for agents owned by the current user
> Previously, the out-of-credits UI (member view indicator and `.agentOutOfCredits` cell in the message list) appeared for any depleted local wallet, even when viewing another user's agent. Both [ConversationMemberView.swift](https://github.com/xmtplabs/convos-ios/pull/1093/files#diff-cd088208597070f0ae7f929237bcabae85387377227f434c9d15f6ec0e5415af) and [MessagesViewController.swift](https://github.com/xmtplabs/convos-ios/pull/1093/files#diff-1427b816e5e93d8bc7ea882f5eabd9671135c6f9b9ebc6b0a6f7116a2f8a37c3) now gate this UI behind an ownership check, only showing it when the current user is the conversation creator.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88120c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->