### PR TITLE
feat(things): show every agent HTML thing, titled by HTML <title>

### DIFF
--- a/Convos/Conversations List/ThingPreviewCell.swift
+++ b/Convos/Conversations List/ThingPreviewCell.swift
@@ -81,6 +81,11 @@ struct ThingPreviewCell: View {
             withAnimation(.smooth(duration: 0.2)) {
                 renderedImage = cached
             }
+        } else {
+            // No cache hit for the current appearance: drop any image
+            // rendered for the previous appearance so the guard below
+            // doesn't short-circuit and leave a stale thumbnail.
+            renderedImage = nil
         }
         guard renderedImage == nil || resolvedTitle == nil else { return }
         do {
@@ -108,6 +113,5 @@ struct ThingPreviewCell: View {
 
     private enum Constant {
         static let cornerRadius: CGFloat = 28.0
-        static let unreadDotSize: CGFloat = 8.0
     }
 }

--- a/Convos/Conversations List/ThingPreviewCell.swift
+++ b/Convos/Conversations List/ThingPreviewCell.swift
@@ -1,18 +1,30 @@
 import ConvosCore
 import SwiftUI
 
-/// One square cell in the Things tab's 2-column grid. Renders the most
-/// recent HTML attachment from the conversation as a square preview
-/// (28pt corner radius, `.colorFillTertiary` placeholder while loading)
-/// with the conversation's display name + unread dot under it.
+/// One square cell in the Things tab's 2-column grid. Renders a single
+/// HTML attachment from the conversation as a square preview (28pt corner
+/// radius, `.colorFillTertiary` placeholder while loading) with the
+/// thing's title under it. The label prefers the HTML document's
+/// `<title>` (resolved via `HTMLPageMetadata`, matching the in-conversation
+/// files list), falling back to the filename, then the conversation name.
 struct ThingPreviewCell: View {
     let item: ThingOverviewItem
 
     @State private var renderedImage: UIImage?
+    @State private var resolvedTitle: String?
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
 
-    private var conversationName: String {
-        item.conversation.computedDisplayName
+    /// Label under the cell. Precedence mirrors `AgentFilesLinksView.FileRow`:
+    /// resolved HTML `<title>` -> filename (extension stripped) -> the
+    /// conversation's display name.
+    private var thingName: String {
+        if let resolvedTitle, !resolvedTitle.isEmpty {
+            return resolvedTitle
+        }
+        if let filename = item.filename, !filename.isEmpty {
+            return (filename as NSString).deletingPathExtension
+        }
+        return item.conversation.computedDisplayName
     }
 
     var body: some View {
@@ -22,7 +34,7 @@ struct ThingPreviewCell: View {
             // cell pushes the file detail view, which doesn't mark the
             // underlying conversation as read. Re-enable once the tap
             // either marks-as-read or routes through the messages list.
-            Text(conversationName)
+            Text(thingName)
                 .font(.caption2)
                 .foregroundStyle(.colorTextSecondary)
                 .lineLimit(1)
@@ -56,8 +68,12 @@ struct ThingPreviewCell: View {
         "\(item.attachmentKey)-\(colorScheme == .dark ? "dark" : "light")"
     }
 
+    @MainActor
     private func loadThumbnail() async {
         let appearance = colorScheme.uiUserInterfaceStyle
+        if let cachedTitle = HTMLPageMetadata.shared.cachedTitle(for: item.attachmentKey) {
+            resolvedTitle = cachedTitle
+        }
         if let cached = HTMLThumbnailRenderer.shared.cachedThumbnail(
             for: item.attachmentKey,
             appearance: appearance
@@ -65,19 +81,25 @@ struct ThingPreviewCell: View {
             withAnimation(.smooth(duration: 0.2)) {
                 renderedImage = cached
             }
-            return
         }
+        guard renderedImage == nil || resolvedTitle == nil else { return }
         do {
             let fileURL = try await FileAttachmentLoader.loadFile(for: item.hydratedAttachment)
-            let image = await HTMLThumbnailRenderer.shared.thumbnail(
-                for: item.attachmentKey,
-                fileURL: fileURL,
-                appearance: appearance
-            )
-            await MainActor.run {
+            if renderedImage == nil {
+                let image = await HTMLThumbnailRenderer.shared.thumbnail(
+                    for: item.attachmentKey,
+                    fileURL: fileURL,
+                    appearance: appearance
+                )
                 withAnimation(.smooth(duration: 0.2)) {
                     renderedImage = image
                 }
+            }
+            if resolvedTitle == nil {
+                resolvedTitle = await HTMLPageMetadata.shared.title(
+                    for: item.attachmentKey,
+                    fileURL: fileURL
+                )
             }
         } catch {
             Log.error("ThingPreviewCell: failed to load thumbnail for \(item.conversation.id): \(error)")

--- a/Convos/Conversations List/ThingsOverviewViewModel.swift
+++ b/Convos/Conversations List/ThingsOverviewViewModel.swift
@@ -2,12 +2,16 @@ import Combine
 import ConvosCore
 import Foundation
 
-/// One cell in the cross-conversation Things grid: the most recent
-/// agent-sent HTML attachment in `conversation`, plus enough info to
-/// render the preview thumbnail and the convo's display name + unread
-/// dot under it.
+/// One cell in the cross-conversation Things grid: a single agent-sent
+/// HTML attachment in `conversation`, plus enough info to render the
+/// preview thumbnail and the convo's display name + unread dot under it.
+/// A conversation may contribute several items (one per distinct HTML
+/// thing), so the identity is the message id, not the conversation id.
 struct ThingOverviewItem: Identifiable, Hashable {
     let conversation: Conversation
+    /// Message id of the attachment send; unique per thing so multiple
+    /// things from the same conversation get distinct grid cells.
+    let messageId: String
     /// Inbox id of the agent that sent the attachment, so the detail
     /// view's indicator can open that agent's contact card.
     let senderInboxId: String
@@ -17,7 +21,7 @@ struct ThingOverviewItem: Identifiable, Hashable {
     let thumbnailDataBase64: String?
     let date: Date
 
-    var id: String { conversation.id }
+    var id: String { messageId }
 
     var hydratedAttachment: HydratedAttachment {
         HydratedAttachment(
@@ -31,9 +35,11 @@ struct ThingOverviewItem: Identifiable, Hashable {
 
 /// View model for the Things tab's cross-conversation grid. Subscribes to
 /// the conversations list and, for each conversation, to that convo's
-/// `AgentFilesLinksRepository.filesPublisher` so we can pull out the
-/// latest HTML file. Builds a deduped, date-sorted array of
-/// [[ThingOverviewItem]] for the grid to render.
+/// `AgentFilesLinksRepository.filesPublisher` so we can pull out every
+/// HTML file (the repository already dedupes re-sends of the same
+/// filename). Builds a flat, date-sorted array of [[ThingOverviewItem]]
+/// for the grid to render, so a single conversation can contribute
+/// multiple cells.
 ///
 /// One subscription per conversation is acceptable scale for v1; if list
 /// sizes ever grow past a couple hundred conversations the right next
@@ -49,7 +55,7 @@ final class ThingsOverviewViewModel {
     @ObservationIgnored private var conversationsCancellable: AnyCancellable?
     @ObservationIgnored private var filesCancellables: [String: AnyCancellable] = [:]
     @ObservationIgnored private var conversationsById: [String: Conversation] = [:]
-    @ObservationIgnored private var latestHTMLPerConvo: [String: AgentFile] = [:]
+    @ObservationIgnored private var htmlFilesPerConvo: [String: [AgentFile]] = [:]
     @ObservationIgnored private let conversationsRepository: any ConversationsRepositoryProtocol
 
     init(session: any SessionManagerProtocol) {
@@ -73,7 +79,7 @@ final class ThingsOverviewViewModel {
         let removedIds = Set(filesCancellables.keys).subtracting(activeIds)
         for id in removedIds {
             filesCancellables.removeValue(forKey: id)
-            latestHTMLPerConvo.removeValue(forKey: id)
+            htmlFilesPerConvo.removeValue(forKey: id)
         }
         for convo in convos where filesCancellables[convo.id] == nil {
             subscribeToFiles(for: convo.id)
@@ -87,11 +93,11 @@ final class ThingsOverviewViewModel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] files in
                 guard let self else { return }
-                let htmlFile = files.first { isHTML($0) }
-                if let htmlFile {
-                    self.latestHTMLPerConvo[conversationId] = htmlFile
+                let htmlFiles = files.filter { isHTML($0) }
+                if htmlFiles.isEmpty {
+                    self.htmlFilesPerConvo.removeValue(forKey: conversationId)
                 } else {
-                    self.latestHTMLPerConvo.removeValue(forKey: conversationId)
+                    self.htmlFilesPerConvo[conversationId] = htmlFiles
                 }
                 self.rebuildItems()
             }
@@ -103,17 +109,20 @@ final class ThingsOverviewViewModel {
     }
 
     private func rebuildItems() {
-        items = latestHTMLPerConvo.compactMap { id, file -> ThingOverviewItem? in
-            guard let convo = conversationsById[id] else { return nil }
-            return ThingOverviewItem(
-                conversation: convo,
-                senderInboxId: file.senderInboxId,
-                attachmentKey: file.attachmentKey,
-                filename: file.filename,
-                mimeType: file.mimeType,
-                thumbnailDataBase64: file.thumbnailDataBase64,
-                date: file.date
-            )
+        items = htmlFilesPerConvo.flatMap { id, files -> [ThingOverviewItem] in
+            guard let convo = conversationsById[id] else { return [] }
+            return files.map { (file: AgentFile) -> ThingOverviewItem in
+                ThingOverviewItem(
+                    conversation: convo,
+                    messageId: file.id,
+                    senderInboxId: file.senderInboxId,
+                    attachmentKey: file.attachmentKey,
+                    filename: file.filename,
+                    mimeType: file.mimeType,
+                    thumbnailDataBase64: file.thumbnailDataBase64,
+                    date: file.date
+                )
+            }
         }
         .sorted { $0.date > $1.date }
     }

--- a/Convos/Conversations List/ThingsOverviewViewModel.swift
+++ b/Convos/Conversations List/ThingsOverviewViewModel.swift
@@ -4,8 +4,9 @@ import Foundation
 
 /// One cell in the cross-conversation Things grid: a single agent-sent
 /// HTML attachment in `conversation`, plus enough info to render the
-/// preview thumbnail and the convo's display name + unread dot under it.
-/// A conversation may contribute several items (one per distinct HTML
+/// preview thumbnail and the thing's title (its HTML `<title>`, falling
+/// back to the filename, then the conversation name) under it. A
+/// conversation may contribute several items (one per distinct HTML
 /// thing), so the identity is the message id, not the conversation id.
 struct ThingOverviewItem: Identifiable, Hashable {
     let conversation: Conversation
@@ -44,8 +45,7 @@ struct ThingOverviewItem: Identifiable, Hashable {
 /// One subscription per conversation is acceptable scale for v1; if list
 /// sizes ever grow past a couple hundred conversations the right next
 /// move is a single SQL query that joins the message + conversation
-/// tables and returns the latest HTML attachment per conversation in one
-/// shot.
+/// tables and returns the HTML attachments per conversation in one shot.
 @MainActor
 @Observable
 final class ThingsOverviewViewModel {
@@ -109,7 +109,7 @@ final class ThingsOverviewViewModel {
     }
 
     private func rebuildItems() {
-        items = htmlFilesPerConvo.flatMap { id, files -> [ThingOverviewItem] in
+        items = htmlFilesPerConvo.flatMap { (id: String, files: [AgentFile]) -> [ThingOverviewItem] in
             guard let convo = conversationsById[id] else { return [] }
             return files.map { (file: AgentFile) -> ThingOverviewItem in
                 ThingOverviewItem(

--- a/Convos/Conversations List/ThingsTabView.swift
+++ b/Convos/Conversations List/ThingsTabView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 /// Cross-conversation "Things" tab. Renders a grid of every agent-sent
 /// HTML attachment across all conversations (a conversation can appear
-/// more than once), with the conversation's display name + unread dot
-/// under each preview square.
+/// more than once), with each thing's title (its HTML `<title>`, falling
+/// back to the filename, then the conversation name) under each preview
+/// square.
 /// See [[ThingsOverviewViewModel]] for the data layer and
 /// [[ThingPreviewCell]] for the cell.
 ///

--- a/Convos/Conversations List/ThingsTabView.swift
+++ b/Convos/Conversations List/ThingsTabView.swift
@@ -1,9 +1,10 @@
 import ConvosCore
 import SwiftUI
 
-/// Cross-conversation "Things" tab. Renders a grid of the most
-/// recent agent-sent HTML attachment from every conversation, with the
-/// conversation's display name + unread dot under each preview square.
+/// Cross-conversation "Things" tab. Renders a grid of every agent-sent
+/// HTML attachment across all conversations (a conversation can appear
+/// more than once), with the conversation's display name + unread dot
+/// under each preview square.
 /// See [[ThingsOverviewViewModel]] for the data layer and
 /// [[ThingPreviewCell]] for the cell.
 ///


### PR DESCRIPTION
Removes the one-thing-per-conversation constraint on the app-level Things grid so it now shows every agent-sent HTML thing across all conversations (still deduped by filename per conversation), sorted newest-first. `ThingOverviewItem.id` is now the message id rather than the conversation id, since a conversation can contribute multiple cells. Each cell is labeled by the HTML document's `<title>` (resolved via `HTMLPageMetadata`), falling back to the filename and then the conversation name, matching the in-conversation files list. The title is resolved from the same file URL already loaded for the thumbnail, so there's no extra fetch.

Note: the full `ConvosCore` test suite could not be run (Docker unavailable in this environment); the change is UI-only and the Dev scheme builds cleanly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784750382&installation_id=128169237&pr_number=1096&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1096&signature=618d2779b199451bc43a86d1277cf147f33555db970912df6dd77c30176a3c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show all agent HTML attachments in Things grid, titled by HTML `<title>`
> - `ThingsOverviewViewModel` now tracks all HTML files per conversation instead of only the latest one, and `ThingOverviewItem` uses `messageId` as its unique identifier so multiple items from the same conversation can coexist in the grid.
> - `rebuildItems` flattens all tracked HTML files across conversations into a single date-sorted list.
> - `ThingPreviewCell` resolves the HTML `<title>` via `HTMLPageMetadata` and displays it as the cell label, falling back to filename (without extension) then conversation name.
> - Behavioral Change: the Things grid may now show multiple entries per conversation, one per HTML attachment sent by the agent.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1096 opened
>
> - Fixed stale thumbnail retention in `ThingPreviewCell` by explicitly setting `renderedImage` to nil when no cached thumbnail exists for the current appearance [c100e45]
> - Updated `ThingsOverviewViewModel.rebuildItems` to include multiple HTML attachments per conversation with explicit closure typing and documented title precedence [c100e45]
> - Removed `Constant.unreadDotSize` constant from `ThingPreviewCell` [c100e45]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9cd455d. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->