### PR TITLE
fix(subscriptions): send platform:"apple" on subscription verify

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -378,6 +378,7 @@ public enum ConvosAPI {
     /// body too would let a caller claim someone else's transaction.
     struct VerifySubscriptionRequest: Encodable {
         let jwsRepresentation: String
+        let platform: String = "apple"
     }
 
     struct VerifySubscriptionResponse: Decodable {


### PR DESCRIPTION
The backend `/api/v2/accounts/me/subscription/verify` now requires a `platform` discriminator (added with Google Play billing). iOS was sending bare `{ jwsRepresentation }` → **400 Bad Request** on every verify (so subscriptions never recorded/credited).

**Fix:** add `platform: "apple"` to the shared `VerifySubscriptionRequest` struct (`ConvosAPIClient+Models.swift`). All three verify paths — purchase, restore-purchases, and the background `Transaction.updates` listener — funnel through it, so the one struct covers them.

**Build:** `BUILD SUCCEEDED` (arm64 sim); SwiftFormat + SwiftLint clean.

Pairs with the backend backwards-compat fix (default `platform → apple` when absent) — that one unblocks already-shipped builds with no app release; this is the forward fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784881385&installation_id=128169237&pr_number=1104&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1104&signature=dd39e48cf1e5101fae01d2502567e1a47f74a8de72c33997d9602771209ca5ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ConvosAPI.VerifySubscriptionRequest` to include `platform: "apple"` in subscription verify requests
> The `platform` field was missing from the IAP subscription verification request body. Adds a `platform` property with a default value of `"apple"` to [ConvosAPI.VerifySubscriptionRequest](https://github.com/xmtplabs/convos-ios/pull/1104/files#diff-869f0fb39659b9175c5a2597ca99467c503f8bdf5805e619872b7c8e07f73ce3) so it is included in all encoded payloads sent to the verification endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 366faf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->