### PR TITLE
feat(messages): long-message handling to fix main-thread hangs

### DIFF
--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -122,7 +122,7 @@ The canonical order (from `qa/SKILL.md` "Run all tests") is:
    → 16 → 17 → 20 → 27 → 28 → 19 → 15 → 34 → 18
 ```
 
-plus secondary tests `14, 22, 23, 23b, 24, 25, 26, 28b, 29, 30, 31, 32, 33` slotted where they don't conflict with destructive steps (09, 18).
+plus secondary tests `14, 22, 23, 23b, 24, 25, 26, 28b, 29, 30, 31, 32, 33, 43` slotted where they don't conflict with destructive steps (09, 18). Test 43 (long-message rendering) explodes the shared conversation in teardown, so slot it late in the sequence, after other tests that reuse `shared_conversation_id`.
 
 **What can actually run in parallel:**
 

--- a/Convos/Assets.xcassets/colorBorderInvertedSubtle.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorBorderInvertedSubtle.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x33",
+          "red" : "0x33"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Convos/Assets.xcassets/colorBorderReadMoreIncoming.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorBorderReadMoreIncoming.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xEB",
+          "red" : "0xEB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x52",
+          "green" : "0x52",
+          "red" : "0x52"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -265,6 +265,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 viewModel.onReply(message)
                 focusCoordinator.moveFocus(to: .message)
             },
+            onOpenMessageDetail: { message in
+                viewModel.presentingMessageDetail = message
+            },
             replyingToMessage: viewModel.replyingToMessage,
             replyingToAudioTranscriptText: viewModel.replyingToAudioTranscriptText,
             onCancelReply: viewModel.cancelReply,
@@ -677,6 +680,19 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 conversation: viewModel.conversation,
                 viewModel: viewModel,
                 profileSheetForMember: profileSheetForMember
+            )
+        }
+        .sheet(item: $viewModel.presentingMessageDetail) { message in
+            MessageDetailView(
+                message: message,
+                onCopy: { text in
+                    UIPasteboard.general.string = text
+                },
+                onReply: { repliedMessage in
+                    viewModel.presentingMessageDetail = nil
+                    viewModel.onReply(repliedMessage)
+                    focusCoordinator.moveFocus(to: .message)
+                }
             )
         }
         .selfSizingSheet(isPresented: $showingLockedInfo) {

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -268,6 +268,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onOpenMessageDetail: { message in
                 viewModel.presentingMessageDetail = message
             },
+            expandedMessageIds: viewModel.expandedMessageIds,
+            onToggleMessageExpanded: { messageId in
+                viewModel.toggleMessageExpanded(messageId)
+            },
             replyingToMessage: viewModel.replyingToMessage,
             replyingToAudioTranscriptText: viewModel.replyingToAudioTranscriptText,
             onCancelReply: viewModel.cancelReply,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1005,6 +1005,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var presentingReactionsForMessage: AnyMessage?
     var presentingReadByForGroup: MessagesGroup?
     var presentingThinkingDetail: ThinkingSessionDescriptor?
+    /// Drives the `MessageDetailView` sheet for a pathological (very long)
+    /// message body, presented when its bubble "Read More" is tapped.
+    var presentingMessageDetail: AnyMessage?
     var replyingToMessage: AnyMessage?
     var presentingShareView: Bool = false
     var presentingPhotosInfoSheet: Bool = false

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1008,6 +1008,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// Drives the `MessageDetailView` sheet for a pathological (very long)
     /// message body, presented when its bubble "Read More" is tapped.
     var presentingMessageDetail: AnyMessage?
+    /// Message ids whose long-body inline expansion is on. Held on the view
+    /// model (not as cell-local `@State`) so an expanded message stays expanded
+    /// across `UICollectionView` cell reuse and never bleeds onto a recycled
+    /// cell showing a different message.
+    var expandedMessageIds: Set<String> = []
     var replyingToMessage: AnyMessage?
     var presentingShareView: Bool = false
     var presentingPhotosInfoSheet: Bool = false
@@ -3454,6 +3459,14 @@ extension ConversationViewModel {
 
     func onReply(_ message: AnyMessage) {
         replyingToMessage = message
+    }
+
+    func toggleMessageExpanded(_ messageId: String) {
+        if expandedMessageIds.contains(messageId) {
+            expandedMessageIds.remove(messageId)
+        } else {
+            expandedMessageIds.insert(messageId)
+        }
     }
 
     func cancelReply() {

--- a/Convos/Conversation Detail/MessageDetailView.swift
+++ b/Convos/Conversation Detail/MessageDetailView.swift
@@ -1,0 +1,122 @@
+import ConvosCore
+import SwiftUI
+import UIKit
+
+/// Full-screen sheet for reading a single long message body. Presented from
+/// `ConversationView` via `.sheet(item: $viewModel.presentingMessageDetail)`
+/// when a pathological message bubble's "Read More" is tapped (mirrors the
+/// `ThinkingDetailView` sheet pattern, since the conversation screen has no
+/// in-line `NavigationStack` and the messages list is a UIKit collection).
+///
+/// The body renders in a scroll-enabled `UITextView` (`SelectableTextView`)
+/// rather than a SwiftUI `Text`: a whole-body `Text` in the sheet would pay
+/// the same synchronous full-height CoreText measure during the present
+/// transition that the inline bubble was hanging on. A scroll-enabled
+/// `UITextView` lays out lazily by line fragment, gives native selection for
+/// free, and detects links.
+struct MessageDetailView: View {
+    let message: AnyMessage
+    let onCopy: (String) -> Void
+    let onReply: (AnyMessage) -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    private var bodyText: String {
+        switch message.content {
+        case .text(let text):
+            return text
+        case .emoji(let text):
+            return text
+        default:
+            return ""
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            SelectableTextView(text: bodyText)
+                .ignoresSafeArea(.container, edges: .bottom)
+                .safeAreaInset(edge: .bottom) { bottomActionBar }
+                .navigationTitle("Message")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar { backToolbarItem }
+        }
+        .accessibilityIdentifier("message-detail-view")
+        .presentationDetents([.large])
+    }
+
+    @ToolbarContentBuilder
+    private var backToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            let backAction: () -> Void = { dismiss() }
+            Button(action: backAction) {
+                Image(systemName: "chevron.backward")
+            }
+            .accessibilityIdentifier("message-detail-back-button")
+            .accessibilityLabel("Back")
+        }
+    }
+
+    private var bottomActionBar: some View {
+        HStack {
+            let copyAction: () -> Void = { onCopy(bodyText) }
+            Button(action: copyAction) {
+                actionIcon("doc.on.doc")
+            }
+            .accessibilityIdentifier("message-detail-copy-button")
+            .accessibilityLabel("Copy")
+
+            Spacer()
+
+            let replyAction: () -> Void = { onReply(message) }
+            Button(action: replyAction) {
+                actionIcon("arrowshape.turn.up.left")
+            }
+            .accessibilityIdentifier("message-detail-reply-button")
+            .accessibilityLabel("Reply")
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.bottom, DesignConstants.Spacing.step3x)
+    }
+
+    private func actionIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.body.weight(.semibold))
+            .foregroundStyle(.colorTextPrimary)
+            .frame(width: Constant.actionButtonSize, height: Constant.actionButtonSize)
+            .glassEffect(.regular.interactive(), in: .circle)
+    }
+
+    private enum Constant {
+        static let actionButtonSize: CGFloat = 44.0
+    }
+}
+
+/// Scroll-enabled, non-editable `UITextView` for the message detail body.
+/// Distinct from `LinkDetectingTextView` (which is `isScrollEnabled = false`
+/// and self-sizes via `sizeThatFits` - the very full-measure cost this view
+/// avoids). Keeping `isScrollEnabled = true` is what makes TextKit lay out
+/// incrementally instead of measuring the whole string up front.
+private struct SelectableTextView: UIViewRepresentable {
+    let text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isScrollEnabled = true
+        textView.isSelectable = true
+        textView.backgroundColor = .clear
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.dataDetectorTypes = .link
+        textView.alwaysBounceVertical = true
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        if uiView.text != text {
+            uiView.text = text
+        }
+    }
+}

--- a/Convos/Conversation Detail/MessageDetailView.swift
+++ b/Convos/Conversation Detail/MessageDetailView.swift
@@ -106,7 +106,8 @@ private struct SelectableTextView: UIViewRepresentable {
         textView.isScrollEnabled = true
         textView.isSelectable = true
         textView.backgroundColor = .clear
-        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        let inset: CGFloat = DesignConstants.Spacing.step4x
+        textView.textContainerInset = UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
         textView.font = .preferredFont(forTextStyle: .body)
         textView.adjustsFontForContentSizeCategory = true
         textView.dataDetectorTypes = .link

--- a/Convos/Conversation Detail/MessageDetailView.swift
+++ b/Convos/Conversation Detail/MessageDetailView.swift
@@ -34,7 +34,7 @@ struct MessageDetailView: View {
 
     var body: some View {
         NavigationStack {
-            SelectableTextView(text: bodyText)
+            SelectableTextView(text: bodyText, bottomClearance: Constant.bottomContentClearance)
                 .ignoresSafeArea(.container, edges: .bottom)
                 .safeAreaInset(edge: .bottom) { bottomActionBar }
                 .navigationTitle("Message")
@@ -89,6 +89,15 @@ struct MessageDetailView: View {
 
     private enum Constant {
         static let actionButtonSize: CGFloat = 44.0
+        /// Bottom content inset for the scrolling body so its last line and
+        /// scroll indicator clear the floating Copy/Reply buttons. Covers the
+        /// button height, the action bar's bottom padding, and a comfortable
+        /// gap. The bottom safe-area inset is added on top automatically by the
+        /// text view's `adjustedContentInset` (the bar is placed via
+        /// `safeAreaInset`, the body extends under it via `ignoresSafeArea`).
+        static let bottomContentClearance: CGFloat = actionButtonSize
+            + DesignConstants.Spacing.step3x
+            + DesignConstants.Spacing.step4x
     }
 }
 
@@ -99,6 +108,11 @@ struct MessageDetailView: View {
 /// incrementally instead of measuring the whole string up front.
 private struct SelectableTextView: UIViewRepresentable {
     let text: String
+    /// Extra bottom inset so the final line and scroll indicator sit above the
+    /// floating Copy/Reply buttons. Applied as `contentInset.bottom` (not
+    /// `textContainerInset`) so the scroll indicator is inset too; the bottom
+    /// safe area is added on top by `adjustedContentInset`.
+    let bottomClearance: CGFloat
 
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
@@ -118,6 +132,10 @@ private struct SelectableTextView: UIViewRepresentable {
     func updateUIView(_ uiView: UITextView, context: Context) {
         if uiView.text != text {
             uiView.text = text
+        }
+        if uiView.contentInset.bottom != bottomClearance {
+            uiView.contentInset.bottom = bottomClearance
+            uiView.verticalScrollIndicatorInsets.bottom = bottomClearance
         }
     }
 }

--- a/Convos/Conversation Detail/MessageDetailView.swift
+++ b/Convos/Conversation Detail/MessageDetailView.swift
@@ -120,6 +120,7 @@ private struct SelectableTextView: UIViewRepresentable {
         textView.isScrollEnabled = true
         textView.isSelectable = true
         textView.backgroundColor = .clear
+        textView.textColor = .label
         let inset: CGFloat = DesignConstants.Spacing.step4x
         textView.textContainerInset = UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
         textView.font = .preferredFont(forTextStyle: .body)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -196,6 +196,8 @@ class MessagesListItemTypeCell: UICollectionViewCell {
             onToggleReaction: config.onToggleReaction,
             onReply: config.onReply,
             onOpenMessageDetail: config.onOpenMessageDetail,
+            expandedMessageIds: config.expandedMessageIds,
+            onToggleMessageExpanded: config.onToggleMessageExpanded,
             onPhotoDimensionsLoaded: config.onPhotoDimensionsLoaded,
             onOpenFile: config.onOpenFile,
             onRetryMessage: config.onRetryMessage,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -195,6 +195,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
             onReaction: config.onReaction,
             onToggleReaction: config.onToggleReaction,
             onReply: config.onReply,
+            onOpenMessageDetail: config.onOpenMessageDetail,
             onPhotoDimensionsLoaded: config.onPhotoDimensionsLoaded,
             onOpenFile: config.onOpenFile,
             onRetryMessage: config.onRetryMessage,

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -29,8 +29,9 @@ struct CellConfig {
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
     /// Surfaces a pathological text bubble's "Read More" tap so the host can
-    /// present `MessageDetailView`.
-    let onOpenMessageDetail: (AnyMessage) -> Void
+    /// present `MessageDetailView`. Nil when no host handler is wired, which
+    /// suppresses the button (nil-handler => no button contract).
+    let onOpenMessageDetail: ((AnyMessage) -> Void)?
     /// Message ids with long-body inline expansion on (owned by the VM, so it
     /// survives `UICollectionView` cell reuse).
     let expandedMessageIds: Set<String>

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -28,6 +28,9 @@ struct CellConfig {
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
+    /// Surfaces a pathological text bubble's "Read More" tap so the host can
+    /// present `MessageDetailView`.
+    let onOpenMessageDetail: (AnyMessage) -> Void
     let contextMenuState: MessageContextMenuState
     let onAgentOutOfCredits: () -> Void
     let creditsDepleted: Bool

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -31,6 +31,11 @@ struct CellConfig {
     /// Surfaces a pathological text bubble's "Read More" tap so the host can
     /// present `MessageDetailView`.
     let onOpenMessageDetail: (AnyMessage) -> Void
+    /// Message ids with long-body inline expansion on (owned by the VM, so it
+    /// survives `UICollectionView` cell reuse).
+    let expandedMessageIds: Set<String>
+    /// Toggles a message id's long-body inline expansion on the host.
+    let onToggleMessageExpanded: (String) -> Void
     let contextMenuState: MessageContextMenuState
     let onAgentOutOfCredits: () -> Void
     let creditsDepleted: Bool

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -18,6 +18,8 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onToggleReaction: ((String, String) -> Void)? { get set }
     var onReply: ((AnyMessage) -> Void)? { get set }
     var onOpenMessageDetail: ((AnyMessage) -> Void)? { get set }
+    var expandedMessageIds: Set<String> { get set }
+    var onToggleMessageExpanded: ((String) -> Void)? { get set }
     var contextMenuState: MessageContextMenuState? { get set }
     var conversationId: String { get set }
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -17,6 +17,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var onReaction: ((String, String) -> Void)? { get set }
     var onToggleReaction: ((String, String) -> Void)? { get set }
     var onReply: ((AnyMessage) -> Void)? { get set }
+    var onOpenMessageDetail: ((AnyMessage) -> Void)? { get set }
     var contextMenuState: MessageContextMenuState? { get set }
     var conversationId: String { get set }
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)? { get set }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -121,8 +121,8 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             onReply: { [weak self] message in
                 self?.onReply?(message)
             },
-            onOpenMessageDetail: { [weak self] message in
-                self?.onOpenMessageDetail?(message)
+            onOpenMessageDetail: onOpenMessageDetail.map { _ in
+                { [weak self] message in self?.onOpenMessageDetail?(message) }
             },
             expandedMessageIds: expandedMessageIds,
             onToggleMessageExpanded: { [weak self] messageId in

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -25,6 +25,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onReaction: ((String, String) -> Void)?
     var onToggleReaction: ((String, String) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
+    var onOpenMessageDetail: ((AnyMessage) -> Void)?
     var contextMenuState: MessageContextMenuState?
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)?
     var onAgentOutOfCredits: (() -> Void)?
@@ -117,6 +118,9 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onReply: { [weak self] message in
                 self?.onReply?(message)
+            },
+            onOpenMessageDetail: { [weak self] message in
+                self?.onOpenMessageDetail?(message)
             },
             contextMenuState: contextMenuState ?? .init(),
             onAgentOutOfCredits: { [weak self] in

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -26,6 +26,8 @@ final class MessagesCollectionViewDataSource: NSObject {
     var onToggleReaction: ((String, String) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
     var onOpenMessageDetail: ((AnyMessage) -> Void)?
+    var expandedMessageIds: Set<String> = []
+    var onToggleMessageExpanded: ((String) -> Void)?
     var contextMenuState: MessageContextMenuState?
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)?
     var onAgentOutOfCredits: (() -> Void)?
@@ -121,6 +123,10 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             },
             onOpenMessageDetail: { [weak self] message in
                 self?.onOpenMessageDetail?(message)
+            },
+            expandedMessageIds: expandedMessageIds,
+            onToggleMessageExpanded: { [weak self] messageId in
+                self?.onToggleMessageExpanded?(messageId)
             },
             contextMenuState: contextMenuState ?? .init(),
             onAgentOutOfCredits: { [weak self] in

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -395,7 +395,13 @@ final class MessagesViewController: UIViewController {
     var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onTapThinkingIndicator: ((ThinkingSessionDescriptor) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
-    var onOpenMessageDetail: ((AnyMessage) -> Void)?
+    /// When nil, the data source forwards nil into `CellConfig` so the bubble's
+    /// "Read more" detail button is suppressed (nil-handler => no button). The
+    /// `didSet` re-applies that mapping whenever the host wires or clears the
+    /// handler, after the data source has been created during setup.
+    var onOpenMessageDetail: ((AnyMessage) -> Void)? {
+        didSet { applyOpenMessageDetailToDataSource() }
+    }
     var onToggleMessageExpanded: ((String) -> Void)?
     /// Message ids whose long-body inline expansion is on. Owned by the VM and
     /// pushed in each render so expansion survives cell reuse; forwarded to the
@@ -484,6 +490,17 @@ final class MessagesViewController: UIViewController {
     /// Reconfigures the visible message cells that contain any of the given
     /// message ids. Used when the long-body expansion set flips, since that
     /// change carries no DifferenceKit changeset on its own.
+    /// Forwards the host's optional detail handler to the data source, keeping
+    /// it nil when the host wired none so the bubble's "Read more" detail button
+    /// is suppressed. Called at setup and from `onOpenMessageDetail.didSet`, so
+    /// it stays correct regardless of whether the host sets the handler before
+    /// or after the data source is created.
+    private func applyOpenMessageDetailToDataSource() {
+        dataSource.onOpenMessageDetail = onOpenMessageDetail.map { _ in
+            { [weak self] message in self?.onOpenMessageDetail?(message) }
+        }
+    }
+
     private func reconfigureCells(forMessageIds messageIds: Set<String>) {
         guard !messageIds.isEmpty else { return }
         var indexPaths: [IndexPath] = []
@@ -691,9 +708,7 @@ final class MessagesViewController: UIViewController {
             guard let self = self else { return }
             self.onReply?(message)
         }
-        dataSource.onOpenMessageDetail = { [weak self] message in
-            self?.onOpenMessageDetail?(message)
-        }
+        applyOpenMessageDetailToDataSource()
         dataSource.onToggleMessageExpanded = { [weak self] messageId in
             self?.onToggleMessageExpanded?(messageId)
         }

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -396,6 +396,21 @@ final class MessagesViewController: UIViewController {
     var onTapThinkingIndicator: ((ThinkingSessionDescriptor) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
     var onOpenMessageDetail: ((AnyMessage) -> Void)?
+    var onToggleMessageExpanded: ((String) -> Void)?
+    /// Message ids whose long-body inline expansion is on. Owned by the VM and
+    /// pushed in each render so expansion survives cell reuse; forwarded to the
+    /// data source so reconfigured cells read the current set.
+    var expandedMessageIds: Set<String> = [] {
+        didSet {
+            guard expandedMessageIds != oldValue else { return }
+            dataSource.expandedMessageIds = expandedMessageIds
+            // A change to the set alone produces no DifferenceKit changeset
+            // (the messages are identical), so the visible cell would not
+            // re-render. Reconfigure the cells whose expansion flipped so the
+            // hosted SwiftUI bubble rebuilds from the updated config.
+            reconfigureCells(forMessageIds: expandedMessageIds.symmetricDifference(oldValue))
+        }
+    }
     var contextMenuState: MessageContextMenuState = .init() {
         didSet { dataSource.contextMenuState = contextMenuState }
     }
@@ -464,6 +479,27 @@ final class MessagesViewController: UIViewController {
     @available(*, unavailable, message: "Use init(messageController:) instead")
     required init?(coder: NSCoder) {
         fatalError()
+    }
+
+    /// Reconfigures the visible message cells that contain any of the given
+    /// message ids. Used when the long-body expansion set flips, since that
+    /// change carries no DifferenceKit changeset on its own.
+    private func reconfigureCells(forMessageIds messageIds: Set<String>) {
+        guard !messageIds.isEmpty else { return }
+        var indexPaths: [IndexPath] = []
+        for (sectionIndex, section) in dataSource.sections.enumerated() {
+            for (itemIndex, cell) in section.cells.enumerated() {
+                guard case .messages(let group) = cell else { continue }
+                let groupContainsChangedId = group.messages.contains { message in
+                    messageIds.contains(message.messageId)
+                }
+                if groupContainsChangedId {
+                    indexPaths.append(IndexPath(item: itemIndex, section: sectionIndex))
+                }
+            }
+        }
+        guard !indexPaths.isEmpty else { return }
+        collectionView.reconfigureItems(at: indexPaths)
     }
 
     override func viewDidLoad() {
@@ -651,6 +687,9 @@ final class MessagesViewController: UIViewController {
         }
         dataSource.onOpenMessageDetail = { [weak self] message in
             self?.onOpenMessageDetail?(message)
+        }
+        dataSource.onToggleMessageExpanded = { [weak self] messageId in
+            self?.onToggleMessageExpanded?(messageId)
         }
         dataSource.onPhotoDimensionsLoaded = { [weak self] attachmentKey, width, height in
             self?.onPhotoDimensionsLoaded?(attachmentKey, width, height)

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -500,6 +500,12 @@ final class MessagesViewController: UIViewController {
         }
         guard !indexPaths.isEmpty else { return }
         collectionView.reconfigureItems(at: indexPaths)
+        // The custom layout only builds `.itemReconfigure` height-diff items
+        // from cells stashed by its own `reconfigureItems`, so pair the
+        // collection-view call with the layout call (matching the DifferenceKit
+        // reconfigure path) or the cell height is not re-measured when a long
+        // message expands or collapses.
+        messagesLayout.reconfigureItems(at: indexPaths)
     }
 
     override func viewDidLoad() {

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -395,6 +395,7 @@ final class MessagesViewController: UIViewController {
     var onTapReadReceipts: ((MessagesGroup) -> Void)?
     var onTapThinkingIndicator: ((ThinkingSessionDescriptor) -> Void)?
     var onReply: ((AnyMessage) -> Void)?
+    var onOpenMessageDetail: ((AnyMessage) -> Void)?
     var contextMenuState: MessageContextMenuState = .init() {
         didSet { dataSource.contextMenuState = contextMenuState }
     }
@@ -647,6 +648,9 @@ final class MessagesViewController: UIViewController {
         dataSource.onReply = { [weak self] message in
             guard let self = self else { return }
             self.onReply?(message)
+        }
+        dataSource.onOpenMessageDetail = { [weak self] message in
+            self?.onOpenMessageDetail?(message)
         }
         dataSource.onPhotoDimensionsLoaded = { [weak self] attachmentKey, width, height in
             self?.onPhotoDimensionsLoaded?(attachmentKey, width, height)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -72,16 +72,17 @@ struct MessageBubble: View {
         }
     }
 
-    /// Subtle outline for the "Read more" pill. Mirrors the bubble's
-    /// inverted/non-inverted context: on an outgoing (dark) bubble the border
-    /// is the inverted subtle grey, on an incoming (light) bubble it is the
-    /// standard subtle border so the outline stays visible against the fill.
+    /// Subtle 1px outline for the "Read more" pill, matching Figma's
+    /// `color/border/subtle` (incoming) and `color/border/inverted/subtle`
+    /// (outgoing). The design system has no inverted-border token, and the
+    /// earlier `colorFillInvertedSubtle` (a fill token) collapsed to a
+    /// near-white value in dark mode, leaving the outgoing border invisible on
+    /// the white-in-dark bubble. `colorBorderSubtle` is a real border token
+    /// (#EB light / #33 dark) that renders a visible subtle outline on both
+    /// bubble fills in both appearances, so the button reads as a button in
+    /// dark mode too.
     private var readMoreBorderColor: Color {
-        if isOutgoing {
-            return Color.colorFillInvertedSubtle
-        } else {
-            return Color.colorBorderSubtle
-        }
+        Color.colorBorderSubtle
     }
 
     private var lengthClass: MessageLengthClass {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -171,6 +171,12 @@ struct MessageBubble: View {
                 .foregroundStyle(textColor.opacity(0.75))
         }
         .buttonStyle(.plain)
+        // The bubble is wrapped by `.messageGesture(...)`, whose gesture
+        // overlay swallows taps on plain in-bubble controls (its `hitTest`
+        // returns the overlay unless the point hits a `LinkHitTestable` view
+        // or a passthrough marker). Mark this button so the overlay lets the
+        // tap through, mirroring the voice-memo transcript buttons.
+        .background(GesturePassthroughBackground())
         .accessibilityIdentifier("message-read-more-button")
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -134,20 +134,17 @@ struct MessageBubble: View {
     }
 
     /// Long (but not pathological) bodies render a bounded preview with an
-    /// inline "Read More" that lifts the line cap in place. `.fixedSize` is
-    /// dropped (the `lineLimit` is what bounds the vertical layout); selection
-    /// is gated to the expanded state so the collapsed measure stays cheap.
-    /// Links render as plain `Text` here to avoid the unbounded TextKit
-    /// `sizeThatFits`; tappable links live in the detail view.
+    /// inline "Read More" that lifts the line cap in place. The collapsed
+    /// preview is a bounded `Text(lineLimit:)` teaser. Once expanded, a body
+    /// that contains a link is rendered through the same scroll-disabled
+    /// `LinkDetectingTextView` (UITextView) that short link-bodies use, so URLs
+    /// in 500-1500 char messages become tappable. Data detection is async and
+    /// a non-scrolling `sizeThatFits` over <=1500 chars is well under a
+    /// millisecond, so this does not reintroduce the layout hang.
     @ViewBuilder
     private var longBody: some View {
         let lineCap: Int? = isExpanded ? nil : MessageBodyClassifier.longPreviewLineLimit
         let duration: Double = MessageBodyClassifier.readMoreExpandAnimationDuration
-        // Links inside the collapsed preview are rendered as plain truncated
-        // Text, so an individual link in the hidden tail is not tappable while
-        // collapsed. Expanding lifts the line cap (links in the full text still
-        // render as plain Text inline); the detail view's UITextView is where
-        // links become individually tappable.
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             longBodyText(lineCap: lineCap)
             if !isExpanded {
@@ -159,19 +156,33 @@ struct MessageBubble: View {
         }
     }
 
-    /// Selection is gated to the expanded state. `.textSelection(.enabled)` and
-    /// `.textSelection(.disabled)` resolve to different concrete types, so the
-    /// gate is an `if` rather than a ternary inside the modifier argument.
+    /// Collapsed: a bounded plain `Text` teaser (links in the hidden tail are
+    /// not tappable, which is fine for a truncated preview). Expanded: if the
+    /// body has a link, switch to `LinkDetectingTextView` so links are
+    /// tappable; otherwise keep plain `Text` (cheaper). Selection is gated to
+    /// the expanded `Text` path; `.textSelection(.enabled)` and `.disabled`
+    /// resolve to different concrete types, so the gate is an `if`, not a
+    /// ternary inside the modifier argument.
     @ViewBuilder
     private func longBodyText(lineCap: Int?) -> some View {
-        let base = Text(message)
-            .font(.callout)
-            .foregroundStyle(textColor)
-            .lineLimit(lineCap)
-        if isExpanded {
-            base.textSelection(.enabled)
+        if isExpanded, TextLinkPresence.containsLinks(message) {
+            LinkDetectingTextView(
+                message,
+                linkColor: textColor,
+                foregroundColor: textColor,
+                font: .preferredFont(forTextStyle: .callout)
+            )
+            .fixedSize(horizontal: false, vertical: true)
         } else {
-            base.textSelection(.disabled)
+            let base = Text(message)
+                .font(.callout)
+                .foregroundStyle(textColor)
+                .lineLimit(lineCap)
+            if isExpanded {
+                base.textSelection(.enabled)
+            } else {
+                base.textSelection(.disabled)
+            }
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -52,8 +52,14 @@ struct MessageBubble: View {
     /// can present `MessageDetailView`. `nil` in previews and the context-menu
     /// preview path, where the bounded preview just renders without a tap.
     var onOpenDetail: ((String) -> Void)?
-
-    @State private var isExpanded: Bool = false
+    /// Whether the long-body inline expansion is on. Owned by the conversation
+    /// view model (keyed by message id) and passed in, not local `@State`, so
+    /// expansion survives `UICollectionView` cell reuse and never bleeds onto
+    /// a recycled cell showing a different message.
+    var isExpanded: Bool = false
+    /// Toggles the long-body inline expansion on the host. `nil` in previews
+    /// and the context-menu preview path (the long body just stays collapsed).
+    var onToggleExpand: (() -> Void)?
 
     private var textColor: Color {
         if isOutgoing {
@@ -125,7 +131,7 @@ struct MessageBubble: View {
             longBodyText(lineCap: lineCap)
             if !isExpanded {
                 let expandAction: () -> Void = {
-                    withAnimation(.easeInOut(duration: 0.18)) { isExpanded = true }
+                    withAnimation(.easeInOut(duration: 0.18)) { onToggleExpand?() }
                 }
                 readMoreButton(action: expandAction, hint: "Double tap to expand the message")
             }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -22,6 +22,9 @@ enum MessageBodyClassifier {
     static let shortNewlineThreshold: Int = 30 // many short lines, e.g. code snippets or poems
     static let longPreviewLineLimit: Int = 12
     static let pathologicalPreviewLineLimit: Int = 8
+    // Short ease so the inline "Read More" expand/collapse reads as a quick
+    // reveal, not a slow unfold that the user has to wait through.
+    static let readMoreExpandAnimationDuration: Double = 0.18
 
     static func classify(_ text: String) -> MessageLengthClass {
         let count: Int = text.count
@@ -127,13 +130,19 @@ struct MessageBubble: View {
     @ViewBuilder
     private var longBody: some View {
         let lineCap: Int? = isExpanded ? nil : MessageBodyClassifier.longPreviewLineLimit
+        let duration: Double = MessageBodyClassifier.readMoreExpandAnimationDuration
+        // Links inside the collapsed preview are rendered as plain truncated
+        // Text, so an individual link in the hidden tail is not tappable while
+        // collapsed. Expanding lifts the line cap (links in the full text still
+        // render as plain Text inline); the detail view's UITextView is where
+        // links become individually tappable.
         VStack(alignment: .leading, spacing: 4.0) {
             longBodyText(lineCap: lineCap)
             if !isExpanded {
                 let expandAction: () -> Void = {
-                    withAnimation(.easeInOut(duration: 0.18)) { onToggleExpand?() }
+                    withAnimation(.easeInOut(duration: duration)) { onToggleExpand?() }
                 }
-                readMoreButton(action: expandAction, hint: "Double tap to expand the message")
+                readMoreButton(action: expandAction, hint: "Expands the message")
             }
         }
     }
@@ -158,13 +167,16 @@ struct MessageBubble: View {
     /// place. A bounded preview shows, and "Read More" opens the detail view.
     @ViewBuilder
     private var pathologicalBody: some View {
+        // The bounded preview is plain truncated Text, so links in it are not
+        // individually tappable here. Tappable links live in the detail view's
+        // UITextView, which "Read More" opens.
         VStack(alignment: .leading, spacing: 4.0) {
             Text(message)
                 .font(.callout)
                 .foregroundStyle(textColor)
                 .lineLimit(MessageBodyClassifier.pathologicalPreviewLineLimit)
             let openDetailAction: () -> Void = { onOpenDetail?(message) }
-            readMoreButton(action: openDetailAction, hint: "Double tap to open the full message")
+            readMoreButton(action: openDetailAction, hint: "Opens the full message")
         }
         .contentShape(Rectangle())
     }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -72,6 +72,18 @@ struct MessageBubble: View {
         }
     }
 
+    /// Subtle outline for the "Read more" pill. Mirrors the bubble's
+    /// inverted/non-inverted context: on an outgoing (dark) bubble the border
+    /// is the inverted subtle grey, on an incoming (light) bubble it is the
+    /// standard subtle border so the outline stays visible against the fill.
+    private var readMoreBorderColor: Color {
+        if isOutgoing {
+            return Color.colorFillInvertedSubtle
+        } else {
+            return Color.colorBorderSubtle
+        }
+    }
+
     private var lengthClass: MessageLengthClass {
         MessageBodyClassifier.classify(message)
     }
@@ -136,7 +148,7 @@ struct MessageBubble: View {
         // collapsed. Expanding lifts the line cap (links in the full text still
         // render as plain Text inline); the detail view's UITextView is where
         // links become individually tappable.
-        VStack(alignment: .leading, spacing: 4.0) {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             longBodyText(lineCap: lineCap)
             if !isExpanded {
                 let expandAction: () -> Void = {
@@ -170,7 +182,7 @@ struct MessageBubble: View {
         // The bounded preview is plain truncated Text, so links in it are not
         // individually tappable here. Tappable links live in the detail view's
         // UITextView, which "Read More" opens.
-        VStack(alignment: .leading, spacing: 4.0) {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             Text(message)
                 .font(.callout)
                 .foregroundStyle(textColor)
@@ -181,12 +193,27 @@ struct MessageBubble: View {
         .contentShape(Rectangle())
     }
 
+    /// Distinct, bordered "Read more" pill (per Quarter's Figma spec): a
+    /// rounded-rect outline with the same subtle inverted/non-inverted border
+    /// as the surrounding bubble, so the affordance reads as a tappable button
+    /// rather than blending into the message text.
     @ViewBuilder
     private func readMoreButton(action: @escaping () -> Void, hint: String) -> some View {
+        let cornerRadius: CGFloat = DesignConstants.CornerRadius.regular
+        let horizontalPadding: CGFloat = DesignConstants.Spacing.step4x
+        let verticalPadding: CGFloat = DesignConstants.Spacing.step2x
+        let borderColor: Color = readMoreBorderColor
+        let labelColor: Color = textColor
         Button(action: action) {
-            Text("Read More")
-                .font(.callout.weight(.semibold))
-                .foregroundStyle(textColor.opacity(0.75))
+            Text("Read more")
+                .font(DesignConstants.Fonts.buttonText)
+                .foregroundStyle(labelColor)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(borderColor, lineWidth: 1.0)
+                )
         }
         .buttonStyle(.plain)
         .accessibilityHint(hint)

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -17,11 +17,11 @@ enum MessageLengthClass {
 /// tunable in one place. Exposed (not private) so any caller that builds a
 /// `MessageBubble` preview shares the same classification semantics.
 enum MessageBodyClassifier {
-    static let longCharThreshold: Int = 1_200 // ~3-4 paragraphs at typical density
-    static let pathologicalCharThreshold: Int = 6_000 // ~1-2 pages of text
-    static let shortNewlineThreshold: Int = 30 // many short lines, e.g. code snippets or poems
-    static let longPreviewLineLimit: Int = 12
-    static let pathologicalPreviewLineLimit: Int = 8
+    static let longCharThreshold: Int = 500 // a few paragraphs; human messages rarely exceed this
+    static let pathologicalCharThreshold: Int = 1_500 // long-form; well past a normal chat message
+    static let shortNewlineThreshold: Int = 20 // many short lines, e.g. code snippets or poems
+    static let longPreviewLineLimit: Int = 6
+    static let pathologicalPreviewLineLimit: Int = 6
     // Short ease so the inline "Read More" expand/collapse reads as a quick
     // reveal, not a slow unfold that the user has to wait through.
     static let readMoreExpandAnimationDuration: Double = 0.18

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -17,9 +17,9 @@ enum MessageLengthClass {
 /// tunable in one place. Exposed (not private) so any caller that builds a
 /// `MessageBubble` preview shares the same classification semantics.
 enum MessageBodyClassifier {
-    static let longCharThreshold: Int = 1_200
-    static let pathologicalCharThreshold: Int = 6_000
-    static let shortNewlineThreshold: Int = 30
+    static let longCharThreshold: Int = 1_200 // ~3-4 paragraphs at typical density
+    static let pathologicalCharThreshold: Int = 6_000 // ~1-2 pages of text
+    static let shortNewlineThreshold: Int = 30 // many short lines, e.g. code snippets or poems
     static let longPreviewLineLimit: Int = 12
     static let pathologicalPreviewLineLimit: Int = 8
 
@@ -127,7 +127,7 @@ struct MessageBubble: View {
                 let expandAction: () -> Void = {
                     withAnimation(.easeInOut(duration: 0.18)) { isExpanded = true }
                 }
-                readMoreButton(action: expandAction)
+                readMoreButton(action: expandAction, hint: "Double tap to expand the message")
             }
         }
     }
@@ -158,19 +158,20 @@ struct MessageBubble: View {
                 .foregroundStyle(textColor)
                 .lineLimit(MessageBodyClassifier.pathologicalPreviewLineLimit)
             let openDetailAction: () -> Void = { onOpenDetail?(message) }
-            readMoreButton(action: openDetailAction)
+            readMoreButton(action: openDetailAction, hint: "Double tap to open the full message")
         }
         .contentShape(Rectangle())
     }
 
     @ViewBuilder
-    private func readMoreButton(action: @escaping () -> Void) -> some View {
+    private func readMoreButton(action: @escaping () -> Void, hint: String) -> some View {
         Button(action: action) {
             Text("Read More")
                 .font(.callout.weight(.semibold))
                 .foregroundStyle(textColor.opacity(0.75))
         }
         .buttonStyle(.plain)
+        .accessibilityHint(hint)
         // The bubble is wrapped by `.messageGesture(...)`, whose gesture
         // overlay swallows taps on plain in-bubble controls (its `hitTest`
         // returns the overlay unless the point hits a `LinkHitTestable` view

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -74,16 +74,23 @@ struct MessageBubble: View {
 
     /// Subtle 1px outline for the "Read more" pill, matching Figma per side:
     /// incoming (received, left) uses `color/border/subtle`, outgoing (sent,
-    /// right) uses `color/border/inverted/subtle`. Both tokens are adaptive, so
+    /// right) uses `color/border/inverted/subtle`. Both are adaptive, so
     /// light/dark is automatic and the border stays visible in all four
     /// sender x appearance combos. `colorBorderInvertedSubtle` is the
     /// appearance-swapped twin of `colorBorderSubtle` (light #33 / dark #EB),
     /// so it contrasts with the black-in-light / white-in-dark outgoing bubble.
+    /// The incoming border uses a dedicated `colorBorderReadMoreIncoming`
+    /// rather than the shared `colorBorderSubtle`: in dark mode the latter is
+    /// #33, the same as the incoming bubble fill (`colorBubbleIncoming` dark),
+    /// so the border vanished. The dedicated token lifts the dark value to #52
+    /// (a gentle step lighter than the #33 bubble) while keeping the light
+    /// value at #EB, and scopes the change to this border so the 16 other
+    /// `colorBorderSubtle` usages are untouched.
     private var readMoreBorderColor: Color {
         if isOutgoing {
             return Color.colorBorderInvertedSubtle
         } else {
-            return Color.colorBorderSubtle
+            return Color.colorBorderReadMoreIncoming
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -175,8 +175,13 @@ struct MessageBubble: View {
         // overlay swallows taps on plain in-bubble controls (its `hitTest`
         // returns the overlay unless the point hits a `LinkHitTestable` view
         // or a passthrough marker). Mark this button so the overlay lets the
-        // tap through, mirroring the voice-memo transcript buttons.
-        .background(GesturePassthroughBackground())
+        // tap through, mirroring the voice-memo transcript buttons. Hide the
+        // marker from accessibility so the representable doesn't surface a
+        // second element carrying the button's identifier.
+        .background(
+            GesturePassthroughBackground()
+                .accessibilityHidden(true)
+        )
         .accessibilityIdentifier("message-read-more-button")
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -72,17 +72,19 @@ struct MessageBubble: View {
         }
     }
 
-    /// Subtle 1px outline for the "Read more" pill, matching Figma's
-    /// `color/border/subtle` (incoming) and `color/border/inverted/subtle`
-    /// (outgoing). The design system has no inverted-border token, and the
-    /// earlier `colorFillInvertedSubtle` (a fill token) collapsed to a
-    /// near-white value in dark mode, leaving the outgoing border invisible on
-    /// the white-in-dark bubble. `colorBorderSubtle` is a real border token
-    /// (#EB light / #33 dark) that renders a visible subtle outline on both
-    /// bubble fills in both appearances, so the button reads as a button in
-    /// dark mode too.
+    /// Subtle 1px outline for the "Read more" pill, matching Figma per side:
+    /// incoming (received, left) uses `color/border/subtle`, outgoing (sent,
+    /// right) uses `color/border/inverted/subtle`. Both tokens are adaptive, so
+    /// light/dark is automatic and the border stays visible in all four
+    /// sender x appearance combos. `colorBorderInvertedSubtle` is the
+    /// appearance-swapped twin of `colorBorderSubtle` (light #33 / dark #EB),
+    /// so it contrasts with the black-in-light / white-in-dark outgoing bubble.
     private var readMoreBorderColor: Color {
-        Color.colorBorderSubtle
+        if isOutgoing {
+            return Color.colorBorderInvertedSubtle
+        } else {
+            return Color.colorBorderSubtle
+        }
     }
 
     private var lengthClass: MessageLengthClass {

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -1,11 +1,59 @@
 import ConvosCore
 import SwiftUI
 
+/// Coarse length class for a message body, used to pick a render strategy that
+/// keeps CoreText layout bounded on the main thread. Classification is cheap
+/// (character count plus a capped newline scan) and never measures or lays out
+/// the text.
+enum MessageLengthClass {
+    case short
+    case long
+    case pathological
+}
+
+/// O(1)-ish body classifier. The original hang came from measuring the whole
+/// body (`Text` + `.fixedSize` with no `lineLimit`), so this must stay cheap:
+/// no CoreText, no `NSAttributedString`, no `boundingRect`. Thresholds are
+/// tunable in one place. Exposed (not private) so any caller that builds a
+/// `MessageBubble` preview shares the same classification semantics.
+enum MessageBodyClassifier {
+    static let longCharThreshold: Int = 1_200
+    static let pathologicalCharThreshold: Int = 6_000
+    static let shortNewlineThreshold: Int = 30
+    static let longPreviewLineLimit: Int = 12
+    static let pathologicalPreviewLineLimit: Int = 8
+
+    static func classify(_ text: String) -> MessageLengthClass {
+        let count: Int = text.count
+        if count > pathologicalCharThreshold { return .pathological }
+        let newlines: Int = newlineCount(in: text, cappedAt: shortNewlineThreshold + 1)
+        if count > longCharThreshold || newlines > shortNewlineThreshold { return .long }
+        return .short
+    }
+
+    /// Counts `\n` but stops as soon as the cap is reached so a newline-spam
+    /// body cannot make the scan itself expensive.
+    private static func newlineCount(in text: String, cappedAt cap: Int) -> Int {
+        var n: Int = 0
+        for ch in text where ch == "\n" {
+            n += 1
+            if n >= cap { break }
+        }
+        return n
+    }
+}
+
 struct MessageBubble: View {
     let style: MessageBubbleType
     let message: String
     let isOutgoing: Bool
     let profile: Profile
+    /// Invoked when a pathological body's "Read More" is tapped, so the host
+    /// can present `MessageDetailView`. `nil` in previews and the context-menu
+    /// preview path, where the bounded preview just renders without a tap.
+    var onOpenDetail: ((String) -> Void)?
+
+    @State private var isExpanded: Bool = false
 
     private var textColor: Color {
         if isOutgoing {
@@ -15,10 +63,13 @@ struct MessageBubble: View {
         }
     }
 
+    private var lengthClass: MessageLengthClass {
+        MessageBodyClassifier.classify(message)
+    }
+
     var body: some View {
         MessageContainer(style: style, isOutgoing: isOutgoing) {
-            bubbleText
-                .fixedSize(horizontal: false, vertical: true)
+            bubbleContent
                 .padding(.horizontal, DesignConstants.Spacing.step3x)
                 .padding(.vertical, 10.0)
         }
@@ -26,12 +77,24 @@ struct MessageBubble: View {
         .accessibilityLabel("\(profile.displayName): \(message)")
     }
 
-    /// Only messages that actually contain a link pay for the TextKit-backed
-    /// `LinkDetectingTextView`; everything else renders as plain `Text`,
-    /// which is far cheaper to build and measure when a conversation opens
-    /// or scrolls.
     @ViewBuilder
-    private var bubbleText: some View {
+    private var bubbleContent: some View {
+        switch lengthClass {
+        case .short:
+            shortBody
+        case .long:
+            longBody
+        case .pathological:
+            pathologicalBody
+        }
+    }
+
+    /// Short bodies are safe to fully measure, so this matches the original
+    /// render exactly, including `.fixedSize`. Only messages that contain a
+    /// link pay for the TextKit-backed `LinkDetectingTextView`; everything
+    /// else is plain `Text`, which is far cheaper to build and measure.
+    @ViewBuilder
+    private var shortBody: some View {
         if TextLinkPresence.containsLinks(message) {
             LinkDetectingTextView(
                 message,
@@ -39,12 +102,76 @@ struct MessageBubble: View {
                 foregroundColor: textColor,
                 font: .preferredFont(forTextStyle: .callout)
             )
+            .fixedSize(horizontal: false, vertical: true)
         } else {
             Text(message)
                 .font(.callout)
                 .foregroundStyle(textColor)
                 .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    /// Long (but not pathological) bodies render a bounded preview with an
+    /// inline "Read More" that lifts the line cap in place. `.fixedSize` is
+    /// dropped (the `lineLimit` is what bounds the vertical layout); selection
+    /// is gated to the expanded state so the collapsed measure stays cheap.
+    /// Links render as plain `Text` here to avoid the unbounded TextKit
+    /// `sizeThatFits`; tappable links live in the detail view.
+    @ViewBuilder
+    private var longBody: some View {
+        let lineCap: Int? = isExpanded ? nil : MessageBodyClassifier.longPreviewLineLimit
+        VStack(alignment: .leading, spacing: 4.0) {
+            longBodyText(lineCap: lineCap)
+            if !isExpanded {
+                let expandAction: () -> Void = {
+                    withAnimation(.easeInOut(duration: 0.18)) { isExpanded = true }
+                }
+                readMoreButton(action: expandAction)
+            }
+        }
+    }
+
+    /// Selection is gated to the expanded state. `.textSelection(.enabled)` and
+    /// `.textSelection(.disabled)` resolve to different concrete types, so the
+    /// gate is an `if` rather than a ternary inside the modifier argument.
+    @ViewBuilder
+    private func longBodyText(lineCap: Int?) -> some View {
+        let base = Text(message)
+            .font(.callout)
+            .foregroundStyle(textColor)
+            .lineLimit(lineCap)
+        if isExpanded {
+            base.textSelection(.enabled)
+        } else {
+            base.textSelection(.disabled)
+        }
+    }
+
+    /// Pathological bodies never render full-size inline and never expand in
+    /// place. A bounded preview shows, and "Read More" opens the detail view.
+    @ViewBuilder
+    private var pathologicalBody: some View {
+        VStack(alignment: .leading, spacing: 4.0) {
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(textColor)
+                .lineLimit(MessageBodyClassifier.pathologicalPreviewLineLimit)
+            let openDetailAction: () -> Void = { onOpenDetail?(message) }
+            readMoreButton(action: openDetailAction)
+        }
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func readMoreButton(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text("Read More")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(textColor.opacity(0.75))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("message-read-more-button")
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/MessageBubble.swift
@@ -214,42 +214,18 @@ struct MessageBubble: View {
         .contentShape(Rectangle())
     }
 
-    /// Distinct, bordered "Read more" pill (per Quarter's Figma spec): a
-    /// rounded-rect outline with the same subtle inverted/non-inverted border
-    /// as the surrounding bubble, so the affordance reads as a tappable button
-    /// rather than blending into the message text.
+    /// Distinct, bordered "Read more" pill (per Quarter's Figma spec). The
+    /// message bubble sits under the `.messageGesture(...)` overlay, so the
+    /// shared `ReadMoreButton` keeps its gesture-passthrough marker here.
     @ViewBuilder
     private func readMoreButton(action: @escaping () -> Void, hint: String) -> some View {
-        let cornerRadius: CGFloat = DesignConstants.CornerRadius.regular
-        let horizontalPadding: CGFloat = DesignConstants.Spacing.step4x
-        let verticalPadding: CGFloat = DesignConstants.Spacing.step2x
-        let borderColor: Color = readMoreBorderColor
-        let labelColor: Color = textColor
-        Button(action: action) {
-            Text("Read more")
-                .font(DesignConstants.Fonts.buttonText)
-                .foregroundStyle(labelColor)
-                .padding(.horizontal, horizontalPadding)
-                .padding(.vertical, verticalPadding)
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .stroke(borderColor, lineWidth: 1.0)
-                )
-        }
-        .buttonStyle(.plain)
-        .accessibilityHint(hint)
-        // The bubble is wrapped by `.messageGesture(...)`, whose gesture
-        // overlay swallows taps on plain in-bubble controls (its `hitTest`
-        // returns the overlay unless the point hits a `LinkHitTestable` view
-        // or a passthrough marker). Mark this button so the overlay lets the
-        // tap through, mirroring the voice-memo transcript buttons. Hide the
-        // marker from accessibility so the representable doesn't surface a
-        // second element carrying the button's identifier.
-        .background(
-            GesturePassthroughBackground()
-                .accessibilityHidden(true)
+        ReadMoreButton(
+            action: action,
+            accessibilityHint: hint,
+            borderColor: readMoreBorderColor,
+            labelColor: textColor,
+            gesturePassthrough: true
         )
-        .accessibilityIdentifier("message-read-more-button")
     }
 }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadMoreButton.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ReadMoreButton.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Distinct, bordered "Read more" pill (per Quarter's Figma spec): a
+/// rounded-rect outline that reads as a tappable button rather than blending
+/// into the surrounding text. Shared by the message bubble's long/pathological
+/// preview and the thinking thought bubble so both get the same affordance.
+///
+/// `gesturePassthrough` marks the button so the `.messageGesture` overlay lets
+/// the tap through (its `hitTest` returns the overlay unless the point hits a
+/// passthrough marker). Message bubbles sit under that overlay and need it; the
+/// thought bubble is not wrapped in `.messageGesture`, so it passes `false` and
+/// no marker is emitted. The accessibility identifier stays the same in both
+/// places since it is the same control.
+struct ReadMoreButton: View {
+    let action: () -> Void
+    let accessibilityHint: String
+    let borderColor: Color
+    let labelColor: Color
+    var gesturePassthrough: Bool = true
+
+    var body: some View {
+        let cornerRadius: CGFloat = DesignConstants.CornerRadius.regular
+        let horizontalPadding: CGFloat = DesignConstants.Spacing.step4x
+        let verticalPadding: CGFloat = DesignConstants.Spacing.step2x
+        Button(action: action) {
+            Text("Read more")
+                .font(DesignConstants.Fonts.buttonText)
+                .foregroundStyle(labelColor)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(borderColor, lineWidth: 1.0)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(accessibilityHint)
+        .background(passthroughBackground)
+        .accessibilityIdentifier("message-read-more-button")
+    }
+
+    /// The gesture-passthrough marker, hidden from accessibility so the
+    /// representable doesn't surface a second element carrying the button's
+    /// identifier. Emitted only where a `.messageGesture` overlay would
+    /// otherwise swallow the tap.
+    @ViewBuilder
+    private var passthroughBackground: some View {
+        if gesturePassthrough {
+            GesturePassthroughBackground()
+                .accessibilityHidden(true)
+        }
+    }
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -11,6 +11,11 @@ struct MessagesGroupItemView: View {
     let onTapAvatar: (AnyMessage) -> Void
     let onTapInvite: (MessageInvite) -> Void
     let onReply: (AnyMessage) -> Void
+    /// Invoked when a pathological (very long) text bubble's "Read More" is
+    /// tapped, so the host can present `MessageDetailView`. `nil` outside the
+    /// main messages list path (reply parents, previews), where the bounded
+    /// preview renders without a tap.
+    var onOpenMessageDetail: ((AnyMessage) -> Void)?
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
     /// Namespace owned by `MessagesView` and threaded down via the cell
@@ -134,11 +139,15 @@ struct MessagesGroupItemView: View {
 
     @ViewBuilder
     private func textBubble(text: String) -> some View {
+        let openDetail: ((String) -> Void)? = onOpenMessageDetail.map { handler in
+            { _ in handler(message) }
+        }
         MessageBubble(
             style: message.content.isEmoji ? .none : bubbleType,
             message: text,
             isOutgoing: message.sender.isCurrentUser,
-            profile: message.sender.profile
+            profile: message.sender.profile,
+            onOpenDetail: openDetail
         )
         .messageGesture(
             message: message,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -16,6 +16,11 @@ struct MessagesGroupItemView: View {
     /// main messages list path (reply parents, previews), where the bounded
     /// preview renders without a tap.
     var onOpenMessageDetail: ((AnyMessage) -> Void)?
+    /// Message ids whose long-body inline expansion is currently on. Owned by
+    /// the conversation view model so expansion survives cell reuse.
+    var expandedMessageIds: Set<String> = []
+    /// Toggles the long-body inline expansion for a message id on the host.
+    var onToggleMessageExpanded: ((String) -> Void)?
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
     /// Namespace owned by `MessagesView` and threaded down via the cell
@@ -142,12 +147,19 @@ struct MessagesGroupItemView: View {
         let openDetail: ((String) -> Void)? = onOpenMessageDetail.map { handler in
             { _ in handler(message) }
         }
+        let messageId: String = message.messageId
+        let isExpanded: Bool = expandedMessageIds.contains(messageId)
+        let toggleExpand: (() -> Void)? = onToggleMessageExpanded.map { handler in
+            { handler(messageId) }
+        }
         MessageBubble(
             style: message.content.isEmoji ? .none : bubbleType,
             message: text,
             isOutgoing: message.sender.isCurrentUser,
             profile: message.sender.profile,
-            onOpenDetail: openDetail
+            onOpenDetail: openDetail,
+            isExpanded: isExpanded,
+            onToggleExpand: toggleExpand
         )
         .messageGesture(
             message: message,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -22,6 +22,10 @@ struct MessagesGroupView: View {
     /// Surfaces a pathological text bubble's "Read More" tap to the host so it
     /// can present `MessageDetailView`. nil outside the main messages list path.
     var onOpenMessageDetail: ((AnyMessage) -> Void)?
+    /// Message ids with long-body inline expansion on (owned by the VM).
+    var expandedMessageIds: Set<String> = []
+    /// Toggles a message id's long-body inline expansion on the host.
+    var onToggleMessageExpanded: ((String) -> Void)?
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
     var onRetryMessage: ((AnyMessage) -> Void)?
@@ -396,6 +400,8 @@ struct MessagesGroupView: View {
                     onTapInvite: onTapInvite,
                     onReply: onReply,
                     onOpenMessageDetail: onOpenMessageDetail,
+                    expandedMessageIds: expandedMessageIds,
+                    onToggleMessageExpanded: onToggleMessageExpanded,
                     onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
                     onOpenFile: onOpenFile,
                     htmlAttachmentTransitionNamespace: htmlAttachmentTransitionNamespace,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -19,6 +19,9 @@ struct MessagesGroupView: View {
     let onReaction: (String, String) -> Void
     let onToggleReaction: (String, String) -> Void
     let onReply: (AnyMessage) -> Void
+    /// Surfaces a pathological text bubble's "Read More" tap to the host so it
+    /// can present `MessageDetailView`. nil outside the main messages list path.
+    var onOpenMessageDetail: ((AnyMessage) -> Void)?
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
     var onRetryMessage: ((AnyMessage) -> Void)?
@@ -392,6 +395,7 @@ struct MessagesGroupView: View {
                     onTapAvatar: onTapAvatar,
                     onTapInvite: onTapInvite,
                     onReply: onReply,
+                    onOpenMessageDetail: onOpenMessageDetail,
                     onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
                     onOpenFile: onOpenFile,
                     htmlAttachmentTransitionNamespace: htmlAttachmentTransitionNamespace,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -364,33 +364,7 @@ struct MessagesGroupView: View {
             }
 
             if displayGroup.usesThoughtBubbleStyle, let text = thoughtBubbleText(for: message) {
-                ThoughtBubbleAppearance(animates: message.origin == .inserted) {
-                    HStack(spacing: 0.0) {
-                        ThoughtBubble {
-                            // Type spec from design: 16pt regular, 24pt
-                            // line height, 0.3pt tracking. `.callout` is
-                            // 16pt by default on iOS and scales with
-                            // Dynamic Type. SF Pro 16pt's natural line
-                            // height is ~19pt, so 5pt extra `lineSpacing`
-                            // brings each line to ~24pt.
-                            Text(text)
-                                .font(.callout)
-                                .tracking(0.3)
-                                .lineSpacing(5.0)
-                                .foregroundStyle(.colorTextSecondary)
-                        }
-                        Spacer(minLength: 50.0)
-                            .layoutPriority(-1)
-                    }
-                }
-                .bubbleRowWidthCap(alignment: .leading)
-                .zIndex(100)
-                .id("messages-group-item-\(message.differenceIdentifier)")
-                .overlay(alignment: .bottomLeading) {
-                    if isLast && !displayGroup.sender.isCurrentUser {
-                        avatarOverlay { onTapAvatar(message) }
-                    }
-                }
+                thoughtBubbleRow(message: message, text: text, isLast: isLast)
             } else {
                 MessagesGroupItemView(
                     message: message,
@@ -450,6 +424,68 @@ struct MessagesGroupView: View {
         guard case .message(let inner, _) = message,
               case .text(let text) = inner.content else { return nil }
         return text
+    }
+
+    /// Renders a thinking moment in a `ThoughtBubble`, bounded the same way the
+    /// message path bounds long bodies so a large `ThinkingMoment.content`
+    /// cannot trigger an unbounded CoreText layout on the main thread. Short
+    /// bodies render in full; long/pathological bodies show a line-capped
+    /// preview plus a "Read more" pill that opens the hang-safe
+    /// `MessageDetailView` (the thought bubble already lives inside
+    /// `ThinkingDetailView`, so the generic full-message reader, not the
+    /// thinking sheet, is the correct detail target). The thought bubble is not
+    /// wrapped in `.messageGesture`, so the pill omits the gesture-passthrough
+    /// marker.
+    @ViewBuilder
+    private func thoughtBubbleRow(message: AnyMessage, text: String, isLast: Bool) -> some View {
+        let lengthClass: MessageLengthClass = MessageBodyClassifier.classify(text)
+        let isBounded: Bool = lengthClass != .short
+        ThoughtBubbleAppearance(animates: message.origin == .inserted) {
+            HStack(spacing: 0.0) {
+                ThoughtBubble {
+                    VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+                        thoughtBubbleText(text, bounded: isBounded)
+                        if isBounded {
+                            let openDetail: () -> Void = { onOpenMessageDetail?(message) }
+                            ReadMoreButton(
+                                action: openDetail,
+                                accessibilityHint: "Opens the full message",
+                                borderColor: .colorBorderSubtle,
+                                labelColor: .colorTextSecondary,
+                                gesturePassthrough: false
+                            )
+                        }
+                    }
+                }
+                Spacer(minLength: 50.0)
+                    .layoutPriority(-1)
+            }
+        }
+        .bubbleRowWidthCap(alignment: .leading)
+        .zIndex(100)
+        .id("messages-group-item-\(message.differenceIdentifier)")
+        .overlay(alignment: .bottomLeading) {
+            if isLast && !displayGroup.sender.isCurrentUser {
+                avatarOverlay { onTapAvatar(message) }
+            }
+        }
+    }
+
+    /// The thought-bubble body text. Type spec from design: 16pt regular, 24pt
+    /// line height, 0.3pt tracking. `.callout` is 16pt by default on iOS and
+    /// scales with Dynamic Type; SF Pro 16pt's natural line height is ~19pt, so
+    /// 5pt extra `lineSpacing` brings each line to ~24pt. When bounded, a
+    /// finite `lineLimit` caps the layout (no vertical `.fixedSize`, which would
+    /// reintroduce the full-height measure).
+    @ViewBuilder
+    private func thoughtBubbleText(_ text: String, bounded: Bool) -> some View {
+        let lineCap: Int? = bounded ? MessageBodyClassifier.longPreviewLineLimit : nil
+        Text(text)
+            .font(.callout)
+            .tracking(0.3)
+            .lineSpacing(5.0)
+            .foregroundStyle(.colorTextSecondary)
+            .lineLimit(lineCap)
     }
 
     private func parentAudioTranscriptText(for message: AnyMessage) -> String? {

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -67,6 +67,8 @@ struct MessagesView<BottomBarContent: View>: View {
     let onTapThinkingIndicator: (ThinkingSessionDescriptor) -> Void
     let onReply: (AnyMessage) -> Void
     var onOpenMessageDetail: (AnyMessage) -> Void = { _ in }
+    var expandedMessageIds: Set<String> = []
+    var onToggleMessageExpanded: (String) -> Void = { _ in }
     let replyingToMessage: AnyMessage?
     var replyingToAudioTranscriptText: String?
     let onCancelReply: () -> Void
@@ -138,6 +140,8 @@ struct MessagesView<BottomBarContent: View>: View {
             onTapThinkingIndicator: onTapThinkingIndicator,
             onReply: onReply,
             onOpenMessageDetail: onOpenMessageDetail,
+            expandedMessageIds: expandedMessageIds,
+            onToggleMessageExpanded: onToggleMessageExpanded,
             contextMenuState: contextMenuState,
             onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
             onAgentOutOfCredits: onAgentOutOfCredits,

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -66,7 +66,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onTapReadReceipts: (MessagesGroup) -> Void
     let onTapThinkingIndicator: (ThinkingSessionDescriptor) -> Void
     let onReply: (AnyMessage) -> Void
-    var onOpenMessageDetail: (AnyMessage) -> Void = { _ in }
+    var onOpenMessageDetail: ((AnyMessage) -> Void)?
     var expandedMessageIds: Set<String> = []
     var onToggleMessageExpanded: (String) -> Void = { _ in }
     let replyingToMessage: AnyMessage?

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -66,6 +66,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onTapReadReceipts: (MessagesGroup) -> Void
     let onTapThinkingIndicator: (ThinkingSessionDescriptor) -> Void
     let onReply: (AnyMessage) -> Void
+    var onOpenMessageDetail: (AnyMessage) -> Void = { _ in }
     let replyingToMessage: AnyMessage?
     var replyingToAudioTranscriptText: String?
     let onCancelReply: () -> Void
@@ -136,6 +137,7 @@ struct MessagesView<BottomBarContent: View>: View {
             onTapReadReceipts: onTapReadReceipts,
             onTapThinkingIndicator: onTapThinkingIndicator,
             onReply: onReply,
+            onOpenMessageDetail: onOpenMessageDetail,
             contextMenuState: contextMenuState,
             onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
             onAgentOutOfCredits: onAgentOutOfCredits,

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -21,6 +21,10 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onTapReadReceipts: (MessagesGroup) -> Void
     let onTapThinkingIndicator: (ThinkingSessionDescriptor) -> Void
     let onReply: (AnyMessage) -> Void
+    /// Surfaces a pathological text bubble's "Read More" tap to the host so it
+    /// can present `MessageDetailView`. Default no-op for hosts (the thinking
+    /// detail sheet) that don't present a message detail.
+    var onOpenMessageDetail: (AnyMessage) -> Void = { _ in }
     let contextMenuState: MessageContextMenuState
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onAgentOutOfCredits: () -> Void
@@ -99,6 +103,7 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onTapReadReceipts = onTapReadReceipts
         messagesViewController.onTapThinkingIndicator = onTapThinkingIndicator
         messagesViewController.onReply = onReply
+        messagesViewController.onOpenMessageDetail = onOpenMessageDetail
         messagesViewController.onPhotoDimensionsLoaded = { key, width, height in
             self.onPhotoDimensionsLoaded(key, width, height)
         }

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -25,6 +25,11 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     /// can present `MessageDetailView`. Default no-op for hosts (the thinking
     /// detail sheet) that don't present a message detail.
     var onOpenMessageDetail: (AnyMessage) -> Void = { _ in }
+    /// Message ids with long-body inline expansion on (owned by the VM so it
+    /// survives cell reuse). Default empty for hosts that never expand.
+    var expandedMessageIds: Set<String> = []
+    /// Toggles a message id's long-body inline expansion on the host.
+    var onToggleMessageExpanded: (String) -> Void = { _ in }
     let contextMenuState: MessageContextMenuState
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onAgentOutOfCredits: () -> Void
@@ -104,6 +109,8 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
         messagesViewController.onTapThinkingIndicator = onTapThinkingIndicator
         messagesViewController.onReply = onReply
         messagesViewController.onOpenMessageDetail = onOpenMessageDetail
+        messagesViewController.onToggleMessageExpanded = onToggleMessageExpanded
+        messagesViewController.expandedMessageIds = expandedMessageIds
         messagesViewController.onPhotoDimensionsLoaded = { key, width, height in
             self.onPhotoDimensionsLoaded(key, width, height)
         }

--- a/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
+++ b/Convos/Conversation Detail/Messages/MessagesViewRepresentable.swift
@@ -22,9 +22,9 @@ struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let onTapThinkingIndicator: (ThinkingSessionDescriptor) -> Void
     let onReply: (AnyMessage) -> Void
     /// Surfaces a pathological text bubble's "Read More" tap to the host so it
-    /// can present `MessageDetailView`. Default no-op for hosts (the thinking
-    /// detail sheet) that don't present a message detail.
-    var onOpenMessageDetail: (AnyMessage) -> Void = { _ in }
+    /// can present `MessageDetailView`. Nil for hosts that don't present a
+    /// message detail, which suppresses the bubble's "Read more" detail button.
+    var onOpenMessageDetail: ((AnyMessage) -> Void)?
     /// Message ids with long-body inline expansion on (owned by the VM so it
     /// survives cell reuse). Default empty for hosts that never expand.
     var expandedMessageIds: Set<String> = []

--- a/Convos/Conversation Detail/ThinkingDetailView.swift
+++ b/Convos/Conversation Detail/ThinkingDetailView.swift
@@ -1,6 +1,7 @@
 import ConvosCore
 import ConvosMetrics
 import SwiftUI
+import UIKit
 
 /// Full-height sheet that renders the per-session thinking history for one
 /// `convos.org/thinking:1.0` descriptor. Reuses `MessagesViewController`
@@ -44,6 +45,11 @@ struct ThinkingDetailView: View {
     @State private var bottomBarHeight: CGFloat = 0.0
     @State private var topBarHeight: CGFloat = 0.0
     @State private var presentingAgentProfile: Bool = false
+    /// A long thinking moment whose "Read more" was tapped. Presented as a
+    /// `MessageDetailView` sheet over this sheet (not via the VM's
+    /// `presentingMessageDetail`, which would try to present from
+    /// `ConversationView` underneath this covered presenter and no-op).
+    @State private var presentingMomentDetail: AnyMessage?
     @State private var navState: ThinkingDetailNavigatorImpl = .init()
     @State private var navigator: ThinkingDetailCollector?
 
@@ -107,6 +113,13 @@ struct ThinkingDetailView: View {
         .presentationBackground(.colorBackgroundRaisedSecondary)
         .sheet(isPresented: $presentingAgentProfile) {
             profileSheetForMember(descriptor.sender)
+        }
+        .sheet(item: $presentingMomentDetail) { moment in
+            MessageDetailView(
+                message: moment,
+                onCopy: { text in UIPasteboard.general.string = text },
+                onReply: { _ in presentingMomentDetail = nil }
+            )
         }
         .onAppear {
             ensureNavigator()
@@ -187,6 +200,7 @@ struct ThinkingDetailView: View {
             onTapReadReceipts: { _ in },
             onTapThinkingIndicator: { _ in },
             onReply: { _ in },
+            onOpenMessageDetail: { presentingMomentDetail = $0 },
             contextMenuState: .init(),
             onPhotoDimensionsLoaded: { _, _, _ in },
             onAgentOutOfCredits: {},

--- a/ConvosTests/MessageBodyClassifierTests.swift
+++ b/ConvosTests/MessageBodyClassifierTests.swift
@@ -1,0 +1,82 @@
+@testable import Convos
+import XCTest
+
+final class MessageBodyClassifierTests: XCTestCase {
+    private func string(count: Int) -> String {
+        String(repeating: "a", count: count)
+    }
+
+    private func newlines(_ count: Int) -> String {
+        String(repeating: "\n", count: count)
+    }
+
+    // MARK: - Short
+
+    func testEmptyIsShort() {
+        XCTAssertEqual(MessageBodyClassifier.classify(""), .short)
+    }
+
+    func testTypicalShortMessageIsShort() {
+        XCTAssertEqual(MessageBodyClassifier.classify("Hello world"), .short)
+    }
+
+    func testExactlyLongCharThresholdIsShort() {
+        // The rule is `> longCharThreshold`, so exactly the threshold stays short.
+        let text = string(count: MessageBodyClassifier.longCharThreshold)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .short)
+    }
+
+    func testExactlyShortNewlineThresholdIsShort() {
+        // The rule is `> shortNewlineThreshold`, so exactly 30 newlines (with a
+        // short char count) stays short.
+        let text = newlines(MessageBodyClassifier.shortNewlineThreshold)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .short)
+    }
+
+    // MARK: - Long
+
+    func testJustOverLongCharThresholdIsLong() {
+        let text = string(count: MessageBodyClassifier.longCharThreshold + 1)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .long)
+    }
+
+    func testExactlyPathologicalCharThresholdIsLong() {
+        // The rule is `> pathologicalCharThreshold`, so exactly the threshold is
+        // still only long, not pathological.
+        let text = string(count: MessageBodyClassifier.pathologicalCharThreshold)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .long)
+    }
+
+    func testShortCharCountWithManyNewlinesIsLong() {
+        // Few characters but more than 30 hard line breaks (e.g. a code snippet
+        // or poem) forces many line fragments, so it is treated as long.
+        let text = "x" + newlines(MessageBodyClassifier.shortNewlineThreshold + 1)
+        XCTAssertLessThanOrEqual(text.count, MessageBodyClassifier.longCharThreshold)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .long)
+    }
+
+    func testJustOverShortNewlineThresholdIsLong() {
+        let text = newlines(MessageBodyClassifier.shortNewlineThreshold + 1)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .long)
+    }
+
+    // MARK: - Pathological
+
+    func testJustOverPathologicalCharThresholdIsPathological() {
+        let text = string(count: MessageBodyClassifier.pathologicalCharThreshold + 1)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .pathological)
+    }
+
+    func testVeryLargeBodyIsPathological() {
+        let text = string(count: MessageBodyClassifier.pathologicalCharThreshold * 3)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .pathological)
+    }
+
+    func testPathologicalCharCountTakesPrecedenceOverNewlineRule() {
+        // A body over the pathological char threshold is pathological even if it
+        // also has many newlines (char threshold is checked first).
+        let text = string(count: MessageBodyClassifier.pathologicalCharThreshold + 1)
+            + newlines(MessageBodyClassifier.shortNewlineThreshold + 5)
+        XCTAssertEqual(MessageBodyClassifier.classify(text), .pathological)
+    }
+}

--- a/ConvosTests/MessageBodyClassifierTests.swift
+++ b/ConvosTests/MessageBodyClassifierTests.swift
@@ -27,10 +27,19 @@ final class MessageBodyClassifierTests: XCTestCase {
     }
 
     func testExactlyShortNewlineThresholdIsShort() {
-        // The rule is `> shortNewlineThreshold`, so exactly 30 newlines (with a
-        // short char count) stays short.
+        // The rule is `> shortNewlineThreshold`, so exactly the threshold count
+        // of newlines (with a short char count) stays short.
         let text = newlines(MessageBodyClassifier.shortNewlineThreshold)
         XCTAssertEqual(MessageBodyClassifier.classify(text), .short)
+    }
+
+    // MARK: - Threshold values (lock the data-backed tuning)
+
+    func testThresholdConstantsMatchTunedValues() {
+        // Quarter's data-backed tuning: human messages over a few hundred chars
+        // are rare, so long starts at 500 and pathological at 1500.
+        XCTAssertEqual(MessageBodyClassifier.longCharThreshold, 500)
+        XCTAssertEqual(MessageBodyClassifier.pathologicalCharThreshold, 1_500)
     }
 
     // MARK: - Long

--- a/docs/plans/long-message-handling.md
+++ b/docs/plans/long-message-handling.md
@@ -1,0 +1,29 @@
+# Long Message Handling
+
+> Status: Approved -- iOS implementation in review.
+
+## Why
+Synchronously laying out unbounded message text (SwiftUI `Text` / CoreText) was the largest iOS UI-hang cluster. This is a performance fix that doubles as product behavior. Non-blocking and reversible.
+
+## Display rules
+Classify a message body by length with a cheap character-count check (never measure or lay out the full text):
+- `<= 500` chars: render in full.
+- `> 500` chars: bounded preview + inline "Read more" that expands in place.
+- `> 1500` chars: bounded preview + "Read more" that opens a dedicated full-message view.
+
+Thresholds are tunable constants, sized from data (human-sent messages rarely exceed ~200 chars).
+
+## "Read more" affordance
+A distinct outline-pill button (1px `color/border/inverted/subtle`), not styled like message text -- clear touch target, visible in light and dark mode.
+
+## Links
+SwiftUI `Text` does not auto-detect links. Link-bearing bodies and the full-message view render via a UIKit text view with `dataDetectorTypes`. Link detection runs asynchronously (benchmarked cheap even for novel-length text), so it stays enabled for long/expanded messages and the detail view.
+
+## Agent messages
+Agents are prompted to keep messages short (~2 sentences). A deterministic backstop rejects outbound agent messages longer than 250 characters, prompting the agent to shorten the message or move the content to an attachment. As a result, agents should effectively never hit "Read more"; it is a human-only edge case (dictation / long typing). The agent-message limit is a separate workstream in the assistants/backend prompt.
+
+## Future
+Genuinely long content (e.g. paste) should use a text-attachment pattern (artifact-style) rather than a single large bubble. As that and the agent backstop land, "Read more" becomes a rare, human-only edge case.
+
+## Cross-platform
+Android should adopt the same display rules (thresholds, "Read more", dedicated view). Owner TBD; kept in sync.

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -53,6 +53,7 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 33 | `qa/tests/33-read-receipts.md` | Read receipts: send on view, display avatars, opt-out setting |
 | 34 | `qa/tests/34-side-convo-stable-emoji.md` | Side convo flow: create linked convo invite, verify invite metadata, and confirm stable conversation emoji across two devices |
 | 42 | `qa/tests/42-agent-builder-attachment-summary.md` | Agent builder: create agent with prompt + photo attachment, verify summary card renders the photo thumbnail (pre- and post-rehydration) |
+| 43 | `qa/tests/43-long-message-rendering.md` | Long-message UX: short renders unchanged, long shows Read More + inline expand, pathological pushes MessageDetailView (Back/Copy/Reply), no-hang guard |
 
 ## Running Tests
 

--- a/qa/tests/43-long-message-rendering.md
+++ b/qa/tests/43-long-message-rendering.md
@@ -1,0 +1,66 @@
+# Test: Long-Message Rendering and Detail View
+
+Verify the two-tier long-message UX that fixes the dominant CoreText app-hang. Short messages render unchanged; long messages show a bounded preview with a Read More that expands inline; pathological (very long) messages show a bounded preview whose Read More opens a pushed MessageDetailView with working Back, Copy, and Reply. A no-hang guard confirms that opening a very long message keeps the UI responsive.
+
+## Prerequisites
+
+- The app is running and past onboarding.
+- The convos CLI is initialized for the dev environment.
+- The app and CLI are both participants in a shared conversation.
+- The app is on the conversation detail screen.
+
+## Setup
+
+1. Reuse (or create) the shared conversation and navigate into it.
+
+## Test data generators
+
+The CLI has no "send long text" helper, so send pre-generated strings whose first ~40 characters contain a stable marker. Generate them with:
+
+- Long (~2500 chars, marker `LONG43B`):
+  `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*90)"`
+- Pathological (~12000 chars, marker `HUGE43C`):
+  `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*440)"`
+
+Send each verbatim with `convos conversation send-text $id "$body" --env dev`. Target the bubble with `label_contains: "LONG43B"` / `"HUGE43C"` so matching uses a short substring, not the whole body.
+
+## Steps
+
+### Short message renders normally
+
+2. CLI sends "Short hello 43A". It appears in full; there is no Read More affordance (`message-read-more-button` does not exist).
+
+### Long message - Read More + inline expand
+
+3. CLI sends the ~2500-char `LONG43B` body. A truncated preview with a Read More button (`message-read-more-button`) appears.
+4. Tap Read More. The message expands inline; the Read More button disappears; no detail view opens (`message-detail-view` does not exist).
+
+### Pathological message - pushes detail
+
+5. CLI sends the ~12000-char `HUGE43C` body. A truncated preview with a Read More button appears (the long bubble from step 4 is already expanded, so this is the only collapsed Read More on screen).
+6. Tap Read More. The `MessageDetailView` opens (`message-detail-view`) with a back chevron (`message-detail-back-button`), a centered "Message" title, and Copy (`message-detail-copy-button`) / Reply (`message-detail-reply-button`) buttons floating at the bottom corners.
+
+### Detail view actions
+
+7. Clear the clipboard, tap Copy, and read the pasteboard. It contains the full body (marker `HUGE43C`).
+8. Tap Reply. The detail view dismisses and the reply composer bar (`reply-composer-bar`) appears above the composer. Cancel the reply afterward.
+9. Re-open the detail view (tap the `HUGE43C` Read More again), then tap Back. You return to the conversation with the composer (`message-text-field`) visible.
+
+### No-hang guard
+
+10. Re-open the detail view for the ~12000-char message; it must present within ~3s. A >= 2s main-thread hang would make the 3s wait time out and fail. There is no `[PERF]` marker for this transition; the timeout is the guard. Dismiss the detail view afterward.
+
+## Teardown
+
+Explode the conversation via CLI (optional; transient CLI errors do not fail the test).
+
+## Pass/Fail Criteria
+
+- [ ] Short message renders fully with no Read More.
+- [ ] Long message shows Read More.
+- [ ] Long message expands inline (Read More disappears, no detail view).
+- [ ] Pathological message opens the detail view with Back, Copy, and Reply.
+- [ ] Detail Copy copies the full body (containing `HUGE43C`) to the pasteboard.
+- [ ] Detail Reply dismisses the detail view and reveals the reply composer bar.
+- [ ] Detail Back dismisses the detail view and returns to the conversation.
+- [ ] Opening a ~12000-char message presents the detail view within 3s (no hang).

--- a/qa/tests/43-long-message-rendering.md
+++ b/qa/tests/43-long-message-rendering.md
@@ -17,8 +17,9 @@ Verify the two-tier long-message UX that fixes the dominant CoreText app-hang. S
 
 The CLI has no "send long text" helper, so send pre-generated strings whose first ~40 characters contain a stable marker. Generate them with:
 
-- Long (~800 chars, marker `LONG43B`):
-  `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*30)"`
+- Long (~800 chars, marker `LONG43B`; prose names the 500-char threshold so the
+  in-sim text matches the current tuning):
+  `python3 -c "print('LONG43B This message is over the five-hundred character preview threshold, so it shows a bounded preview with a Read more button that expands it inline. ' + 'It keeps going past five hundred characters but stays under the fifteen-hundred pathological threshold so it expands in place. '*5)"`
 - Pathological (~3000 chars, marker `HUGE43C`):
   `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*110)"`
 

--- a/qa/tests/43-long-message-rendering.md
+++ b/qa/tests/43-long-message-rendering.md
@@ -17,10 +17,10 @@ Verify the two-tier long-message UX that fixes the dominant CoreText app-hang. S
 
 The CLI has no "send long text" helper, so send pre-generated strings whose first ~40 characters contain a stable marker. Generate them with:
 
-- Long (~2500 chars, marker `LONG43B`):
-  `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*90)"`
-- Pathological (~12000 chars, marker `HUGE43C`):
-  `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*440)"`
+- Long (~800 chars, marker `LONG43B`):
+  `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*30)"`
+- Pathological (~3000 chars, marker `HUGE43C`):
+  `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*110)"`
 
 Send each verbatim with `convos conversation send-text $id "$body" --env dev`. Target the bubble with `label_contains: "LONG43B"` / `"HUGE43C"` so matching uses a short substring, not the whole body.
 
@@ -32,12 +32,12 @@ Send each verbatim with `convos conversation send-text $id "$body" --env dev`. T
 
 ### Long message - Read More + inline expand
 
-3. CLI sends the ~2500-char `LONG43B` body. A truncated preview with a Read More button (`message-read-more-button`) appears.
+3. CLI sends the ~800-char `LONG43B` body. A truncated preview with a Read More button (`message-read-more-button`) appears.
 4. Tap Read More. The message expands inline; the Read More button disappears; no detail view opens (`message-detail-view` does not exist).
 
 ### Pathological message - pushes detail
 
-5. CLI sends the ~12000-char `HUGE43C` body. A truncated preview with a Read More button appears (the long bubble from step 4 is already expanded, so this is the only collapsed Read More on screen).
+5. CLI sends the ~3000-char `HUGE43C` body. A truncated preview with a Read More button appears (the long bubble from step 4 is already expanded, so this is the only collapsed Read More on screen).
 6. Tap Read More. The `MessageDetailView` opens (`message-detail-view`) with a back chevron (`message-detail-back-button`), a centered "Message" title, and Copy (`message-detail-copy-button`) / Reply (`message-detail-reply-button`) buttons floating at the bottom corners.
 
 ### Detail view actions
@@ -48,7 +48,7 @@ Send each verbatim with `convos conversation send-text $id "$body" --env dev`. T
 
 ### No-hang guard
 
-10. Re-open the detail view for the ~12000-char message; it must present within ~3s. A >= 2s main-thread hang would make the 3s wait time out and fail. There is no `[PERF]` marker for this transition; the timeout is the guard. Dismiss the detail view afterward.
+10. Re-open the detail view for the ~3000-char message; it must present within ~3s. A >= 2s main-thread hang would make the 3s wait time out and fail. There is no `[PERF]` marker for this transition; the timeout is the guard. Dismiss the detail view afterward.
 
 ## Teardown
 
@@ -63,4 +63,4 @@ Explode the conversation via CLI (optional; transient CLI errors do not fail the
 - [ ] Detail Copy copies the full body (containing `HUGE43C`) to the pasteboard.
 - [ ] Detail Reply dismisses the detail view and reveals the reply composer bar.
 - [ ] Detail Back dismisses the detail view and returns to the conversation.
-- [ ] Opening a ~12000-char message presents the detail view within 3s (no hang).
+- [ ] Opening a ~3000-char message presents the detail view within 3s (no hang).

--- a/qa/tests/structured/43-long-message-rendering.yaml
+++ b/qa/tests/structured/43-long-message-rendering.yaml
@@ -58,9 +58,10 @@ steps:
       Send a body of roughly 800 characters that crosses the long threshold
       (500) but stays under pathological (1500). The body MUST start with the
       marker "LONG43B " so `label_contains` targets a short stable substring,
-      not the whole giant body. Generator (bash):
-      `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*30)"`
-      yields ~820 chars. Send that string verbatim via cli_send_text.
+      not the whole giant body. The sample prose names the 500-char threshold so
+      what shows in the sim matches the current tuning. Generator (bash):
+      `python3 -c "print('LONG43B This message is over the five-hundred character preview threshold, so it shows a bounded preview with a Read more button that expands it inline. ' + 'It keeps going past five hundred characters but stays under the fifteen-hundred pathological threshold so it expands in place. '*5)"`
+      yields ~790 chars. Send that string verbatim via cli_send_text.
 
   - id: long_message_expands_inline
     name: "Read More expands the long message inline"

--- a/qa/tests/structured/43-long-message-rendering.yaml
+++ b/qa/tests/structured/43-long-message-rendering.yaml
@@ -1,0 +1,186 @@
+id: "43"
+name: "Long-Message Rendering and Detail View"
+description: >
+  Verify the two-tier long-message UX that fixes the dominant CoreText
+  app-hang. Short messages render unchanged with no Read More. Long messages
+  (over ~1200 chars) show a bounded preview with a Read More that expands
+  inline. Pathological messages (over ~6000 chars) show a bounded preview whose
+  Read More opens a pushed MessageDetailView with working Back, Copy, and
+  Reply. Includes a no-hang guard that opening a very long message keeps the UI
+  responsive.
+tags: [messaging, rendering, performance, core]
+depends_on: ["02"]
+estimated_duration_s: 300
+
+prerequisites:
+  app_running: true
+  cli_initialized: true
+  shared_conversation: true
+  screen: conversation_detail
+
+state:
+  conversation_id: null
+
+setup:
+  - action: ensure_shared_conversation
+    save:
+      conversation_id: run_state.shared_conversation_id
+  - action: navigate_to_conversation
+    args: { id: "$conversation_id" }
+
+steps:
+  - id: short_message_renders_normally
+    name: "Short message renders inline with no Read More"
+    actions:
+      - cli_send_text:
+          conversation: "$conversation_id"
+          text: "Short hello 43A"
+      - wait_for_element: { label_contains: "Short hello 43A", timeout: 15 }
+    verify:
+      - element_exists: { label_contains: "Short hello 43A" }
+      - element_not_exists: { id: "message-read-more-button" }
+    criteria: short_renders_normally
+    note: >
+      Short bodies (under ~1200 chars and under 30 newlines) keep the original
+      full Text render with no Read More affordance.
+
+  - id: long_message_shows_read_more
+    name: "Long message shows bounded preview + Read More"
+    actions:
+      - cli_send_text:
+          conversation: "$conversation_id"
+          text: "LONG43B <~2500-char body>"
+      - wait_for_element: { label_contains: "LONG43B", timeout: 15 }
+    verify:
+      - element_exists: { id: "message-read-more-button" }
+    criteria: long_shows_read_more
+    note: >
+      Send a body of roughly 2500 characters that crosses the long threshold
+      (1200) but stays under pathological (6000). The body MUST start with the
+      marker "LONG43B " so `label_contains` targets a short stable substring,
+      not the whole giant body. Generator (bash):
+      `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*90)"`
+      yields ~2500 chars. Send that string verbatim via cli_send_text.
+
+  - id: long_message_expands_inline
+    name: "Read More expands the long message inline"
+    actions:
+      - tap: { id: "message-read-more-button" }
+      - wait_for_element: { label_contains: "LONG43B", timeout: 5 }
+    verify:
+      - element_not_exists: { id: "message-read-more-button" }
+      - element_not_exists: { id: "message-detail-view" }
+    criteria: long_expands_inline
+    note: >
+      A long-but-not-pathological body expands in place; it does NOT open the
+      detail view. The Read More button disappears once expanded. Only one
+      long bubble (LONG43B) is on screen, so there is exactly one
+      message-read-more-button to tap at this point.
+
+  - id: pathological_pushes_detail
+    name: "Pathological message opens MessageDetailView"
+    actions:
+      - cli_send_text:
+          conversation: "$conversation_id"
+          text: "HUGE43C <~12000-char body>"
+      - wait_for_element: { label_contains: "HUGE43C", timeout: 20 }
+      - tap: { id: "message-read-more-button" }
+      - wait_for_element: { id: "message-detail-view", timeout: 5 }
+    verify:
+      - element_exists: { id: "message-detail-view" }
+      - element_exists: { id: "message-detail-copy-button" }
+      - element_exists: { id: "message-detail-reply-button" }
+      - element_exists: { id: "message-detail-back-button" }
+    criteria: pathological_pushes_detail
+    note: >
+      Send a body of roughly 12000 characters that crosses the pathological
+      threshold (6000), starting with the marker "HUGE43C ". Generator (bash):
+      `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*440)"`
+      yields ~12000 chars. After the long bubble was expanded in the prior
+      step, the only collapsed Read More on screen belongs to the HUGE43C
+      bubble, so tapping message-read-more-button targets it. Read More here
+      opens the detail view instead of expanding inline.
+
+  - id: detail_copy_works
+    name: "Detail view Copy puts full text on pasteboard"
+    actions:
+      - clear_clipboard: {}
+      - tap: { id: "message-detail-copy-button" }
+      - read_clipboard: {}
+    verify:
+      - clipboard_contains: "HUGE43C"
+    criteria: detail_copy_works
+    note: >
+      Copy reuses UIPasteboard.general.string = text. Read the pasteboard via
+      `xcrun simctl pbpaste $UDID`; assert it contains the body marker HUGE43C.
+
+  - id: detail_reply_works
+    name: "Detail view Reply dismisses and arms the reply composer"
+    actions:
+      - tap: { id: "message-detail-reply-button" }
+      - wait_for_element: { id: "reply-composer-bar", timeout: 5 }
+    verify:
+      - element_not_exists: { id: "message-detail-view" }
+      - element_exists: { id: "reply-composer-bar" }
+    criteria: detail_reply_works
+    note: >
+      Reply dismisses the detail view, then calls viewModel.onReply (the same
+      action as the long-press menu Reply) which sets replyingToMessage, so the
+      reply-composer-bar appears above the composer. Cancel the reply (tap the
+      X on reply-composer-bar) before the next step so it does not interfere.
+
+  - id: detail_back_works
+    name: "Detail view Back returns to the conversation"
+    actions:
+      - tap: { id: "message-read-more-button" }
+      - wait_for_element: { id: "message-detail-view", timeout: 5 }
+      - tap: { id: "message-detail-back-button" }
+      - wait_for_element: { id: "message-text-field", timeout: 5 }
+    verify:
+      - element_not_exists: { id: "message-detail-view" }
+      - element_exists: { id: "message-text-field" }
+    criteria: detail_back_works
+    note: >
+      The prior Reply step dismissed the detail view, so re-open it first by
+      tapping the HUGE43C bubble's Read More, then tap Back. Back uses the
+      sheet dismiss and returns to the conversation with the composer visible.
+
+  - id: no_hang_on_huge_message
+    name: "Opening a huge message does not freeze the UI"
+    actions:
+      - tap: { id: "message-read-more-button" }
+      - wait_for_element: { id: "message-detail-view", timeout: 3 }
+    verify:
+      - element_exists: { id: "message-detail-view" }
+    criteria: no_hang_on_huge_message
+    note: >
+      Soft hang guard: a >= 2s main-thread stall makes the 3s wait_for_element
+      time out and fail the step. The fix bounds every inline render path with
+      a finite lineLimit and lays the full pathological body out only inside
+      the detail view's scroll-enabled UITextView (incremental TextKit), so
+      presenting the detail view for a 12000-char body must not block. There is
+      no [PERF] marker emitted for this transition; the timeout is the guard.
+      Dismiss the detail view (Back) after this step.
+
+teardown:
+  - action: explode_conversation
+    args: { id: "$conversation_id" }
+    optional: true
+
+criteria:
+  short_renders_normally:
+    description: "Short message body is fully visible and no message-read-more-button exists"
+  long_shows_read_more:
+    description: "Long (~2500 char) message shows a message-read-more-button"
+  long_expands_inline:
+    description: "Tapping Read More on a long message removes the button and shows more text without opening message-detail-view"
+  pathological_pushes_detail:
+    description: "Tapping Read More on a pathological (~12000 char) message opens message-detail-view with Back, Copy, and Reply buttons"
+  detail_copy_works:
+    description: "Detail Copy places the full message text (containing marker HUGE43C) on the pasteboard"
+  detail_reply_works:
+    description: "Detail Reply dismisses message-detail-view and reveals reply-composer-bar"
+  detail_back_works:
+    description: "Detail Back dismisses message-detail-view and returns to the conversation with message-text-field visible"
+  no_hang_on_huge_message:
+    description: "Opening a ~12000 char message presents message-detail-view within 3s (no >= 2s main-thread hang)"

--- a/qa/tests/structured/43-long-message-rendering.yaml
+++ b/qa/tests/structured/43-long-message-rendering.yaml
@@ -3,8 +3,8 @@ name: "Long-Message Rendering and Detail View"
 description: >
   Verify the two-tier long-message UX that fixes the dominant CoreText
   app-hang. Short messages render unchanged with no Read More. Long messages
-  (over ~1200 chars) show a bounded preview with a Read More that expands
-  inline. Pathological messages (over ~6000 chars) show a bounded preview whose
+  (over ~500 chars) show a bounded preview with a Read More that expands
+  inline. Pathological messages (over ~1500 chars) show a bounded preview whose
   Read More opens a pushed MessageDetailView with working Back, Copy, and
   Reply. Includes a no-hang guard that opening a very long message keeps the UI
   responsive.
@@ -41,7 +41,7 @@ steps:
       - element_not_exists: { id: "message-read-more-button" }
     criteria: short_renders_normally
     note: >
-      Short bodies (under ~1200 chars and under 30 newlines) keep the original
+      Short bodies (under ~500 chars and under 20 newlines) keep the original
       full Text render with no Read More affordance.
 
   - id: long_message_shows_read_more
@@ -49,18 +49,18 @@ steps:
     actions:
       - cli_send_text:
           conversation: "$conversation_id"
-          text: "LONG43B <~2500-char body>"
+          text: "LONG43B <~800-char body>"
       - wait_for_element: { label_contains: "LONG43B", timeout: 15 }
     verify:
       - element_exists: { id: "message-read-more-button" }
     criteria: long_shows_read_more
     note: >
-      Send a body of roughly 2500 characters that crosses the long threshold
-      (1200) but stays under pathological (6000). The body MUST start with the
+      Send a body of roughly 800 characters that crosses the long threshold
+      (500) but stays under pathological (1500). The body MUST start with the
       marker "LONG43B " so `label_contains` targets a short stable substring,
       not the whole giant body. Generator (bash):
-      `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*90)"`
-      yields ~2500 chars. Send that string verbatim via cli_send_text.
+      `python3 -c "print('LONG43B ' + 'lorem ipsum dolor sit amet '*30)"`
+      yields ~820 chars. Send that string verbatim via cli_send_text.
 
   - id: long_message_expands_inline
     name: "Read More expands the long message inline"
@@ -82,7 +82,7 @@ steps:
     actions:
       - cli_send_text:
           conversation: "$conversation_id"
-          text: "HUGE43C <~12000-char body>"
+          text: "HUGE43C <~3000-char body>"
       - wait_for_element: { label_contains: "HUGE43C", timeout: 20 }
       - tap: { id: "message-read-more-button" }
       - wait_for_element: { id: "message-detail-view", timeout: 5 }
@@ -93,10 +93,10 @@ steps:
       - element_exists: { id: "message-detail-back-button" }
     criteria: pathological_pushes_detail
     note: >
-      Send a body of roughly 12000 characters that crosses the pathological
-      threshold (6000), starting with the marker "HUGE43C ". Generator (bash):
-      `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*440)"`
-      yields ~12000 chars. After the long bubble was expanded in the prior
+      Send a body of roughly 3000 characters that crosses the pathological
+      threshold (1500), starting with the marker "HUGE43C ". Generator (bash):
+      `python3 -c "print('HUGE43C ' + 'lorem ipsum dolor sit amet '*110)"`
+      yields ~3000 chars. After the long bubble was expanded in the prior
       step, the only collapsed Read More on screen belongs to the HUGE43C
       bubble, so tapping message-read-more-button targets it. Read More here
       opens the detail view instead of expanding inline.
@@ -158,7 +158,7 @@ steps:
       time out and fail the step. The fix bounds every inline render path with
       a finite lineLimit and lays the full pathological body out only inside
       the detail view's scroll-enabled UITextView (incremental TextKit), so
-      presenting the detail view for a 12000-char body must not block. There is
+      presenting the detail view for a 3000-char body must not block. There is
       no [PERF] marker emitted for this transition; the timeout is the guard.
       Dismiss the detail view (Back) after this step.
 
@@ -171,11 +171,11 @@ criteria:
   short_renders_normally:
     description: "Short message body is fully visible and no message-read-more-button exists"
   long_shows_read_more:
-    description: "Long (~2500 char) message shows a message-read-more-button"
+    description: "Long (~800 char) message shows a message-read-more-button"
   long_expands_inline:
     description: "Tapping Read More on a long message removes the button and shows more text without opening message-detail-view"
   pathological_pushes_detail:
-    description: "Tapping Read More on a pathological (~12000 char) message opens message-detail-view with Back, Copy, and Reply buttons"
+    description: "Tapping Read More on a pathological (~3000 char) message opens message-detail-view with Back, Copy, and Reply buttons"
   detail_copy_works:
     description: "Detail Copy places the full message text (containing marker HUGE43C) on the pasteboard"
   detail_reply_works:
@@ -183,4 +183,4 @@ criteria:
   detail_back_works:
     description: "Detail Back dismisses message-detail-view and returns to the conversation with message-text-field visible"
   no_hang_on_huge_message:
-    description: "Opening a ~12000 char message presents message-detail-view within 3s (no >= 2s main-thread hang)"
+    description: "Opening a ~3000 char message presents message-detail-view within 3s (no >= 2s main-thread hang)"


### PR DESCRIPTION
## Why

Our biggest cluster of unresolved Sentry issues is app **hangs** -- the UI freezes 2s+ (no crash, just frozen). ~11 of 19 open issues trace to one cause: SwiftUI synchronously lays out the *entire* body of a message on the main thread. The system font is a variable font, so shaping a very long string is expensive -- one pasted "novel" can freeze the app on arrival and on every re-layout.

## What (Signal's model)

Classify each message by length -- cheaply, by character count, never by measuring it (measuring the novel is the bug):

- **Short** -> renders exactly as today.
- **Long** (>500chars) -> bounded 12-line preview + **"Read More"** that expands inline.
- **Pathological** (>1,500 chars) -> bounded 8-line preview that opens a dedicated **"Message"** screen, rendered with TextKit (`UITextView`) which lays out large text lazily instead of all at once.

We never lay out unbounded text on the main thread, and normal messages are untouched. Thresholds are tunable constants.

## Verification

- **No-hang:** a 12,000-char message renders in ~190-250ms with zero main-thread stall (previously 2s+ hangs).
- **Tiers:** short / long / pathological all render correctly (accessibility ids verified).
- **Read More tap:** confirmed working on device. (Required a gesture-passthrough fix so the message bubble's gesture overlay does not swallow the tap.)
- Build clean (Dev), SwiftLint clean, zero type-check-budget warnings.
- QA: new structured suite `43-long-message-rendering` (8 steps). Full click-automation of taps is pending UI-automation/device.

## Buy-in requested

1. The two-tier UX -- inline "Read More" for long, a pushed "Message" view for pathological (mirrors Signal).
2. The thresholds (long >500, pathological >1,500) -- happy to calibrate against real p99 message length.

Non-blocking, reversible, and it directly retires our biggest hang cluster.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add long-message handling to fix main-thread hangs in conversation view
> - Introduces `MessageBodyClassifier` to categorize messages as short, long, or pathological based on character/newline count without layout measurement
> - Long messages render a preview with an inline Read More button that expands/collapses in place; expansion state is tracked in `ConversationViewModel` to survive cell reuse
> - Pathological (extremely long) messages open a new `MessageDetailView` sheet with a scroll-enabled `UITextView`, link detection, and Copy/Reply actions
> - Threads new callbacks (`onOpenMessageDetail`, `onToggleMessageExpanded`) and `expandedMessageIds` state through the full stack: `MessagesView` → `MessagesViewRepresentable` → `MessagesViewController` → data source → cells
> - Behavioral Change: extremely long messages no longer render inline at full length; they are truncated with a Read More that opens a detail sheet instead
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1105 opened
>
> - Added bounded rendering with line limits and 'Read more' button for long thought-bubble messages [18d4946]
> - Added sheet presentation for message detail in thinking view [18d4946]
> - Changed `onOpenMessageDetail` handler to optional throughout the architecture [18d4946]
> - Created reusable `ReadMoreButton` SwiftUI view component [18d4946]
> - Refactored `MessageBubble.readMoreButton` to use shared component [18d4946]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e1edf1.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->