### PR TITLE
feat(prompt-hints): dice prompt hints in the agent builder

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b82d23fc47fd2a9ed41370369a783306b9fbdc8a"
+        "revision" : "8b5f741bb0368c1a4edea87f00c1ec0463b181bb"
       }
     },
     {

--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -96,11 +96,13 @@ struct AgentBuilderView: View {
 
     /// The dice is shown only when hints exist in memory and the draft is in a
     /// state that permits a roll (no attachments / connections, composer empty
-    /// or showing an unedited dice result). Hoisted to a typed `Bool` so the
-    /// toolbar modifier chain stays inside the type-check budget.
+    /// or showing an unedited dice result). It is also hidden once the builder
+    /// has committed, otherwise `commit()` clearing `composerText` would let the
+    /// dice reappear in the revealed conversation's toolbar. Hoisted to a typed
+    /// `Bool` so the toolbar modifier chain stays inside the type-check budget.
     private var isDiceVisible: Bool {
         let hintsAvailable: Bool = !(promptHints?.hints.isEmpty ?? true)
-        return hintsAvailable && viewModel.allowsDiceRoll
+        return hintsAvailable && viewModel.allowsDiceRoll && !viewModel.hasCommitted
     }
 
     private var composerHintText: String {

--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -27,6 +27,10 @@ struct AgentBuilderView: View {
     @Environment(\.dismiss) private var dismiss: DismissAction
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Environment(\.openURL) private var openURL: OpenURLAction
+    /// Prewarmed prompt hints, injected at `MainTabView` scope. Optional so the
+    /// builder still renders (dice hidden) from entry points / previews that
+    /// don't provide it.
+    @Environment(PromptHintsModel.self) private var promptHints: PromptHintsModel?
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
     @State private var sidebarWidth: CGFloat = 0
     @State private var presentingDiscardConfirmation: Bool = false
@@ -88,6 +92,15 @@ struct AgentBuilderView: View {
     /// avatar would default to the unverified grey style.
     private var forcedVerification: AgentVerification? {
         viewModel.hasCommitted ? nil : .verified(.convos)
+    }
+
+    /// The dice is shown only when hints exist in memory and the draft is in a
+    /// state that permits a roll (no attachments / connections, composer empty
+    /// or showing an unedited dice result). Hoisted to a typed `Bool` so the
+    /// toolbar modifier chain stays inside the type-check budget.
+    private var isDiceVisible: Bool {
+        let hintsAvailable: Bool = !(promptHints?.hints.isEmpty ?? true)
+        return hintsAvailable && viewModel.allowsDiceRoll
     }
 
     private var composerHintText: String {
@@ -277,6 +290,7 @@ struct AgentBuilderView: View {
                 .toolbar {
                     if mode == .sheet {
                         closeToolbarItem
+                        diceToolbarItem
                     }
                 }
                 .toolbarTitleDisplayMode(.inline)
@@ -488,6 +502,26 @@ struct AgentBuilderView: View {
         }
     }
 
+    /// Top-right dice control. Tapping drops a random prompt hint into the
+    /// composer (see `AgentBuilderViewModel.rollDice`). The whole item is
+    /// omitted when `isDiceVisible` is false, so the slot stays empty rather
+    /// than reserving space for a hidden control.
+    @ToolbarContentBuilder
+    private var diceToolbarItem: some ToolbarContent {
+        if isDiceVisible {
+            ToolbarItem(placement: .topBarTrailing) {
+                let action = {
+                    viewModel.rollDice(hints: promptHints?.hints ?? [])
+                }
+                Button(action: action) {
+                    Image(systemName: "dice.fill")
+                }
+                .accessibilityLabel("Roll a prompt idea")
+                .accessibilityIdentifier("agent-builder-dice-button")
+            }
+        }
+    }
+
     private func handleCloseTapped() {
         if viewModel.hasCommitted {
             dismiss()
@@ -525,5 +559,6 @@ struct AgentBuilderView: View {
                 viewModel: viewModel,
                 profileSettingsViewModel: profileSettingsViewModel
             )
+            .environment(PromptHintsModel.preview())
         }
 }

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -104,6 +104,16 @@ enum AgentBuilderEntryMode {
     case voiceMemo
 }
 
+/// Whether the composer's current text was dropped by the dice (`.dice`) or
+/// typed / edited by the user (`.manual`). Drives dice *visibility* only: the
+/// dice stays visible while re-rolling (text stays `.dice`) and hides as soon
+/// as the user edits (flips to `.manual`). Deliberately separate from the
+/// metrics-facing `fromPromptHint` flag, which survives edits.
+enum ComposerTextSource {
+    case manual
+    case dice
+}
+
 @MainActor
 @Observable
 final class AgentBuilderViewModel: Identifiable {
@@ -138,6 +148,46 @@ final class AgentBuilderViewModel: Identifiable {
     let newConversationViewModel: NewConversationViewModel
 
     var composerText: String = ""
+
+    /// Source of the current `composerText`, used purely to decide whether the
+    /// dice control stays visible (see `allowsDiceRoll`). Flips to `.manual` on
+    /// any user keystroke via `composerTextBinding`'s setter; a programmatic
+    /// dice roll keeps it `.dice`.
+    private(set) var composerTextSource: ComposerTextSource = .manual
+
+    /// Metrics-only: `true` once a dice hint seeded the prompt, and stays true
+    /// through subsequent edits. Reset to `false` only when the composer is
+    /// emptied. Reported on the `built_agent` event as `from_prompt_hint`.
+    private(set) var fromPromptHint: Bool = false
+
+    /// Metrics-only: running count of dice taps in this builder session.
+    /// Reported on every `prompt_hint_tapped` event and on `built_agent`.
+    private(set) var promptHintTapCount: Int = 0
+
+    /// Last hint dropped by the dice, so a re-roll can avoid an immediate
+    /// repeat. Not observed -- it only influences the next roll.
+    @ObservationIgnored
+    private var lastRolledHint: String?
+
+    /// Binding the composer's text field uses instead of `$viewModel.composerText`.
+    /// SwiftUI invokes the setter only on user keystrokes -- never on the
+    /// programmatic assignment the dice performs -- so editing flips the source
+    /// to `.manual` (hiding the dice once non-empty), while a dice roll keeps it
+    /// `.dice` (dice stays visible for re-rolls). Clearing the box resets the
+    /// metrics `fromPromptHint` flag.
+    var composerTextBinding: Binding<String> {
+        Binding(
+            get: { [weak self] in self?.composerText ?? "" },
+            set: { [weak self] newValue in
+                guard let self else { return }
+                self.composerText = newValue
+                self.composerTextSource = .manual
+                if newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    self.fromPromptHint = false
+                }
+            }
+        )
+    }
 
     /// Routes attachment state through the underlying conversation view
     /// model so eager upload + thumbnail generation are reused. The view
@@ -496,6 +546,51 @@ final class AgentBuilderViewModel: Identifiable {
             || !enabledConnections.isEmpty
     }
 
+    // MARK: - Dice / prompt hints
+
+    /// Whether the dice control's draft preconditions hold: no staged
+    /// attachments (media, voice memo, recording, or connections) and the
+    /// composer is either empty or still showing an unedited dice result. The
+    /// hints-non-empty check is layered on by the view (`isDiceVisible`).
+    var allowsDiceRoll: Bool {
+        guard pendingMediaAttachments.isEmpty else { return false }
+        guard recordedVoiceMemo == nil, !isRecordingVoiceMemo else { return false }
+        guard enabledConnections.isEmpty else { return false }
+        let trimmed: String = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty || composerTextSource == .dice
+    }
+
+    /// Drops a random hint into the composer, avoiding an immediate repeat of
+    /// the current one. Marks the source `.dice` so the dice stays visible for
+    /// repeated re-rolls, sets the metrics `fromPromptHint` flag (which survives
+    /// later edits), and fires a `prompt_hint_tapped` metric carrying the
+    /// running tap count.
+    func rollDice(hints: [String]) {
+        let available: [String] = hints.filter {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !available.isEmpty else { return }
+        let chosen: String = Self.randomHint(from: available, avoiding: lastRolledHint)
+        lastRolledHint = chosen
+        composerText = chosen
+        composerTextSource = .dice
+        fromPromptHint = true
+        promptHintTapCount += 1
+        emitPromptHintTappedMetric()
+    }
+
+    /// Picks a random hint, excluding `current` when there is more than one
+    /// option so a tap never lands on the same hint twice in a row.
+    private static func randomHint(from hints: [String], avoiding current: String?) -> String {
+        let pool: [String]
+        if let current, hints.count > 1 {
+            pool = hints.filter { $0 != current }
+        } else {
+            pool = hints
+        }
+        return pool.randomElement() ?? hints.first ?? ""
+    }
+
     /// Set to true when the user taps Make. Until then the builder is in
     /// "draft" mode: the conversation indicator is non-interactive
     /// (renaming/re-imaging the draft happens *after* commit, in the
@@ -539,6 +634,11 @@ final class AgentBuilderViewModel: Identifiable {
 
         let textToSend = composerText
         composerText = ""
+        // Reset the dice visibility state now that the draft text is cleared.
+        // The metrics flags (`fromPromptHint`, `promptHintTapCount`) are read by
+        // `emitBuiltAgentMetric` just below, so they are left intact here.
+        composerTextSource = .manual
+        lastRolledHint = nil
         emitBuiltAgentMetric(text: textToSend, isSuccess: true)
 
         // Hand the prompt to the session-scoped repository, which submits the
@@ -891,6 +991,8 @@ extension AgentBuilderViewModel {
         let voiceMemoDuration: Float = recordedVoiceMemo.map { Float($0.duration) } ?? 0
         let connectionTypes: [String] = enabledConnections.map { $0.rawValue }
         let metricsEntryMode: ConvosMetrics.AgentBuilderEntryMode = (entryMode == .voiceMemo) ? .voiceMemo : .composer
+        let fromHint: Bool = fromPromptHint
+        let tapCount: Int = promptHintTapCount
         let actions: any CoreActions = coreActions
         Task {
             await actions.builtAgent(
@@ -902,8 +1004,20 @@ extension AgentBuilderViewModel {
                 voiceMemoDuration: voiceMemoDuration,
                 connectionTypes: connectionTypes,
                 entryMode: metricsEntryMode,
-                isSuccess: isSuccess
+                isSuccess: isSuccess,
+                fromPromptHint: fromHint,
+                tapCount: tapCount
             )
+        }
+    }
+
+    /// Fires the `prompt_hint_tapped` event on each dice tap, carrying the
+    /// running per-session tap count, through the shared metrics `CoreActions`.
+    private func emitPromptHintTappedMetric() {
+        let tapCount: Int = promptHintTapCount
+        let actions: any CoreActions = coreActions
+        Task {
+            await actions.promptHintTapped(tapCount: tapCount)
         }
     }
 }

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -170,16 +170,20 @@ final class AgentBuilderViewModel: Identifiable {
     private var lastRolledHint: String?
 
     /// Binding the composer's text field uses instead of `$viewModel.composerText`.
-    /// SwiftUI invokes the setter only on user keystrokes -- never on the
-    /// programmatic assignment the dice performs -- so editing flips the source
-    /// to `.manual` (hiding the dice once non-empty), while a dice roll keeps it
-    /// `.dice` (dice stays visible for re-rolls). Clearing the box resets the
-    /// metrics `fromPromptHint` flag.
+    /// A genuine keystroke changes the text and flips the source to `.manual`
+    /// (hiding the dice once non-empty), while a dice roll assigns `composerText`
+    /// directly and keeps the source `.dice` (dice stays visible for re-rolls).
+    /// A re-presented sheet reconstructs the field, which can echo the current
+    /// value back through this setter with no real edit, so writes that don't
+    /// change the text are ignored -- otherwise the first dice tap after a reopen
+    /// would register a phantom edit, flip the source to `.manual`, and hide the
+    /// dice. Clearing the box resets the metrics `fromPromptHint` flag.
     var composerTextBinding: Binding<String> {
         Binding(
             get: { [weak self] in self?.composerText ?? "" },
             set: { [weak self] newValue in
                 guard let self else { return }
+                guard newValue != self.composerText else { return }
                 self.composerText = newValue
                 self.composerTextSource = .manual
                 if newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/Convos/Agent Builder/AgentDraftComposer.swift
+++ b/Convos/Agent Builder/AgentDraftComposer.swift
@@ -221,7 +221,7 @@ struct AgentDraftComposer: View {
     private var textField: some View {
         TextField(
             textFieldPlaceholder,
-            text: $viewModel.composerText,
+            text: viewModel.composerTextBinding,
             axis: .vertical
         )
         .focused(focusState, equals: .agentBuilder)

--- a/Convos/Agent Builder/PromptHintsModel.swift
+++ b/Convos/Agent Builder/PromptHintsModel.swift
@@ -1,0 +1,122 @@
+import ConvosCore
+import Foundation
+import Observation
+
+/// Disk persistence seam for the agent builder's prompt hints. The default
+/// implementation uses `UserDefaults` (the app's lightweight key-value store,
+/// matching other simple caches like `GlobalConvoDefaults`). Injectable so
+/// tests and previews can supply an in-memory double.
+struct PromptHintsDiskCache {
+    let load: () -> [String]
+    let save: ([String]) -> Void
+
+    static let userDefaultsKey: String = "convos.agentBuilder.promptHints"
+
+    /// Backed by `UserDefaults.standard`. Hints are short, low-cardinality
+    /// strings, so a plain string-array default is the lightest fit.
+    static var userDefaults: PromptHintsDiskCache {
+        PromptHintsDiskCache(
+            load: { UserDefaults.standard.stringArray(forKey: userDefaultsKey) ?? [] },
+            save: { hints in UserDefaults.standard.set(hints, forKey: userDefaultsKey) }
+        )
+    }
+}
+
+/// In-memory cache of curated agent prompt hints. Owned at `MainTabView`
+/// scope, prewarmed once on launch, and read by the agent builder's dice
+/// control through the SwiftUI environment.
+///
+/// Mirrors `SuggestedAgentsModel`'s fetch/cache shape, with the two
+/// differences the dice feature requires:
+///   - the hints are persisted to disk and re-hydrated in-memory on launch, so
+///     the dice can appear on a warm launch before the first network round-trip
+///   - the network refresh retries with exponential backoff + jitter and never
+///     clears the last good hints on a failed refetch
+///
+/// The in-memory `hints` is the single source of truth for dice visibility:
+/// the dice is hidden whenever it is empty (see `AgentBuilderView.isDiceVisible`).
+@Observable
+@MainActor
+final class PromptHintsModel {
+    private let service: (any PromptHintsServiceProtocol)?
+    private let store: PromptHintsDiskCache
+
+    /// Seconds to wait before retry `attempt` (0-based). Defaults to the shared
+    /// exponential-backoff-with-jitter curve; injectable so tests can drive the
+    /// retry loop without real sleeps.
+    @ObservationIgnored
+    private let backoffSeconds: (Int) -> TimeInterval
+
+    private(set) var hints: [String] = []
+
+    @ObservationIgnored
+    private var hasStartedLaunchLoad: Bool = false
+
+    init(
+        service: (any PromptHintsServiceProtocol)?,
+        store: PromptHintsDiskCache = .userDefaults,
+        backoffSeconds: @escaping (Int) -> TimeInterval = { TimeInterval.calculateExponentialBackoff(for: $0) }
+    ) {
+        self.service = service
+        self.store = store
+        self.backoffSeconds = backoffSeconds
+        // Hydrate the in-memory copy from disk immediately so a warm launch can
+        // show the dice without waiting for the network refresh below.
+        self.hints = Self.sanitize(store.load())
+    }
+
+    /// True when a service is wired and the cache should refresh on launch.
+    var isActive: Bool {
+        service != nil
+    }
+
+    /// Fetch once per app launch. Disk hydration already happened in `init`, so
+    /// this only refreshes from the network with exponential backoff + jitter,
+    /// overwriting both memory and disk on success. Total failure leaves the
+    /// hydrated hints untouched -- a failed refetch never clears a good cache.
+    func loadOnLaunch() async {
+        guard let service, !hasStartedLaunchLoad else { return }
+        hasStartedLaunchLoad = true
+        var attempt: Int = 0
+        while attempt < Constant.maxAttempts {
+            if Task.isCancelled { return }
+            do {
+                let fetched: [String] = try await service.promptHints()
+                let sanitized: [String] = Self.sanitize(fetched)
+                // Only overwrite when the fetch yields usable hints; an empty
+                // payload should not wipe a previously good cache.
+                if !sanitized.isEmpty {
+                    hints = sanitized
+                    store.save(sanitized)
+                }
+                return
+            } catch {
+                attempt += 1
+                if attempt >= Constant.maxAttempts || Task.isCancelled {
+                    Log.error("PromptHintsModel: fetch failed after \(attempt) attempt(s): \(error.localizedDescription)")
+                    return
+                }
+                let delaySecs: TimeInterval = backoffSeconds(attempt - 1)
+                if delaySecs > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(delaySecs * 1_000_000_000))
+                }
+            }
+        }
+    }
+
+    /// Trim, drop empties, and clamp each hint to the backend's 240-char
+    /// contract so a malformed row can't blow out the composer.
+    private static func sanitize(_ raw: [String]) -> [String] {
+        raw
+            .map { (hint: String) -> String in
+                let trimmed: String = hint.trimmingCharacters(in: .whitespacesAndNewlines)
+                return String(trimmed.prefix(Constant.maxHintLength))
+            }
+            .filter { !$0.isEmpty }
+    }
+
+    private enum Constant {
+        static let maxAttempts: Int = 5
+        static let maxHintLength: Int = 240
+    }
+}

--- a/Convos/Agent Builder/PromptHintsService+Live.swift
+++ b/Convos/Agent Builder/PromptHintsService+Live.swift
@@ -1,0 +1,31 @@
+import ConvosCore
+import Foundation
+
+extension PromptHintsService {
+    /// Builds the live service from the current environment's API client.
+    /// Mirrors `SuggestedAgentsService.live()`. Used by `MainTabView` to
+    /// prewarm the agent builder's dice hints once on launch.
+    static func live() -> PromptHintsService {
+        PromptHintsService(
+            apiClient: ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)
+        )
+    }
+}
+
+extension PromptHintsModel {
+    /// Live model backed by the environment's API client. Hydrates from disk
+    /// synchronously in `init`; the network refresh is kicked off by
+    /// `loadOnLaunch()` from `MainTabView`'s launch task.
+    static func live() -> PromptHintsModel {
+        PromptHintsModel(service: PromptHintsService.live())
+    }
+
+    /// Preview/test helper: an in-memory model pre-seeded with `hints` (via a
+    /// fake disk cache) so the dice control renders without a network round-trip.
+    static func preview(hints: [String] = MockPromptHintsService.defaultHints) -> PromptHintsModel {
+        PromptHintsModel(
+            service: MockPromptHintsService(hints: hints),
+            store: PromptHintsDiskCache(load: { hints }, save: { _ in })
+        )
+    }
+}

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -117,6 +117,12 @@ struct MainTabView: View {
     /// `.onReceive` on the publisher.
     @State private var userSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
     @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
+    /// Curated agent-builder prompt hints, hydrated from disk on init and
+    /// refreshed once on launch (see `body`'s `.task`). Injected into the
+    /// environment so the agent builder's dice control -- in this view's
+    /// builder sheet and in builders presented from descendant conversation
+    /// screens -- can read the cached hints.
+    @State private var promptHints: PromptHintsModel = .live()
     /// Shared namespace for the agent-builder bar -> sheet zoom
     /// transition and the app-settings pill -> sheet zoom transition.
     /// The bar / pill apply
@@ -273,6 +279,10 @@ struct MainTabView: View {
 
     var body: some View {
         bodyCore
+            .environment(promptHints)
+            .task {
+                await promptHints.loadOnLaunch()
+            }
             .onAppear {
                 ensureNavigators()
                 tabRootNavState.markScreenAppeared()

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0b364bfb8f0346d1f6144dd2f64db564429002e9293bc18e0ec046475b7ca1b2",
+  "originHash" : "1df5b4ee6fed5d5b871e1d15a8c8645e2c0b749f3301c7918d30ddcf35a967ad",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -34,7 +34,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b82d23fc47fd2a9ed41370369a783306b9fbdc8a"
+        "revision" : "8b5f741bb0368c1a4edea87f00c1ec0463b181bb"
       }
     },
     {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -332,6 +332,19 @@ public enum ConvosAPI {
         }
     }
 
+    /// Response envelope for `GET /v2/agent-prompt-hints` -- a flat list of
+    /// curated prompt strings (each <= 240 chars) the agent builder's dice
+    /// control drops into the "What needs done?" composer. Public and
+    /// unauthenticated; decoding is tolerant of extra keys via default Codable
+    /// behavior.
+    public struct AgentPromptHintsResponse: Codable, Sendable {
+        public let hints: [String]
+
+        public init(hints: [String]) {
+            self.hints = hints
+        }
+    }
+
     // MARK: - Common Error Response
 
     public struct ErrorResponse: Codable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -118,6 +118,13 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// serves them to anonymous callers (mirrors `getAgentTemplate`).
     func getFeaturedAgentTemplates(limit: Int, cursor: String?) async throws -> ConvosAPI.AgentTemplatesPage
 
+    /// Lists curated agent prompt hints (`GET /v2/agent-prompt-hints`) -- a flat
+    /// array of short prompt strings used to seed the agent builder's composer
+    /// via the dice control. Unauthenticated: the hints are public, so
+    /// `request(for:)` builds a bare GET (no auth header), mirroring
+    /// `getFeaturedAgentTemplates`.
+    func getAgentPromptHints() async throws -> [String]
+
     /// Submits an async template generation (`POST /v2/agent-templates/generations`).
     /// Returns 202 with `status: pending` by default; the caller polls
     /// `getAgentTemplateGeneration` for the terminal state. `idempotencyKey`
@@ -949,6 +956,14 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         }
         let request = try request(for: "v2/agent-templates", queryParameters: queryParameters)
         return try await performRequest(request)
+    }
+
+    func getAgentPromptHints() async throws -> [String] {
+        // Public, unauthenticated GET -- the curated hints are not user-scoped,
+        // so `request(for:)` builds a bare GET (no auth header).
+        let request = try request(for: "v2/agent-prompt-hints")
+        let response: ConvosAPI.AgentPromptHintsResponse = try await performRequest(request)
+        return response.hints
     }
 
     func createAgentTemplateGeneration(

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -141,6 +141,16 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         return .init(data: templates, hasMore: false, nextCursor: nil)
     }
 
+    func getAgentPromptHints() async throws -> [String] {
+        [
+            "Plan a 3-day trip to Lisbon with a $1000 budget",
+            "Draft a weekly meal plan and a grocery list",
+            "Summarize long articles into five quick bullet points",
+            "Be my daily Spanish conversation partner",
+            "Track my workouts and suggest the next session",
+        ]
+    }
+
     func createAgentTemplateGeneration(
         text: String,
         source: String,

--- a/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
+++ b/ConvosCore/Sources/ConvosCore/Metrics/NoOpCoreActions.swift
@@ -58,8 +58,12 @@ public final class NoOpCoreActions: CoreActions, @unchecked Sendable {
         voiceMemoDuration: Float,
         connectionTypes: [String],
         entryMode: AgentBuilderEntryMode,
-        isSuccess: Bool
+        isSuccess: Bool,
+        fromPromptHint: Bool,
+        tapCount: Int
     ) async {}
+
+    public func promptHintTapped(tapCount: Int) async {}
 
     public func purchaseInitiated(
         productId: String,

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockPromptHintsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockPromptHintsService.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Test/preview double for `PromptHintsServiceProtocol`. Serves a fixed list
+/// of hints (or throws a supplied error) and records the call count so tests
+/// can assert fetch + retry behavior. Mirrors `MockSuggestedAgentsService`.
+public final class MockPromptHintsService: PromptHintsServiceProtocol, @unchecked Sendable {
+    public private(set) var fetchCount: Int = 0
+
+    private let hints: [String]
+    private let error: Error?
+    private let delay: Duration?
+
+    public init(
+        hints: [String] = MockPromptHintsService.defaultHints,
+        error: Error? = nil,
+        delay: Duration? = nil
+    ) {
+        self.hints = hints
+        self.error = error
+        self.delay = delay
+    }
+
+    public func promptHints() async throws -> [String] {
+        fetchCount += 1
+        if let delay {
+            try await Task.sleep(for: delay)
+        }
+        if let error {
+            throw error
+        }
+        return hints
+    }
+
+    public static let defaultHints: [String] = [
+        "Plan a 3-day trip to Lisbon with a $1000 budget",
+        "Draft a weekly meal plan and a grocery list",
+        "Summarize long articles into five quick bullet points",
+        "Be my daily Spanish conversation partner",
+        "Track my workouts and suggest the next session",
+    ]
+}

--- a/ConvosCore/Sources/ConvosCore/Services/PromptHintsService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/PromptHintsService.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Fetches curated agent prompt hints for the agent builder's dice control.
+/// A narrow seam over `ConvosAPIClientProtocol` so the in-memory cache model
+/// can be driven by a stub in previews and tests without conforming to the
+/// full API client surface. Mirrors `SuggestedAgentsServiceProtocol`.
+public protocol PromptHintsServiceProtocol: Sendable {
+    func promptHints() async throws -> [String]
+}
+
+public final class PromptHintsService: PromptHintsServiceProtocol {
+    private let apiClient: any ConvosAPIClientProtocol
+
+    public init(apiClient: any ConvosAPIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    public func promptHints() async throws -> [String] {
+        try await apiClient.getAgentPromptHints()
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/PromptHintsServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PromptHintsServiceTests.swift
@@ -1,0 +1,37 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("PromptHintsService")
+struct PromptHintsServiceTests {
+    @Test("returns the hints the API client serves")
+    func returnsHintsFromAPIClient() async throws {
+        let service = PromptHintsService(apiClient: MockAPIClient())
+        let hints = try await service.promptHints()
+        #expect(!hints.isEmpty)
+    }
+
+    @Test("decodes the { hints: [...] } envelope into a flat array")
+    func decodesHintsEnvelope() throws {
+        let json = Data(#"{"hints":["one","two","three"]}"#.utf8)
+        let response = try JSONDecoder().decode(ConvosAPI.AgentPromptHintsResponse.self, from: json)
+        #expect(response.hints == ["one", "two", "three"])
+    }
+
+    @Test("mock service records call count and serves its hints")
+    func mockServiceServesHints() async throws {
+        let mock = MockPromptHintsService(hints: ["a", "b"])
+        let hints = try await mock.promptHints()
+        #expect(hints == ["a", "b"])
+        #expect(mock.fetchCount == 1)
+    }
+
+    @Test("mock service throws the supplied error")
+    func mockServiceThrows() async {
+        struct SampleError: Error {}
+        let mock = MockPromptHintsService(error: SampleError())
+        await #expect(throws: SampleError.self) {
+            _ = try await mock.promptHints()
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -89,6 +89,13 @@ extension ConvosAPIClientProtocol {
         ConvosAPI.AgentTemplatesPage(data: [], hasMore: false, nextCursor: nil)
     }
 
+    /// Default for the agent prompt-hints list backing the builder's dice
+    /// control. Tests that exercise it specifically should override on their
+    /// fixture.
+    func getAgentPromptHints() async throws -> [String] {
+        []
+    }
+
     /// Defaults for the backend connection-grant push so pre-existing fixtures
     /// don't have to re-stub them. Tests that exercise the push specifically
     /// should override on their fixture.

--- a/ConvosTests/AgentBuilderViewModelDiceTests.swift
+++ b/ConvosTests/AgentBuilderViewModelDiceTests.swift
@@ -1,0 +1,87 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Coverage for the agent builder's dice control: visibility preconditions,
+/// random non-repeating rolls, the visibility-vs-metrics source split, and the
+/// per-session tap count.
+@MainActor
+final class AgentBuilderViewModelDiceTests: XCTestCase {
+    private func makeViewModel() -> AgentBuilderViewModel {
+        AgentBuilderViewModel(session: ConvosClient.mock().session)
+    }
+
+    func testDiceAllowedOnEmptyDraft() {
+        let viewModel = makeViewModel()
+        XCTAssertTrue(viewModel.allowsDiceRoll, "An empty draft should permit a roll")
+        XCTAssertEqual(viewModel.composerTextSource, .manual)
+    }
+
+    func testManualTypingHidesDice() {
+        let viewModel = makeViewModel()
+        viewModel.composerTextBinding.wrappedValue = "a hand-typed prompt"
+        XCTAssertEqual(viewModel.composerTextSource, .manual,
+                       "A user keystroke should mark the source manual")
+        XCTAssertFalse(viewModel.allowsDiceRoll,
+                       "Manual non-empty text should hide the dice")
+    }
+
+    func testDiceStaysVisibleWhileRolling() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: ["one", "two", "three"])
+        XCTAssertFalse(viewModel.composerText.isEmpty, "A roll drops a hint into the composer")
+        XCTAssertEqual(viewModel.composerTextSource, .dice)
+        XCTAssertTrue(viewModel.allowsDiceRoll,
+                      "Dice-sourced text should keep the dice visible for re-rolls")
+    }
+
+    func testRollAvoidsImmediateRepeat() {
+        let viewModel = makeViewModel()
+        let hints = ["a", "b", "c"]
+        var previous: String?
+        for _ in 0..<40 {
+            viewModel.rollDice(hints: hints)
+            let current = viewModel.composerText
+            XCTAssertNotEqual(current, previous, "A roll must not repeat the current hint")
+            previous = current
+        }
+    }
+
+    func testSingleHintRollsThatHint() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: ["only"])
+        XCTAssertEqual(viewModel.composerText, "only")
+        viewModel.rollDice(hints: ["only"])
+        XCTAssertEqual(viewModel.composerText, "only",
+                       "With a single hint, a re-roll re-applies it rather than stalling")
+    }
+
+    func testFromPromptHintSurvivesEditAndResetsOnClear() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: ["seeded prompt"])
+        XCTAssertTrue(viewModel.fromPromptHint, "A roll sets the metrics flag")
+
+        viewModel.composerTextBinding.wrappedValue = "seeded prompt with edits"
+        XCTAssertTrue(viewModel.fromPromptHint, "Editing must not clear the metrics flag")
+        XCTAssertEqual(viewModel.composerTextSource, .manual)
+
+        viewModel.composerTextBinding.wrappedValue = ""
+        XCTAssertFalse(viewModel.fromPromptHint, "Clearing the composer resets the metrics flag")
+    }
+
+    func testTapCountAccumulates() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: ["a", "b"])
+        viewModel.rollDice(hints: ["a", "b"])
+        viewModel.rollDice(hints: ["a", "b"])
+        XCTAssertEqual(viewModel.promptHintTapCount, 3)
+    }
+
+    func testEmptyHintsAreIgnored() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: [])
+        XCTAssertTrue(viewModel.composerText.isEmpty)
+        XCTAssertEqual(viewModel.composerTextSource, .manual)
+        XCTAssertEqual(viewModel.promptHintTapCount, 0)
+    }
+}

--- a/ConvosTests/AgentBuilderViewModelDiceTests.swift
+++ b/ConvosTests/AgentBuilderViewModelDiceTests.swift
@@ -77,6 +77,48 @@ final class AgentBuilderViewModelDiceTests: XCTestCase {
         XCTAssertEqual(viewModel.promptHintTapCount, 3)
     }
 
+    func testEchoedSetDoesNotRegisterPhantomEdit() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: ["seeded prompt"])
+        XCTAssertEqual(viewModel.composerTextSource, .dice)
+
+        // A re-presented sheet reconstructs the text field, which echoes the
+        // current value back through the binding with no real keystroke. That
+        // must not count as an edit, otherwise the first dice tap after a reopen
+        // hides the dice.
+        viewModel.composerTextBinding.wrappedValue = viewModel.composerText
+        XCTAssertEqual(viewModel.composerTextSource, .dice,
+                       "An echoed no-op write must not flip the source to manual")
+        XCTAssertTrue(viewModel.allowsDiceRoll,
+                      "The dice must stay visible after an echoed no-op write")
+        XCTAssertTrue(viewModel.fromPromptHint,
+                      "An echoed no-op write must not clear the metrics flag")
+    }
+
+    func testReopenThenRollKeepsDiceVisible() {
+        let viewModel = makeViewModel()
+        let hints = ["one", "two", "three"]
+        viewModel.rollDice(hints: hints)
+
+        // Simulate the sheet reopen: the reconstructed field echoes the held
+        // hint, then the user taps the dice once.
+        viewModel.composerTextBinding.wrappedValue = viewModel.composerText
+        viewModel.rollDice(hints: hints)
+        XCTAssertEqual(viewModel.composerTextSource, .dice)
+        XCTAssertTrue(viewModel.allowsDiceRoll,
+                      "The first dice tap after a reopen must keep the dice visible")
+    }
+
+    func testGenuineEditStillHidesDiceAfterRoll() {
+        let viewModel = makeViewModel()
+        viewModel.rollDice(hints: ["seeded prompt"])
+        viewModel.composerTextBinding.wrappedValue = "seeded prompt edited by hand"
+        XCTAssertEqual(viewModel.composerTextSource, .manual,
+                       "A real keystroke that changes the text must mark the source manual")
+        XCTAssertFalse(viewModel.allowsDiceRoll,
+                       "Genuinely edited text should hide the dice")
+    }
+
     func testEmptyHintsAreIgnored() {
         let viewModel = makeViewModel()
         viewModel.rollDice(hints: [])

--- a/ConvosTests/PromptHintsModelTests.swift
+++ b/ConvosTests/PromptHintsModelTests.swift
@@ -1,0 +1,85 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Coverage for the agent builder's prompt-hint cache: disk hydration on
+/// init, refresh-overwrites-on-success, retain-last-good-on-failure, and the
+/// empty-payload / sanitize guards.
+@MainActor
+final class PromptHintsModelTests: XCTestCase {
+    /// In-memory `PromptHintsDiskCache` double recording the last saved value.
+    private final class DiskSpy {
+        var stored: [String]
+        var saved: [String]?
+
+        init(stored: [String]) {
+            self.stored = stored
+        }
+
+        var cache: PromptHintsDiskCache {
+            PromptHintsDiskCache(
+                load: { [weak self] in self?.stored ?? [] },
+                save: { [weak self] hints in self?.saved = hints }
+            )
+        }
+    }
+
+    private struct SampleError: Error {}
+
+    private func makeModel(
+        service: (any PromptHintsServiceProtocol)?,
+        disk: DiskSpy
+    ) -> PromptHintsModel {
+        PromptHintsModel(service: service, store: disk.cache, backoffSeconds: { _ in 0 })
+    }
+
+    func testHydratesFromDiskOnInit() {
+        let disk = DiskSpy(stored: ["cached one", "cached two"])
+        let model = makeModel(service: MockPromptHintsService(), disk: disk)
+        XCTAssertEqual(model.hints, ["cached one", "cached two"],
+                       "Init should hydrate the in-memory hints from disk")
+    }
+
+    func testRefreshOverwritesMemoryAndDiskOnSuccess() async {
+        let disk = DiskSpy(stored: ["old"])
+        let model = makeModel(service: MockPromptHintsService(hints: ["new one", "new two"]), disk: disk)
+        await model.loadOnLaunch()
+        XCTAssertEqual(model.hints, ["new one", "new two"], "A successful fetch overwrites memory")
+        XCTAssertEqual(disk.saved, ["new one", "new two"], "A successful fetch overwrites disk")
+    }
+
+    func testRetainsLastGoodOnFetchFailure() async {
+        let disk = DiskSpy(stored: ["cached"])
+        let model = makeModel(service: MockPromptHintsService(error: SampleError()), disk: disk)
+        await model.loadOnLaunch()
+        XCTAssertEqual(model.hints, ["cached"], "A failed refetch must retain the last good hints")
+        XCTAssertNil(disk.saved, "A failed refetch must not overwrite disk")
+    }
+
+    func testEmptyPayloadDoesNotWipeCache() async {
+        let disk = DiskSpy(stored: ["cached"])
+        let model = makeModel(service: MockPromptHintsService(hints: []), disk: disk)
+        await model.loadOnLaunch()
+        XCTAssertEqual(model.hints, ["cached"], "An empty payload must not wipe a good cache")
+        XCTAssertNil(disk.saved, "An empty payload must not overwrite disk")
+    }
+
+    func testSanitizeTrimsDropsEmptyAndClamps() async {
+        let long = String(repeating: "x", count: 300)
+        let disk = DiskSpy(stored: [])
+        let model = makeModel(service: MockPromptHintsService(hints: ["  spaced  ", "", long]), disk: disk)
+        await model.loadOnLaunch()
+        XCTAssertEqual(model.hints.count, 2, "Empty / whitespace-only hints are dropped")
+        XCTAssertEqual(model.hints.first, "spaced", "Hints are trimmed")
+        XCTAssertEqual(model.hints.last?.count, 240, "Hints are clamped to the 240-char contract")
+    }
+
+    func testLoadOnLaunchRunsOnlyOnce() async {
+        let disk = DiskSpy(stored: [])
+        let service = MockPromptHintsService(hints: ["one"])
+        let model = makeModel(service: service, disk: disk)
+        await model.loadOnLaunch()
+        await model.loadOnLaunch()
+        XCTAssertEqual(service.fetchCount, 1, "The launch refresh should fetch at most once per process")
+    }
+}

--- a/docs/plans/prompt-hints.md
+++ b/docs/plans/prompt-hints.md
@@ -1,0 +1,123 @@
+# Prompt Hints (dice roll)
+
+> **Status**: Implemented
+> **Branch**: `feature/dice-roll-templates`
+> **Source of truth**: Notion "Prompt Hints" spec
+> **Backend**: separate PR on `convos-backend` (`feature/prompt-hints`)
+
+## Overview
+
+A `dice.fill` control in the Agent Builder's top-right toolbar drops a short, curated prompt snippet into the "What needs done?" composer. Tapping it rolls a random hint; the user can re-roll repeatedly. Hints come from a new public, unauthenticated backend endpoint, are cached on disk and in memory, refreshed once per launch, and surfaced only when the composer is a clean slate. The whole feature is text-only and adds two metrics signals so we can see whether hints actually move the needle on agent creation.
+
+## Problem
+
+When a user makes an agent, the first thing they meet is the empty "What needs done?" composer. The empty box is intimidating: people are unsure what a prompt can contain and reluctant to commit to typing something before they hit the button. That hesitation is a drop-off point right at the top of the agent-creation funnel.
+
+## Goals
+
+- Educate first-time users about what a prompt can contain by showing concrete, varied examples in place.
+- Lower the reluctance to try agent creation by giving a one-tap way to fill the box with something usable.
+- Make the prompts delightful and a little playful, so rolling the dice is itself an invitation to experiment.
+
+## Non-Goals
+
+- Attachments or connections in the hint flow. Hints are text-only.
+- Suggested agent templates inside the builder. Hints are short prompt snippets, not published templates, and are stored in a dedicated table so they never pollute the agent catalog.
+- A second prompt surface anywhere outside the Agent Builder.
+
+## Behavior
+
+The dice is an `Image(systemName: "dice.fill")` `ToolbarItem(placement: .topBarTrailing)`, added alongside the existing top-left close button, only in the builder's `.sheet` mode. It follows the project Button pattern (extracted `action`) and its whole `ToolbarItem` is omitted (not just emptied) when hidden, so no space is reserved and the toolbar chain stays cheap to type-check.
+
+### Visibility rule
+
+The dice shows only when all of the following hold:
+
+- The in-memory hint list is non-empty. If nothing is in memory, the dice is hidden entirely (graceful when the endpoint is unseeded or unreachable).
+- There are no media attachments, no recorded or in-progress voice memo, and no enabled connections.
+- The trimmed composer text is empty, or the box still contains an unedited dice-rolled prompt (`composerTextSource == .dice`).
+
+In the view this reduces to one typed `let`: `isDiceVisible = hints non-empty AND viewModel.allowsDiceRoll`, where `allowsDiceRoll` folds the attachment/voice/connection/text checks into a single `Bool` on the view model. The attachment and connection signals are real properties already on `AgentBuilderViewModel` (`pendingMediaAttachments`, `recordedVoiceMemo` / `isRecordingVoiceMemo`, `enabledConnections`), not invented for this feature.
+
+### Roll
+
+Each tap picks a random hint, excluding the last-shown hint when more than one option exists (no immediate repeats). The roll sets the composer text programmatically, marks the source as dice, flags the build as hint-seeded, increments the tap counter, and fires the per-tap metric. Because the assignment is programmatic, SwiftUI does not call the composer's binding setter, so the source stays `.dice` and the dice remains visible for further re-rolls. The moment the user edits the text, the binding setter flips the source to `.manual` and the dice disappears.
+
+## Technical Design
+
+The feature is split across `ConvosCore` (platform-independent service + API) and the app target (cache model, view model state, view wiring). It builds on macOS, with no UIKit dependencies.
+
+### Three separated state fields, and why they differ
+
+The view model keeps three intentionally distinct fields. Conflating them is the main correctness trap, so they are split by purpose:
+
+- `composerTextSource { manual, dice }` -- drives dice **visibility** only. A custom `Binding` (`composerTextBinding`) replaces the direct `$viewModel.composerText` binding on the text field; its setter marks `.manual` before assigning. SwiftUI calls the setter only on user keystrokes, never on programmatic assignment, so a roll keeps the source `.dice` (dice stays for re-rolls) while a single keystroke flips it to `.manual` (dice hides).
+- `fromPromptHint: Bool` -- drives **metrics**. True once a hint seeds the prompt. It persists through edits, because the resulting agent still originated from a hint, and resets to false only when the box is cleared, not when it is edited.
+- `promptHintTapCount: Int` -- drives **metrics**. Accumulates dice taps for the builder session (the view model is per-session).
+
+The key distinction: editing a rolled hint hides the dice (visibility, via `composerTextSource`) but keeps `fromPromptHint = true` (metrics). `commit()` clears the text and resets `composerTextSource` and `lastRolledHint`, after the `built_agent` metric has read the flags.
+
+### API layer (ConvosCore)
+
+- `ConvosAPIClient+Models.swift` -- new `ConvosAPI.AgentPromptHintsResponse { hints: [String] }`.
+- `ConvosAPIClient.swift` -- protocol method plus concrete `getAgentPromptHints()`: a public, bare (unauthenticated) GET to `v2/agent-prompt-hints`, mirroring `getFeaturedAgentTemplates`.
+- `MockAPIClient.swift` -- sample-hints implementation for dev, preview, and tests.
+- `Services/PromptHintsService.swift` -- new `PromptHintsServiceProtocol` + `PromptHintsService`, mirroring `SuggestedAgentsService`.
+- `Mocks/MockPromptHintsService.swift` -- mirrors `MockSuggestedAgentsService`.
+- Test-stub default `getAgentPromptHints()` (returns `[]`) so existing stub conformers keep compiling, plus `PromptHintsServiceTests`.
+
+### Cache model (app target)
+
+`Agent Builder/PromptHintsModel.swift` is an `@Observable @MainActor` class owned by `MainTabView` (`@State = .live()`, injected via `.environment`), so the builder sheet and any builder presented from a descendant conversation screen inherit it.
+
+- Disk cache via `UserDefaults` (`PromptHintsDiskCache`, an injectable seam). `init` hydrates the in-memory `hints` from disk synchronously, so on a warm launch the dice can appear before any network call. The in-memory copy is the single source of truth for the "hints non-empty" gate.
+- `loadOnLaunch()` is called once from a `MainTabView` `.task`, guarded by `hasStartedLaunchLoad` (one fetch per process). It refreshes with up to five attempts using exponential backoff + jitter via the shared `TimeInterval.calculateExponentialBackoff(for:)` (30s cap). On success with usable hints it overwrites both memory and disk. An empty payload or total failure leaves the cached hints intact -- the last good cache is never cleared on a failed refetch.
+- The backoff is an injectable closure (production default is the shared curve), so unit tests drive the retry loop with no sleeps.
+- Hints are sanitized on the way in: trimmed, blank-dropped, and clamped to 240 characters.
+
+`Agent Builder/PromptHintsService+Live.swift` adds the `.live()` factories and a `.preview(hints:)` helper for SwiftUI previews and tests.
+
+### View and view model wiring (app target)
+
+- `AgentBuilderViewModel.swift` -- `ComposerTextSource`, `composerTextBinding`, `fromPromptHint`, `promptHintTapCount`, `allowsDiceRoll`, `rollDice`, and the metrics rewrite.
+- `AgentDraftComposer.swift` -- the text field now binds `composerTextBinding` instead of `$viewModel.composerText`.
+- `AgentBuilderView.swift` -- reads the model via `@Environment(PromptHintsModel.self)`, computes the typed `isDiceVisible`, and adds `diceToolbarItem` to the existing `.toolbar` block.
+- `MainTabView.swift` -- owns `PromptHintsModel`, injects it into the environment, and kicks `loadOnLaunch()` from its launch `.task`.
+
+### Backend contract
+
+`GET /api/v2/agent-prompt-hints` -> `{ "hints": [String] }` where each string is at most 240 characters and the collection is capped at 1000 items. The endpoint is public with no auth middleware (consistent with existing public template reads); the global rate limiter is the only protection needed. Hints live in a dedicated `AgentPromptHint` table (id, text, published, sortOrder, timestamps), distinct from `AgentTemplate`, returning published rows ordered by `sortOrder`. The per-item 240-char cap and the 1000-item collection cap are enforced by the API, not the schema. The backend ships in a separate PR; until that endpoint is seeded and live, the app falls back to its cache or to an empty list, in which case the dice stays hidden.
+
+### Metrics
+
+The feature uses the existing metrics system. The canonical typed events live in the `convos-shared` SPM package, pinned by branch in `ConvosCore/Package.swift`; the merged change adds the API below, and the pin (and both `Package.resolved` files) were advanced to that revision.
+
+- `built_agent` (existing event, fired on agent creation) gains `from_prompt_hint: Bool` and `tap_count: Int`, wired from `fromPromptHint` and `promptHintTapCount`.
+- `prompt_hint_tapped` (new event) carries `tap_count: Int`, fired on each dice tap.
+
+Wiring goes through the typed `CoreActions` methods (`builtAgent(..., fromPromptHint:tapCount:)` and `promptHintTapped(tapCount:)`), so there are no hand-rolled event strings on the app side. `NoOpCoreActions` was updated to the new protocol shape; the builder view model is the only `builtAgent` call site.
+
+## Testing
+
+- `ConvosCoreTests/PromptHintsServiceTests` -- service over the API client.
+- `ConvosTests/PromptHintsModelTests` -- disk hydration, launch refetch, backoff retry loop (sleepless via the injected closure), last-good-cache survival on failure.
+- `ConvosTests/AgentBuilderViewModelDiceTests` -- roll behavior, no-immediate-repeat, the three state fields, and visibility gating.
+
+Live end-to-end QA needs the backend endpoint seeded on the local stack first: bring up the stack with `./dev/up`, apply backend migrations, then build and run the iOS worktree. Until the endpoint is live, the preview model and unit tests exercise the logic.
+
+## Fast-follow: hints admin CRUD
+
+Not in this PR. The curated list is seeded by a backend migration for v1; editing it later wants an admin surface:
+
+- Backend first: agent-API-key-gated write endpoints on `convos-backend` (`POST /api/v2/agent-prompt-hints`, `PATCH /:id`, `DELETE /:id`, optional reorder).
+- Then a thin Hono proxy in `convos-assistants` (alongside the existing `admin/templates`) that passes through to those endpoints, inheriting the parent admin router's auth, optionally with a static admin page. The proxy is inert until the backend write endpoints exist.
+
+`convos-assistants` requires no changes to ship v1 -- it shares no database with `convos-backend` and the new table is inert to it.
+
+## References
+
+- Notion "Prompt Hints" spec -- problem, goals, and the canonical event definitions.
+- `convos-backend` `feature/prompt-hints` -- the `AgentPromptHint` table, seed migration, and the public `GET /api/v2/agent-prompt-hints` endpoint (separate PR).
+- `Convos/Agent Builder/AgentBuilderView.swift`, `AgentBuilderViewModel.swift`, `AgentDraftComposer.swift`, `PromptHintsModel.swift`, `PromptHintsService+Live.swift` -- the app-side surface.
+- `ConvosCore/Sources/ConvosCore/Services/PromptHintsService.swift`, `API/ConvosAPIClient.swift` -- the service and API client.
+- `agent-builder-flow-simplification.md` -- the direct (non-conversation) builder flow the composer lives in.


### PR DESCRIPTION
Adds "Prompt Hints" to the agent builder: a dice button on the "What needs done?" composer that drops a short, curated prompt to beat the empty-box problem. Implements the Notion "Prompt Hints" spec.

- Dice (`dice.fill`) in the Agent Builder top-right toolbar; shown only when hints are loaded, the composer is empty or holds an unedited dice roll, and there are no attachments/connections. Tapping rolls a random hint (no immediate repeat); re-rollable.
- `PromptHintsModel` fetches once on launch from the new public backend endpoint `GET /api/v2/agent-prompt-hints`, disk-cached + in-memory, with exponential-backoff+jitter retry and last-good retention.
- Metrics via the convos-shared `ConvosMetrics` API: `built_agent` gains `from_prompt_hint` + `tap_count`; new `prompt_hint_tapped` event.
- Spec: `docs/plans/prompt-hints.md`. Backend is a separate PR (convos-backend #336). Admin CRUD for hints is a planned convos-assistants fast-follow.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dice button to Agent Builder that populates the composer with a random prompt hint
> - Adds a `dice.fill` toolbar button to the Agent Builder sheet that inserts a random, non-repeating prompt hint into the composer when tapped.
> - Introduces `PromptHintsModel` ([PromptHintsModel.swift](https://github.com/xmtplabs/convos-ios/pull/1110/files#diff-a46d63c5b42e53ef90fb6464c02db07656f07e780ec4837a400cddbd600d9c62)) which hydrates hints from disk on launch and refreshes them once per session with exponential-backoff retries, making hints available app-wide via the SwiftUI environment.
> - Adds `getAgentPromptHints()` to `ConvosAPIClientProtocol` ([ConvosAPIClient.swift](https://github.com/xmtplabs/convos-ios/pull/1110/files#diff-d9c911c02b64ae370c51a1048b35e6e5dfc05805b43efd9be61a31fa422500b8)), fetching hints from the public unauthenticated `GET /v2/agent-prompt-hints` endpoint.
> - Tracks whether an agent was built from a prompt hint and emits a `prompt_hint_tapped` metric per dice tap via updated `CoreActions`.
> - Behavioral Change: `AgentDraftComposer` now uses `viewModel.composerTextBinding` instead of `$viewModel.composerText`, so programmatic dice assignments no longer trigger the dice-visibility reset that manual keystrokes do.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e50448.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->