### PR TITLE
ci(fly): surface fly errors in ci

### DIFF
--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -61,12 +61,25 @@ flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
 # Deploy multi-container machine
 echo "Deploying multi-container machine..." >&2
+
+# --- TEMPORARY CI DEBUG (remove once the prompt cause is identified) ---
+# `flyctl machine run` is failing with "prompt: non interactive". Surface the
+# flyctl version and the exact `machine run` usage/flags so we can see what
+# input it is trying to prompt for (suspected: the required image positional,
+# since machine-config.json is multi-container with no top-level image).
+echo "DEBUG: flyctl version:" >&2
+flyctl version >&2 || true
+echo "DEBUG: machine run help:" >&2
+flyctl machine run --help >&2 || true
+echo "DEBUG: end debug ---" >&2
+
 flyctl machine run \
     --app "$APP_NAME" \
     --region "$FLY_REGION" \
     --rm \
     --restart no \
-    --machine-config "$MACHINE_CONFIG"
+    --machine-config "$MACHINE_CONFIG" \
+    --verbose
 
 # Wait for TLS to be ready
 APP_HOSTNAME="${APP_NAME}.fly.dev"

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -43,9 +43,13 @@ fi
 
 echo "Creating app: $APP_NAME" >&2
 
-# Create the app; if it already exists continue, otherwise surface the real error
+# Create the app; if it already exists continue, otherwise surface the real
+# error. Existence is checked via `apps list` (there is no `apps show` command
+# in flyctl, and an unknown subcommand prints help and exits 0 - which would
+# mask real create failures like overdue billing or missing permissions as a
+# false "already exists").
 if ! CREATE_OUT="$(flyctl apps create "$APP_NAME" --org "$FLY_ORG" 2>&1)"; then
-    if flyctl apps show "$APP_NAME" >/dev/null 2>&1; then
+    if flyctl apps list 2>/dev/null | grep -qF "$APP_NAME"; then
         echo "App already exists, continuing: $APP_NAME" >&2
     else
         echo "Failed to create app: $APP_NAME" >&2
@@ -59,27 +63,12 @@ echo "Allocating IP addresses..." >&2
 flyctl ips allocate-v4 --shared --app "$APP_NAME" 2>/dev/null || true
 flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
-# --- TEMPORARY CI DEBUG: identify the app's org + why create failed ---
-# `machine run` still prompts "app does not exist" even with --org, so confirm
-# where the app actually lives and what `apps create` reported.
-echo "DEBUG: configured FLY_ORG=$FLY_ORG" >&2
-echo "DEBUG: apps create result: ${CREATE_OUT:-<created fresh, no error captured>}" >&2
-echo "DEBUG: apps show ($APP_NAME) - look for Owner/Organization:" >&2
-flyctl apps show "$APP_NAME" 2>&1 | sed 's/^/DEBUG: /' >&2 || true
-echo "DEBUG: apps list (name + org):" >&2
-flyctl apps list 2>&1 | sed 's/^/DEBUG: /' >&2 || true
-echo "DEBUG: ---" >&2
-
 # Deploy multi-container machine.
 #
-# Pass --org so `machine run` resolves the already-created app (it otherwise
-# looks in the default org, fails to find the app, and prompts "App ... does
-# not exist, would you like to create it?", which FLYCTL_NO_PROMPT turns into a
-# fatal "prompt: non interactive"). The <image> positional is also required
-# even with --machine-config; we pass the first container's image so it's a
-# no-op if flyctl maps it onto the default container (the authoritative set
-# comes from --machine-config; keep in sync with machine-config.json's first
-# container, currently postgres:16).
+# `machine run` requires an <image> positional even with --machine-config; we
+# pass the first container's image (keep in sync with machine-config.json's
+# first container, currently postgres:16) - the authoritative container set
+# comes from --machine-config. --org targets the app's organization.
 echo "Deploying multi-container machine..." >&2
 flyctl machine run "postgres:16" \
     --app "$APP_NAME" \

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -65,14 +65,13 @@ flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
 # Deploy multi-container machine.
 #
-# `machine run` requires an <image> positional even with --machine-config; we
-# pass the first container's image (keep in sync with machine-config.json's
-# first container, currently postgres:16) - the authoritative container set
-# comes from --machine-config. --org targets the app's organization.
+# `machine run` requires an <image> positional even with --machine-config, so
+# we pass the first container's image (keep in sync with machine-config.json's
+# first container, currently postgres:16); the authoritative container set comes
+# from --machine-config.
 echo "Deploying multi-container machine..." >&2
 flyctl machine run "postgres:16" \
     --app "$APP_NAME" \
-    --org "$FLY_ORG" \
     --region "$FLY_REGION" \
     --rm \
     --restart no \

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -59,21 +59,19 @@ echo "Allocating IP addresses..." >&2
 flyctl ips allocate-v4 --shared --app "$APP_NAME" 2>/dev/null || true
 flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
-# Deploy multi-container machine
+# Deploy multi-container machine.
+#
+# `flyctl machine run` requires an <image> positional even when
+# --machine-config fully specifies the containers (see `machine run --help`:
+# "machine run <image> [command] [flags]"). Without it, flyctl prompts for the
+# image and FLYCTL_NO_PROMPT turns that into "prompt: non interactive".
+#
+# We pass the first container's image so that if flyctl maps the positional
+# onto the default container it is a no-op; the authoritative container set
+# still comes from --machine-config. Keep this in sync with the first entry in
+# machine-config.json (currently the "db" container, postgres:16).
 echo "Deploying multi-container machine..." >&2
-
-# --- TEMPORARY CI DEBUG (remove once the prompt cause is identified) ---
-# `flyctl machine run` is failing with "prompt: non interactive". Surface the
-# flyctl version and the exact `machine run` usage/flags so we can see what
-# input it is trying to prompt for (suspected: the required image positional,
-# since machine-config.json is multi-container with no top-level image).
-echo "DEBUG: flyctl version:" >&2
-flyctl version >&2 || true
-echo "DEBUG: machine run help:" >&2
-flyctl machine run --help >&2 || true
-echo "DEBUG: end debug ---" >&2
-
-flyctl machine run \
+flyctl machine run "postgres:16" \
     --app "$APP_NAME" \
     --region "$FLY_REGION" \
     --rm \

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -59,25 +59,30 @@ echo "Allocating IP addresses..." >&2
 flyctl ips allocate-v4 --shared --app "$APP_NAME" 2>/dev/null || true
 flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
-# Deploy multi-container machine.
-#
-# `flyctl machine run` requires an <image> positional even when
-# --machine-config fully specifies the containers (see `machine run --help`:
-# "machine run <image> [command] [flags]"). Without it, flyctl prompts for the
-# image and FLYCTL_NO_PROMPT turns that into "prompt: non interactive".
-#
-# We pass the first container's image so that if flyctl maps the positional
-# onto the default container it is a no-op; the authoritative container set
-# still comes from --machine-config. Keep this in sync with the first entry in
-# machine-config.json (currently the "db" container, postgres:16).
+# Deploy multi-container machine
 echo "Deploying multi-container machine..." >&2
-flyctl machine run "postgres:16" \
+
+# --- TEMPORARY CI DEBUG: capture the exact prompt text ---
+# Adding the <image> positional did not help and FLYCTL_NO_PROMPT hides the
+# actual question. Re-run with prompting ENABLED but stdin closed (/dev/null):
+# flyctl prints the prompt it is stuck on, then fails on EOF. --debug adds
+# traces. We capture everything, print it, and fail the step.
+echo "DEBUG: probing for the actual prompt (prompts on, stdin=/dev/null)" >&2
+set +e
+env -u FLYCTL_NO_PROMPT flyctl machine run "postgres:16" \
     --app "$APP_NAME" \
     --region "$FLY_REGION" \
     --rm \
     --restart no \
     --machine-config "$MACHINE_CONFIG" \
-    --verbose
+    --debug < /dev/null > /tmp/flyprobe.log 2>&1
+PROBE_RC=$?
+set -e
+echo "DEBUG: probe exit code: $PROBE_RC" >&2
+echo "DEBUG: ---- probe output start ----" >&2
+cat /tmp/flyprobe.log >&2 || true
+echo "DEBUG: ---- probe output end ----" >&2
+exit 1
 
 # Wait for TLS to be ready
 APP_HOSTNAME="${APP_NAME}.fly.dev"

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -59,30 +59,35 @@ echo "Allocating IP addresses..." >&2
 flyctl ips allocate-v4 --shared --app "$APP_NAME" 2>/dev/null || true
 flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
-# Deploy multi-container machine
-echo "Deploying multi-container machine..." >&2
+# --- TEMPORARY CI DEBUG: identify the app's org + why create failed ---
+# `machine run` still prompts "app does not exist" even with --org, so confirm
+# where the app actually lives and what `apps create` reported.
+echo "DEBUG: configured FLY_ORG=$FLY_ORG" >&2
+echo "DEBUG: apps create result: ${CREATE_OUT:-<created fresh, no error captured>}" >&2
+echo "DEBUG: apps show ($APP_NAME) - look for Owner/Organization:" >&2
+flyctl apps show "$APP_NAME" 2>&1 | sed 's/^/DEBUG: /' >&2 || true
+echo "DEBUG: apps list (name + org):" >&2
+flyctl apps list 2>&1 | sed 's/^/DEBUG: /' >&2 || true
+echo "DEBUG: ---" >&2
 
-# --- TEMPORARY CI DEBUG: capture the exact prompt text ---
-# Adding the <image> positional did not help and FLYCTL_NO_PROMPT hides the
-# actual question. Re-run with prompting ENABLED but stdin closed (/dev/null):
-# flyctl prints the prompt it is stuck on, then fails on EOF. --debug adds
-# traces. We capture everything, print it, and fail the step.
-echo "DEBUG: probing for the actual prompt (prompts on, stdin=/dev/null)" >&2
-set +e
-env -u FLYCTL_NO_PROMPT flyctl machine run "postgres:16" \
+# Deploy multi-container machine.
+#
+# Pass --org so `machine run` resolves the already-created app (it otherwise
+# looks in the default org, fails to find the app, and prompts "App ... does
+# not exist, would you like to create it?", which FLYCTL_NO_PROMPT turns into a
+# fatal "prompt: non interactive"). The <image> positional is also required
+# even with --machine-config; we pass the first container's image so it's a
+# no-op if flyctl maps it onto the default container (the authoritative set
+# comes from --machine-config; keep in sync with machine-config.json's first
+# container, currently postgres:16).
+echo "Deploying multi-container machine..." >&2
+flyctl machine run "postgres:16" \
     --app "$APP_NAME" \
+    --org "$FLY_ORG" \
     --region "$FLY_REGION" \
     --rm \
     --restart no \
-    --machine-config "$MACHINE_CONFIG" \
-    --debug < /dev/null > /tmp/flyprobe.log 2>&1
-PROBE_RC=$?
-set -e
-echo "DEBUG: probe exit code: $PROBE_RC" >&2
-echo "DEBUG: ---- probe output start ----" >&2
-cat /tmp/flyprobe.log >&2 || true
-echo "DEBUG: ---- probe output end ----" >&2
-exit 1
+    --machine-config "$MACHINE_CONFIG"
 
 # Wait for TLS to be ready
 APP_HOSTNAME="${APP_NAME}.fly.dev"

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -47,9 +47,10 @@ echo "Creating app: $APP_NAME" >&2
 # error. Existence is checked via `apps list` (there is no `apps show` command
 # in flyctl, and an unknown subcommand prints help and exits 0 - which would
 # mask real create failures like overdue billing or missing permissions as a
-# false "already exists").
+# false "already exists"). Match the app name against the first column exactly
+# so a substring like "foo" doesn't match an unrelated "foo-prod".
 if ! CREATE_OUT="$(flyctl apps create "$APP_NAME" --org "$FLY_ORG" 2>&1)"; then
-    if flyctl apps list 2>/dev/null | grep -qF "$APP_NAME"; then
+    if flyctl apps list 2>/dev/null | awk -v name="$APP_NAME" '$1 == name { found = 1 } END { exit !found }'; then
         echo "App already exists, continuing: $APP_NAME" >&2
     else
         echo "Failed to create app: $APP_NAME" >&2

--- a/ci/fly/deploy
+++ b/ci/fly/deploy
@@ -63,14 +63,9 @@ echo "Allocating IP addresses..." >&2
 flyctl ips allocate-v4 --shared --app "$APP_NAME" 2>/dev/null || true
 flyctl ips allocate-v6 --app "$APP_NAME" 2>/dev/null || true
 
-# Deploy multi-container machine.
-#
-# `machine run` requires an <image> positional even with --machine-config, so
-# we pass the first container's image (keep in sync with machine-config.json's
-# first container, currently postgres:16); the authoritative container set comes
-# from --machine-config.
+# Deploy multi-container machine
 echo "Deploying multi-container machine..." >&2
-flyctl machine run "postgres:16" \
+flyctl machine run \
     --app "$APP_NAME" \
     --region "$FLY_REGION" \
     --rm \


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784921920&installation_id=128169237&pr_number=1107&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1107&signature=f1417a9913e491f766e0fa7f7a5a40a292f65539929cbace45cbab39802a7ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix post-create app existence check in fly deploy CI script
> The deploy script previously used `flyctl apps show` to check if an app already existed after a failed `flyctl apps create`, but `apps show` is not a valid subcommand and exits 0, causing the script to always continue regardless of actual app state. Replaces the check with `flyctl apps list | awk '$1 == name'` to match the app name exactly on the first column, avoiding both false positives and substring collisions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c38c996.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->