### PR TITLE
one less add to chat context menu option

### DIFF
--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -6,7 +6,6 @@ struct AddToConversationMenu: View {
     var isAgentJoinPending: Bool = false
     let isEnabled: Bool
     let onConvoCode: () -> Void
-    let onCopyLink: () -> Void
     let onInviteAgent: () -> Void
     /// Opens the contacts picker scoped to the destination conversation.
     /// Every menu surface (chat header, info view, members list) offers
@@ -31,16 +30,9 @@ struct AddToConversationMenu: View {
 
     var body: some View {
         Menu {
-            Button(action: onCopyLink) {
-                Text("Invite link")
-                Text("Copy to clipboard")
-                Image(systemName: "link")
-            }
-            .accessibilityIdentifier("context-menu-copy-link")
-
             Button(action: onConvoCode) {
-                Text("Convo code")
-                Text("Show, share or AirDrop it")
+                Text("Invite Friends")
+                Text("Show or share invite link")
                 Image(systemName: "qrcode")
             }
             .accessibilityIdentifier("context-menu-convo-code")
@@ -79,7 +71,6 @@ struct AddToConversationMenu: View {
                         isFull: false,
                         isEnabled: true,
                         onConvoCode: {},
-                        onCopyLink: {},
                         onInviteAgent: {},
                         onAddFromContacts: {}
                     )

--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -30,28 +30,28 @@ struct AddToConversationMenu: View {
 
     var body: some View {
         Menu {
-            Button(action: onConvoCode) {
-                Text("Invite Friends")
-                Text("Show or share invite link")
-                Image(systemName: "qrcode")
-            }
-            .accessibilityIdentifier("context-menu-convo-code")
-
             Button(action: onAddFromContacts) {
-                Text("Add from Contacts")
+                Text("Contacts")
                 Text("People and agents")
                 Image(systemName: "person.crop.circle.badge.plus")
             }
             .accessibilityIdentifier("context-menu-add-from-contacts")
 
             Button(action: onInviteAgent) {
-                Text("New Agent")
+                Text("New agent")
                 Text(agentSubtitle)
                 Image("addAgentIcon")
                     .renderingMode(.template)
             }
             .disabled(isAgentActionDisabled)
             .accessibilityIdentifier("context-menu-add-agent")
+
+            Button(action: onConvoCode) {
+                Text("Invite friends")
+                Text("Link, Airdrop or QR Code")
+                Image(systemName: "square.and.arrow.up")
+            }
+            .accessibilityIdentifier("context-menu-convo-code")
         } label: {
             Image(systemName: "person.crop.circle.badge.plus")
                 .foregroundStyle(labelColor)

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -448,9 +448,6 @@ struct ConversationInfoView: View {
                                 presentingShareView = true
                             }
                         },
-                        onCopyLink: {
-                            viewModel.copyInviteLink()
-                        },
                         onInviteAgent: {
                             if viewModel.consumeAgentsIntroGate() {
                                 presentingAgentsIntro = true

--- a/Convos/Conversation Detail/ConversationMembersListView.swift
+++ b/Convos/Conversation Detail/ConversationMembersListView.swift
@@ -104,9 +104,6 @@ struct ConversationMembersListView: View {
                     onConvoCode: {
                         viewModel.presentingShareView = true
                     },
-                    onCopyLink: {
-                        viewModel.copyInviteLink()
-                    },
                     onInviteAgent: {
                         if viewModel.consumeAgentsIntroGate() {
                             presentingAgentsIntro = true

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -383,9 +383,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
                     viewModel.presentingShareView = true
                 }
             },
-            onCopyLink: {
-                viewModel.copyInviteLink()
-            },
             onInviteAgent: {
                 viewModel.presentAgentBuilder()
             },

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
@@ -19,13 +19,6 @@ struct NewConvoIdentityView: View {
         VStack(spacing: DesignConstants.Spacing.step4x) {
             if showInviteMenu {
                 Menu {
-                    let convoCodeAction: () -> Void = { onConvoCode?() }
-                    Button(action: convoCodeAction) {
-                        Text("Invite Friends")
-                        Text("Show or share invite link")
-                        Image(systemName: "qrcode")
-                    }
-
                     let addFromContactsAction: () -> Void = {
                         // Routed via notification rather than a callback to
                         // avoid plumbing through ~9 layers of Messages / cell
@@ -37,7 +30,7 @@ struct NewConvoIdentityView: View {
                         )
                     }
                     Button(action: addFromContactsAction) {
-                        Text("Add from Contacts")
+                        Text("Contacts")
                         Text("People and agents")
                         Image(systemName: "person.crop.circle.badge.plus")
                     }
@@ -45,12 +38,19 @@ struct NewConvoIdentityView: View {
 
                     let agentAction: () -> Void = { onInviteAgent?() }
                     Button(action: agentAction) {
-                        Text("New Agent")
+                        Text("New agent")
                         Text(agentSubtitle)
                         Image("addAgentIcon")
                             .renderingMode(.template)
                     }
                     .disabled(isAgentActionDisabled)
+
+                    let convoCodeAction: () -> Void = { onConvoCode?() }
+                    Button(action: convoCodeAction) {
+                        Text("Invite friends")
+                        Text("Link, Airdrop or QR Code")
+                        Image(systemName: "square.and.arrow.up")
+                    }
                 } label: {
                     HStack(spacing: DesignConstants.Spacing.step2x) {
                         Image(systemName: "plus")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/NewConvoIdentityView.swift
@@ -19,17 +19,10 @@ struct NewConvoIdentityView: View {
         VStack(spacing: DesignConstants.Spacing.step4x) {
             if showInviteMenu {
                 Menu {
-                    let copyLinkAction: () -> Void = { onCopyLink?() }
-                    Button(action: copyLinkAction) {
-                        Text("Invite link")
-                        Text("Copy to clipboard")
-                        Image(systemName: "link")
-                    }
-
                     let convoCodeAction: () -> Void = { onConvoCode?() }
                     Button(action: convoCodeAction) {
-                        Text("Convo code")
-                        Text("Show, share or AirDrop it")
+                        Text("Invite Friends")
+                        Text("Show or share invite link")
                         Image(systemName: "qrcode")
                     }
 


### PR DESCRIPTION
- context menu invite link option removed
- Convo code option updated to say "Invite Friends"; subtext "Show or share invite link"

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e8bee8cb-8efe-4ada-be94-e7a09290465a" />


<img width="300"  alt="image" src="https://github.com/user-attachments/assets/02b0a102-72fd-45e4-a11b-3683d19ee19d" />





<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785000442&installation_id=128169237&pr_number=1109&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1109&signature=71b5fc712ef9a4e2c52da986860aa6d3de4ffbece6f354b0544dd06ff8fd22cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate invite options in chat context menu into a single 'Invite friends' action
> - Removes the separate 'Invite link' menu item from `AddToConversationMenu` and `NewConvoIdentityView`, replacing it with a single 'Invite friends' button (subtitle: 'Link, Airdrop or QR Code') that triggers `onConvoCode`.
> - Renames 'Add from Contacts' to 'Contacts' and 'New Agent' to 'New agent' for consistency.
> - Removes the `onCopyLink` callback from `AddToConversationMenu` and updates all three call sites in [ConversationInfoView.swift](https://github.com/xmtplabs/convos-ios/pull/1109/files#diff-30ae741e90f8fd3b2d28bd543f330b1bb685d691d37fd1e95edcc8bd87159a2a), [ConversationMembersListView.swift](https://github.com/xmtplabs/convos-ios/pull/1109/files#diff-4f6327b83be3b677c5716dbf458124de0ee3d97d60d7075e366f53a49ebda2f2), and [ConversationView.swift](https://github.com/xmtplabs/convos-ios/pull/1109/files#diff-8d85226aa6385ce7a0aca11596c32eb20e3c3e89b37f51651c35fceb5e28f6bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92eefdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->