### PR TITLE
fix(notifications): drop pushes after leaving or being removed from a conversation (IOS-467)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -430,6 +430,20 @@ extension MessagingService {
 
         let dbConversation = try await storeConversation(group, inboxId: currentInboxId)
 
+        // Second line of defense behind the app-side leave/removed unsubscribe:
+        // suppress the banner when the local conversation says the user is no
+        // longer in it. Mirrors the denied-welcome guard above, and covers the
+        // in-flight-push race (a push already sent before the backend
+        // unsubscribe landed) plus the removed-but-still-`.allowed` kick case
+        // that the reconcile desired set never drops.
+        if try await shouldDropGroupNotification(
+            conversationId: dbConversation.id,
+            consent: dbConversation.consent,
+            currentInboxId: currentInboxId
+        ) {
+            return .droppedMessage
+        }
+
         _ = try await messageWriter.store(message: decodedMessage, for: dbConversation)
 
         let notificationTitle = (try? await getComputedDisplayName(
@@ -479,6 +493,53 @@ extension MessagingService {
                 currentInboxId: currentInboxId
             )
         }
+    }
+
+    private func shouldDropGroupNotification(
+        conversationId: String,
+        consent: Consent,
+        currentInboxId: String
+    ) async throws -> Bool {
+        try await databaseReader.read { db in
+            try Self.shouldDropGroupNotification(
+                db: db,
+                conversationId: conversationId,
+                consent: consent,
+                currentInboxId: currentInboxId
+            )
+        }
+    }
+
+    /// True when a group push should be suppressed because the local state says
+    /// the user is no longer in the conversation: the user left (consent
+    /// `.denied`), was removed (`ConversationLocalState.wasRemoved`), or the
+    /// current inbox is absent from `DBConversationMember` (robust to the kick
+    /// path, which sets `wasRemoved` but leaves consent untouched). The
+    /// membership read mirrors `otherMemberCount` / `computedDisplayName`,
+    /// which already gate on `DBConversationMember` in this file.
+    static func shouldDropGroupNotification(
+        db: Database,
+        conversationId: String,
+        consent: Consent,
+        currentInboxId: String
+    ) throws -> Bool {
+        if consent == .denied {
+            return true
+        }
+
+        let wasRemoved = try ConversationLocalState
+            .filter(ConversationLocalState.Columns.conversationId == conversationId)
+            .fetchOne(db)?
+            .wasRemoved ?? false
+        if wasRemoved {
+            return true
+        }
+
+        let isCurrentMember = try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .filter(DBConversationMember.Columns.inboxId == currentInboxId)
+            .fetchCount(db) > 0
+        return !isCurrentMember
     }
 
     /// Counts the conversation's current members excluding the current user,

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -211,7 +211,11 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     func conversationConsentWriter() -> any ConversationConsentWriterProtocol {
         ConversationConsentWriter(
             sessionStateManager: sessionStateManager,
-            databaseWriter: databaseWriter
+            databaseWriter: databaseWriter,
+            pushTopicSubscriptionManager: PushTopicSubscriptionManager(
+                identityStore: identityStore,
+                deviceInfoProvider: deviceInfoProvider
+            )
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationConsentWriter.swift
@@ -17,11 +17,19 @@ class ConversationConsentWriter: ConversationConsentWriterProtocol, @unchecked S
 
     private let sessionStateManager: any SessionStateManagerProtocol
     private let databaseWriter: any DatabaseWriter
+    /// Unsubscribes the conversation's push topic on leave so the backend
+    /// stops pushing it immediately, instead of waiting for the next full
+    /// reconcile. Best-effort: failures are swallowed by the manager and
+    /// the next reconcile re-converges. Nil in unit tests that don't
+    /// exercise the push path.
+    private let pushTopicSubscriptionManager: (any PushTopicSubscriptionManaging)?
 
     init(sessionStateManager: any SessionStateManagerProtocol,
-         databaseWriter: any DatabaseWriter) {
+         databaseWriter: any DatabaseWriter,
+         pushTopicSubscriptionManager: (any PushTopicSubscriptionManaging)? = nil) {
         self.sessionStateManager = sessionStateManager
         self.databaseWriter = databaseWriter
+        self.pushTopicSubscriptionManager = pushTopicSubscriptionManager
     }
 
     func join(conversation: Conversation) async throws {
@@ -51,9 +59,19 @@ class ConversationConsentWriter: ConversationConsentWriterProtocol, @unchecked S
             return
         }
 
-        let client = try await sessionStateManager.waitForInboxReadyResult().client
-        try await client.update(consent: .denied, for: targetId)
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        try await inboxReady.client.update(consent: .denied, for: targetId)
         try await persistDeniedConsent(conversationId: targetId)
+
+        // Drop the conversation's push topic now that the user has left, so the
+        // backend stops pushing it immediately. The full reconcile would also
+        // diff a denied conversation out of the desired set, but only on the
+        // next resume / cold start / token change; this closes that window.
+        await pushTopicSubscriptionManager?.unsubscribeFromGroupTopic(
+            conversationId: targetId,
+            params: SyncClientParams(client: inboxReady.client, apiClient: inboxReady.apiClient),
+            context: "leave conversation"
+        )
     }
 
     /// A pending invite can resolve while the delete is in flight: the real

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -127,7 +127,10 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
 
         self.conversationConsentWriter = ConversationConsentWriter(
             sessionStateManager: sessionStateManager,
-            databaseWriter: databaseWriter
+            databaseWriter: databaseWriter,
+            pushTopicSubscriptionManager: PushTopicSubscriptionManager(
+                identityStore: identityStore
+            )
         )
 
         self.conversationLocalStateWriter = ConversationLocalStateWriter(

--- a/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/PushTopicSubscriptionManager.swift
@@ -33,6 +33,16 @@ protocol PushTopicSubscriptionManaging: Actor {
         context: String
     ) async
 
+    /// Unsubscribes from a group's message topic. Used when the user leaves
+    /// or is removed from a conversation so the backend stops pushing it
+    /// immediately, rather than waiting for the next full reconcile to diff
+    /// the topic out of the desired set.
+    func unsubscribeFromGroupTopic(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async
+
     /// Re-derives and resends the full topic set (welcome + groups +
     /// invite DMs) so server state matches the local conversation list.
     /// Called on resume / cold start to recover from missed deltas.
@@ -213,6 +223,31 @@ actor PushTopicSubscriptionManager: PushTopicSubscriptionManaging {
     }
 
     func unsubscribeFromInviteDMTopics(
+        conversationIds: [String],
+        params: SyncClientParams,
+        context: String
+    ) async {
+        guard !conversationIds.isEmpty else { return }
+        await unsubscribe(
+            topics: conversationIds.map(\.xmtpGroupTopicFormat),
+            params: params,
+            context: context
+        )
+    }
+
+    func unsubscribeFromGroupTopic(
+        conversationId: String,
+        params: SyncClientParams,
+        context: String
+    ) async {
+        await unsubscribeFromGroupTopics(
+            conversationIds: [conversationId],
+            params: params,
+            context: context
+        )
+    }
+
+    func unsubscribeFromGroupTopics(
         conversationIds: [String],
         params: SyncClientParams,
         context: String

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -314,6 +314,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                     )
 
                     let result = try await messageWriter.store(message: message, for: dbConversation)
+                    await unsubscribePushTopicIfRemoved(result, conversationId: conversation.id, params: params)
 
                     // Mark unread if needed (shared predicate with the
                     // catch-up paths so the gate can't drift).
@@ -851,6 +852,17 @@ actor StreamProcessor: StreamProcessorProtocol {
     }
 
     func clearPushSubscriptionCache() async { await pushTopicSubscriptionManager.clearCache() }
+
+    /// Drops the conversation's push topic when a stream message removed the
+    /// local user from the group. Removal sets only `wasRemoved` (consent stays
+    /// unchanged), so the reconcile desired set never diffs it out and the
+    /// backend would keep pushing indefinitely without this targeted unsubscribe.
+    private func unsubscribePushTopicIfRemoved(_ result: IncomingMessageWriterResult, conversationId: String, params: SyncClientParams) async {
+        guard result.wasRemovedFromConversation else { return }
+        await pushTopicSubscriptionManager.unsubscribeFromGroupTopic(
+            conversationId: conversationId, params: params, context: "removed from conversation"
+        )
+    }
 
     private func handleJoinRequestOutcome(
         _ outcome: InviteJoinRequestOutcome,

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationConsentWriterDeleteTests.swift
@@ -147,6 +147,46 @@ struct ConversationConsentWriterDeleteTests {
         #expect(stored?.consent == .allowed)
     }
 
+    @Test("delete(conversation:) on a real conversation unsubscribes its group push topic")
+    func deleteUnsubscribesGroupPushTopic() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let conversationId = "conv-unsub-1"
+        try seedAllowedConversation(in: dbManager.dbWriter, conversationId: conversationId)
+
+        let recordingManager = RecordingGroupUnsubscribeManager()
+        let writer = ConversationConsentWriter(
+            sessionStateManager: MockSessionStateManager(),
+            databaseWriter: dbManager.dbWriter,
+            pushTopicSubscriptionManager: recordingManager
+        )
+
+        try await writer.delete(conversation: .mock(id: conversationId))
+
+        let unsubscribed = await recordingManager.unsubscribedGroupIds
+        #expect(unsubscribed == [conversationId])
+    }
+
+    @Test("delete(conversation:) on a pending-invite draft does not unsubscribe a group topic")
+    func deleteDraftDoesNotUnsubscribeGroupPushTopic() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let draftId = "draft-unsub-1"
+        try seedAllowedConversation(in: dbManager.dbWriter, conversationId: draftId)
+
+        // A draft has no XMTP group, so there is no group topic to drop. The
+        // writer must not even reach the network path for a draft.
+        let recordingManager = RecordingGroupUnsubscribeManager()
+        let writer = ConversationConsentWriter(
+            sessionStateManager: InboxUnavailableSessionStateManager(),
+            databaseWriter: dbManager.dbWriter,
+            pushTopicSubscriptionManager: recordingManager
+        )
+
+        try await writer.delete(conversation: .mock(id: draftId))
+
+        let unsubscribed = await recordingManager.unsubscribedGroupIds
+        #expect(unsubscribed.isEmpty)
+    }
+
     @Test("After delete, a fetch filtered on [.allowed] no longer returns the row")
     func repositoryFilterExcludesDeniedRow() async throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
@@ -202,6 +242,23 @@ private final class InboxUnavailableSessionStateManager: SessionStateManagerProt
     func observeState(_ handler: @escaping (SessionStateMachine.State) -> Void) -> StateObserverHandle {
         StateObserverHandle(observer: ClosureStateObserver(handler: handler), manager: self)
     }
+}
+
+/// Records group-topic unsubscribe calls so the leave path can be asserted
+/// without a live backend. Other protocol methods are no-ops.
+private actor RecordingGroupUnsubscribeManager: PushTopicSubscriptionManaging {
+    private(set) var unsubscribedGroupIds: [String] = []
+
+    func subscribeToGroupAndWelcome(conversationId: String, params: SyncClientParams, context: String) async {}
+    func subscribeToInviteDMTopic(conversationId: String, params: SyncClientParams, context: String) async {}
+    func unsubscribeFromInviteDMTopic(conversationId: String, params: SyncClientParams, context: String) async {}
+
+    func unsubscribeFromGroupTopic(conversationId: String, params: SyncClientParams, context: String) async {
+        unsubscribedGroupIds.append(conversationId)
+    }
+
+    func reconcilePushTopics(params: SyncClientParams, context: String) async {}
+    func clearCache() async {}
 }
 
 private func seedAllowedConversation(

--- a/ConvosCore/Tests/ConvosCoreTests/NSEGroupNotificationDropGuardTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/NSEGroupNotificationDropGuardTests.swift
@@ -1,0 +1,140 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for `MessagingService.shouldDropGroupNotification` -- the NSE
+/// second line of defense that suppresses a group push banner when the local
+/// state says the user is no longer in the conversation. Closes the in-flight
+/// push race (a push already sent before the backend unsubscribe landed) and
+/// the removed-but-still-`.allowed` kick case the reconcile never drops.
+@Suite("NSE group-notification drop guard", .serialized)
+struct NSEGroupNotificationDropGuardTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let otherInboxId: String = "inbox-other"
+
+    private static func seedConversation(
+        db: Database,
+        id: String,
+        consent: Consent = .allowed,
+        wasRemoved: Bool = false,
+        currentIsMember: Bool = true
+    ) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBMember(inboxId: otherInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: otherInboxId,
+            kind: .group,
+            consent: consent,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: Date(),
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            wasRemoved: wasRemoved
+        ).insert(db)
+
+        var memberInboxIds: [String] = [otherInboxId]
+        if currentIsMember {
+            memberInboxIds.append(currentInboxId)
+        }
+        for inboxId in memberInboxIds {
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: .member,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            ).insert(db)
+        }
+    }
+
+    private static func shouldDrop(
+        db: Database,
+        id: String,
+        consent: Consent
+    ) throws -> Bool {
+        try MessagingService.shouldDropGroupNotification(
+            db: db,
+            conversationId: id,
+            consent: consent,
+            currentInboxId: currentInboxId
+        )
+    }
+
+    @Test("Renders for an active conversation the user is still in")
+    func rendersForActiveMembership() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let result = try dbManager.dbWriter.write { db -> Bool in
+            try Self.seedConversation(db: db, id: "active")
+            return try Self.shouldDrop(db: db, id: "active", consent: .allowed)
+        }
+        #expect(result == false)
+    }
+
+    @Test("Drops when the user left (consent denied)")
+    func dropsWhenConsentDenied() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let result = try dbManager.dbWriter.write { db -> Bool in
+            try Self.seedConversation(db: db, id: "left", consent: .denied)
+            return try Self.shouldDrop(db: db, id: "left", consent: .denied)
+        }
+        #expect(result == true)
+    }
+
+    @Test("Drops when the user was removed (wasRemoved), even with consent still allowed")
+    func dropsWhenRemovedWithConsentAllowed() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        // The kick path sets wasRemoved but leaves consent untouched -- this is
+        // the case the reconcile desired set never diffs out, so the guard must
+        // catch it on the consent-allowed value the row still carries.
+        let result = try dbManager.dbWriter.write { db -> Bool in
+            try Self.seedConversation(db: db, id: "kicked", consent: .allowed, wasRemoved: true)
+            return try Self.shouldDrop(db: db, id: "kicked", consent: .allowed)
+        }
+        #expect(result == true)
+    }
+
+    @Test("Drops when the current inbox is absent from the member list")
+    func dropsWhenNotAMember() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        // Membership pruned after removal (XMTP no longer lists the local inbox)
+        // but wasRemoved not yet persisted -- the membership check still drops.
+        let result = try dbManager.dbWriter.write { db -> Bool in
+            try Self.seedConversation(db: db, id: "not-member", consent: .allowed, currentIsMember: false)
+            return try Self.shouldDrop(db: db, id: "not-member", consent: .allowed)
+        }
+        #expect(result == true)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PushTopicSubscriptionManagerTests.swift
@@ -89,6 +89,81 @@ struct PushTopicSubscriptionManagerTests {
         #expect(calls.first?.topics == ["dm-1".xmtpGroupTopicFormat])
     }
 
+    @Test("Unsubscribes group topic on leave/removal")
+    func unsubscribesGroupTopic() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1")
+        )
+
+        await manager.unsubscribeFromGroupTopic(
+            conversationId: "group-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "leave"
+        )
+
+        let calls = apiClient.unsubscribeCalls
+        #expect(calls.count == 1)
+        #expect(calls.first?.clientId == "client-1")
+        // Same topic derivation reconcile uses for groups, so it diffs cleanly.
+        #expect(calls.first?.topics == ["group-1".xmtpGroupTopicFormat])
+    }
+
+    @Test("Group-topic unsubscribe removes it from the mirror so reconcile re-adds it on rejoin")
+    func groupUnsubscribeUpdatesMirror() async throws {
+        let identityStore = MockKeychainIdentityStore()
+        let keys = try await identityStore.generateKeys()
+        _ = try await identityStore.save(inboxId: "test-inbox-id", clientId: "client-1", keys: keys)
+
+        let client = TestableMockClient()
+        client.inboxId = "test-inbox-id"
+        let apiClient = RecordingPushAPIClient()
+        let conversationLister = RecordingPushConversationLister(
+            groupIds: ["group-1"],
+            dmIds: []
+        )
+        let cache = isolatedCache()
+        let manager = PushTopicSubscriptionManager(
+            identityStore: identityStore,
+            deviceInfoProvider: MockDeviceInfoProvider(deviceIdentifier: "device-1"),
+            conversationLister: conversationLister,
+            cache: cache,
+            pushTokenProvider: { "fake-apns-token" }
+        )
+
+        // Establish mirror = {welcome, group-1} via a full reconcile.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "seed"
+        )
+        #expect(apiClient.subscribeCalls.count == 1)
+
+        // Unsubscribe the group topic -> mirror becomes {welcome}.
+        await manager.unsubscribeFromGroupTopic(
+            conversationId: "group-1",
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "leave"
+        )
+        #expect(apiClient.unsubscribeCalls.count == 1)
+        #expect(apiClient.unsubscribeCalls.last?.topics == ["group-1".xmtpGroupTopicFormat])
+
+        // Reconcile again: group-1 is still in the listing but no longer in the
+        // mirror, so it must be re-added as a delta -> proves removeTopics ran.
+        await manager.reconcilePushTopics(
+            params: SyncClientParams(client: client, apiClient: apiClient),
+            context: "reconcile-after-leave"
+        )
+        #expect(apiClient.subscribeCalls.count == 2)
+        #expect(apiClient.subscribeCalls.last?.topics == ["group-1".xmtpGroupTopicFormat])
+    }
+
     @Test("Skips subscription when stored identity does not match client")
     func skipsSubscriptionForIdentityMismatch() async throws {
         let identityStore = MockKeychainIdentityStore()


### PR DESCRIPTION
Fixes [IOS-467](https://linear.app/convos/issue/IOS-467): a user who leaves or is removed from a conversation kept receiving push notifications for it.

## Root cause
Leaving (`ConversationConsentWriter.delete`) only flipped consent to `.denied` -- it never unsubscribed the conversation's push topic, and there was no group-level unsubscribe API (only DM). Group topics were dropped only by the periodic full reconcile (sync / resume / token-change), never on the leave event. The Notification Service Extension also rendered any decryptable group message without checking membership/consent. Being removed/kicked was worse: removal sets `wasRemoved` but does not flip consent, so reconcile never diffed it out.

## Fix (defense-in-depth, iOS-only -- no backend changes)
**A -- app-side unsubscribe:** new `unsubscribeFromGroupTopic` on `PushTopicSubscriptionManager` (mirrors the existing DM unsubscribe; group-topic-id derivation matches reconcile's `xmtpGroupTopicFormat`). Called on leave (`ConversationConsentWriter.delete`) and on removal (`StreamProcessor`, `wasRemovedFromConversation`).

**B -- NSE drop guard:** `shouldDropGroupNotification` returns `.droppedMessage` when the conversation is `.denied`, `wasRemoved`, or the current inbox is not a member. Closes the in-flight-push race and the kick leak regardless of subscription state. Verified no over-suppression (rejoin clears `wasRemoved`; non-member rows pruned).

## Verification
- `swift test --package-path ConvosCore`: 1312 tests / 185 suites pass.
- App + NotificationService extension build (Dev).
- SwiftLint `--strict` clean.
- New tests: group-unsubscribe; leave-delete (real convo unsubscribes, draft does not); NSE drop-guard (all four predicate cases).

## Manual QA (real device -- pending)
- [ ] Leave a conversation -> confirm no further push notifications.
- [ ] Get removed by an admin -> confirm no further pushes.
- [ ] Rejoin -> confirm pushes resume (no over-suppression).

## Note
The removed-case unsubscribe runs at the foreground-stream seam (not inside `persistRemovedMarker`, which is a GRDB transaction with no client). `BatchCatchUp`'s removed conversations are covered by Fix B + eventual reconcile.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop push notifications after leaving or being removed from a group conversation
> - Adds `MessagingService.shouldDropGroupNotification` to suppress incoming push notifications when the local DB shows the user has denied consent, was removed (`ConversationLocalState.wasRemoved`), or is absent from `DBConversationMember` for the current inbox.
> - Extends `ConversationConsentWriter.delete(conversation:)` to call `PushTopicSubscriptionManager.unsubscribeFromGroupTopic` immediately after persisting consent denial; drafts are unaffected.
> - Adds `StreamProcessor` logic to unsubscribe from a group push topic when a processed stream message indicates the user was removed from the conversation.
> - Wires `PushTopicSubscriptionManager` into both `ConversationConsentWriter` and `ConversationStateManager` so unsubscribe calls are issued on leave/delete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 907242d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->