### PR TITLE
ci(fly): force non-interactive flyctl and surface apps-create errors

### DIFF
--- a/.github/workflows/convoscore-tests.yml
+++ b/.github/workflows/convoscore-tests.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: 0.4.60
 
       - name: Deploy ephemeral backend
         id: deploy
@@ -125,6 +127,8 @@ jobs:
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: 0.4.60
 
       - name: Destroy ephemeral app
         env:

--- a/.github/workflows/fly-cleanup.yml
+++ b/.github/workflows/fly-cleanup.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: 0.4.60
 
       - name: Run cleanup
         env:

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -18,6 +18,7 @@
 #   FLY_REGION    - Region to deploy to (default: iad)
 
 set -e
+export FLYCTL_NO_PROMPT=1
 
 # Validate required environment variables
 if [ -z "$FLY_API_TOKEN" ]; then
@@ -42,13 +43,16 @@ fi
 
 echo "Creating app: $APP_NAME" >&2
 
-# Create the app (fail if creation fails for reasons other than "already exists")
-flyctl apps create "$APP_NAME" --org "$FLY_ORG" 2>/dev/null || {
-    flyctl apps show "$APP_NAME" >/dev/null 2>&1 || {
+# Create the app; if it already exists continue, otherwise surface the real error
+if ! CREATE_OUT="$(flyctl apps create "$APP_NAME" --org "$FLY_ORG" 2>&1)"; then
+    if flyctl apps show "$APP_NAME" >/dev/null 2>&1; then
+        echo "App already exists, continuing: $APP_NAME" >&2
+    else
         echo "Failed to create app: $APP_NAME" >&2
+        echo "$CREATE_OUT" >&2
         exit 1
-    }
-}
+    fi
+fi
 
 # Allocate IP addresses for the app (ignore if already allocated)
 echo "Allocating IP addresses..." >&2


### PR DESCRIPTION
Export FLYCTL_NO_PROMPT=1 in ci/fly/deploy so flyctl can never block on an
interactive app-name/app-creation prompt in CI. Stop discarding the
`flyctl apps create` stderr with 2>/dev/null; capture it and, when the app
does not already exist, print the real Fly.io error and exit non-zero
instead of falling through to an opaque "prompt: non interactive" failure
in the downstream machine run. Idempotent already-exists handling is
preserved.

Pin flyctl to 0.4.60 (last-known-good) on the setup-flyctl steps in
convoscore-tests.yml and fly-cleanup.yml so CI tooling stays reproducible.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784822144&installation_id=128169237&pr_number=1102&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1102&signature=61c8c7d32a30d51b4e9c6b9559b20cda256c20182da2e368e3b93ece814db716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force non-interactive flyctl and surface `apps create` errors in CI deploy script
> - Sets `FLYCTL_NO_PROMPT=1` in [ci/fly/deploy](https://github.com/xmtplabs/convos-ios/pull/1102/files#diff-61e6241979a19fbcf5c3d2392602f31309167b23a2084e784dd4595494ab7ba9) to prevent flyctl from blocking on interactive prompts.
> - Reworks app creation logic to capture output from `flyctl apps create` and distinguish between "app already exists" (logs and continues) vs. a real failure (logs error output and exits with status 1).
> - Pins flyctl to version `0.4.60` across all CI workflows to ensure consistent CLI behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6f5e4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->