### PR TITLE
fix: prevent display names from being cleared

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -664,7 +664,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
             }
         }
         .selfSizingSheet(item: $viewModel.presentingReadByForGroup) { group in
-            ReadByDrawerView(members: group.readByMembers)
+            ReadByDrawerView(
+                members: group.readByMembers,
+                memberContactOverride: contactOverride
+            )
         }
         .sheet(item: $viewModel.presentingThinkingDetail) { descriptor in
             ThinkingDetailView(

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -202,7 +202,8 @@ class MessagesListItemTypeCell: UICollectionViewCell {
             onRetryTranscript: config.onRetryTranscript,
             allVoiceMemoTranscripts: config.allVoiceMemoTranscripts,
             htmlAttachmentTransitionNamespace: config.htmlAttachmentTransitionNamespace,
-            creditsDepleted: config.creditsDepleted
+            creditsDepleted: config.creditsDepleted,
+            memberContactOverride: config.memberContactOverride
         )
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadByDrawerView.swift
@@ -3,12 +3,20 @@ import SwiftUI
 
 struct ReadByDrawerView: View {
     let members: [ConversationMember]
+    /// Resolves the local contact name for an inbox. Used fallback-only (the
+    /// per-conversation name wins; the contact name fills an empty name instead
+    /// of "Somebody"), matching the in-chat bubble. Defaults to no override.
+    var memberContactOverride: (String) -> Contact? = { _ in nil }
+
+    private func displayName(for member: ConversationMember) -> String {
+        member.displayName(contactNameFallback: { memberContactOverride($0)?.displayName })
+    }
 
     private var sortedMembers: [ConversationMember] {
         members.sorted { lhs, rhs in
             if lhs.isCurrentUser && !rhs.isCurrentUser { return true }
             if !lhs.isCurrentUser && rhs.isCurrentUser { return false }
-            return lhs.profile.displayName.localizedCaseInsensitiveCompare(rhs.profile.displayName)
+            return displayName(for: lhs).localizedCaseInsensitiveCompare(displayName(for: rhs))
                 == .orderedAscending
         }
     }
@@ -23,7 +31,7 @@ struct ReadByDrawerView: View {
             BoundedScrollView(maxHeight: 600.0) {
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
                     ForEach(sortedMembers, id: \.self) { member in
-                        ReadByRowView(member: member)
+                        ReadByRowView(member: member, resolvedName: displayName(for: member))
                     }
                 }
             }
@@ -35,6 +43,7 @@ struct ReadByDrawerView: View {
 
 private struct ReadByRowView: View {
     let member: ConversationMember
+    let resolvedName: String
 
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step3x) {
@@ -46,7 +55,7 @@ private struct ReadByRowView: View {
             )
             .frame(width: 40.0, height: 40.0)
 
-            Text(member.isCurrentUser ? "You" : member.profile.displayName.capitalized)
+            Text(member.isCurrentUser ? "You" : resolvedName.capitalized)
                 .font(.callout)
                 .foregroundStyle(.colorTextPrimary)
 
@@ -54,7 +63,7 @@ private struct ReadByRowView: View {
         }
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(member.isCurrentUser ? "You" : member.profile.displayName) read this message")
+        .accessibilityLabel("\(member.isCurrentUser ? "You" : resolvedName) read this message")
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -34,6 +34,13 @@ struct MessagesGroupView: View {
     /// `bolt.fill` glyph next to an agent sender's display name when
     /// the global credit balance is depleted.
     var creditsDepleted: Bool = false
+    /// Resolves an inbox id to the local contact-name override so the sender
+    /// label matches the contact card and conversation title (contact name ->
+    /// per-conversation profile name -> "Somebody"). Without this the label
+    /// reads only the per-conversation profile and shows "Somebody" even when
+    /// a contact name exists. Defaults to no override for previews / the unused
+    /// SwiftUI list path.
+    var memberContactOverride: (String) -> Contact? = { _ in nil }
 
     @Environment(\.displayScale) private var displayScale: CGFloat
     @State private var isAppearing: Bool = true
@@ -78,6 +85,13 @@ struct MessagesGroupView: View {
         DesignConstants.Spacing.step2x
     }
 
+    /// Sender name with the same precedence as the contact card and
+    /// conversation title: contact-name override, then per-conversation profile
+    /// name, then "Somebody" / "Agent".
+    private var senderDisplayName: String {
+        displayGroup.sender.displayName(memberNameOverride: { memberContactOverride($0)?.displayName })
+    }
+
     private var senderLabel: some View {
         senderLabelContent
             .scaleEffect(isAppearing ? 0.9 : 1.0)
@@ -94,7 +108,7 @@ struct MessagesGroupView: View {
         let tapAction = { onTapSender(displayGroup.sender) }
         return Button(action: tapAction) {
             HStack(spacing: DesignConstants.Spacing.stepX) {
-                Text(displayGroup.sender.profile.displayName)
+                Text(senderDisplayName)
                 if displayGroup.sender.isAgent && creditsDepleted {
                     Image(systemName: "bolt.fill")
                         .foregroundStyle(.colorLava)
@@ -115,7 +129,7 @@ struct MessagesGroupView: View {
                 y: 0.0
             )
             .id("profile-\(displayGroup.id)")
-            .accessibilityLabel("View \(displayGroup.sender.profile.displayName)'s profile")
+            .accessibilityLabel("View \(senderDisplayName)'s profile")
             .accessibilityAddTraits(.isButton)
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -85,11 +85,13 @@ struct MessagesGroupView: View {
         DesignConstants.Spacing.step2x
     }
 
-    /// Sender name with the same precedence as the contact card and
-    /// conversation title: contact-name override, then per-conversation profile
-    /// name, then "Somebody" / "Agent".
+    /// Sender name, fallback-only: the per-conversation profile name wins when
+    /// present, and the contact name is used only to fill an empty name instead
+    /// of "Somebody". This can only replace a blank - it never overrides a name
+    /// that already renders correctly - so it can't surface a stale contact name
+    /// over a fresh member name.
     private var senderDisplayName: String {
-        displayGroup.sender.displayName(memberNameOverride: { memberContactOverride($0)?.displayName })
+        displayGroup.sender.displayName(contactNameFallback: { memberContactOverride($0)?.displayName })
     }
 
     private var senderLabel: some View {

--- a/Convos/Profile/MyProfileViewModel.swift
+++ b/Convos/Profile/MyProfileViewModel.swift
@@ -194,6 +194,10 @@ class MyProfileViewModel {
         if !wouldClearExistingName, latestProfile == nil || latestProfile?.name != trimmedDisplayName {
             update(displayName: trimmedDisplayName, conversationId: conversationId)
             didChange = true
+        } else if wouldClearExistingName {
+            // Clearing was prevented; restore the field so it doesn't show blank
+            // while the stored name is actually preserved (mirrors saveAndAwait).
+            editingDisplayName = latestProfile?.name ?? ""
         }
 
         let updatedMetadata: ProfileMetadata? = {

--- a/Convos/Profile/MyProfileViewModel.swift
+++ b/Convos/Profile/MyProfileViewModel.swift
@@ -187,7 +187,11 @@ class MyProfileViewModel {
         let trimmedDisplayName = editingDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedEmoji = editingEmoji.trimmingCharacters(in: .whitespacesAndNewlines)
         let latestProfile = try? myProfileRepository.fetch()
-        if latestProfile == nil || latestProfile?.name != trimmedDisplayName {
+        // Don't push an empty name over an existing one (it would render as
+        // "Somebody"). The writer guards this too, but skipping here avoids a
+        // redundant re-broadcast of the unchanged name.
+        let wouldClearExistingName = trimmedDisplayName.isEmpty && (latestProfile?.name?.isEmpty == false)
+        if !wouldClearExistingName, latestProfile == nil || latestProfile?.name != trimmedDisplayName {
             update(displayName: trimmedDisplayName, conversationId: conversationId)
             didChange = true
         }

--- a/Convos/Profile/MyProfileViewModel.swift
+++ b/Convos/Profile/MyProfileViewModel.swift
@@ -191,13 +191,18 @@ class MyProfileViewModel {
         // "Somebody"). The writer guards this too, but skipping here avoids a
         // redundant re-broadcast of the unchanged name.
         let wouldClearExistingName = trimmedDisplayName.isEmpty && (latestProfile?.name?.isEmpty == false)
+        // The name we actually use everywhere below: never blank out an existing
+        // name. When a clear is prevented this is the preserved stored name, so
+        // neither the field nor the "save as profile" forward gets the stale
+        // empty string.
+        let resolvedDisplayName = wouldClearExistingName ? (latestProfile?.name ?? "") : trimmedDisplayName
         if !wouldClearExistingName, latestProfile == nil || latestProfile?.name != trimmedDisplayName {
             update(displayName: trimmedDisplayName, conversationId: conversationId)
             didChange = true
         } else if wouldClearExistingName {
             // Clearing was prevented; restore the field so it doesn't show blank
             // while the stored name is actually preserved (mirrors saveAndAwait).
-            editingDisplayName = latestProfile?.name ?? ""
+            editingDisplayName = resolvedDisplayName
         }
 
         let updatedMetadata: ProfileMetadata? = {
@@ -226,7 +231,7 @@ class MyProfileViewModel {
             // ProfileSettingsViewModel.shared via an inline binding, so no need to copy it
             // here. Image and name still flow through this view model and need forwarding.
             let settingsViewModel = ProfileSettingsViewModel.shared
-            settingsViewModel.editingDisplayName = trimmedDisplayName
+            settingsViewModel.editingDisplayName = resolvedDisplayName
             settingsViewModel.profileImage = pendingProfileImage
             settingsViewModel.save()
             saveDisplayNameAsProfile = false

--- a/Convos/Profile/ProfileSettingsViewModel.swift
+++ b/Convos/Profile/ProfileSettingsViewModel.swift
@@ -167,6 +167,14 @@ class ProfileSettingsViewModel {
             imageAssetIdentifier: assetIdentifier,
             metadata: nil
         )
+        // Arm the empty-save guard immediately. `loadedDisplayName` is otherwise
+        // only refreshed by the async profile observation, so a first-time user
+        // who saves a name and then clears + saves again before that fires would
+        // skip the guard above. (The writer also preserves the stored name on an
+        // empty save, so this is defense-in-depth + keeps the field restore working.)
+        if let resolvedName {
+            loadedDisplayName = resolvedName
+        }
         markProfileEditorShownIfPopulated()
     }
 

--- a/Convos/Profile/ProfileSettingsViewModel.swift
+++ b/Convos/Profile/ProfileSettingsViewModel.swift
@@ -54,6 +54,9 @@ class ProfileSettingsViewModel {
     private var writer: (any MyGlobalProfileWriterProtocol)?
     private var repository: (any MyGlobalProfileRepositoryProtocol)?
     private var cancellables: Set<AnyCancellable> = []
+    /// The last name loaded from (or saved to) the global profile. Used to
+    /// reject an empty save: once a name is set it cannot be cleared.
+    private var loadedDisplayName: String?
 
     private init() {}
 
@@ -125,6 +128,7 @@ class ProfileSettingsViewModel {
 
     private func apply(profile: MyProfile?) {
         editingDisplayName = profile?.name ?? ""
+        loadedDisplayName = profile?.name
         profileImage = profile?.imageData.flatMap(UIImage.init(data:))
         profileImageAssetIdentifier = profile?.imageAssetIdentifier
         profileImageContentDigest = profile?.imageContentDigest
@@ -144,7 +148,17 @@ class ProfileSettingsViewModel {
             throw ProfileSettingsError.notBound
         }
         let trimmedName = editingDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedName: String? = trimmedName.isEmpty ? nil : trimmedName
+        // A name, once set, cannot be cleared: an empty field falls back to the
+        // stored name rather than writing nil, and the field is restored so the
+        // UI reflects that the empty value was rejected. First-time users with
+        // no stored name are unaffected (there is nothing to preserve).
+        let resolvedName: String?
+        if trimmedName.isEmpty, let loadedDisplayName {
+            resolvedName = loadedDisplayName
+            editingDisplayName = loadedDisplayName
+        } else {
+            resolvedName = trimmedName.isEmpty ? nil : trimmedName
+        }
         let imageData = profileImage?.jpegData(compressionQuality: 1.0)
         let assetIdentifier = imageData == nil ? nil : profileImageAssetIdentifier
         try await writer.save(
@@ -188,6 +202,7 @@ class ProfileSettingsViewModel {
 
     private func clearEditingFields() {
         editingDisplayName = ""
+        loadedDisplayName = nil
         profileImage = nil
         profileImageAssetIdentifier = nil
         profileImageContentDigest = nil

--- a/Convos/Profile/ProfileSettingsViewModel.swift
+++ b/Convos/Profile/ProfileSettingsViewModel.swift
@@ -57,6 +57,11 @@ class ProfileSettingsViewModel {
     /// The last name loaded from (or saved to) the global profile. Used to
     /// reject an empty save: once a name is set it cannot be cleared.
     private var loadedDisplayName: String?
+    /// The last metadata loaded from the global profile. The My Info editor does
+    /// not edit metadata, so we carry this through on save instead of writing
+    /// nil - otherwise a name-only edit would clear stored metadata (e.g. the
+    /// profile emoji). Kept fresh by `apply(profile:)`.
+    private var loadedMetadata: ProfileMetadata?
 
     private init() {}
 
@@ -129,6 +134,7 @@ class ProfileSettingsViewModel {
     private func apply(profile: MyProfile?) {
         editingDisplayName = profile?.name ?? ""
         loadedDisplayName = profile?.name
+        loadedMetadata = profile?.metadata
         profileImage = profile?.imageData.flatMap(UIImage.init(data:))
         profileImageAssetIdentifier = profile?.imageAssetIdentifier
         profileImageContentDigest = profile?.imageContentDigest
@@ -165,7 +171,7 @@ class ProfileSettingsViewModel {
             name: resolvedName,
             imageData: imageData,
             imageAssetIdentifier: assetIdentifier,
-            metadata: nil
+            metadata: loadedMetadata
         )
         // Arm the empty-save guard immediately. `loadedDisplayName` is otherwise
         // only refreshed by the async profile observation, so a first-time user
@@ -211,6 +217,7 @@ class ProfileSettingsViewModel {
     private func clearEditingFields() {
         editingDisplayName = ""
         loadedDisplayName = nil
+        loadedMetadata = nil
         profileImage = nil
         profileImageAssetIdentifier = nil
         profileImageContentDigest = nil

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -835,7 +835,12 @@ extension MessagingService {
                     avatar: nil
                 )
 
-                profile = profile.with(name: update.hasName ? update.name : nil)
+                // Don't let a name-less or blank ProfileUpdate (e.g. the startup
+                // update an agent publishes) clear a name we already have - it
+                // would render the member as "Somebody". A real incoming name
+                // still wins; a member we have no name for is unaffected.
+                let incomingName: String? = update.hasName ? update.name : nil
+                profile = profile.with(name: (incomingName?.isEmpty == false) ? incomingName : profile.name)
 
                 if update.hasEncryptedImage, update.encryptedImage.isValid {
                     let encryptionKey: Data? = if let existingKey = profile.avatarKey {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -835,12 +835,9 @@ extension MessagingService {
                     avatar: nil
                 )
 
-                // Don't let a name-less or blank ProfileUpdate (e.g. the startup
-                // update an agent publishes) clear a name we already have - it
-                // would render the member as "Somebody". A real incoming name
-                // still wins; a member we have no name for is unaffected.
-                let incomingName: String? = update.hasName ? update.name : nil
-                profile = profile.with(name: (incomingName?.isEmpty == false) ? incomingName : profile.name)
+                // Never clear an existing name with a name-less/blank update
+                // (see DBMemberProfile.withInboundName).
+                profile = profile.withInboundName(update.hasName ? update.name : nil)
 
                 if update.hasEncryptedImage, update.encryptedImage.isValid {
                     let encryptionKey: Data? = if let existingKey = profile.avatarKey {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBContact.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBContact.swift
@@ -110,22 +110,30 @@ extension DBContact {
     /// `addedViaConversationId`) and `blockedAt` are preserved. Used by
     /// `ContactsWriter.replacingProfile(of:with:)`.
     ///
+    /// `displayName` is sticky against blank incoming values: an empty or
+    /// whitespace-only name (e.g. the name-less `ProfileUpdate` an agent
+    /// publishes at startup) coalesces to the stored name rather than clearing
+    /// it. Clearing a contact's name is never the intent of a profile sync, so
+    /// a blank update can only update other fields. A non-blank name still wins.
+    ///
     /// The agent-template *identity* columns (templateId / publishedURL /
-    /// emoji) are sticky-coalesced: a metadata-less `ProfileUpdate` (e.g. the
-    /// name-only update `convos agent serve` publishes at startup) carries
-    /// `nil` for these, and must not clear a templateId the contact was
-    /// already mirrored with - otherwise the agent silently drops out of the
-    /// canonical dedup + cache pipeline. `agentVerification` is intentionally
-    /// not sticky (it is wholesale-replaced like the other profile fields).
+    /// emoji) are sticky-coalesced for the same reason: a metadata-less
+    /// `ProfileUpdate` carries `nil` for these, and must not clear a templateId
+    /// the contact was already mirrored with - otherwise the agent silently
+    /// drops out of the canonical dedup + cache pipeline. `agentVerification`
+    /// and the avatar fields are intentionally not sticky (they are
+    /// wholesale-replaced).
     func replacingProfileFields(
         with snapshot: ContactProfileSnapshot,
         at timestamp: Date
     ) -> DBContact {
-        DBContact(
+        let trimmedIncomingName: String? = snapshot.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedDisplayName: String? = (trimmedIncomingName?.isEmpty == false) ? trimmedIncomingName : displayName
+        return DBContact(
             inboxId: inboxId,
             addedAt: addedAt,
             addedViaConversationId: addedViaConversationId,
-            displayName: snapshot.displayName,
+            displayName: resolvedDisplayName,
             avatarURL: snapshot.avatarURL,
             avatarSalt: snapshot.avatarSalt,
             avatarNonce: snapshot.avatarNonce,

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberProfile.swift
@@ -161,6 +161,16 @@ extension DBMemberProfile {
         )
     }
 
+    /// Applies an inbound name update without ever clearing an existing name: a
+    /// nil or empty/whitespace incoming name keeps the current name, a real name
+    /// wins. Single source of truth for every inbound apply path (stream, NSE
+    /// push, catch-up/history) so a name-less or blank ProfileUpdate can never
+    /// render the member as "Somebody".
+    func withInboundName(_ incoming: String?) -> DBMemberProfile {
+        let trimmed = incoming?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return with(name: (trimmed?.isEmpty == false) ? trimmed : name)
+    }
+
     func with(avatar: String?) -> DBMemberProfile {
         .init(
             conversationId: conversationId, inboxId: inboxId, name: name, avatar: avatar,

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -1,11 +1,19 @@
 import Foundation
 
 extension DBConversationDetails {
-    func hydrateConversation(currentInboxId: String) -> Conversation {
+    /// `contactNameResolver` supplies the fallback contact name for the
+    /// last-message preview only (the conversation-list subtitle), so a member
+    /// with an empty per-conversation name shows the contact name instead of
+    /// "Somebody". Defaults to a no-op.
+    func hydrateConversation(
+        currentInboxId: String,
+        contactNameResolver: (String) -> String? = { _ in nil }
+    ) -> Conversation {
         let lastMessage: MessagePreview? = conversationLastMessageWithSource?.hydrateMessagePreview(
             conversationKind: conversation.kind,
             currentInboxId: currentInboxId,
-            members: conversationMembers
+            members: conversationMembers,
+            contactNameResolver: contactNameResolver
         )
         let members = hydrateConversationMembers(currentInboxId: currentInboxId)
         let creator = conversationCreator.hydrateConversationMember(currentInboxId: currentInboxId)

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBMessage+MessagePreview.swift
@@ -14,7 +14,8 @@ extension DBLastMessageWithSource {
     func hydrateMessagePreview(
         conversationKind: ConversationKind,
         currentInboxId: String,
-        members: [DBConversationMemberProfileWithRole]
+        members: [DBConversationMemberProfileWithRole],
+        contactNameResolver: (String) -> String? = { _ in nil }
     ) -> MessagePreview {
         let text: String
         let isCurrentUser = senderId == currentInboxId
@@ -24,7 +25,9 @@ extension DBLastMessageWithSource {
         // pattern `resolvedMemberDisplayName` uses in ModelMocks.swift.
         let senderName = Self.resolveSenderName(
             isCurrentUser: isCurrentUser,
-            profile: senderProfile?.memberProfile
+            inboxId: senderId,
+            profile: senderProfile?.memberProfile,
+            contactNameResolver: contactNameResolver
         )
         let attachmentsCount = attachmentUrls.count
         let attachmentsString = Self.attachmentsPreviewString(attachmentUrls: attachmentUrls, count: attachmentsCount)
@@ -146,17 +149,22 @@ extension DBLastMessageWithSource {
     }
 
     /// Resolves the sender's rendered name for a message preview row.
-    /// Precedence: "You" for the local user, the per-conversation profile
-    /// name when set, then "Agent" / "Somebody" keyed on the profile's
-    /// `isAgent` (mirrors `Profile.displayName`). Hoisted out of
-    /// `hydrateMessagePreview` so the agent-aware branch doesn't push that
-    /// function past the cyclomatic complexity threshold.
+    /// Precedence: "You" for the local user, the per-conversation profile name
+    /// when set, then the local contact name as a fallback, then "Agent" /
+    /// "Somebody" keyed on `isAgent`. The contact name is fallback-only (it
+    /// fills an empty name, it does not override a present one), matching the
+    /// in-chat bubble. Hoisted out of `hydrateMessagePreview` so the extra
+    /// branch doesn't push that function past the cyclomatic complexity
+    /// threshold.
     private static func resolveSenderName(
         isCurrentUser: Bool,
-        profile: DBMemberProfile?
+        inboxId: String,
+        profile: DBMemberProfile?,
+        contactNameResolver: (String) -> String? = { _ in nil }
     ) -> String {
         if isCurrentUser { return "You" }
         if let name = profile?.name, !name.isEmpty { return name }
+        if let contactName = contactNameResolver(inboxId), !contactName.isEmpty { return contactName }
         return profile?.isAgent == true ? "Agent" : "Somebody"
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
@@ -83,6 +83,26 @@ public struct ConversationMember: Codable, Hashable, Identifiable, Sendable {
         }
         return profile.displayName
     }
+
+    /// Fallback-only contact resolution: the per-conversation profile name
+    /// **wins** when present, and the contact name is used only to fill an
+    /// empty name (in place of "Somebody"/"Agent"). Unlike
+    /// `displayName(memberNameOverride:)`, this can never replace a name that is
+    /// already rendering correctly - it can only turn a blank into a real name -
+    /// so it is the safe choice for message-derived surfaces. Pass
+    /// `{ _ in nil }` for the legacy behavior (no fallback).
+    public func displayName(contactNameFallback: (String) -> String?) -> String {
+        if let name = profile.name, !name.isEmpty {
+            return name
+        }
+        if let fallback = contactNameFallback(profile.inboxId), !fallback.isEmpty {
+            return fallback
+        }
+        if isAgent && !agentVerification.isVerified {
+            return "Agent"
+        }
+        return profile.displayName
+    }
 }
 
 public extension Array where Element == ConversationMember {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -176,6 +176,23 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
         return name
     }
 
+    /// Bulk inbox-id -> contact display-name resolver for hydration. Returns a
+    /// closure backed by a single fetch of the `contact` table; empty names are
+    /// omitted so a missing key means "no contact name" and the caller's
+    /// fallback applies. Building this inside a `ValueObservation` read closure
+    /// also registers the observation on the `contact` table, so a contact
+    /// rename refreshes surfaces hydrated through the resolver.
+    static func contactNameResolverInTransaction(db: Database) throws -> (String) -> String? {
+        let names: [String: String] = try DBContact
+            .fetchAll(db)
+            .reduce(into: [:]) { map, contact in
+                if let name = contact.displayName, !name.isEmpty {
+                    map[contact.inboxId] = name
+                }
+            }
+        return { names[$0] }
+    }
+
     func sourceConversations(forIds ids: Set<String>) throws -> [String: ContactSourceConversation] {
         guard !ids.isEmpty else { return [:] }
         return try databaseReader.read { db in

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -95,11 +95,19 @@ extension Array where Element == DBConversationDetails {
         // Empty string when no inbox is authorized yet — hydration treats
         // that as "no member is current user".
         let currentInboxId = try DBInbox.currentInboxId(database) ?? ""
+        // Fallback contact name for the last-message preview when a member's
+        // per-conversation name is empty. Fetching here also registers this
+        // observation on the `contact` table, so a contact rename refreshes the
+        // list previews.
+        let contactNameResolver = try ContactsRepository.contactNameResolverInTransaction(db: database)
         let dbConversations: [DBConversationDetails] = self
 
         let conversations: [Conversation] = dbConversations
             .compactMap { dbConversationDetails in
-            dbConversationDetails.hydrateConversation(currentInboxId: currentInboxId)
+            dbConversationDetails.hydrateConversation(
+                currentInboxId: currentInboxId,
+                contactNameResolver: contactNameResolver
+            )
         }
 
         return conversations
@@ -204,7 +212,8 @@ fileprivate extension Database {
             .fetchOne(self)
         guard let details = dbConversationDetails else { return nil }
         let currentInboxId = try DBInbox.currentInboxId(self) ?? ""
-        return details.hydrateConversation(currentInboxId: currentInboxId)
+        let contactNameResolver = try ContactsRepository.contactNameResolverInTransaction(db: self)
+        return details.hydrateConversation(currentInboxId: currentInboxId, contactNameResolver: contactNameResolver)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -270,12 +270,14 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     /// the snapshot should be applied; returns `nil` if the caller should
     /// leave the stored row untouched.
     ///
-    /// The snapshot is treated as one authoritative unit: when applied,
-    /// every profile field on the stored row is replaced by the snapshot's
-    /// value (including `nil`s, which clear the stored field). There is no
-    /// per-field merging. This matches the wire-format contract for
-    /// `ProfileUpdate`, where a message with no name and no encrypted
-    /// image clears the sender's profile.
+    /// The snapshot is treated as one authoritative unit: when applied, every
+    /// profile field on the stored row is replaced by the snapshot's value
+    /// (including `nil`s, which clear the stored field), matching the wire-
+    /// format contract for `ProfileUpdate` where a message with no encrypted
+    /// image clears the sender's avatar. The exceptions are the sticky fields
+    /// in `DBContact.replacingProfileFields`: `displayName` (a blank incoming
+    /// name never clears the stored name) and the agent-template identity
+    /// columns. There is otherwise no per-field merging.
     ///
     /// Application rules:
     /// - Untimestamped snapshots (`profile.profileUpdatedAt == nil`) never
@@ -284,8 +286,8 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
     ///   profiles) and the stored row is authoritative.
     /// - Timestamped snapshots older than the stored `profileUpdatedAt`
     ///   are dropped (most-recent-wins).
-    /// - Timestamped snapshots greater-than-or-equal to the stored
-    ///   timestamp wholesale-replace every profile field on the row.
+    /// - Timestamped snapshots greater-than-or-equal to the stored timestamp
+    ///   replace the row's profile fields (subject to the sticky exceptions).
     private static func replacingProfile(
         of existing: DBContact,
         with profile: ContactProfileSnapshot

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -1135,11 +1135,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
 
         // Never clear an existing name with a name-less/blank update. This is
         // the catch-up/history apply path (cold launch, reconnect, conversation
-        // open, backfill); reprocessing a name-less ProfileUpdate here would
-        // otherwise wipe a populated name and render the member as "Somebody".
-        // A real incoming name still wins; a member we have no name for is
-        // unaffected. Mirrors the guards in StreamProcessor / the NSE handler.
-        profile = profile.with(name: (name?.isEmpty == false) ? name : profile.name)
+        // open, backfill) (see DBMemberProfile.withInboundName).
+        profile = profile.withInboundName(name)
 
         if let image = encryptedImage, image.isValid {
             profile = profile.with(

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -1133,7 +1133,13 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             db, conversationId: conversationId, inboxId: inboxId
         ) ?? DBMemberProfile(conversationId: conversationId, inboxId: inboxId, name: nil, avatar: nil)
 
-        profile = profile.with(name: name)
+        // Never clear an existing name with a name-less/blank update. This is
+        // the catch-up/history apply path (cold launch, reconnect, conversation
+        // open, backfill); reprocessing a name-less ProfileUpdate here would
+        // otherwise wipe a populated name and render the member as "Somebody".
+        // A real incoming name still wins; a member we have no name for is
+        // unaffected. Mirrors the guards in StreamProcessor / the NSE handler.
+        profile = profile.with(name: (name?.isEmpty == false) ? name : profile.name)
 
         if let image = encryptedImage, image.isValid {
             profile = profile.with(

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyGlobalProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyGlobalProfileWriter.swift
@@ -26,26 +26,41 @@ final class MyGlobalProfileWriter: MyGlobalProfileWriterProtocol, Sendable {
 
     func save(name: String?, imageData: Data?, imageAssetIdentifier: String?, metadata: ProfileMetadata?) async throws {
         let inboxId = try await currentInboxId()
-        let row = DBMyProfile(
-            inboxId: inboxId,
-            name: trim(name),
-            imageData: imageData,
-            imageAssetIdentifier: imageData == nil ? nil : imageAssetIdentifier,
-            imageContentDigest: Self.digest(of: imageData),
-            metadata: (metadata?.isEmpty ?? true) ? nil : metadata,
-            updatedAt: Date()
-        )
+        let trimmedName = trim(name)
         try await databaseWriter.write { db in
+            // Never clear an existing name with an empty save: a blank name
+            // would render the local user as "Somebody". A real name still
+            // wins; a first save with no existing name is unaffected.
+            let existing = try DBMyProfile
+                .filter(DBMyProfile.Columns.inboxId == inboxId)
+                .fetchOne(db)
+            // Treat empty/whitespace as "no name provided" independently of
+            // trim()'s nil-for-empty contract, so a future trim() change can't
+            // reintroduce a name-clearing path.
+            let resolvedName: String? = (trimmedName?.isEmpty == false) ? trimmedName : existing?.name
+            let row = DBMyProfile(
+                inboxId: inboxId,
+                name: resolvedName,
+                imageData: imageData,
+                imageAssetIdentifier: imageData == nil ? nil : imageAssetIdentifier,
+                imageContentDigest: Self.digest(of: imageData),
+                metadata: (metadata?.isEmpty ?? true) ? nil : metadata,
+                updatedAt: Date()
+            )
             try row.save(db)
         }
     }
 
     func update(name: String?) async throws {
-        let resolved = trim(name)
+        let trimmedName = trim(name)
         try await mutate { current in
-            DBMyProfile(
+            // Never clear an existing name with an empty update (would render
+            // the local user as "Somebody"). Treat empty/whitespace as "no
+            // name provided" independently of trim() (see save()).
+            let resolvedName: String? = (trimmedName?.isEmpty == false) ? trimmedName : current.name
+            return DBMyProfile(
                 inboxId: current.inboxId,
-                name: resolved,
+                name: resolvedName,
                 imageData: current.imageData,
                 imageAssetIdentifier: current.imageAssetIdentifier,
                 imageContentDigest: current.imageContentDigest,

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/MyProfileWriter.swift
@@ -56,12 +56,19 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
         let profile = try await databaseWriter.write { db in
             let member = DBMember(inboxId: inboxId)
             try member.save(db)
-            let profile = (try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId) ?? .init(
+            let existing = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: inboxId)
+            // Never clear an existing name with an empty update: a blank name
+            // would render the local user as "Somebody". A real name still
+            // wins; a first write with no existing name is unaffected. Treat
+            // empty/whitespace as "no name provided" so we don't depend on the
+            // caller having already normalized it to nil.
+            let resolvedName: String? = (name?.isEmpty == false) ? name : existing?.name
+            let profile = (existing ?? .init(
                 conversationId: conversationId,
                 inboxId: inboxId,
-                name: name,
+                name: resolvedName,
                 avatar: nil
-            )).with(name: name)
+            )).with(name: resolvedName)
             try profile.save(db)
             return profile
         }
@@ -219,8 +226,12 @@ final class MyProfileWriter: MyProfileWriterProtocol, @unchecked Sendable {
 
         // global.name is already trim/clamp/nil-if-empty normalized by MyGlobalProfileWriter,
         // so it can be compared to member?.name directly without re-normalizing here.
-        if global.name != member?.name {
-            try await update(displayName: global.name ?? "", conversationId: conversationId)
+        // Only propagate a real name. A nil/empty global name must never be
+        // pushed out as a clear - it would surface as "Somebody" in the chat
+        // and broadcast that to everyone. global.name is already nil-if-empty
+        // normalized by MyGlobalProfileWriter.
+        if let globalName = global.name, !globalName.isEmpty, globalName != member?.name {
+            try await update(displayName: globalName, conversationId: conversationId)
         }
 
         if global.imageData == nil {

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -494,12 +494,9 @@ actor StreamProcessor: StreamProcessorProtocol {
                     avatar: nil
                 )
 
-                // Don't let a name-less or blank ProfileUpdate (e.g. the startup
-                // update an agent publishes) clear a name we already have - it
-                // would render the member as "Somebody". A real incoming name
-                // still wins; a member we have no name for is unaffected.
-                let incomingName: String? = update.hasName ? update.name : nil
-                profile = profile.with(name: (incomingName?.isEmpty == false) ? incomingName : profile.name)
+                // Never clear an existing name with a name-less/blank update
+                // (see DBMemberProfile.withInboundName).
+                profile = profile.withInboundName(update.hasName ? update.name : nil)
 
                 if update.hasEncryptedImage, update.encryptedImage.isValid {
                     let encryptionKey: Data? = if let existingKey = profile.avatarKey {

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -494,7 +494,12 @@ actor StreamProcessor: StreamProcessorProtocol {
                     avatar: nil
                 )
 
-                profile = profile.with(name: update.hasName ? update.name : nil)
+                // Don't let a name-less or blank ProfileUpdate (e.g. the startup
+                // update an agent publishes) clear a name we already have - it
+                // would render the member as "Somebody". A real incoming name
+                // still wins; a member we have no name for is unaffected.
+                let incomingName: String? = update.hasName ? update.name : nil
+                profile = profile.with(name: (incomingName?.isEmpty == false) ? incomingName : profile.name)
 
                 if update.hasEncryptedImage, update.encryptedImage.isValid {
                     let encryptionKey: Data? = if let existingKey = profile.avatarKey {

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
@@ -152,6 +152,61 @@ struct ContactsWriterTests {
         #expect(contact?.displayName == "Newest")
     }
 
+    @Test("A newer update with a nil name preserves the stored name but still applies other fields")
+    func testNilNameDoesNotClearStoredName() async throws {
+        // Clearing a contact name is never the intent of a profile sync, so a
+        // newer update carrying no name leaves the stored name intact while
+        // still updating the other (non-sticky) fields it does carry.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        let inboxId = "inbox-1"
+
+        try await writer.upsertContact(
+            inboxId: inboxId,
+            addedViaConversationId: nil,
+            profile: ContactProfileSnapshot(displayName: "Bob", profileUpdatedAt: Date(timeIntervalSince1970: 100))
+        )
+
+        try await writer.updateProfileIfNewer(
+            inboxId: inboxId,
+            profile: ContactProfileSnapshot(
+                displayName: nil,
+                avatarURL: "https://example.com/bob.png",
+                profileUpdatedAt: Date(timeIntervalSince1970: 200)
+            )
+        )
+
+        let contact = try await dbManager.dbReader.read { db in
+            try DBContact.fetchOne(db, key: inboxId)
+        }
+        #expect(contact?.displayName == "Bob")
+        #expect(contact?.avatarURL == "https://example.com/bob.png")
+        #expect(contact?.profileUpdatedAt == Date(timeIntervalSince1970: 200))
+    }
+
+    @Test("A newer update with a whitespace-only name preserves the stored name")
+    func testBlankNameDoesNotClearStoredName() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        let inboxId = "inbox-1"
+
+        try await writer.upsertContact(
+            inboxId: inboxId,
+            addedViaConversationId: nil,
+            profile: ContactProfileSnapshot(displayName: "Bob", profileUpdatedAt: Date(timeIntervalSince1970: 100))
+        )
+
+        try await writer.updateProfileIfNewer(
+            inboxId: inboxId,
+            profile: ContactProfileSnapshot(displayName: "   ", profileUpdatedAt: Date(timeIntervalSince1970: 200))
+        )
+
+        let contact = try await dbManager.dbReader.read { db in
+            try DBContact.fetchOne(db, key: inboxId)
+        }
+        #expect(contact?.displayName == "Bob")
+    }
+
     @Test("updateProfileIfNewer no-ops when contact does not exist")
     func testUpdateProfileForUnknownContactNoOps() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()

--- a/ConvosCore/Tests/ConvosCoreTests/DBMemberProfileWithHelpersTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DBMemberProfileWithHelpersTests.swift
@@ -116,3 +116,46 @@ struct DBMemberProfileWithHelpersTests {
         #expect(updated.metadata == Self.baseMetadata)
     }
 }
+
+/// Pins the never-clear invariant shared by every inbound apply path (stream,
+/// NSE push, catch-up/history): a name-less or blank `ProfileUpdate` must never
+/// wipe a name we already have, which would render the member as "Somebody".
+/// All three paths funnel through `DBMemberProfile.withInboundName`, so this is
+/// the single place the invariant is tested.
+@Suite("DBMemberProfile.withInboundName never clears an existing name")
+struct DBMemberProfileInboundNameTests {
+    private static func profile(name: String?) -> DBMemberProfile {
+        DBMemberProfile(conversationId: "convo-1", inboxId: "inbox-1", name: name, avatar: nil)
+    }
+
+    @Test("a real incoming name wins")
+    func realNameWins() {
+        #expect(Self.profile(name: "Bob").withInboundName("Robert").name == "Robert")
+    }
+
+    @Test("a nil incoming name preserves the existing name")
+    func nilPreservesExisting() {
+        #expect(Self.profile(name: "Bob").withInboundName(nil).name == "Bob")
+    }
+
+    @Test("an empty incoming name preserves the existing name")
+    func emptyPreservesExisting() {
+        #expect(Self.profile(name: "Bob").withInboundName("").name == "Bob")
+    }
+
+    @Test("a whitespace-only incoming name preserves the existing name")
+    func whitespacePreservesExisting() {
+        #expect(Self.profile(name: "Bob").withInboundName("   ").name == "Bob")
+    }
+
+    @Test("a real name is set when none existed")
+    func firstNameIsSet() {
+        #expect(Self.profile(name: nil).withInboundName("Bob").name == "Bob")
+    }
+
+    @Test("a blank incoming name with no existing name stays nil")
+    func blankWithNoExistingStaysNil() {
+        #expect(Self.profile(name: nil).withInboundName(nil).name == nil)
+        #expect(Self.profile(name: nil).withInboundName("").name == nil)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfilePersistenceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfilePersistenceTests.swift
@@ -119,18 +119,6 @@ struct ProfilePersistenceTests {
         let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == group.id })
         try await groupB.sync()
 
-        // Seed a previously-known name for A in B's database.
-        try await fixtures.databaseManager.dbWriter.write { db in
-            let member = DBMember(inboxId: clientA.inboxID)
-            try member.save(db)
-            try DBMemberProfile(
-                conversationId: group.id,
-                inboxId: clientA.inboxID,
-                name: "Alice",
-                avatar: nil
-            ).save(db)
-        }
-
         let mockMessageWriter = MockIncomingMessageWriter()
         let conversationWriter = ConversationWriter(
             identityStore: fixtures.identityStore,
@@ -138,6 +126,24 @@ struct ProfilePersistenceTests {
             messageWriter: mockMessageWriter
         )
 
+        // First store persists the conversation + member rows (so the
+        // memberProfile foreign keys resolve) and processes the name-less
+        // update, leaving A with no name.
+        _ = try await conversationWriter.store(
+            conversation: groupB,
+            inboxId: inboxIdB
+        )
+
+        // Seed a previously-known name for A now that the conversation row
+        // exists. This models a name we already had before re-running catch-up.
+        try await fixtures.databaseManager.dbWriter.write { db in
+            let existing = try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: clientA.inboxID)
+                ?? DBMemberProfile(conversationId: group.id, inboxId: clientA.inboxID, name: nil, avatar: nil)
+            try existing.with(name: "Alice").save(db)
+        }
+
+        // Re-running store reprocesses the same name-less update from history.
+        // With the guard, A's name must survive (not revert to "Somebody").
         _ = try await conversationWriter.store(
             conversation: groupB,
             inboxId: inboxIdB

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfilePersistenceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfilePersistenceTests.swift
@@ -88,6 +88,69 @@ struct ProfilePersistenceTests {
         try? await fixtures.cleanup()
     }
 
+    @Test("A name-less inbound ProfileUpdate does not clear an existing member name (catch-up)")
+    func nameLessUpdateDoesNotClearExistingName() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB as? Client,
+              let clientIdB = fixtures.clientIdB else {
+            throw TestError.missingClients
+        }
+
+        let inboxIdB = clientB.inboxID
+        try await fixtures.databaseManager.dbWriter.write { db in
+            try DBInbox(inboxId: inboxIdB, clientId: clientIdB, createdAt: Date()).insert(db)
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxID],
+            name: "Test Group"
+        )
+
+        // A publishes a name-less ProfileUpdate (e.g. the startup ping an agent
+        // sends, or any partial update). Reprocessing it on catch-up must not
+        // clear A's already-known name and surface "Somebody".
+        let nameLessUpdate = ProfileUpdate()
+        _ = try await group.send(encodedContent: try ProfileUpdateCodec().encode(content: nameLessUpdate))
+
+        try await clientB.conversations.sync()
+        let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == group.id })
+        try await groupB.sync()
+
+        // Seed a previously-known name for A in B's database.
+        try await fixtures.databaseManager.dbWriter.write { db in
+            let member = DBMember(inboxId: clientA.inboxID)
+            try member.save(db)
+            try DBMemberProfile(
+                conversationId: group.id,
+                inboxId: clientA.inboxID,
+                name: "Alice",
+                avatar: nil
+            ).save(db)
+        }
+
+        let mockMessageWriter = MockIncomingMessageWriter()
+        let conversationWriter = ConversationWriter(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            messageWriter: mockMessageWriter
+        )
+
+        _ = try await conversationWriter.store(
+            conversation: groupB,
+            inboxId: inboxIdB
+        )
+
+        let profile = try await fixtures.databaseManager.dbReader.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: clientA.inboxID)
+        }
+        #expect(profile?.name == "Alice")
+
+        try? await fixtures.cleanup()
+    }
+
     @Test("AppData profile fills gap for member without message-sourced data")
     func appDataProfileFillsGap() async throws {
         let fixtures = TestFixtures()

--- a/ConvosCore/Tests/ConvosCoreTests/MemberNameOverrideTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberNameOverrideTests.swift
@@ -242,4 +242,40 @@ struct MemberNameOverrideTests {
         #expect(result.contains("AliceContact"))
         #expect(!result.contains("Somebody"))
     }
+
+    // MARK: - ConversationMember.displayName(contactNameFallback:)
+    // Fallback-only variant used by message-derived surfaces (in-chat bubble,
+    // conversation-list preview). The per-conversation name wins; the contact
+    // name only fills an empty name. Unlike the override variant, it can never
+    // replace a name that already renders correctly.
+
+    @Test("Fallback: the per-conversation name wins over the contact name")
+    func testFallbackProfileNameWins() {
+        let member = Self.member(inboxId: "alice", name: "AliceProfile")
+        let result = member.displayName(contactNameFallback: { _ in "AliceContact" })
+        #expect(result == "AliceProfile")
+    }
+
+    @Test("Fallback: the contact name fills an empty per-conversation name")
+    func testFallbackFillsEmptyName() {
+        let member = Self.member(inboxId: "alice", name: nil)
+        let result = member.displayName(contactNameFallback: { inboxId in
+            inboxId == "alice" ? "AliceContact" : nil
+        })
+        #expect(result == "AliceContact")
+    }
+
+    @Test("Fallback: empty name and no contact still renders Somebody")
+    func testFallbackNoNameNoContactSomebody() {
+        let member = Self.member(inboxId: "alice", name: nil)
+        let result = member.displayName(contactNameFallback: { _ in nil })
+        #expect(result == "Somebody")
+    }
+
+    @Test("Fallback: an empty contact name is ignored")
+    func testFallbackEmptyContactIgnored() {
+        let member = Self.member(inboxId: "alice", name: nil)
+        let result = member.displayName(contactNameFallback: { _ in "" })
+        #expect(result == "Somebody")
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/MyGlobalProfileTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MyGlobalProfileTests.swift
@@ -90,6 +90,31 @@ struct MyGlobalProfileTests {
         #expect(profile?.imageData == nil)
     }
 
+    @Test("save does not clear an existing name when passed an empty name")
+    func saveDoesNotClearExistingName() async throws {
+        let fixture = try await Fixture.make()
+        try await fixture.writer.save(name: "Alice", imageData: nil, imageAssetIdentifier: nil, metadata: nil)
+
+        // A blank name must not wipe the stored name (would render as "Somebody").
+        try await fixture.writer.save(name: "   ", imageData: nil, imageAssetIdentifier: nil, metadata: nil)
+        #expect(try fixture.repository.fetch()?.name == "Alice")
+
+        try await fixture.writer.save(name: nil, imageData: nil, imageAssetIdentifier: nil, metadata: nil)
+        #expect(try fixture.repository.fetch()?.name == "Alice")
+    }
+
+    @Test("update(name:) does not clear an existing name when passed an empty name")
+    func updateNameDoesNotClearExistingName() async throws {
+        let fixture = try await Fixture.make()
+        try await fixture.writer.save(name: "Alice", imageData: nil, imageAssetIdentifier: nil, metadata: nil)
+
+        try await fixture.writer.update(name: "")
+        #expect(try fixture.repository.fetch()?.name == "Alice")
+
+        try await fixture.writer.update(name: nil)
+        #expect(try fixture.repository.fetch()?.name == "Alice")
+    }
+
     @Test("repository fetch returns nil before any save")
     func fetchReturnsNilWhenEmpty() async throws {
         let fixture = try await Fixture.make()


### PR DESCRIPTION
### 1. An empty name can never overwrite a populated name (all flows)

#### Your own name (outbound)

- Global profile writer (`save`, `update(name:)`) will never clear an existing name when given a blank value.
- Per-conversation writer (`update(displayName:)`) will never clear an existing name when given a blank value.
- Both "My Info" and the in-chat quick edit UI preserve the existing name if the field is left blank.

#### Other members' names (inbound)

The following code paths all refuse to clear an existing name when an incoming update has a blank or missing name:

- Live stream updates
- NSE push handler
- Catch-up/history reprocessing

These paths all share the same helper:

- `DBMemberProfile.withInboundName`

This ensures the "never clear on blank" rule is implemented in a single location.

#### Contact mirror

- A blank contact update never clears a stored contact name (`DBContact.displayName` remains sticky).

---

### 2. Fall back to the contact name when the member name is empty (fallback-only)

A few places in code only referenced conversation member name, and not contact name, so it was possible for an existing contact to be shown as Somebody inside a chat. Now in those cases, the contact name is now used **only** when the member name is empty. 

#### Applies to

- In-chat message bubble sender label
- Conversation list last-message preview subtitle

#### Behavior

- The per-conversation member name always takes precedence.
- The contact name is used only as a fallback instead of displaying `"Somebody"`.
- A contact name can **never** replace a valid member name.
- This change only affects rendering—it does **not** change name propagation or synchronization behavior.

#### Reactivity

The conversation list observation now also watches the contact table, so renaming a contact immediately refreshes conversation previews.

---

### 3. Tests

#### Unit tests (no Docker)

- `DBMemberProfile.withInboundName` never clears an existing name.
- `displayName(contactNameFallback:)` correctly performs fallback-only resolution.

#### Integration tests (Docker)

- Catch-up/history reprocessing preserves an existing name when replaying a name-less update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784766900&installation_id=128169237&pr_number=1098&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1098&signature=05508543aa8fadec7311d145e0d420bff8f5d4d727853c76c44cffbe71872eb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent display names from being cleared by blank or empty name updates
> - Blank or empty names no longer overwrite existing display names across profile save, per-conversation name edits, contact sync, push notifications, stream processing, and catch-up/history store.
> - Introduces `DBMemberProfile.withInboundName(_:)` to apply inbound names without clearing, replacing direct `with(name:)` calls in [`StreamProcessor`](https://github.com/xmtplabs/convos-ios/pull/1098/files#diff-f78e6097ff7047f6d74818393ba23110c801e841158bb8edeaee24ec74566791) and [`ConversationWriter`](https://github.com/xmtplabs/convos-ios/pull/1098/files#diff-113bfd0c28b1a3b561f19e4574a0937082fe5c92a262e57573eee7728940a726).
> - Adds contact-name fallback resolution via `ConversationMember.displayName(contactNameFallback:)`, threading a `contactNameResolver` through conversation hydration, message previews, `MessagesGroupView`, and `ReadByDrawerView`.
> - `MyGlobalProfileWriter`, `MyProfileWriter`, `ProfileSettingsViewModel`, and `MyProfileViewModel` each guard against writing an empty name when a stored name already exists.
> - New unit and integration tests cover the no-clear behavior for contacts, member profiles, global profile writes, and the fallback display name logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ca3fff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->