### PR TITLE
fix(messages): long-press preview respects expanded "Read more" state

### DIFF
--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -362,7 +362,8 @@ struct MessageContextMenuOverlay: View {
                     style: state.bubbleStyle,
                     message: text,
                     isOutgoing: state.isOutgoing,
-                    profile: message.sender.profile
+                    profile: message.sender.profile,
+                    isExpanded: state.isExpanded
                 )
 
             case .emoji(let text):

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
@@ -8,6 +8,12 @@ class MessageContextMenuState: @unchecked Sendable {
     var isOutgoing: Bool = false
     var bubbleStyle: MessageBubbleType = .normal
     var isReplyParent: Bool = false
+    /// Whether the source bubble's long-body inline expansion was on when the
+    /// menu opened, so the preview matches what's on screen (full text when
+    /// expanded, bounded teaser when collapsed). Owned by the conversation view
+    /// model and captured at present time, mirroring the on-screen bubble's
+    /// `isExpanded`.
+    var isExpanded: Bool = false
     var sourceID: UUID?
 
     var currentSourceFrame: CGRect = .zero
@@ -23,11 +29,12 @@ class MessageContextMenuState: @unchecked Sendable {
         return dx > 2 || dy > 2
     }
 
-    func present(message: AnyMessage, bubbleFrame: CGRect, bubbleStyle: MessageBubbleType) {
+    func present(message: AnyMessage, bubbleFrame: CGRect, bubbleStyle: MessageBubbleType, isExpanded: Bool) {
         self.isOutgoing = message.sender.isCurrentUser
         self.bubbleFrame = bubbleFrame
         self.bubbleStyle = bubbleStyle
         self.isReplyParent = false
+        self.isExpanded = isExpanded
         self.presentedMessage = message
     }
 
@@ -36,6 +43,7 @@ class MessageContextMenuState: @unchecked Sendable {
         self.bubbleFrame = bubbleFrame
         self.bubbleStyle = .normal
         self.isReplyParent = true
+        self.isExpanded = false
         self.sourceID = sourceID
         self.presentedMessage = message
     }
@@ -43,6 +51,7 @@ class MessageContextMenuState: @unchecked Sendable {
     func dismiss() {
         presentedMessage = nil
         isReplyParent = false
+        isExpanded = false
         sourceID = nil
     }
 }

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessageContextMenuWrapper.swift
@@ -20,6 +20,10 @@ extension EnvironmentValues {
 struct MessageGestureModifier: ViewModifier {
     let message: AnyMessage
     let bubbleStyle: MessageBubbleType
+    /// Whether the source bubble's long-body inline expansion is currently on,
+    /// captured into the context menu so its preview matches the on-screen
+    /// bubble. Only the text-bubble path ever passes a non-default value.
+    var isExpanded: Bool = false
     let onSingleTap: (() -> Void)?
     let onDoubleTap: (() -> Void)?
     let onReply: (AnyMessage) -> Void
@@ -138,7 +142,8 @@ struct MessageGestureModifier: ViewModifier {
         contextMenuState.present(
             message: message,
             bubbleFrame: frame,
-            bubbleStyle: bubbleStyle
+            bubbleStyle: bubbleStyle,
+            isExpanded: isExpanded
         )
     }
 
@@ -202,6 +207,7 @@ extension View {
     func messageGesture(
         message: AnyMessage,
         bubbleStyle: MessageBubbleType = .normal,
+        isExpanded: Bool = false,
         onSingleTap: (() -> Void)? = nil,
         onDoubleTap: (() -> Void)? = nil,
         onReply: @escaping (AnyMessage) -> Void,
@@ -211,6 +217,7 @@ extension View {
         modifier(MessageGestureModifier(
             message: message,
             bubbleStyle: bubbleStyle,
+            isExpanded: isExpanded,
             onSingleTap: onSingleTap,
             onDoubleTap: onDoubleTap,
             onReply: onReply,

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupItemView.swift
@@ -164,6 +164,7 @@ struct MessagesGroupItemView: View {
         .messageGesture(
             message: message,
             bubbleStyle: message.content.isEmoji ? .none : bubbleType,
+            isExpanded: isExpanded,
             onReply: onReply,
             onToggleReaction: onToggleReaction
         )


### PR DESCRIPTION
## Bug

After expanding a long message with "Read more", long-pressing it showed the *truncated* preview in the context menu instead of the expanded full text. A non-expanded long message correctly previews truncated -- only the expanded case was wrong.

## Root cause

The custom long-press context menu (a custom overlay, not native `UIContextMenu`) rebuilds the preview bubble from the raw message body without the expanded flag. At `MessageContextMenuOverlay.swift:360-366` the `.text` case constructed `MessageBubble(...)` with no `isExpanded:`, so it defaulted to `false` and a `.long` message always rendered its bounded teaser. The expanded state lives in `ConversationViewModel.expandedMessageIds` (read on screen as `isExpanded`) but was never carried into `MessageContextMenuState`.

## Fix

Thread the same on-screen `isExpanded` signal through `MessageContextMenuState.present(...)` into the overlay's preview `MessageBubble`:

- expanded -> full text (no Read-more pill)
- collapsed -> unchanged teaser (the case that already worked)

Reply-parent previews stay collapsed (correct). The only two non-preview `MessageBubble(` sites were checked: the list item (already correct) and the overlay (now fixed). 4 files, +21/-3.

## Verification

- `Convos (Dev)` build clean: 0 type-check-budget warnings, 0 errors (app target enforces warnings-as-errors + the 100ms budget).
- SwiftLint `--strict` clean.
- Not click-verified via UI automation -- reliably driving the animated long-press overlay on a >500-char message in an authenticated chat is flaky -- so this is build- and code-trace-verified.

## Manual QA

- [ ] Expand a long message with "Read more" -> long-press -> preview shows the FULL message.
- [ ] A non-expanded long message -> long-press -> preview shows the truncated teaser (unchanged).

Targets `release/2.0.3` (the "Read more" code this fixes shipped on that release, not yet on dev's release line).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785078350&installation_id=128169237&pr_number=1113&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1113&signature=21c4299404a2d5c63bd9bb8c772e7d96667d2a717516bab5e1af4c6a9baf493d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix long-press context menu preview to respect the expanded 'Read more' state of message bubbles
> When a long-press triggers the message context menu, the preview bubble now mirrors whether the source bubble was already expanded by the user.
>
> - `MessageContextMenuState` gains an `isExpanded: Bool` property, set when `present(...)` is called and reset to `false` on dismiss or reply-parent presentation.
> - `MessageGestureModifier` and the `.messageGesture` view extension are updated to accept and forward `isExpanded` from the call site.
> - `MessagesGroupItemView` passes the current expansion flag into `.messageGesture`, completing the data flow from source bubble to context menu preview.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfb7b83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->