### PR TITLE
Use person.crop.circle.fill for Contacts tab icon

### DIFF
--- a/Convos/Conversations List/ConvosTab.swift
+++ b/Convos/Conversations List/ConvosTab.swift
@@ -20,7 +20,7 @@ enum ConvosTab: Hashable {
         switch self {
         case .chats: "message.fill"
         case .things: "square.grid.2x2.fill"
-        case .contacts: "person.fill"
+        case .contacts: "person.crop.circle.fill"
         }
     }
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784810839&installation_id=128169237&pr_number=1099&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1099&signature=92b7fac4414bd5e2c45910a0078302a3a5ce7f05d25a4aedba3cd79eb80d1bfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `person.crop.circle.fill` SF Symbol for the Contacts tab icon
> Updates the `ConvosTab.symbol` computed property in [ConvosTab.swift](https://github.com/xmtplabs/convos-ios/pull/1099/files#diff-b17057ddfe6dd0f73844581fe3b3c9feb6a879b44545a3a5e2aca39a221fc543) to return `person.crop.circle.fill` instead of `person.fill` for the `.contacts` case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d82eb43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->