### PR TITLE
fix: late group-joiner sees agent as "Somebody" (incomplete profile snapshot)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/ConversationCustomMetadata+Profiles.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/ConversationCustomMetadata+Profiles.swift
@@ -12,6 +12,31 @@ extension DBMemberProfile {
     }
 }
 
+// MARK: - DBMemberProfile + Snapshot MemberProfile
+
+extension DBMemberProfile {
+    /// Projects this authoritative row into the `MemberProfile` used inside a
+    /// `ProfileSnapshot` message. The wire format carries only encrypted image
+    /// refs, so a plain (unencrypted) avatar URL is represented by name with
+    /// the image omitted rather than fabricating an encrypted ref. Returns nil
+    /// when the inbox id is not valid hex and so cannot be put on the wire.
+    var snapshotMemberProfile: MemberProfile? {
+        let encryptedImage: EncryptedProfileImageRef? = encryptedImageRef.map(EncryptedProfileImageRef.init)
+        guard var profile = MemberProfile(
+            inboxIdString: inboxId,
+            name: name,
+            encryptedImage: encryptedImage,
+            metadata: metadata
+        ) else {
+            return nil
+        }
+        if let memberKind {
+            profile.memberKind = memberKind.protoMemberKind
+        }
+        return profile
+    }
+}
+
 // MARK: - MemberKind <-> DBMemberKind
 
 extension MemberKind {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -476,7 +476,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
                 let memberInboxIds = try await group.members.map(\.inboxId)
                 try await ProfileSnapshotBuilder.sendSnapshot(
                     group: group,
-                    memberInboxIds: memberInboxIds
+                    memberInboxIds: memberInboxIds,
+                    databaseReader: databaseReader
                 )
                 sent += 1
             } catch {

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -473,10 +473,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         for conversation in conversations {
             guard case let .group(group) = conversation else { continue }
             do {
-                let memberInboxIds = try await group.members.map(\.inboxId)
                 try await ProfileSnapshotBuilder.sendSnapshot(
                     group: group,
-                    memberInboxIds: memberInboxIds,
                     databaseReader: databaseReader
                 )
                 sent += 1

--- a/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileSnapshotBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileSnapshotBuilder.swift
@@ -144,10 +144,14 @@ public enum ProfileSnapshotBuilder {
 
     public static func sendSnapshot(
         group: XMTPiOS.Group,
-        memberInboxIds: [String],
         databaseReader: (any DatabaseReader)? = nil
     ) async throws {
+        // Sync first, then read the member list, so a just-added joiner (for
+        // example on the already-member re-publish path, where this
+        // installation may not have synced the group yet) is in the roster
+        // rather than filtered out by a stale member list.
         try await group.sync()
+        let memberInboxIds = try await group.members.map(\.inboxId)
         let dbProfiles = try await fetchDBProfiles(
             databaseReader,
             conversationId: group.id,
@@ -163,7 +167,7 @@ public enum ProfileSnapshotBuilder {
         let codec = ProfileSnapshotCodec()
         let encoded = try codec.encode(content: snapshot)
         if encoded.content.count > Constant.snapshotSizeWarningThreshold {
-            print("[ConvosProfiles] Large ProfileSnapshot: \(encoded.content.count) bytes, \(snapshot.profiles.count) profiles")
+            Log.warning("Large ProfileSnapshot: \(encoded.content.count) bytes, \(snapshot.profiles.count) profiles")
         }
         _ = try await group.send(encodedContent: encoded)
     }

--- a/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileSnapshotBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileSnapshotBuilder.swift
@@ -1,11 +1,31 @@
 import ConvosAppData
 import Foundation
+import GRDB
 @preconcurrency import XMTPiOS
 
 public enum ProfileSnapshotBuilder {
+    /// Builds the roster bundle a member publishes so new joiners learn
+    /// everyone's profile at once (in-group messages do not reach members
+    /// who join later, so this snapshot is the joiner's only source for
+    /// pre-join members).
+    ///
+    /// The roster unions two sources, keyed by inbox id and filtered to the
+    /// current `memberInboxIds`:
+    /// - `dbProfiles`: the sender's authoritative per-conversation rows. These
+    ///   include members the sender learned only via group appData (agents,
+    ///   directly-added members) and members whose profile update has aged out
+    ///   of the recent-message window.
+    /// - the recent-message scan: profile updates (and a fallback snapshot)
+    ///   from the last `maxMessagesToScan` messages. This catches an update
+    ///   that has been synced but not yet flushed to the database.
+    ///
+    /// When both sources carry a member, the recent message wins per field and
+    /// the database row fills any gap, so a freshly received update is honored
+    /// without ever regressing a known name back to nothing.
     public static func buildSnapshot(
         group: XMTPiOS.Group,
-        memberInboxIds: [String]
+        memberInboxIds: [String],
+        dbProfiles: [MemberProfile] = []
     ) async throws -> ProfileSnapshot {
         let messages = try await group.messages(
             limit: Constant.maxMessagesToScan,
@@ -28,16 +48,56 @@ public enum ProfileSnapshotBuilder {
             if allMembersResolved { break }
         }
 
+        var dbProfilesByInboxId: [String: MemberProfile] = [:]
+        for profile in dbProfiles {
+            dbProfilesByInboxId[profile.inboxIdString] = profile
+        }
+
         var result: [MemberProfile] = []
         for inboxId in memberInboxIds {
-            if let profile = profilesByInboxId[inboxId] {
-                result.append(profile)
-            } else if let snapshotProfile = latestSnapshotProfiles[inboxId] {
-                result.append(snapshotProfile)
+            let messageProfile = profilesByInboxId[inboxId] ?? latestSnapshotProfiles[inboxId]
+            let dbProfile = dbProfilesByInboxId[inboxId]
+            guard let merged = mergedProfile(base: dbProfile, overlay: messageProfile),
+                  merged.hasSnapshotContent else {
+                continue
             }
+            result.append(merged)
         }
 
         return ProfileSnapshot(profiles: result)
+    }
+
+    /// Combines a database-sourced base with a recent-message overlay. The
+    /// overlay wins on any field it sets; the base fills the rest. This keeps
+    /// a just-received name while never clearing a known name when the overlay
+    /// lacks one.
+    private static func mergedProfile(
+        base: MemberProfile?,
+        overlay: MemberProfile?
+    ) -> MemberProfile? {
+        switch (base, overlay) {
+        case (nil, nil):
+            return nil
+        case let (base?, nil):
+            return base
+        case let (nil, overlay?):
+            return overlay
+        case let (base?, overlay?):
+            var merged = overlay
+            if !overlay.hasName, base.hasName {
+                merged.name = base.name
+            }
+            if !overlay.hasEncryptedImage, base.hasEncryptedImage {
+                merged.encryptedImage = base.encryptedImage
+            }
+            if overlay.memberKind == .unspecified, base.memberKind != .unspecified {
+                merged.memberKind = base.memberKind
+            }
+            if overlay.metadata.isEmpty, !base.metadata.isEmpty {
+                merged.metadata = base.metadata
+            }
+            return merged
+        }
     }
 
     private static func processProfileUpdate(
@@ -78,10 +138,20 @@ public enum ProfileSnapshotBuilder {
 
     public static func sendSnapshot(
         group: XMTPiOS.Group,
-        memberInboxIds: [String]
+        memberInboxIds: [String],
+        databaseReader: (any DatabaseReader)? = nil
     ) async throws {
         try await group.sync()
-        let snapshot = try await buildSnapshot(group: group, memberInboxIds: memberInboxIds)
+        let dbProfiles = try await fetchDBProfiles(
+            databaseReader,
+            conversationId: group.id,
+            memberInboxIds: memberInboxIds
+        )
+        let snapshot = try await buildSnapshot(
+            group: group,
+            memberInboxIds: memberInboxIds,
+            dbProfiles: dbProfiles
+        )
         guard !snapshot.profiles.isEmpty else { return }
 
         let codec = ProfileSnapshotCodec()
@@ -92,8 +162,29 @@ public enum ProfileSnapshotBuilder {
         _ = try await group.send(encodedContent: encoded)
     }
 
+    private static func fetchDBProfiles(
+        _ databaseReader: (any DatabaseReader)?,
+        conversationId: String,
+        memberInboxIds: [String]
+    ) async throws -> [MemberProfile] {
+        guard let databaseReader else { return [] }
+        let rows = try await databaseReader.read { db in
+            try DBMemberProfile.fetchAll(db, conversationId: conversationId, inboxIds: memberInboxIds)
+        }
+        return rows.compactMap(\.snapshotMemberProfile)
+    }
+
     private enum Constant {
         static let maxMessagesToScan: Int = 500
         static let snapshotSizeWarningThreshold: Int = 50_000
+    }
+}
+
+private extension MemberProfile {
+    /// Whether the profile carries anything worth broadcasting. An inbox-id-only
+    /// entry (a cleared profile with no name, image, agent kind, or metadata)
+    /// conveys nothing to a joiner, so it is dropped from the snapshot.
+    var hasSnapshotContent: Bool {
+        hasName || hasEncryptedImage || memberKind != .unspecified || !metadata.isEmpty
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileSnapshotBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileSnapshotBuilder.swift
@@ -84,10 +84,16 @@ public enum ProfileSnapshotBuilder {
             return overlay
         case let (base?, overlay?):
             var merged = overlay
-            if !overlay.hasName, base.hasName {
+            // A usable (non-blank) incoming name wins; an empty or
+            // whitespace-only incoming name (hasName=true but blank) must not
+            // clobber a populated name back to "Somebody" - mirrors
+            // DBMemberProfile.withInboundName.
+            if !overlay.hasUsableName, base.hasName {
                 merged.name = base.name
             }
-            if !overlay.hasEncryptedImage, base.hasEncryptedImage {
+            // Likewise a set-but-malformed incoming image ref must not clobber
+            // a valid database image.
+            if !overlay.hasUsableEncryptedImage, base.hasEncryptedImage {
                 merged.encryptedImage = base.encryptedImage
             }
             if overlay.memberKind == .unspecified, base.memberKind != .unspecified {
@@ -181,10 +187,24 @@ public enum ProfileSnapshotBuilder {
 }
 
 private extension MemberProfile {
+    /// Whether the profile carries a usable, non-blank name. An empty or
+    /// whitespace-only name is treated as absent so it never wins a merge or
+    /// counts as snapshot content.
+    var hasUsableName: Bool {
+        guard hasName else { return false }
+        return !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Whether the profile carries a well-formed encrypted image ref (valid
+    /// url, salt, and nonce). A set-but-malformed ref is treated as absent.
+    var hasUsableEncryptedImage: Bool {
+        hasEncryptedImage && encryptedImage.isValid
+    }
+
     /// Whether the profile carries anything worth broadcasting. An inbox-id-only
-    /// entry (a cleared profile with no name, image, agent kind, or metadata)
-    /// conveys nothing to a joiner, so it is dropped from the snapshot.
+    /// entry (a cleared profile with no usable name, image, agent kind, or
+    /// metadata) conveys nothing to a joiner, so it is dropped from the snapshot.
     var hasSnapshotContent: Bool {
-        hasName || hasEncryptedImage || memberKind != .unspecified || !metadata.isEmpty
+        hasUsableName || hasUsableEncryptedImage || memberKind != .unspecified || !metadata.isEmpty
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -469,7 +469,8 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
         do {
             try await ProfileSnapshotBuilder.sendSnapshot(
                 group: group,
-                memberInboxIds: allMemberInboxIds
+                memberInboxIds: allMemberInboxIds,
+                databaseReader: databaseWriter
             )
             Log.debug("Sent ProfileSnapshot after adding members to \(conversationId)")
         } catch {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -465,11 +465,9 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
             }
         }
 
-        let allMemberInboxIds = try await group.members.map(\.inboxId)
         do {
             try await ProfileSnapshotBuilder.sendSnapshot(
                 group: group,
-                memberInboxIds: allMemberInboxIds,
                 databaseReader: databaseWriter
             )
             Log.debug("Sent ProfileSnapshot after adding members to \(conversationId)")

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -223,12 +223,12 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         _ outcome: JoinRequestDMOutcome,
         client: AnyClientProvider
     ) async -> InviteJoinRequestOutcome {
+        let mapped: InviteJoinRequestOutcome
         switch outcome {
         case let .accepted(result, dmConversationId: dmConversationId):
             logAccepted(result)
             await persistJoinerProfile(result)
-            await sendProfileSnapshotAfterJoin(conversationId: result.conversationId, client: client)
-            return .accepted(
+            mapped = .accepted(
                 JoinRequestResult(
                     conversationId: result.conversationId,
                     conversationName: result.conversationName,
@@ -240,26 +240,50 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
             )
         case let .benignFailure(dmConversationId, senderInboxId, error):
             Log.info("Join request failed without blocking DM \(dmConversationId): \(error)")
-            return .benignFailure(
+            mapped = .benignFailure(
                 dmConversationId: dmConversationId,
                 senderInboxId: senderInboxId,
                 error: error
             )
         case let .malicious(dmConversationId, senderInboxId, error):
             Log.warning("Join request marked malicious for DM \(dmConversationId), sender \(senderInboxId): \(error)")
-            return .malicious(
+            mapped = .malicious(
                 dmConversationId: dmConversationId,
                 senderInboxId: senderInboxId,
                 error: error
             )
-        case let .alreadyMember(dmConversationId, joinerInboxId):
+        case let .alreadyMember(dmConversationId, joinerInboxId, _):
             Log.debug("Join request for \(joinerInboxId) already handled by another pass (DM \(dmConversationId))")
-            return .alreadyMember(
+            mapped = .alreadyMember(
                 dmConversationId: dmConversationId,
                 joinerInboxId: joinerInboxId
             )
         case .noJoinRequest:
-            return .noJoinRequest
+            mapped = .noJoinRequest
+        }
+        // A fresh accept and a verified already-member result both re-publish
+        // the roster: the already-member path covers re-invites and dedup
+        // races where the accept that added the member ran in another pass, so
+        // the joiner still needs a complete snapshot. The `.accepted` persist
+        // above runs first so the snapshot build sees the joiner's own row.
+        if let conversationId = Self.profileSnapshotConversationId(for: outcome) {
+            await sendProfileSnapshotAfterJoin(conversationId: conversationId, client: client)
+        }
+        return mapped
+    }
+
+    /// The conversation whose roster should be (re)published for an outcome, or
+    /// nil when no snapshot is warranted. Verified already-member results carry
+    /// a `conversationId`; the handled-request ledger pre-check does not, and a
+    /// snapshot there would have been sent on the original accept anyway.
+    static func profileSnapshotConversationId(for outcome: JoinRequestDMOutcome) -> String? {
+        switch outcome {
+        case let .accepted(result, dmConversationId: _):
+            return result.conversationId
+        case let .alreadyMember(_, _, conversationId):
+            return conversationId
+        case .benignFailure, .malicious, .noJoinRequest:
+            return nil
         }
     }
 
@@ -281,7 +305,8 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
             let allMemberInboxIds = try await group.members.map(\.inboxId)
             try await ProfileSnapshotBuilder.sendSnapshot(
                 group: group,
-                memberInboxIds: allMemberInboxIds
+                memberInboxIds: allMemberInboxIds,
+                databaseReader: databaseWriter
             )
             Log.debug("Sent ProfileSnapshot after join request for \(conversationId)")
         } catch {

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -162,13 +162,18 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         try await coordinator.hasOutgoingJoinRequest(for: conversation, client: InviteClientProviderAdapter(client))
     }
 
-    private func persistJoinerProfile(
+    func persistJoinerProfile(
         joinerInboxId: String,
         conversationId: String,
         profile: JoinRequestProfile?,
         metadata: [String: String]?
     ) async {
-        guard profile?.name != nil || profile?.imageURL != nil || profile?.memberKind != nil || metadata != nil else { return }
+        // An empty metadata dictionary is non-nil but carries nothing usable;
+        // treating it as present would write an all-blank row and overwrite a
+        // good existing profile back to "Somebody" on the already-member replay
+        // path. Persist only when at least one field is actually populated.
+        let hasMetadata = !(metadata?.isEmpty ?? true)
+        guard profile?.name != nil || profile?.imageURL != nil || profile?.memberKind != nil || hasMetadata else { return }
 
         let baseMemberKind: DBMemberKind? = profile?.memberKind == "agent" ? .agent : nil
         let profileMetadata: ProfileMetadata? = metadata.flatMap { dict in

--- a/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/InviteJoinRequestsManager.swift
@@ -162,9 +162,12 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         try await coordinator.hasOutgoingJoinRequest(for: conversation, client: InviteClientProviderAdapter(client))
     }
 
-    private func persistJoinerProfile(_ result: JoinResult) async {
-        let profile = result.profile
-        let metadata = result.metadata
+    private func persistJoinerProfile(
+        joinerInboxId: String,
+        conversationId: String,
+        profile: JoinRequestProfile?,
+        metadata: [String: String]?
+    ) async {
         guard profile?.name != nil || profile?.imageURL != nil || profile?.memberKind != nil || metadata != nil else { return }
 
         let baseMemberKind: DBMemberKind? = profile?.memberKind == "agent" ? .agent : nil
@@ -176,8 +179,8 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         let memberKind: DBMemberKind?
         if baseMemberKind != nil, let profileMetadata {
             let tempProfile = Profile(
-                inboxId: result.joinerInboxId,
-                conversationId: result.conversationId,
+                inboxId: joinerInboxId,
+                conversationId: conversationId,
                 name: profile?.name,
                 avatar: profile?.imageURL,
                 isAgent: true,
@@ -191,29 +194,29 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
 
         do {
             try await databaseWriter.write { db in
-                let member = DBMember(inboxId: result.joinerInboxId)
+                let member = DBMember(inboxId: joinerInboxId)
                 try member.save(db)
 
                 let dbProfile = DBMemberProfile(
-                    conversationId: result.conversationId,
-                    inboxId: result.joinerInboxId,
+                    conversationId: conversationId,
+                    inboxId: joinerInboxId,
                     name: profile?.name,
                     avatar: profile?.imageURL,
                     memberKind: memberKind,
                     metadata: profileMetadata
                 )
                 // Note: `Date()` here rather than the message's `sentAtNs`
-                // because `JoinResult` doesn't carry the original timestamp.
-                // Tracked as a follow-up — see the contacts MVP plan.
+                // because the join request does not carry the original
+                // timestamp. Tracked as a follow-up — see the contacts MVP plan.
                 try ContactsWriter.saveMemberProfileAndMirrorToContactInTransaction(db: db, profile: dbProfile, receivedAt: Date())
 
                 if dbProfile.agentVerification.isConvosAgent,
-                   let conversation = try DBConversation.fetchOne(db, id: result.conversationId),
+                   let conversation = try DBConversation.fetchOne(db, id: conversationId),
                    !conversation.hasHadVerifiedAgent {
                     try conversation.with(hasHadVerifiedAgent: true).save(db)
                 }
             }
-            Log.debug("Persisted join request profile for \(result.joinerInboxId) in \(result.conversationId)")
+            Log.debug("Persisted join request profile for \(joinerInboxId) in \(conversationId)")
         } catch {
             Log.warning("Failed to persist join request profile: \(error.localizedDescription)")
         }
@@ -227,7 +230,12 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         switch outcome {
         case let .accepted(result, dmConversationId: dmConversationId):
             logAccepted(result)
-            await persistJoinerProfile(result)
+            await persistJoinerProfile(
+                joinerInboxId: result.joinerInboxId,
+                conversationId: result.conversationId,
+                profile: result.profile,
+                metadata: result.metadata
+            )
             mapped = .accepted(
                 JoinRequestResult(
                     conversationId: result.conversationId,
@@ -252,8 +260,22 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
                 senderInboxId: senderInboxId,
                 error: error
             )
-        case let .alreadyMember(dmConversationId, joinerInboxId, _):
+        case let .alreadyMember(dmConversationId, joinerInboxId, verified):
             Log.debug("Join request for \(joinerInboxId) already handled by another pass (DM \(dmConversationId))")
+            // A verified already-member result targets a dedup race or a
+            // re-invite where this installation may never have processed the
+            // original accept, so it has no local row for the joiner. Persist
+            // the joiner's profile (carried on the verified context) before the
+            // snapshot is built, or the re-published roster would omit the
+            // joiner and render them as "Somebody".
+            if let verified {
+                await persistJoinerProfile(
+                    joinerInboxId: joinerInboxId,
+                    conversationId: verified.conversationId,
+                    profile: verified.profile,
+                    metadata: verified.metadata
+                )
+            }
             mapped = .alreadyMember(
                 dmConversationId: dmConversationId,
                 joinerInboxId: joinerInboxId
@@ -264,8 +286,8 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
         // A fresh accept and a verified already-member result both re-publish
         // the roster: the already-member path covers re-invites and dedup
         // races where the accept that added the member ran in another pass, so
-        // the joiner still needs a complete snapshot. The `.accepted` persist
-        // above runs first so the snapshot build sees the joiner's own row.
+        // the joiner still needs a complete snapshot. The persist above runs
+        // first so the snapshot build sees the joiner's own row.
         if let conversationId = Self.profileSnapshotConversationId(for: outcome) {
             await sendProfileSnapshotAfterJoin(conversationId: conversationId, client: client)
         }
@@ -274,14 +296,14 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
 
     /// The conversation whose roster should be (re)published for an outcome, or
     /// nil when no snapshot is warranted. Verified already-member results carry
-    /// a `conversationId`; the handled-request ledger pre-check does not, and a
+    /// a conversation; the handled-request ledger pre-check does not, and a
     /// snapshot there would have been sent on the original accept anyway.
     static func profileSnapshotConversationId(for outcome: JoinRequestDMOutcome) -> String? {
         switch outcome {
         case let .accepted(result, dmConversationId: _):
             return result.conversationId
-        case let .alreadyMember(_, _, conversationId):
-            return conversationId
+        case let .alreadyMember(_, _, verified):
+            return verified?.conversationId
         case .benignFailure, .malicious, .noJoinRequest:
             return nil
         }
@@ -302,10 +324,8 @@ final class InviteJoinRequestsManager: InviteJoinRequestsManagerProtocol, Sendab
             ), case .group(let group) = conversation else {
                 return
             }
-            let allMemberInboxIds = try await group.members.map(\.inboxId)
             try await ProfileSnapshotBuilder.sendSnapshot(
                 group: group,
-                memberInboxIds: allMemberInboxIds,
                 databaseReader: databaseWriter
             )
             Log.debug("Sent ProfileSnapshot after join request for \(conversationId)")

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -631,10 +631,8 @@ actor StreamProcessor: StreamProcessorProtocol {
 
     private func sendInitialProfileSnapshot(group: XMTPiOS.Group) async {
         do {
-            let allMemberInboxIds = try await group.members.map(\.inboxId)
             try await ProfileSnapshotBuilder.sendSnapshot(
                 group: group,
-                memberInboxIds: allMemberInboxIds,
                 databaseReader: databaseReader
             )
             Log.debug("Sent initial ProfileSnapshot for \(group.id)")

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -634,7 +634,8 @@ actor StreamProcessor: StreamProcessorProtocol {
             let allMemberInboxIds = try await group.members.map(\.inboxId)
             try await ProfileSnapshotBuilder.sendSnapshot(
                 group: group,
-                memberInboxIds: allMemberInboxIds
+                memberInboxIds: allMemberInboxIds,
+                databaseReader: databaseReader
             )
             Log.debug("Sent initial ProfileSnapshot for \(group.id)")
         } catch {

--- a/ConvosCore/Tests/ConvosCoreTests/DBMemberProfileWithHelpersTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DBMemberProfileWithHelpersTests.swift
@@ -117,6 +117,74 @@ struct DBMemberProfileWithHelpersTests {
     }
 }
 
+/// Pins the projection from an authoritative `DBMemberProfile` row to the
+/// `MemberProfile` carried inside a `ProfileSnapshot`. This is the path that
+/// lets a late joiner learn an agent (or any appData-sourced member) even when
+/// no recent profile message exists for it.
+@Suite("DBMemberProfile.snapshotMemberProfile projection")
+struct DBMemberProfileSnapshotProjectionTests {
+    private static let hexInboxId: String = String(repeating: "ab", count: 32)
+
+    @Test("Agent row projects name and agent kind, with no image")
+    func agentRowProjectsNameAndKind() throws {
+        let row = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: Self.hexInboxId,
+            name: "My Agent",
+            avatar: nil,
+            memberKind: .agent,
+            metadata: ["templateId": .string("t1")]
+        )
+        let projected = try #require(row.snapshotMemberProfile)
+        #expect(projected.inboxIdString == Self.hexInboxId)
+        #expect(projected.name == "My Agent")
+        #expect(projected.memberKind == .agent)
+        #expect(!projected.hasEncryptedImage)
+        #expect(projected.metadata["templateId"]?.stringValue == "t1")
+    }
+
+    @Test("A valid encrypted avatar projects an encrypted image ref")
+    func encryptedAvatarProjectsImage() throws {
+        let row = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: Self.hexInboxId,
+            name: "Alice",
+            avatar: "https://example.com/a.enc",
+            avatarSalt: Data(repeating: 0x01, count: 32),
+            avatarNonce: Data(repeating: 0x02, count: 12)
+        )
+        let projected = try #require(row.snapshotMemberProfile)
+        #expect(projected.hasEncryptedImage)
+        #expect(projected.encryptedImage.url == "https://example.com/a.enc")
+        #expect(projected.encryptedImage.salt.count == 32)
+        #expect(projected.encryptedImage.nonce.count == 12)
+    }
+
+    @Test("A plain avatar URL is dropped: name kept, no fabricated encrypted ref")
+    func plainAvatarOmitsImage() throws {
+        let row = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: Self.hexInboxId,
+            name: "Alice",
+            avatar: "https://example.com/plain.png"
+        )
+        let projected = try #require(row.snapshotMemberProfile)
+        #expect(projected.name == "Alice")
+        #expect(!projected.hasEncryptedImage)
+    }
+
+    @Test("A non-hex inbox id cannot be put on the wire and projects nil")
+    func nonHexInboxIdProjectsNil() {
+        let row = DBMemberProfile(
+            conversationId: "convo-1",
+            inboxId: "not-hex",
+            name: "Alice",
+            avatar: nil
+        )
+        #expect(row.snapshotMemberProfile == nil)
+    }
+}
+
 /// Pins the never-clear invariant shared by every inbound apply path (stream,
 /// NSE push, catch-up/history): a name-less or blank `ProfileUpdate` must never
 /// wipe a name we already have, which would render the member as "Somebody".

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -513,6 +513,64 @@ struct InviteCoordinatorIntegrationTests {
         #expect(errorCount == 0, "An .unknown consent state must not send an error reply")
     }
 
+    /// A re-invite / dedup-race revalidation must still let the joiner receive
+    /// the roster. The coordinator returns `.alreadyMember` without re-adding,
+    /// but a verified result now carries the `conversationId` so ConvosCore can
+    /// re-publish a complete profile snapshot for that conversation.
+    @Test("Verified already-member result carries the conversation id for re-snapshotting")
+    func alreadyMemberCarriesConversationId() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let key = creatorInviteKey
+        let firstPass = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await firstPass.revokeInvites(for: group)
+        let invite = try await firstPass.createInvite(for: group, client: creatorClient)
+
+        // Text-only join: no handled marker is sent, so the revalidation pass
+        // reaches the membership-dedup branch (which carries the conversation
+        // id) rather than the marker branch.
+        let dm = try await joinerClient.conversations.findOrCreateDm(with: creatorClient.inboxID)
+        _ = try await dm.send(content: invite.slug)
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let firstOutcomes = await firstPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
+
+        // A fresh installation (empty ledger) revalidates the same request
+        // while the joiner is still a member.
+        let secondPass = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+        let replayOutcomes = await secondPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+
+        #expect(
+            replayOutcomes.compactMap(\.joinResult).isEmpty,
+            "Revalidation must not re-add the joiner"
+        )
+
+        var alreadyMemberConversationIds: [String?] = []
+        for outcome in replayOutcomes {
+            if case .alreadyMember(_, _, let conversationId) = outcome {
+                alreadyMemberConversationIds.append(conversationId)
+            }
+        }
+        #expect(
+            alreadyMemberConversationIds.contains(group.id),
+            "A verified already-member result must carry the conversation id so the joiner can be re-snapshotted"
+        )
+    }
+
     private func joinErrors(inDmWith peerInboxId: String, client: Client) async throws -> [InviteJoinError] {
         let dm = try await client.conversations.findOrCreateDm(with: peerInboxId)
         let messages = try await dm.messages()

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/InviteCoordinatorIntegrationTests.swift
@@ -561,13 +561,62 @@ struct InviteCoordinatorIntegrationTests {
 
         var alreadyMemberConversationIds: [String?] = []
         for outcome in replayOutcomes {
-            if case .alreadyMember(_, _, let conversationId) = outcome {
-                alreadyMemberConversationIds.append(conversationId)
-            }
+            alreadyMemberConversationIds.append(outcome.alreadyMemberContext?.conversationId)
         }
         #expect(
             alreadyMemberConversationIds.contains(group.id),
             "A verified already-member result must carry the conversation id so the joiner can be re-snapshotted"
+        )
+    }
+
+    /// The verified already-member result must carry the joiner's own profile
+    /// from the join request. An installation that never processed the original
+    /// accept (cross-installation or dedup race) uses it to persist the joiner's
+    /// row, so the re-published snapshot includes the joiner by name rather than
+    /// rendering them as "Somebody".
+    @Test("Verified already-member result carries the joiner's profile from the request")
+    func alreadyMemberCarriesJoinerProfile() async throws {
+        let creatorClient = try await createClient()
+        let joinerClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? joinerClient.deleteLocalDatabase()
+        }
+        let key = creatorInviteKey
+        let firstPass = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+
+        let group = try await creatorClient.conversations.newGroup(with: [])
+        try await group.updateConsentState(state: .allowed)
+        _ = try await firstPass.revokeInvites(for: group)
+        let invite = try await firstPass.createInvite(for: group, client: creatorClient)
+
+        // Typed join carrying the joiner's profile.
+        let joinerProfile = JoinRequestProfile(name: "Joiner Jane", imageURL: nil, memberKind: nil)
+        _ = try await firstPass.sendJoinRequest(
+            for: invite.signedInvite,
+            client: joinerClient,
+            profile: joinerProfile
+        )
+
+        _ = try await creatorClient.conversations.syncAllConversations(consentStates: nil)
+        let firstOutcomes = await firstPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+        #expect(firstOutcomes.compactMap(\.joinResult).contains { $0.conversationId == group.id })
+
+        // A fresh installation (empty ledger) revalidates while the joiner is
+        // still a member, producing a verified already-member result.
+        let secondPass = InviteCoordinator(
+            privateKeyProvider: { _ in key },
+            handledRequestStore: InMemoryHandledJoinRequestStore()
+        )
+        let replayOutcomes = await secondPass.processJoinRequestOutcomes(since: nil, client: creatorClient)
+
+        let verifiedContexts = replayOutcomes.compactMap(\.alreadyMemberContext)
+        #expect(
+            verifiedContexts.contains { $0.conversationId == group.id && $0.profile?.name == "Joiner Jane" },
+            "A verified already-member result must carry the joiner's profile so it can be persisted and re-snapshotted"
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -212,6 +212,78 @@ struct ProfileMessageIntegrationTests {
         #expect(agentProfile?.memberKind == .agent)
     }
 
+    // MARK: - Snapshot builder unions database rows with recent messages
+
+    @Test("Snapshot builder includes a database-only member with no recent profile message")
+    func snapshotBuilderIncludesDatabaseOnlyMember() async throws {
+        let clientA = try await createClient()
+        let clientB = try await createClient()
+        defer {
+            try? clientA.deleteLocalDatabase()
+            try? clientB.deleteLocalDatabase()
+        }
+
+        let groupA = try await clientA.conversations.newGroup(with: [clientB.inboxID])
+
+        // The human (clientA) has a recent profile update. The agent (clientB)
+        // never published one, so the inviter knows it only through the
+        // authoritative database row - the case that rendered "Somebody".
+        _ = try await groupA.send(encodedContent: try ProfileUpdateCodec().encode(content: ProfileUpdate(name: "Human")))
+        try await groupA.sync()
+
+        var agentProfile = try #require(MemberProfile(inboxIdString: clientB.inboxID, name: "My Agent"))
+        agentProfile.memberKind = .agent
+
+        let allMembers = try await groupA.members.map(\.inboxId)
+        let builtSnapshot = try await ProfileSnapshotBuilder.buildSnapshot(
+            group: groupA,
+            memberInboxIds: allMembers,
+            dbProfiles: [agentProfile]
+        )
+
+        let humanProfile = builtSnapshot.findProfile(inboxId: clientA.inboxID)
+        let resolvedAgent = builtSnapshot.findProfile(inboxId: clientB.inboxID)
+        #expect(humanProfile?.name == "Human")
+        #expect(resolvedAgent?.name == "My Agent")
+        #expect(resolvedAgent?.memberKind == .agent)
+    }
+
+    @Test("Snapshot builder includes a message-only member missing from the database")
+    func snapshotBuilderUnionsMessageOnlyMember() async throws {
+        let clientA = try await createClient()
+        let clientB = try await createClient()
+        defer {
+            try? clientA.deleteLocalDatabase()
+            try? clientB.deleteLocalDatabase()
+        }
+
+        let groupA = try await clientA.conversations.newGroup(with: [clientB.inboxID])
+
+        // clientB publishes a profile update the inviter has synced but not yet
+        // flushed to its database; only clientA has a database row. The union
+        // must surface both: the message-only member and the database-only one.
+        try await clientB.conversations.sync()
+        let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == groupA.id })
+        try await groupB.sync()
+        _ = try await groupB.send(encodedContent: try ProfileUpdateCodec().encode(content: ProfileUpdate(name: "Fresh Bob")))
+
+        try await groupA.sync()
+
+        let aliceProfile = try #require(MemberProfile(inboxIdString: clientA.inboxID, name: "DB Alice"))
+
+        let allMembers = try await groupA.members.map(\.inboxId)
+        let builtSnapshot = try await ProfileSnapshotBuilder.buildSnapshot(
+            group: groupA,
+            memberInboxIds: allMembers,
+            dbProfiles: [aliceProfile]
+        )
+
+        let resolvedAlice = builtSnapshot.findProfile(inboxId: clientA.inboxID)
+        let resolvedBob = builtSnapshot.findProfile(inboxId: clientB.inboxID)
+        #expect(resolvedAlice?.name == "DB Alice")
+        #expect(resolvedBob?.name == "Fresh Bob")
+    }
+
     // MARK: - Empty group
 
     @Test("Snapshot builder returns empty profiles when no profile messages exist")

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -1,6 +1,7 @@
 import ConvosAppData
 @testable import ConvosCore
 import Foundation
+import GRDB
 import Testing
 @preconcurrency import XMTPiOS
 
@@ -282,6 +283,75 @@ struct ProfileMessageIntegrationTests {
         let resolvedBob = builtSnapshot.findProfile(inboxId: clientB.inboxID)
         #expect(resolvedAlice?.name == "DB Alice")
         #expect(resolvedBob?.name == "Fresh Bob")
+    }
+
+    // MARK: - sendSnapshot wires the database reader to the builder
+
+    @Test("sendSnapshot with a database reader includes a DB-only agent in the received snapshot")
+    func sendSnapshotIncludesDatabaseOnlyAgentInReceivedSnapshot() async throws {
+        let clientA = try await createClient()
+        let clientB = try await createClient()
+        let clientC = try await createClient()
+        defer {
+            try? clientA.deleteLocalDatabase()
+            try? clientB.deleteLocalDatabase()
+            try? clientC.deleteLocalDatabase()
+        }
+
+        let groupA = try await clientA.conversations.newGroup(with: [clientB.inboxID])
+        try await groupA.sync()
+
+        _ = try await groupA.addMembers(inboxIds: [clientC.inboxID])
+
+        let minimalDB = try DatabaseQueue()
+        try await minimalDB.write { db in
+            try db.create(table: "memberProfile") { t in
+                t.column("conversationId", .text).notNull()
+                t.column("inboxId", .text).notNull()
+                t.column("name", .text)
+                t.column("avatar", .text)
+                t.column("avatarSalt", .blob)
+                t.column("avatarNonce", .blob)
+                t.column("avatarKey", .blob)
+                t.column("avatarLastRenewed", .datetime)
+                t.column("memberKind", .text)
+                t.column("metadata", .jsonText)
+                t.column("imageSourceAssetIdentifier", .text)
+                t.column("imageSourceContentDigest", .text)
+                t.primaryKey(["conversationId", "inboxId"])
+            }
+            let agentRow = DBMemberProfile(
+                conversationId: groupA.id,
+                inboxId: clientB.inboxID,
+                name: "Agent Bob",
+                avatar: nil,
+                memberKind: .agent
+            )
+            try agentRow.insert(db)
+        }
+
+        let allMembers = try await groupA.members.map(\.inboxId)
+        try await ProfileSnapshotBuilder.sendSnapshot(
+            group: groupA,
+            memberInboxIds: allMembers,
+            databaseReader: minimalDB
+        )
+
+        try await clientC.conversations.sync()
+        let groupC = try #require(try clientC.conversations.listGroups().first { $0.id == groupA.id })
+        try await groupC.sync()
+
+        let messages = try await groupC.messages(limit: 20, direction: .descending)
+        let snapshotMessages = messages.filter {
+            (try? $0.encodedContent.type) == ContentTypeProfileSnapshot
+        }
+
+        #expect(!snapshotMessages.isEmpty, "Late joiner must receive a profile snapshot")
+
+        let snapshot = try ProfileSnapshotCodec().decode(content: snapshotMessages[0].encodedContent)
+        let agentProfile = snapshot.findProfile(inboxId: clientB.inboxID)
+        #expect(agentProfile?.name == "Agent Bob", "Snapshot must carry the database-only agent name")
+        #expect(agentProfile?.memberKind == .agent)
     }
 
     // MARK: - Empty group

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -88,8 +88,7 @@ struct ProfileMessageIntegrationTests {
         try await groupA.sync()
         _ = try await groupA.addMembers(inboxIds: [clientC.inboxID])
 
-        let allMembers = try await groupA.members.map(\.inboxId)
-        try await ProfileSnapshotBuilder.sendSnapshot(group: groupA, memberInboxIds: allMembers)
+        try await ProfileSnapshotBuilder.sendSnapshot(group: groupA)
 
         try await clientC.conversations.sync()
         let groupC = try #require(try clientC.conversations.listGroups().first { $0.id == groupA.id })
@@ -330,10 +329,8 @@ struct ProfileMessageIntegrationTests {
             try agentRow.insert(db)
         }
 
-        let allMembers = try await groupA.members.map(\.inboxId)
         try await ProfileSnapshotBuilder.sendSnapshot(
             group: groupA,
-            memberInboxIds: allMembers,
             databaseReader: minimalDB
         )
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/ProfileMessageIntegrationTests.swift
@@ -354,6 +354,45 @@ struct ProfileMessageIntegrationTests {
         #expect(agentProfile?.memberKind == .agent)
     }
 
+    @Test("A blank incoming name does not clobber a populated database name")
+    func snapshotBuilderBlankNameKeepsDatabaseName() async throws {
+        let clientA = try await createClient()
+        let clientB = try await createClient()
+        defer {
+            try? clientA.deleteLocalDatabase()
+            try? clientB.deleteLocalDatabase()
+        }
+
+        let groupA = try await clientA.conversations.newGroup(with: [clientB.inboxID])
+
+        // clientA publishes a real new name (must win over its database row);
+        // clientB publishes a whitespace-only name (hasName=true but blank),
+        // the clear-style update that must not regress a known name.
+        _ = try await groupA.send(encodedContent: try ProfileUpdateCodec().encode(content: ProfileUpdate(name: "Fresh A")))
+
+        try await clientB.conversations.sync()
+        let groupB = try #require(try clientB.conversations.listGroups().first { $0.id == groupA.id })
+        try await groupB.sync()
+        _ = try await groupB.send(encodedContent: try ProfileUpdateCodec().encode(content: ProfileUpdate(name: "   ")))
+
+        try await groupA.sync()
+
+        let dbAlice = try #require(MemberProfile(inboxIdString: clientA.inboxID, name: "DB A"))
+        let dbBob = try #require(MemberProfile(inboxIdString: clientB.inboxID, name: "DB B"))
+
+        let allMembers = try await groupA.members.map(\.inboxId)
+        let builtSnapshot = try await ProfileSnapshotBuilder.buildSnapshot(
+            group: groupA,
+            memberInboxIds: allMembers,
+            dbProfiles: [dbAlice, dbBob]
+        )
+
+        let resolvedAlice = builtSnapshot.findProfile(inboxId: clientA.inboxID)
+        let resolvedBob = builtSnapshot.findProfile(inboxId: clientB.inboxID)
+        #expect(resolvedAlice?.name == "Fresh A")
+        #expect(resolvedBob?.name == "DB B")
+    }
+
     // MARK: - Empty group
 
     @Test("Snapshot builder returns empty profiles when no profile messages exist")

--- a/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
@@ -1,6 +1,7 @@
 @testable import ConvosCore
 import ConvosInvites
 import Foundation
+import GRDB
 import Testing
 
 @Suite("InviteJoinRequestsManager Tests")
@@ -83,5 +84,94 @@ struct InviteJoinRequestsManagerTests {
         let boundary = now.addingTimeInterval(-day)
         let effective = InviteJoinRequestsManager.effectiveCatchUpSince(since: boundary, now: now)
         #expect(effective == boundary)
+    }
+}
+
+@Suite("InviteJoinRequestsManager profile persistence", .serialized)
+struct InviteJoinRequestsManagerPersistenceTests {
+    private func makeManager(_ dbManager: MockDatabaseManager) -> InviteJoinRequestsManager {
+        InviteJoinRequestsManager(
+            identityStore: MockKeychainIdentityStore(),
+            databaseWriter: dbManager.dbWriter
+        )
+    }
+
+    private func seedConversation(_ db: Database, id: String) throws {
+        let creatorInboxId = "creator-\(id)"
+        try DBMember(inboxId: creatorInboxId).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: "tag-\(id)",
+            creatorId: creatorInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+    }
+
+    @Test("Empty metadata and no profile fields does not blank an existing member row")
+    func emptyMetadataDoesNotBlankExistingRow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let manager = makeManager(dbManager)
+
+        let conversationId = "convo-persist-1"
+        let joinerInboxId = "joiner-persist-1"
+
+        try await dbManager.dbWriter.write { db in
+            try self.seedConversation(db, id: conversationId)
+            try DBMember(inboxId: joinerInboxId).save(db, onConflict: .ignore)
+            try DBMemberProfile(
+                conversationId: conversationId,
+                inboxId: joinerInboxId,
+                name: "Good Name",
+                avatar: nil,
+                memberKind: nil,
+                metadata: ["k": .string("v")]
+            ).insert(db)
+        }
+
+        // All-nil profile with an empty (but non-nil) metadata dictionary must
+        // be a no-op, not an overwrite that blanks the existing row.
+        await manager.persistJoinerProfile(
+            joinerInboxId: joinerInboxId,
+            conversationId: conversationId,
+            profile: nil,
+            metadata: [:]
+        )
+
+        let afterEmpty = try await dbManager.dbReader.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: joinerInboxId)
+        }
+        #expect(afterEmpty?.name == "Good Name", "Empty-metadata persist must not blank an existing row")
+        #expect(afterEmpty?.metadata?["k"]?.stringValue == "v")
+
+        // A populated profile still persists as before.
+        await manager.persistJoinerProfile(
+            joinerInboxId: joinerInboxId,
+            conversationId: conversationId,
+            profile: JoinRequestProfile(name: "New Name", imageURL: nil, memberKind: nil),
+            metadata: nil
+        )
+
+        let afterReal = try await dbManager.dbReader.read { db in
+            try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: joinerInboxId)
+        }
+        #expect(afterReal?.name == "New Name", "A populated profile must still persist")
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
@@ -1,4 +1,5 @@
 @testable import ConvosCore
+import ConvosInvites
 import Foundation
 import Testing
 
@@ -6,6 +7,56 @@ import Testing
 struct InviteJoinRequestsManagerTests {
     let now = Date(timeIntervalSince1970: 1_780_000_000)
     let day: TimeInterval = 24 * 60 * 60
+
+    // MARK: - Post-join snapshot routing
+
+    @Test("Accepted join re-publishes the joined conversation's snapshot")
+    func acceptedTriggersSnapshot() {
+        let result = JoinResult(
+            conversationId: "group-1",
+            joinerInboxId: "joiner-1",
+            conversationName: "Group"
+        )
+        let outcome = JoinRequestDMOutcome.accepted(result, dmConversationId: "dm-1")
+        #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: outcome) == "group-1")
+    }
+
+    @Test("Verified already-member result re-publishes the snapshot for its conversation")
+    func verifiedAlreadyMemberTriggersSnapshot() {
+        let outcome = JoinRequestDMOutcome.alreadyMember(
+            dmConversationId: "dm-1",
+            joinerInboxId: "joiner-1",
+            conversationId: "group-1"
+        )
+        #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: outcome) == "group-1")
+    }
+
+    @Test("Ledger-only already-member result does not re-publish a snapshot")
+    func ledgerAlreadyMemberSkipsSnapshot() {
+        let outcome = JoinRequestDMOutcome.alreadyMember(
+            dmConversationId: "dm-1",
+            joinerInboxId: "joiner-1",
+            conversationId: nil
+        )
+        #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: outcome) == nil)
+    }
+
+    @Test("Non-joining outcomes never re-publish a snapshot")
+    func nonJoiningOutcomesSkipSnapshot() {
+        let benign = JoinRequestDMOutcome.benignFailure(
+            dmConversationId: "dm-1",
+            senderInboxId: "joiner-1",
+            error: .addMemberFailed
+        )
+        let malicious = JoinRequestDMOutcome.malicious(
+            dmConversationId: "dm-1",
+            senderInboxId: "joiner-1",
+            error: .invalidSignature
+        )
+        #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: benign) == nil)
+        #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: malicious) == nil)
+        #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: .noJoinRequest) == nil)
+    }
 
     @Test("Nil cursor clamps to the 24h window instead of sweeping all history")
     func nilCursorClampsToWindow() {

--- a/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/InviteJoinRequestsManagerTests.swift
@@ -26,7 +26,7 @@ struct InviteJoinRequestsManagerTests {
         let outcome = JoinRequestDMOutcome.alreadyMember(
             dmConversationId: "dm-1",
             joinerInboxId: "joiner-1",
-            conversationId: "group-1"
+            verified: AlreadyMemberContext(conversationId: "group-1", profile: nil, metadata: nil)
         )
         #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: outcome) == "group-1")
     }
@@ -36,7 +36,7 @@ struct InviteJoinRequestsManagerTests {
         let outcome = JoinRequestDMOutcome.alreadyMember(
             dmConversationId: "dm-1",
             joinerInboxId: "joiner-1",
-            conversationId: nil
+            verified: nil
         )
         #expect(InviteJoinRequestsManager.profileSnapshotConversationId(for: outcome) == nil)
     }

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -272,9 +272,12 @@ public final class InviteCoordinator: @unchecked Sendable {
         // Removal is not a block - a removed member rejoins by sending a
         // fresh request (new message ID) with the same invite.
         if await handledRequestStore.isHandled(messageId: request.messageId) {
+            // No conversation resolved yet: the ledger short circuits before
+            // the invite is validated, so there is no group to re-snapshot.
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
-                joinerInboxId: request.joinerInboxId
+                joinerInboxId: request.joinerInboxId,
+                conversationId: nil
             )
         }
 
@@ -508,7 +511,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             await handledRequestStore.markHandled(messageId: request.messageId)
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
-                joinerInboxId: request.joinerInboxId
+                joinerInboxId: request.joinerInboxId,
+                conversationId: conversationId
             )
         }
 
@@ -532,7 +536,8 @@ public final class InviteCoordinator: @unchecked Sendable {
             await sendJoinHandledMarker(for: request, client: client)
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
-                joinerInboxId: request.joinerInboxId
+                joinerInboxId: request.joinerInboxId,
+                conversationId: conversationId
             )
         }
 
@@ -640,9 +645,12 @@ public final class InviteCoordinator: @unchecked Sendable {
             // verification, so tampered slugs still reach the malicious
             // detection and DM blocking path.
             if await handledRequestStore.isHandled(messageId: message.id) {
+                // Ledger pre-check before validation: no conversation resolved,
+                // so nothing to re-snapshot here.
                 handledOutcome = handledOutcome ?? .alreadyMember(
                     dmConversationId: dm.id,
-                    joinerInboxId: message.senderInboxId
+                    joinerInboxId: message.senderInboxId,
+                    conversationId: nil
                 )
                 continue
             }

--- a/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
+++ b/ConvosInvites/Sources/ConvosInvites/InviteCoordinator.swift
@@ -277,7 +277,7 @@ public final class InviteCoordinator: @unchecked Sendable {
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
                 joinerInboxId: request.joinerInboxId,
-                conversationId: nil
+                verified: nil
             )
         }
 
@@ -512,7 +512,11 @@ public final class InviteCoordinator: @unchecked Sendable {
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
                 joinerInboxId: request.joinerInboxId,
-                conversationId: conversationId
+                verified: AlreadyMemberContext(
+                    conversationId: conversationId,
+                    profile: request.profile,
+                    metadata: request.metadata
+                )
             )
         }
 
@@ -537,7 +541,11 @@ public final class InviteCoordinator: @unchecked Sendable {
             return .alreadyMember(
                 dmConversationId: request.dmConversationId,
                 joinerInboxId: request.joinerInboxId,
-                conversationId: conversationId
+                verified: AlreadyMemberContext(
+                    conversationId: conversationId,
+                    profile: request.profile,
+                    metadata: request.metadata
+                )
             )
         }
 
@@ -647,10 +655,13 @@ public final class InviteCoordinator: @unchecked Sendable {
             if await handledRequestStore.isHandled(messageId: message.id) {
                 // Ledger pre-check before validation: no conversation resolved,
                 // so nothing to re-snapshot here.
-                handledOutcome = handledOutcome ?? .alreadyMember(
-                    dmConversationId: dm.id,
-                    joinerInboxId: message.senderInboxId,
-                    conversationId: nil
+                handledOutcome = Self.preferringVerified(
+                    handledOutcome,
+                    over: .alreadyMember(
+                        dmConversationId: dm.id,
+                        joinerInboxId: message.senderInboxId,
+                        verified: nil
+                    )
                 )
                 continue
             }
@@ -662,7 +673,7 @@ public final class InviteCoordinator: @unchecked Sendable {
                 try? await dm.updateConsentState(state: .allowed)
                 return outcome
             case .alreadyMember:
-                handledOutcome = handledOutcome ?? outcome
+                handledOutcome = Self.preferringVerified(handledOutcome, over: outcome)
                 continue
             case .malicious:
                 return outcome
@@ -943,5 +954,23 @@ extension XMTPiOS.Dm {
         /// interleaved creator bookkeeping. Join DMs carry very little
         /// traffic, so a handful of messages is plenty.
         static let outgoingInviteScanLimit: Int = 10
+    }
+}
+
+extension InviteCoordinator {
+    /// Picks the already-member outcome to keep across one DM scan. A verified
+    /// context (a real conversation + the joiner's profile) lets the caller
+    /// re-publish the roster snapshot, so it must win over an earlier
+    /// ledger-only outcome whose context is nil. Same-richness outcomes keep
+    /// the first one seen, preserving the prior first-wins behavior.
+    static func preferringVerified(
+        _ existing: JoinRequestDMOutcome?,
+        over candidate: JoinRequestDMOutcome
+    ) -> JoinRequestDMOutcome {
+        guard let existing else { return candidate }
+        if existing.alreadyMemberContext == nil, candidate.alreadyMemberContext != nil {
+            return candidate
+        }
+        return existing
     }
 }

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -156,18 +156,24 @@ public struct JoinResult: Sendable {
 /// - `malicious`: Signature verification failed in a way that indicates
 ///   tampering. The DM is denied and the device unsubscribes from its
 ///   topic so it can no longer wake the inbox.
-/// - `alreadyMember`: The request needs no action - either the joiner is
+/// - `alreadyMember`: The request needs no re-add - either the joiner is
 ///   already in the group, or this exact message already admitted them
 ///   once (handled-request ledger) and they may have since been removed.
 ///   Another processing path (stream vs batch vs poll) handled this
-///   request first. No re-add, no snapshot, no error DM; the DM stays
-///   subscribed like `accepted`.
+///   request first. No re-add, no error DM; the DM stays subscribed like
+///   `accepted`. `conversationId` is carried when the request was verified
+///   against a known group (the joiner is currently a member), so the
+///   caller can still re-publish a complete profile snapshot for that
+///   conversation - a re-invite or a dedup race where the accept that added
+///   the member ran in another pass still needs the joiner to receive the
+///   roster. It is nil on the handled-request ledger pre-check, which short
+///   circuits before the conversation is resolved.
 /// - `noJoinRequest`: The message was not a join-request candidate.
 public enum JoinRequestDMOutcome: Sendable {
     case accepted(JoinResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)
     case malicious(dmConversationId: String, senderInboxId: String, error: JoinRequestError)
-    case alreadyMember(dmConversationId: String, joinerInboxId: String)
+    case alreadyMember(dmConversationId: String, joinerInboxId: String, conversationId: String?)
     case noJoinRequest
 
     public var joinResult: JoinResult? {
@@ -183,7 +189,7 @@ public enum JoinRequestDMOutcome: Sendable {
             return dmConversationId
         case .malicious(let dmConversationId, _, _):
             return dmConversationId
-        case .alreadyMember(let dmConversationId, _):
+        case .alreadyMember(let dmConversationId, _, _):
             return dmConversationId
         case .noJoinRequest:
             return nil

--- a/ConvosInvites/Sources/ConvosInvites/Models.swift
+++ b/ConvosInvites/Sources/ConvosInvites/Models.swift
@@ -161,24 +161,32 @@ public struct JoinResult: Sendable {
 ///   once (handled-request ledger) and they may have since been removed.
 ///   Another processing path (stream vs batch vs poll) handled this
 ///   request first. No re-add, no error DM; the DM stays subscribed like
-///   `accepted`. `conversationId` is carried when the request was verified
-///   against a known group (the joiner is currently a member), so the
-///   caller can still re-publish a complete profile snapshot for that
-///   conversation - a re-invite or a dedup race where the accept that added
-///   the member ran in another pass still needs the joiner to receive the
-///   roster. It is nil on the handled-request ledger pre-check, which short
+///   `accepted`. A `verified` context is carried when the request was
+///   validated against a known group (the joiner is currently a member), so
+///   the caller can still re-publish a complete profile snapshot and persist
+///   the joiner's own profile - a re-invite, or a dedup race where the accept
+///   that added the member ran in another pass (or on another installation),
+///   still needs the joiner to receive the roster and to appear in it. The
+///   context is nil on the handled-request ledger pre-check, which short
 ///   circuits before the conversation is resolved.
 /// - `noJoinRequest`: The message was not a join-request candidate.
 public enum JoinRequestDMOutcome: Sendable {
     case accepted(JoinResult, dmConversationId: String)
     case benignFailure(dmConversationId: String, senderInboxId: String?, error: JoinRequestError)
     case malicious(dmConversationId: String, senderInboxId: String, error: JoinRequestError)
-    case alreadyMember(dmConversationId: String, joinerInboxId: String, conversationId: String?)
+    case alreadyMember(dmConversationId: String, joinerInboxId: String, verified: AlreadyMemberContext?)
     case noJoinRequest
 
     public var joinResult: JoinResult? {
         guard case .accepted(let result, dmConversationId: _) = self else { return nil }
         return result
+    }
+
+    /// The verified context of an already-member outcome, or nil for any other
+    /// case (including a ledger-only already-member result).
+    public var alreadyMemberContext: AlreadyMemberContext? {
+        guard case .alreadyMember(_, _, let verified) = self else { return nil }
+        return verified
     }
 
     public var dmConversationId: String? {
@@ -208,6 +216,26 @@ public enum JoinRequestDMOutcome: Sendable {
     public var isMalicious: Bool {
         guard case .malicious = self else { return false }
         return true
+    }
+}
+
+/// What a caller needs to finish a verified already-member result: the
+/// conversation to re-publish a roster snapshot for, plus the joiner's own
+/// profile (from the join request) so an installation that never processed the
+/// original accept can still persist it and include the joiner in the snapshot.
+public struct AlreadyMemberContext: Sendable {
+    public let conversationId: String
+    public let profile: JoinRequestProfile?
+    public let metadata: [String: String]?
+
+    public init(
+        conversationId: String,
+        profile: JoinRequestProfile?,
+        metadata: [String: String]?
+    ) {
+        self.conversationId = conversationId
+        self.profile = profile
+        self.metadata = metadata
     }
 }
 

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -329,12 +329,12 @@ struct JoinRequestProcessingTests {
         let alreadyMember = JoinRequestDMOutcome.alreadyMember(
             dmConversationId: "dm-123",
             joinerInboxId: "joiner-123",
-            conversationId: "group-123"
+            verified: AlreadyMemberContext(conversationId: "group-123", profile: nil, metadata: nil)
         )
         let alreadyMemberLedger = JoinRequestDMOutcome.alreadyMember(
             dmConversationId: "dm-123",
             joinerInboxId: "joiner-123",
-            conversationId: nil
+            verified: nil
         )
 
         #expect(accepted.shouldKeepDMSubscribed)
@@ -351,16 +351,35 @@ struct JoinRequestProcessingTests {
         // A verified already-member result carries the conversation so the
         // caller can re-publish a complete snapshot; the ledger pre-check does
         // not resolve a conversation.
-        guard case .alreadyMember(_, _, let verifiedConversationId) = alreadyMember else {
-            Issue.record("expected alreadyMember case")
-            return
-        }
-        #expect(verifiedConversationId == "group-123")
-        guard case .alreadyMember(_, _, let ledgerConversationId) = alreadyMemberLedger else {
-            Issue.record("expected alreadyMember case")
-            return
-        }
-        #expect(ledgerConversationId == nil)
+        #expect(alreadyMember.alreadyMemberContext?.conversationId == "group-123")
+        #expect(alreadyMemberLedger.alreadyMemberContext == nil)
+    }
+
+    @Test("Outcome selection prefers a verified already-member over a ledger-only one")
+    func preferringVerifiedKeepsTheVerifiedOutcome() {
+        let ledger = JoinRequestDMOutcome.alreadyMember(
+            dmConversationId: "dm-123",
+            joinerInboxId: "joiner-123",
+            verified: nil
+        )
+        let verified = JoinRequestDMOutcome.alreadyMember(
+            dmConversationId: "dm-123",
+            joinerInboxId: "joiner-123",
+            verified: AlreadyMemberContext(conversationId: "group-123", profile: nil, metadata: nil)
+        )
+
+        // A verified outcome arriving after a ledger-only one upgrades it.
+        #expect(
+            InviteCoordinator.preferringVerified(ledger, over: verified).alreadyMemberContext?.conversationId == "group-123"
+        )
+        // A ledger-only outcome arriving after a verified one does not downgrade it.
+        #expect(
+            InviteCoordinator.preferringVerified(verified, over: ledger).alreadyMemberContext?.conversationId == "group-123"
+        )
+        // With nothing accumulated yet, the candidate is taken as-is.
+        #expect(
+            InviteCoordinator.preferringVerified(nil, over: ledger).alreadyMemberContext == nil
+        )
     }
 
     // MARK: - InviteJoinError Feedback

--- a/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
+++ b/ConvosInvites/Tests/ConvosInvitesTests/JoinRequestProcessingTests.swift
@@ -328,7 +328,13 @@ struct JoinRequestProcessingTests {
         )
         let alreadyMember = JoinRequestDMOutcome.alreadyMember(
             dmConversationId: "dm-123",
-            joinerInboxId: "joiner-123"
+            joinerInboxId: "joiner-123",
+            conversationId: "group-123"
+        )
+        let alreadyMemberLedger = JoinRequestDMOutcome.alreadyMember(
+            dmConversationId: "dm-123",
+            joinerInboxId: "joiner-123",
+            conversationId: nil
         )
 
         #expect(accepted.shouldKeepDMSubscribed)
@@ -341,6 +347,20 @@ struct JoinRequestProcessingTests {
         #expect(alreadyMember.dmConversationId == "dm-123")
         #expect(alreadyMember.joinResult == nil)
         #expect(!alreadyMember.isMalicious)
+
+        // A verified already-member result carries the conversation so the
+        // caller can re-publish a complete snapshot; the ledger pre-check does
+        // not resolve a conversation.
+        guard case .alreadyMember(_, _, let verifiedConversationId) = alreadyMember else {
+            Issue.record("expected alreadyMember case")
+            return
+        }
+        #expect(verifiedConversationId == "group-123")
+        guard case .alreadyMember(_, _, let ledgerConversationId) = alreadyMemberLedger else {
+            Issue.record("expected alreadyMember case")
+            return
+        }
+        #expect(ledgerConversationId == nil)
     }
 
     // MARK: - InviteJoinError Feedback


### PR DESCRIPTION
## Problem

A late joiner to a group sees an agent member rendered as a raw "Somebody" (no name/avatar) until some participant later fires a `profile_update`.

Root cause: the post-join `profile_snapshot` is built by scanning only the last 500 group messages. If a member's `ProfileUpdate` (e.g. an agent's) isn't in that window when the inviter builds the snapshot, that member's entry ships with `name: null`. XMTP does not deliver pre-join history to new members, so this one join-time snapshot is the joiner's only source for that member -- incomplete once means stuck on "Somebody" until a brand-new post-join `profile_update`. iOS members are masked by the appData fallback; agents (which never write their profile into the group appData) have no fallback, so they are the visibly broken case.

There is also a second path: the `.alreadyMember` join outcome sent no snapshot at all.

## Fix (iOS, ConvosCore + ConvosInvites)

- `ProfileSnapshotBuilder.buildSnapshot` now sources the roster from the sender's authoritative `DBMemberProfile` rows unioned with the existing recent-message scan (recent message wins per non-empty field, DB fills the gaps), filtered to the current group members. This includes appData-only / agent members and members whose update was evicted from the 500-message window. The encrypted-image-only constraint is respected (plain avatar URL keeps the name, omits the image) and the 50 KB guard / genuine-empty no-send behavior are preserved.
- An empty or blank incoming name no longer clobbers a known DB name; the same empty-clobber guard is applied to the encrypted image ref (a malformed incoming ref cannot wipe a valid DB image).
- The `.alreadyMember` join path now re-publishes the (now complete) snapshot too; `JoinRequestDMOutcome.alreadyMember` carries the `conversationId` on the verified-member branches.

## Tests

- Unit: builder union (agent-only and window-evicted members), `DBMemberProfile` snapshot projection, empty/blank-name guard, `.alreadyMember` decision helper.
- Live-XMTP integration: an inviter holding an agent-only DB row -> the late joiner receives that member by name (`.agent` kind). This exercises the full wiring `sendSnapshot(databaseReader:)` -> GRDB fetch -> projection -> `buildSnapshot` -> XMTP send -> joiner receive.
- All changed-code suites pass (250+ tests across ConvosCore + ConvosInvites); SwiftLint `--strict` clean.

## Scope and backend follow-up

This is the iOS-as-inviter fix. The convos CLI and the Hermes agent backend carry their own TypeScript copy of this same message-only snapshot logic (`resolveProfilesFromMessages` / join-request processing) with the same defect, and agents still never write their profile into the group appData path. Both live in `convos-assistants` and are a backend follow-up for full coverage (non-iOS inviters, and fresh devices syncing beyond the 500-message window).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix late group-joiners seeing agent profiles as "Somebody" by merging DB profiles into snapshots
> - `ProfileSnapshotBuilder.sendSnapshot` now accepts a `databaseReader` and internally merges `DBMemberProfile` rows with recent message-derived profiles, so members who have no recent profile message are still included in snapshots.
> - `DBMemberProfile` gains a `snapshotMemberProfile` projection that maps database rows to `MemberProfile`, omitting plain (unencrypted) avatars and returning nil for invalid inbox IDs.
> - `InviteCoordinator` extends `.alreadyMember` outcomes to carry a verified context (conversationId + joiner profile), enabling snapshot re-publish and profile persistence in that path.
> - `InviteJoinRequestsManager` now sends a profile snapshot on verified already-member outcomes and skips persisting joiner profiles when only empty metadata is provided, preventing blank overwrites.
> - Behavioral Change: all snapshot send sites (post-pair, post-join, initial sync) now derive the member list internally from the group rather than accepting a pre-fetched array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33ac82c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->