### PR TITLE
chore(ui): remove "Soon" coming-soon placeholder entries

### DIFF
--- a/Convos/App Settings/CustomizeSettingsView.swift
+++ b/Convos/App Settings/CustomizeSettingsView.swift
@@ -52,16 +52,6 @@ struct CustomizeSettingsView: View {
                     toggleAccessibilityIdentifier: "read-receipts-toggle"
                 )
             }
-
-            Section {
-                HStack {
-                    Text("Colors")
-                        .foregroundStyle(.colorTextTertiary)
-                    Spacer()
-                    SoonLabel()
-                }
-            }
-            .disabled(true)
         }
         .scrollContentBackground(.hidden)
         .background(.colorBackgroundRaisedSecondary)

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -64,8 +64,8 @@ struct FeatureRowItem<AccessoryView: View>: View {
 }
 
 #Preview {
-    FeatureRowItem(imageName: nil, symbolName: "eyeglasses", title: "Peek-a-boo", subtitle: "Blur when people peek") {
-        SoonLabel()
+    FeatureRowItem(imageName: nil, symbolName: "folder", title: "Files & Links", subtitle: "Managed by Agents") {
+        EmptyView()
     }
     .padding(DesignConstants.Spacing.step4x)
 }
@@ -364,52 +364,8 @@ struct ConversationInfoView: View {
             .accessibilityValue(viewModel.sendReadReceipts ? "on" : "off")
             .accessibilityAddTraits(.isButton)
             .accessibilityIdentifier("convo-read-receipts-toggle")
-
-            FeatureRowItem(
-                imageName: nil,
-                symbolName: "eyeglasses",
-                title: "Peek-a-boo",
-                subtitle: "Blur when people peek"
-            ) {
-                SoonLabel()
-            }
-
-            FeatureRowItem(
-                imageName: nil,
-                symbolName: "tray.fill",
-                title: "Allow DMs",
-                subtitle: "From group members"
-            ) {
-                SoonLabel()
-            }
-
-            FeatureRowItem(
-                imageName: nil,
-                symbolName: "faceid",
-                title: "Require FaceID",
-                subtitle: "Or passcode"
-            ) {
-                SoonLabel()
-            }
         } header: {
             Text("Personal preferences")
-                .font(.footnote.weight(.medium))
-                .foregroundStyle(.colorTextSecondary)
-        }
-    }
-
-    private var convoRulesSection: some View {
-        Section {
-            FeatureRowItem(
-                imageName: nil,
-                symbolName: "timer",
-                title: "Disappear",
-                subtitle: "Messages"
-            ) {
-                SoonLabel()
-            }
-        } header: {
-            Text("Convo rules")
                 .font(.footnote.weight(.medium))
                 .foregroundStyle(.colorTextSecondary)
         }
@@ -431,40 +387,6 @@ struct ConversationInfoView: View {
             .onChange(of: presentingEditView) { oldValue, newValue in
                 handleEditViewChanged(from: oldValue, to: newValue)
             }
-    }
-
-    private var vanishSection: some View {
-        Section {
-            HStack {
-                Text("Vanish")
-                    .foregroundStyle(.colorTextPrimary)
-                Spacer()
-                SoonLabel()
-            }
-        } footer: {
-            Text("Choose when this convo disappears from your device")
-                .foregroundStyle(.colorTextSecondary)
-        }
-        .disabled(true)
-    }
-
-    private var permissionsSection: some View {
-        Section {
-            NavigationLink {
-                EmptyView()
-            } label: {
-                HStack {
-                    Text("Permissions")
-                        .foregroundStyle(.colorTextPrimary)
-                    Spacer()
-                    SoonLabel()
-                }
-            }
-            .disabled(true)
-        } footer: {
-            Text("Choose who can manage the group")
-                .foregroundStyle(.colorTextSecondary)
-        }
     }
 
     private var infoList: some View {
@@ -493,12 +415,6 @@ struct ConversationInfoView: View {
                let connectionsViewModel {
                 ConversationConnectionsSection(viewModel: connectionsViewModel)
             }
-
-            convoRulesSection
-
-            vanishSection
-
-            permissionsSection
 
             debugInfoSection
         }

--- a/Convos/Explode/ExplodeInfoView.swift
+++ b/Convos/Explode/ExplodeInfoView.swift
@@ -1,22 +1,6 @@
 import ConvosMetrics
 import SwiftUI
 
-struct SoonLabel: View {
-    var body: some View {
-        Text("Soon")
-            .font(.subheadline)
-            .foregroundStyle(.colorTextTertiary)
-            .padding(.vertical, 6.0)
-            .padding(.horizontal, DesignConstants.Spacing.step3x)
-            .frame(minHeight: DesignConstants.Spacing.step8x)
-            .background(
-                Capsule()
-                    .fill(.colorFillMinimal)
-            )
-            .accessibilityLabel("Coming soon")
-    }
-}
-
 struct ExplodeInfoView: View {
     @Environment(\.dismiss) var dismiss: DismissAction
     @State private var navState: ExplodeInfoNavigatorImpl = .init()

--- a/Convos/Profile/MyInfoView.swift
+++ b/Convos/Profile/MyInfoView.swift
@@ -109,8 +109,6 @@ struct MyInfoView: View {
             headerSection
             profileSection
             editProfileSection
-            socialNamesSection
-            humanAgeSection
         }
     }
 
@@ -204,42 +202,6 @@ struct MyInfoView: View {
         .background(Capsule().fill(.colorFillPrimary))
         .accessibilityLabel(didUseProfile ? "Profile applied" : "Use profile")
         .accessibilityIdentifier("use-profile-button")
-    }
-
-    @ViewBuilder
-    private var socialNamesSection: some View {
-        Section {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                Text("Social names · Phone number")
-                    .font(.body)
-                    .foregroundStyle(.colorTextTertiary)
-                Spacer()
-                SoonLabel()
-            }
-            .padding(.vertical, 10.0)
-            .listRowInsets(.init(top: 0, leading: DesignConstants.Spacing.step4x, bottom: 0, trailing: 10.0))
-        } footer: {
-            Text("Verified info")
-                .foregroundStyle(.colorTextSecondary)
-        }
-    }
-
-    @ViewBuilder
-    private var humanAgeSection: some View {
-        Section {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                Text("Human · Age")
-                    .font(.body)
-                    .foregroundStyle(.colorTextTertiary)
-                Spacer()
-                SoonLabel()
-            }
-            .padding(.vertical, 10.0)
-            .listRowInsets(.init(top: 0, leading: DesignConstants.Spacing.step4x, bottom: 0, trailing: 10.0))
-        } footer: {
-            Text("Proofs")
-                .foregroundStyle(.colorTextSecondary)
-        }
     }
 }
 


### PR DESCRIPTION
Removes static "Soon"-labeled coming-soon placeholder UI across three screens, plus the now-unused shared `SoonLabel` badge. Every entry removed was a pure static placeholder — no view-model binding, no enum case, no backend/data dependency, no analytics event, and no test references.

## What was removed

### Conversation Info — `Convos/Conversation Detail/ConversationInfoView.swift`
- **Rows** (from the Personal preferences section, which also has real rows that are kept): "Peek-a-boo / Blur when people peek", "Allow DMs / From group members", "Require FaceID / Or passcode".
- **Whole sections** (computed property + its `infoList` reference): "Convo rules" (Disappear) section, "Vanish" section, "Permissions" section.
- Swapped the `SoonLabel` accessory in the `FeatureRowItem` `#Preview` for a benign `EmptyView()`.

### My Info — `Convos/Profile/MyInfoView.swift`
- **Whole sections** (computed property + its `body` reference): `socialNamesSection` ("Verified info" / Social names · Phone number), `humanAgeSection` ("Proofs" / Human · Age).

### Customize Settings — `Convos/App Settings/CustomizeSettingsView.swift`
- **Inline section**: the "Colors" placeholder `Section` (`.disabled(true)`).

### Shared badge — `Convos/Explode/ExplodeInfoView.swift`
- Deleted the `SoonLabel` struct itself. Zero remaining references in source. `struct ExplodeInfoView` and its preview are unchanged.

## Notes
- All removed entries were static placeholders with no logic (no bindings, no backend, no analytics, no tests).
- Unrelated `clientNotAvailable` enum cases and the "soon" relative-time string in `MessagingService+PushNotifications.swift` were left untouched.

## Verification
- `xcodebuild build -scheme "Convos (Local)" -configuration Local` → **BUILD SUCCEEDED**.
- Pre-commit hooks (SwiftFormat + SwiftLint) pass; no source references to `SoonLabel` remain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784741005&installation_id=128169237&pr_number=1095&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1095&signature=b6f4e91954608ca112edb7c0f3f80edd85fb05507d80bf47ae76418336970a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove coming-soon placeholder sections from settings and profile screens
> Removes all `SoonLabel` placeholder UI entries across the app, including disabled sections in the Customize settings, Conversation Info, and Profile screens. Affected areas include Colors (Customize), Peek-a-boo/Allow DMs/Require FaceID/Convo rules/Vanish/Permissions (Conversation Info), and Social names/Human age (Profile). Also deletes the `SoonLabel` view definition from [ExplodeInfoView.swift](https://github.com/xmtplabs/convos-ios/pull/1095/files#diff-e892d06a06226a32dd4118cb7c7dfc6232c1df2d69f444281feb8c759f4c16ca).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ed0394.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
