### PR TITLE
fix: profile saves not working after Delete all app data

### DIFF
--- a/Convos/App Settings/AppSettingsViewModel.swift
+++ b/Convos/App Settings/AppSettingsViewModel.swift
@@ -48,15 +48,19 @@ final class AppSettingsViewModel {
     }
 
     private func resetLocalState() {
-        Self.resetProfile()
+        Self.resetProfile(session: session)
         Self.resetGlobalDefaults()
         Self.resetConversationDefaults()
         Self.resetConversationsDefaults()
         Self.resetOnboardingDefaults()
     }
 
-    private static func resetProfile() {
-        ProfileSettingsViewModel.shared.delete()
+    // The profile singleton holds a writer bound to the old inbox. Delete-all
+    // registers a fresh inbox, so we rebind to point it at the new one;
+    // otherwise a later "My Info" save targets the dead inbox and never reaches
+    // new conversations. rebind also clears the editing fields
+    private static func resetProfile(session: any SessionManagerProtocol) {
+        ProfileSettingsViewModel.shared.rebind(session: session)
     }
 
     private static func resetGlobalDefaults() {

--- a/Convos/Profile/ProfileSettingsViewModel.swift
+++ b/Convos/Profile/ProfileSettingsViewModel.swift
@@ -92,10 +92,7 @@ class ProfileSettingsViewModel {
         self.session = nil
         writer = nil
         repository = nil
-        editingDisplayName = ""
-        profileImage = nil
-        profileImageAssetIdentifier = nil
-        profileImageContentDigest = nil
+        clearEditingFields()
         loadState = .loading
         bindInternal(session: session)
     }
@@ -178,10 +175,7 @@ class ProfileSettingsViewModel {
     }
 
     func delete() {
-        editingDisplayName = ""
-        profileImage = nil
-        profileImageAssetIdentifier = nil
-        profileImageContentDigest = nil
+        clearEditingFields()
         guard let writer else { return }
         Task {
             do {
@@ -190,5 +184,12 @@ class ProfileSettingsViewModel {
                 Log.error("Failed deleting profile settings: \(error.localizedDescription)")
             }
         }
+    }
+
+    private func clearEditingFields() {
+        editingDisplayName = ""
+        profileImage = nil
+        profileImageAssetIdentifier = nil
+        profileImageContentDigest = nil
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -25,12 +25,16 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     private let _reactionWriter: any ReactionWriterProtocol
     private let _readReceiptWriter: any ReadReceiptWriterProtocol
     private let _replyWriter: any ReplyMessageWriterProtocol
+    private let _myGlobalProfileWriter: any MyGlobalProfileWriterProtocol
+    private let _myGlobalProfileRepository: any MyGlobalProfileRepositoryProtocol
 
     // MARK: - Initialization
 
     public init(
         sessionStateManager: (any SessionStateManagerProtocol)? = nil,
         myProfileWriter: (any MyProfileWriterProtocol)? = nil,
+        myGlobalProfileWriter: (any MyGlobalProfileWriterProtocol)? = nil,
+        myGlobalProfileRepository: (any MyGlobalProfileRepositoryProtocol)? = nil,
         conversationStateManager: (any ConversationStateManagerProtocol)? = nil,
         conversationConsentWriter: (any ConversationConsentWriterProtocol)? = nil,
         conversationLocalStateWriter: (any ConversationLocalStateWriterProtocol)? = nil,
@@ -54,6 +58,8 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         self._reactionWriter = reactionWriter ?? MockReactionWriter()
         self._readReceiptWriter = readReceiptWriter ?? MockReadReceiptWriter()
         self._replyWriter = replyWriter ?? MockReplyMessageWriter()
+        self._myGlobalProfileWriter = myGlobalProfileWriter ?? MockMyGlobalProfileWriter()
+        self._myGlobalProfileRepository = myGlobalProfileRepository ?? MockMyGlobalProfileRepository()
     }
 
     // MARK: - MessagingServiceProtocol
@@ -75,11 +81,11 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     }
 
     public func myGlobalProfileWriter() -> any MyGlobalProfileWriterProtocol {
-        MockMyGlobalProfileWriter()
+        _myGlobalProfileWriter
     }
 
     public func myGlobalProfileRepository() -> any MyGlobalProfileRepositoryProtocol {
-        MockMyGlobalProfileRepository()
+        _myGlobalProfileRepository
     }
 
     public func conversationStateManager() -> any ConversationStateManagerProtocol {

--- a/ConvosTests/ProfileSettingsViewModelTests.swift
+++ b/ConvosTests/ProfileSettingsViewModelTests.swift
@@ -65,4 +65,83 @@ final class ProfileSettingsViewModelTests: XCTestCase {
             "Whitespace-only names should be treated as empty"
         )
     }
+
+    // MARK: - Rebind after Delete all data
+
+    /// `rebind` must re-point the singleton's writer at the new session, so a
+    /// save after rebind lands in the new inbox's writer and not the stale one.
+    /// This is the core of the "profile not saving after Delete all data" fix:
+    /// delete-all registers a fresh inbox, and the singleton must follow it.
+    func testRebindRoutesSavesToTheNewSessionsWriter() async throws {
+        let oldWriter = MockMyGlobalProfileWriter()
+        let newWriter = MockMyGlobalProfileWriter()
+        let oldSession = MockInboxesService(
+            mockMessagingService: MockMessagingService(myGlobalProfileWriter: oldWriter)
+        )
+        let newSession = MockInboxesService(
+            mockMessagingService: MockMessagingService(myGlobalProfileWriter: newWriter)
+        )
+
+        let viewModel = ProfileSettingsViewModel.shared
+
+        viewModel.rebind(session: oldSession)
+        viewModel.editingDisplayName = "Alice"
+        try await viewModel.saveAndAwait()
+        XCTAssertEqual(oldWriter.stored?.name, "Alice")
+
+        // Simulate "Delete all data": the singleton is rebound to a fresh
+        // session backed by a new inbox/writer.
+        viewModel.rebind(session: newSession)
+        viewModel.editingDisplayName = "Bob"
+        try await viewModel.saveAndAwait()
+
+        XCTAssertEqual(
+            newWriter.stored?.name, "Bob",
+            "After rebind, a save must target the new session's writer"
+        )
+        XCTAssertEqual(
+            oldWriter.stored?.name, "Alice",
+            "The pre-rebind (stale) writer must not receive saves after rebind"
+        )
+    }
+
+    /// End-to-end: `AppSettingsViewModel.deleteAllData` must rebind the profile
+    /// singleton to the new session, so a later "My Info" save reaches the new
+    /// inbox instead of the dead one (the reported bug).
+    func testDeleteAllDataRebindsProfileSettingsToTheNewSession() async {
+        // The singleton starts bound to a stale session (the pre-delete inbox) -
+        // the state that, before the fix, survived "Delete all data" and
+        // swallowed later saves.
+        let staleWriter = MockMyGlobalProfileWriter()
+        ProfileSettingsViewModel.shared.rebind(
+            session: MockInboxesService(
+                mockMessagingService: MockMessagingService(myGlobalProfileWriter: staleWriter)
+            )
+        )
+
+        // The session AppSettings holds; after delete-all its messaging service
+        // is the freshly-built one. Model that with a distinct writer.
+        let newWriter = MockMyGlobalProfileWriter()
+        let session = MockInboxesService(
+            mockMessagingService: MockMessagingService(myGlobalProfileWriter: newWriter)
+        )
+        let appSettings = AppSettingsViewModel(session: session)
+
+        let done = expectation(description: "delete-all complete")
+        appSettings.deleteAllData { done.fulfill() }
+        await fulfillment(of: [done], timeout: 5)
+
+        // A "My Info" save after delete-all must reach the new session's writer.
+        ProfileSettingsViewModel.shared.editingDisplayName = "Cameron"
+        try? await ProfileSettingsViewModel.shared.saveAndAwait()
+
+        XCTAssertEqual(
+            newWriter.stored?.name, "Cameron",
+            "After Delete all data, a My Info save must target the freshly-bound session"
+        )
+        XCTAssertNil(
+            staleWriter.stored?.name,
+            "Saves must not reach the pre-delete session's writer"
+        )
+    }
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784761886&installation_id=128169237&pr_number=1097&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1097&signature=b4ea3f35a9d713eb17dcf132fdacca6238373ac75e18adc125edeb612b08cddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix profile saves routing to stale session after "Delete all app data"
> - After "Delete all app data", `ProfileSettingsViewModel` was left bound to the old session, causing subsequent profile saves to fail or write to the wrong destination.
> - `AppSettingsViewModel.resetProfile` now calls `ProfileSettingsViewModel.shared.rebind(session:)` instead of `delete()`, ensuring the singleton is reattached to the current session.
> - `ProfileSettingsViewModel` gains a `clearEditingFields()` helper, used by both `rebind` and `delete` to reset in-progress edits.
> - `MockMessagingService` is updated to accept injectable profile writer/repository instances, enabling the two new regression tests that verify saves route to the correct writer before and after a rebind.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89a6c8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->