### PR TITLE
fix: prevent image cache from clobbering imageUrl for a given identifier

### DIFF
--- a/Convos/Contacts/Profile+ContactOverlay.swift
+++ b/Convos/Contacts/Profile+ContactOverlay.swift
@@ -1,6 +1,78 @@
 import ConvosCore
 import Foundation
 
+extension Contact {
+    /// Builds a contact-shaped override that takes only the live per-conversation
+    /// member profile's current avatar image, passing every other field through
+    /// from the stored contact unchanged. System-message and read-receipt rows
+    /// resolve avatars through the contact override, but the stored contacts table
+    /// lags a live avatar change (it is mirrored from member profiles
+    /// asynchronously). Preferring the member profile's avatar - the same source
+    /// the message bubble renders - keeps those rows in sync with the bubble after
+    /// a participant changes their photo.
+    ///
+    /// The avatar image (url + its crypto) is taken wholesale from the member
+    /// profile - never field-by-field merged with the stored contact - so a
+    /// change-photo shows the new image, and a partial/malformed member avatar
+    /// renders the same monogram as the bubble (copying the fields verbatim keeps
+    /// `Profile.isEncryptedImage`'s all-or-nothing crypto check identical).
+    ///
+    /// The display name is deliberately left as the stored contact's, so
+    /// contact-authoritative name resolution (and any future local nickname) is
+    /// unaffected - only the avatar is freshened.
+    ///
+    /// Known limitation (deferred): this does not handle a member who *clears*
+    /// their avatar (nil url) or switches to emoji-only. The caller renders via
+    /// `Profile.overlaying(contact:)`, which falls back to the frozen per-message
+    /// snapshot's avatar/metadata when the override carries no avatar url, so the
+    /// row would resurface the stale snapshot photo/emoji rather than the member's
+    /// cleared state. There is no UI to clear an avatar today, so this is
+    /// unreachable in practice; it is fully resolved by member-authoritative
+    /// rendering (`displayAvatar(for:)`) in the ProfilesRepository refactor, when
+    /// this whole stopgap is removed.
+    ///
+    /// Interim stopgap: remove once identity resolves from ProfilesRepository
+    /// (see docs/plans/2026-06-29-profile-table-implementation.md, section 10.1).
+    static func liveOverride(member: Profile, stored: Contact?) -> Contact {
+        Contact(
+            inboxId: member.inboxId,
+            displayName: stored?.displayName,
+            avatarURL: member.avatar,
+            avatarSalt: member.avatarSalt,
+            avatarNonce: member.avatarNonce,
+            avatarKey: member.avatarKey,
+            addedAt: stored?.addedAt ?? Date(),
+            addedViaConversationId: stored?.addedViaConversationId,
+            isBlocked: stored?.isBlocked ?? false,
+            agentVerification: stored?.agentVerification,
+            agentTemplateId: stored?.agentTemplateId,
+            agentTemplatePublishedURL: stored?.agentTemplatePublishedURL,
+            profileEmoji: member.profileEmoji
+        )
+    }
+
+    /// Builds a member-aware contact resolver: freshens the current conversation
+    /// member's avatar image (the source the message bubble uses) over the lagging
+    /// stored contact, falling back to the stored contact for non-members. Name
+    /// and other identity fields are left as the stored contact's. See
+    /// `liveOverride`. Interim stopgap; see
+    /// docs/plans/2026-06-29-profile-table-implementation.md, section 10.1.
+    static func memberAwareResolver(
+        members: [ConversationMember],
+        contactLookup: @escaping @Sendable (String) -> Contact?
+    ) -> @Sendable (String) -> Contact? {
+        let memberProfiles: [String: Profile] = Dictionary(
+            members.map { ($0.profile.inboxId, $0.profile) },
+            uniquingKeysWith: { current, _ in current }
+        )
+        return { inboxId in
+            let stored = contactLookup(inboxId)
+            guard let member = memberProfiles[inboxId] else { return stored }
+            return Contact.liveOverride(member: member, stored: stored)
+        }
+    }
+}
+
 extension Profile {
     /// Returns a new `Profile` with `name` and `avatar*` substituted
     /// from the supplied contact when - and only when - the contact

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -192,7 +192,12 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// profile. Built once per `ConversationView` lifetime; reads
     /// through the messaging service's contacts repository.
     private var contactOverride: @Sendable (String) -> Contact? {
-        viewModel.messagingService.contactsRepository().contact(for:)
+        // Prefer current member profiles over the lagging contacts table so
+        // system-message and receipt rows stay in sync with the message bubble.
+        Contact.memberAwareResolver(
+            members: viewModel.conversation.members,
+            contactLookup: viewModel.messagingService.contactsRepository().contact(for:)
+        )
     }
 
     private var messagesView: some View {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -9,6 +9,15 @@ import SwiftUI
 import UIKit
 import UserNotifications
 
+/// Moves a staged invite image into the URL-keyed byte cache under the finalized
+/// invite's real image URL, so the invite card renders it without dropping to a
+/// placeholder or re-downloading. No-op when the text has no parseable image URL.
+private func cacheFinalizedInviteImage(_ image: UIImage, inviteText: String) {
+    guard let invite = MessageInvite.from(text: inviteText),
+          let imageURLString = invite.imageURL?.absoluteString else { return }
+    ImageCache.shared.cacheAfterUpload(image, for: invite, url: imageURLString)
+}
+
 struct PendingInvite {
     let code: String
     var fullURL: String
@@ -1630,7 +1639,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 guard let self, !self.isConversationImageDirty else { return }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    self.conversationImage = await ImageCache.shared.loadImage(for: self.conversation)
+                    self.conversationImage = await ImageCache.shared.loadImageOrContinuity(for: self.conversation)
                     self.isConversationImageDirty = false
                 }
             }
@@ -1737,7 +1746,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         loadConversationImageTask?.cancel()
         loadConversationImageTask = Task { [weak self] in
             guard let self else { return }
-            let image = await ImageCache.shared.loadImage(for: conversation)
+            let image = await ImageCache.shared.loadImageOrContinuity(for: conversation)
             guard !Task.isCancelled, !self.isConversationImageDirty else { return }
             self.conversationImage = image
             self.isConversationImageDirty = false
@@ -3235,7 +3244,13 @@ extension ConversationViewModel {
         }
 
         if let invite = MessageInvite.from(text: inviteURL) {
-            ImageCache.shared.cacheAfterUpload(image, for: invite, url: invite.imageURL?.absoluteString ?? invite.inviteSlug)
+            if let imageURLString = invite.imageURL?.absoluteString {
+                ImageCache.shared.cacheAfterUpload(image, for: invite, url: imageURLString)
+            } else {
+                // No upload URL yet: stage the selected image under the invite's
+                // identity so image(for:) shows it until the real URL arrives.
+                _ = ImageCache.shared.prepareForUpload(image, for: invite)
+            }
         }
         pendingMessageId = try? await messageWriter.insertPendingInvite(text: inviteURL)
 
@@ -3252,6 +3267,7 @@ extension ConversationViewModel {
                 if let updatedInvite = try await metadataWriter.refreshInvite(for: linkedId),
                    let pendingMessageId {
                     try await messageWriter.finalizeInvite(clientMessageId: pendingMessageId, finalText: updatedInvite.inviteURLString)
+                    cacheFinalizedInviteImage(image, inviteText: updatedInvite.inviteURLString)
                 }
             }
         } catch {

--- a/ConvosCore/Sources/ConvosCore/Crypto/EncryptedImagePrefetcher.swift
+++ b/ConvosCore/Sources/ConvosCore/Crypto/EncryptedImagePrefetcher.swift
@@ -71,10 +71,10 @@ actor EncryptedImagePrefetcher: EncryptedImagePrefetcherProtocol {
             }
             seen.insert(identifier)
 
+            // URL-keyed byte cache: a different avatar URL is just a cache miss,
+            // so "is the current URL cached?" subsumes the old hasURLChanged check.
             let notCached = await ImageCacheContainer.shared.imageAsync(for: hydratedProfile) == nil
-            let urlChanged = await ImageCacheContainer.shared.hasURLChanged(profile.avatar, for: identifier)
-
-            if notCached || urlChanged {
+            if notCached {
                 uncached.append(profile)
             }
         }

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -35,15 +35,20 @@ public enum ImageStorageTier: Sendable {
 // MARK: - ImageCacheable Protocol
 
 /// Protocol for objects that can have their images cached.
+///
+/// An object carries two keys: `imageCacheURL` (the authoritative content key -
+/// the byte cache stores `url -> bytes`) and `imageCacheIdentifier` (the stable
+/// identity key - used only for the read-only continuity hint). Callers pass the
+/// object; the cache resolves truth by URL and continuity by identity.
 public protocol ImageCacheable: Sendable {
-    /// Unique identifier used for caching the image
+    /// Stable identity key, used only for the continuity hint (last-shown image).
     var imageCacheIdentifier: String { get }
 
-    /// The current image URL for this object (nil if no image or not URL-based)
+    /// The current image URL for this object (nil if no image or not URL-based).
+    /// This is the authoritative byte-cache key.
     var imageCacheURL: URL? { get }
 
     /// Whether the image at the URL is encrypted and requires decryption
-    /// For encrypted images, loadImage() returns cached image and lets the prefetcher handle fetching
     var isEncryptedImage: Bool { get }
 
     /// The encryption key for decrypting the image (32-byte AES-256 key)
@@ -77,15 +82,6 @@ public enum ImageCacheContainer {
     }()
 }
 
-// MARK: - URL Change Event
-
-/// Event emitted when an image URL changes for a cached identifier
-public struct ImageURLChange: Sendable {
-    public let identifier: String
-    public let oldURL: URL?
-    public let newURL: URL?
-}
-
 #if canImport(UIKit)
 import SwiftUI
 
@@ -103,141 +99,33 @@ private struct CacheConfiguration {
     static let memoryCacheTotalCostLimit: Int = 300 * 1024 * 1024
 }
 
-// MARK: - URL Tracker
-
-/// Thread-safe tracker for identifier → URL mapping.
-///
-/// State is durable across launches via per-entry sidecar files
-/// (`<sha256(identifier)>.url`) co-located with the disk-cached image.
-/// In-memory `trackedURLs` is a hot-path cache populated lazily on first
-/// access for an identifier — peek/track/url consult disk only when the
-/// in-memory map misses, so steady-state operations stay pure-memory.
-///
-/// The previous in-memory-only implementation treated a missing entry as
-/// `(changed: true)` on cold launch and forced a network round trip even
-/// when the disk cache had a perfectly valid image — that's the source
-/// of the "avatars missing for a second on launch" regression. With
-/// sidecars restored on demand, cold launch knows what URL each cached
-/// image came from and can answer truthfully.
-private actor URLTracker {
-    private var trackedURLs: [String: URL] = [:]
-    private let sidecarDirectory: URL?
-    private let fileManager: FileManager
-
-    init(sidecarDirectory: URL?, fileManager: FileManager = .default) {
-        self.sidecarDirectory = sidecarDirectory
-        self.fileManager = fileManager
-    }
-
-    /// Track a URL for an identifier, returning whether it changed.
-    func track(_ url: URL?, for identifier: String) -> (changed: Bool, oldURL: URL?) {
-        let oldURL = loadIntoMemoryIfNeeded(for: identifier)
-        guard url != oldURL else {
-            return (changed: false, oldURL: oldURL)
-        }
-        if let url {
-            trackedURLs[identifier] = url
-            writeSidecar(url: url, for: identifier)
-        } else {
-            trackedURLs.removeValue(forKey: identifier)
-            deleteSidecar(for: identifier)
-        }
-        return (changed: true, oldURL: oldURL)
-    }
-
-    /// Get the currently tracked URL for an identifier.
-    func url(for identifier: String) -> URL? {
-        loadIntoMemoryIfNeeded(for: identifier)
-    }
-
-    /// Check whether a URL would be considered changed without committing
-    /// the new URL to the tracker.
-    ///
-    /// Returns `(changed: false, oldURL: nil)` when both the requested url
-    /// and the tracked oldURL are nil — same nil-equals-nil semantic as
-    /// `track`'s `guard url != oldURL` short-circuit. With sidecars, cold
-    /// launches for previously-cached entries hit `(changed: false, oldURL: <url>)`
-    /// and callers can serve the disk image without a network round trip.
-    /// Genuinely-unknown identifiers asked about a non-nil url return
-    /// `(changed: true, oldURL: nil)` — caller should fetch.
-    func peek(_ url: URL?, for identifier: String) -> (changed: Bool, oldURL: URL?) {
-        let oldURL = loadIntoMemoryIfNeeded(for: identifier)
-        return (changed: url != oldURL, oldURL: oldURL)
-    }
-
-    /// Remove tracking for an identifier (in-memory and on-disk sidecar).
-    func remove(for identifier: String) {
-        trackedURLs.removeValue(forKey: identifier)
-        deleteSidecar(for: identifier)
-    }
-
-    // MARK: - Sidecar Persistence
-
-    /// Returns the in-memory URL for `identifier`, restoring it from the
-    /// on-disk sidecar lazily if necessary. Returns `nil` only when
-    /// neither memory nor disk knows the URL.
-    private func loadIntoMemoryIfNeeded(for identifier: String) -> URL? {
-        if let cached = trackedURLs[identifier] {
-            return cached
-        }
-        guard let restored = readSidecar(for: identifier) else {
-            return nil
-        }
-        trackedURLs[identifier] = restored
-        return restored
-    }
-
-    private func sidecarFileURL(for identifier: String) -> URL? {
-        guard let sidecarDirectory else { return nil }
-        let data = Data(identifier.utf8)
-        let hashData = data.sha256Hash()
-        let hashString = hashData.map { String(format: "%02x", $0) }.joined()
-        return sidecarDirectory.appendingPathComponent(hashString + ".url")
-    }
-
-    private func readSidecar(for identifier: String) -> URL? {
-        guard let sidecarURL = sidecarFileURL(for: identifier),
-              let data = try? Data(contentsOf: sidecarURL),
-              let urlString = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
-
-    private func writeSidecar(url: URL, for identifier: String) {
-        guard let sidecarURL = sidecarFileURL(for: identifier) else { return }
-        try? url.absoluteString.write(to: sidecarURL, atomically: true, encoding: .utf8)
-    }
-
-    private func deleteSidecar(for identifier: String) {
-        guard let sidecarURL = sidecarFileURL(for: identifier) else { return }
-        try? fileManager.removeItem(at: sidecarURL)
-    }
-}
-
 // MARK: - Generic Image Cache
 
-/// Smart reactive image cache that stores images for any ImageCacheable object with instant updates.
-/// Supports three-tier caching: memory → disk → network
-/// When a new image is uploaded for an object, all views showing that object update instantly.
+/// Reactive image cache split into two responsibilities:
 ///
-/// @unchecked Sendable: Thread safety is ensured through:
-/// - NSCache: Internally thread-safe for all operations
-/// - diskCacheQueue: Serial DispatchQueue serializing all disk I/O
-/// - cleanupLock: OSAllocatedUnfairLock coordinating cleanup task scheduling
-/// - urlTracker: Actor isolation for URL tracking
-/// - loadingTasksLock: OSAllocatedUnfairLock for network request deduplication
-/// - cacheUpdateSubject/urlChangeSubject: Combine subjects are thread-safe for send/subscribe
-/// All properties are immutable after init except for cleanup task coordination.
+/// 1. **Authoritative byte cache** - keyed by image URL, immutable. `url -> bytes`
+///    is a pure function (a URL pairs with one encryption key and decrypts to the
+///    same bytes), so two URLs are two independent entries and there is no shared
+///    identity slot for callers to clobber.
+/// 2. **Read-only continuity hint** - `identity -> last-shown image`, disk-backed.
+///    Consulted only as the placeholder while the current URL is being fetched.
+///    Written when an image successfully displays/resolves for an identity. It
+///    never triggers a fetch and never decides the canonical URL.
+///
+/// @unchecked Sendable: thread safety via NSCache (internally thread-safe), the
+/// serial `diskCacheQueue`, `OSAllocatedUnfairLock`s for cleanup coordination,
+/// network dedup, and the in-memory continuity hint, and the thread-safe Combine
+/// subject. All other properties are immutable after init.
 @Observable
 public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     public static var shared: any ImageCacheProtocol { ImageCacheContainer.shared }
 
     private let cache: NSCache<NSString, UIImage>
 
-    // Disk cache properties
+    // Disk cache directories
     private let diskCacheURL: URL
     private let persistentCacheURL: URL
+    private let lastShownCacheURL: URL
     private let diskCacheQueue: DispatchQueue
     private let fileManager: FileManager
     private let maxDiskCacheSize: Int = CacheConfiguration.maxDiskCacheSize
@@ -245,45 +133,40 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     // Cleanup coordination
     private let cleanupLock: OSAllocatedUnfairLock<Task<Void, Never>?> = OSAllocatedUnfairLock(initialState: nil)
 
-    // URL tracking for detecting URL changes. Sidecar directory is wired
-    // in init() once diskCacheURL has been computed.
-    private let urlTracker: URLTracker
-
     // Network request deduplication: tracks in-flight loading tasks by URL
     private let loadingTasksLock: OSAllocatedUnfairLock<[URL: Task<UIImage?, Never>]> = OSAllocatedUnfairLock(initialState: [:])
 
-    /// Publisher for specific cache updates by identifier (kept for backward compatibility)
+    // Read-only continuity hint: identity -> last-shown image (in-memory).
+    // `uncheckedState` because UIImage is not Sendable; access is serialized by
+    // the lock and the surrounding @unchecked Sendable contract.
+    private let lastShownLock: OSAllocatedUnfairLock<[String: UIImage]> = OSAllocatedUnfairLock(uncheckedState: [:])
+
+    // Pending pre-upload images: identity -> staged image, for objects whose
+    // imageCacheURL is still nil (e.g. an invite or avatar mid-upload). Kept
+    // separate from the continuity hint so a nil URL only ever shows an
+    // explicitly staged image, never a stale leftover (a cleared avatar must
+    // show the placeholder, not its old picture).
+    private let stagedLock: OSAllocatedUnfairLock<[String: UIImage]> = OSAllocatedUnfairLock(uncheckedState: [:])
+
+    /// Publisher that emits a cache key when new bytes are ready for it. The key
+    /// is either an image URL (byte-cache write) or an identity (continuity-hint
+    /// write, e.g. pre-upload staging). Views filter on both their URL and their
+    /// identity.
     private let cacheUpdateSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
 
-    /// Publisher for URL change events
-    private let urlChangeSubject: PassthroughSubject<ImageURLChange, Never> = PassthroughSubject<ImageURLChange, Never>()
-
-    /// Publisher that emits when a specific cached image is updated (backward compatibility)
     public var cacheUpdates: AnyPublisher<String, Never> {
         cacheUpdateSubject.receive(on: DispatchQueue.main).eraseToAnyPublisher()
     }
 
-    /// Publisher that emits when an image URL changes for an identifier.
-    ///
-    /// - Important: **For testing only.** Do not use this for UI observation.
-    ///   Use `cacheUpdates` instead, which emits when an image is cached and ready to display.
-    ///   `urlChanges` only indicates the URL tracker was updated, not that the new image is available.
-    internal var urlChanges: AnyPublisher<ImageURLChange, Never> {
-        urlChangeSubject.receive(on: DispatchQueue.main).eraseToAnyPublisher()
-    }
-
-    /// Check if the URL might have changed for an identifier (without updating tracker)
-    /// Used by prefetcher to detect if it needs to re-fetch encrypted images
-    /// Returns true if:
-    /// - The URL differs from the tracked URL (actual change)
-    /// - OR no URL is tracked for this identifier (cold start - need to verify)
-    public func hasURLChanged(_ url: String?, for identifier: String) async -> Bool {
-        guard let urlString = url, let parsedURL = URL(string: urlString) else {
-            // URL is nil, changed if we had a previous URL
-            return await urlTracker.url(for: identifier) != nil
+    /// Publish a byte-cache update under both keys so listeners that filter on
+    /// the URL (the `.cachedImage` modifier) and those that filter on the object
+    /// identity (e.g. `ConversationViewModel` filtering by `imageCacheIdentifier`)
+    /// both fire.
+    private func publishCacheUpdate(urlKey: String, identifier: String) {
+        cacheUpdateSubject.send(urlKey)
+        if identifier != urlKey {
+            cacheUpdateSubject.send(identifier)
         }
-        let peek = await urlTracker.peek(parsedURL, for: identifier)
-        return peek.changed  // Now includes cold start case since peek() returns changed:true when no entry exists
     }
 
     init() {
@@ -291,19 +174,22 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         cache.countLimit = CacheConfiguration.memoryCacheCountLimit
         cache.totalCostLimit = CacheConfiguration.memoryCacheTotalCostLimit
 
-        // Setup disk cache
         fileManager = FileManager.default
         diskCacheQueue = DispatchQueue(label: "com.convos.imagecache.disk", qos: .utility)
 
-        // Create evictable disk cache directory (Caches/ - iOS may purge under storage pressure)
+        // Evictable byte cache (Caches/ - iOS may purge under storage pressure)
         let cacheDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
         diskCacheURL = cacheDir.appendingPathComponent("ImageCache", isDirectory: true)
 
-        // Create persistent photo store (Application Support/ - not purged by iOS)
+        // Continuity hints (small thumbnails, identity-keyed). Kept in a separate
+        // directory so the byte-cache LRU never evicts them.
+        lastShownCacheURL = cacheDir.appendingPathComponent("ImageCacheLastShown", isDirectory: true)
+
+        // Persistent photo store (Application Support/ - not purged by iOS)
         let appSupportDir = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         persistentCacheURL = appSupportDir.appendingPathComponent("PhotoStore", isDirectory: true)
 
-        for dir in [diskCacheURL, persistentCacheURL] {
+        for dir in [diskCacheURL, persistentCacheURL, lastShownCacheURL] {
             do {
                 try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
             } catch {
@@ -311,301 +197,247 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             }
         }
 
-        // Co-locate URL sidecars in the same directory as the cached images
-        // so eviction and removal stay in lockstep.
-        urlTracker = URLTracker(sidecarDirectory: diskCacheURL, fileManager: fileManager)
-
-        // Clean up disk cache on init if needed
         scheduleCleanupIfNeeded()
     }
 
-    // MARK: - Primary API: Load with URL Tracking
+    // MARK: - Primary API (object-based, URL-keyed)
 
-    /// Load image for an ImageCacheable object, using its URL for fetching
-    /// This is the primary API - handles memory → disk → network with URL tracking
-    /// - Parameter object: The ImageCacheable object to load an image for
-    /// - Returns: The loaded image, or nil if no URL or loading failed
+    /// Synchronous best-available image: the byte cache for the object's URL if
+    /// present, otherwise the in-memory continuity hint for the object's identity.
+    /// Used for instant display; the hint may be a slightly stale bridge.
+    public func image(for object: any ImageCacheable) -> UIImage? {
+        // A nil URL means "no image yet": show an explicitly staged pre-upload
+        // image if one exists, but never a stale continuity hint (so a cleared
+        // or never-set avatar shows the placeholder).
+        guard let url = object.imageCacheURL else {
+            return stagedInMemory(for: object.imageCacheIdentifier)
+        }
+        if let memoryImage = cache.object(forKey: url.absoluteString as NSString) {
+            rememberLastShown(memoryImage, for: object.imageCacheIdentifier, persist: false)
+            return memoryImage
+        }
+        // Non-nil URL not cached yet: bridge with the continuity hint.
+        return lastShownInMemory(for: object.imageCacheIdentifier)
+    }
+
+    /// Continuity placeholder for an identity (memory hint, then disk hint).
+    /// Never fetches the network. Used by the view modifier to bridge a fresh
+    /// render while the authoritative URL is being resolved.
+    public func continuityImage(for object: any ImageCacheable) async -> UIImage? {
+        // A nil URL: show only an explicitly staged pre-upload image, never the
+        // continuity hint (so a cleared avatar shows the placeholder).
+        guard object.imageCacheURL != nil else {
+            return stagedInMemory(for: object.imageCacheIdentifier)
+        }
+        if let memory = lastShownInMemory(for: object.imageCacheIdentifier) {
+            return memory
+        }
+        return await loadLastShownFromDisk(for: object.imageCacheIdentifier)
+    }
+
+    /// Authoritative resolve: URL-keyed memory -> disk -> network/decrypt.
     public func loadImage(for object: any ImageCacheable) async -> UIImage? {
+        // A nil URL: only an explicitly staged pre-upload image, nothing else.
+        guard let url = object.imageCacheURL else {
+            return stagedInMemory(for: object.imageCacheIdentifier)
+        }
+        let urlKey = url.absoluteString
         let identifier = object.imageCacheIdentifier
 
-        guard let url = object.imageCacheURL else {
-            // URL is nil - return cached image if available, don't clear
-            // (Image might be locally staged for upload, or caller should use removeImage() explicitly)
-            return await loadImageFromCache(identifier: identifier, source: "loadImage (nil URL)")
-        }
-
-        // Cache-first for both encrypted and unencrypted: serve any cached
-        // image immediately and refresh in the background only when the URL
-        // has drifted. The only path that blocks on the network is a true
-        // cold cache (no memory, no disk). With sidecar-backed URL tracking
-        // (see URLTracker), cold launches on previously-cached identifiers
-        // report `changed: false` and don't schedule any refresh at all.
-        let peek = await urlTracker.peek(url, for: identifier)
-
-        if let memoryImage = cache.object(forKey: identifier as NSString) {
-            if peek.changed {
-                scheduleBackgroundRefresh(for: object, url: url, identifier: identifier)
-            }
+        if let memoryImage = cache.object(forKey: urlKey as NSString) {
+            rememberLastShown(memoryImage, for: identifier, persist: false)
             return memoryImage
         }
-        if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: .jpg) {
-            cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "loadImage (from disk)")
-            if peek.changed {
-                scheduleBackgroundRefresh(for: object, url: url, identifier: identifier)
-            }
+        if let diskImage = await loadImageFromDisk(key: urlKey, imageFormat: .jpg) {
+            cacheImageInMemory(diskImage, key: urlKey, cache: cache, logContext: "loadImage (from disk)")
+            rememberLastShown(diskImage, for: identifier, persist: false)
             return diskImage
         }
 
-        // Cold path: nothing in memory or on disk. Block on the network so
-        // the caller gets the image rather than a placeholder. Interactive
-        // priority: the UI is waiting on this fetch, so it must not queue
-        // behind background sync's prefetch burst.
+        // Cold path: nothing in memory or on disk. Block on the network so the
+        // caller gets the image rather than a placeholder.
         if object.isEncryptedImage {
-            return await fetchEncryptedImageInline(for: object, url: url, identifier: identifier, priority: .interactive)
+            return await fetchEncryptedImageInline(for: object, url: url, urlKey: urlKey, identifier: identifier, priority: .interactive)
         }
-        if let networkImage = await fetchImageFromNetwork(url: url, identifier: identifier) {
-            _ = await urlTracker.track(url, for: identifier)
-            return networkImage
-        }
-        return nil
+        return await fetchImageFromNetwork(url: url, urlKey: urlKey, identifier: identifier)
     }
 
-    /// Fire-and-forget refresh used when a cache hit was served but the URL
-    /// has drifted. Inline fetch helpers handle their own deduplication
-    /// (loadingTasksLock for network, EncryptedImageLoader internally) and
-    /// commit the new URL on success, so the new bytes propagate via
-    /// `cacheUpdates`/`urlChanges` once the fetch completes — no UI delay.
-    private func scheduleBackgroundRefresh(for object: any ImageCacheable, url: URL, identifier: String) {
-        Task.detached(priority: .background) {
-            if object.isEncryptedImage {
-                _ = await self.fetchEncryptedImageInline(for: object, url: url, identifier: identifier, priority: .background)
-                return
-            }
-            if await self.fetchImageFromNetwork(url: url, identifier: identifier) != nil {
-                _ = await self.urlTracker.track(url, for: identifier)
-            }
+    /// Authoritative resolve with a placeholder bridge: the real image if it can
+    /// be fetched, otherwise the continuity hint so a failed fetch keeps showing
+    /// the last image instead of blanking. Use when `loadImage` is the sole image
+    /// source (no `.cachedImage` modifier layering the bridge). A removed avatar
+    /// (nil URL) still resolves to nil, since `continuityImage` returns only the
+    /// staged image for a nil URL, not the hint.
+    public func loadImageOrContinuity(for object: any ImageCacheable) async -> UIImage? {
+        if let resolved = await loadImage(for: object) {
+            return resolved
         }
+        return await continuityImage(for: object)
     }
 
-    private func loadImageFromCache(identifier: String, source: String) async -> UIImage? {
-        if let memoryImage = cache.object(forKey: identifier as NSString) {
+    /// Get cached image for an object (async, checks memory -> disk). Unlike
+    /// `image(for:)` this does NOT fall back to the continuity hint - it answers
+    /// "are the real bytes cached?" (used by the prefetcher).
+    public func imageAsync(for object: any ImageCacheable) async -> UIImage? {
+        guard let url = object.imageCacheURL else { return nil }
+        let urlKey = url.absoluteString
+        if let memoryImage = cache.object(forKey: urlKey as NSString) {
             return memoryImage
         }
-        if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: .jpg) {
-            cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: source)
+        if let diskImage = await loadImageFromDisk(key: urlKey, imageFormat: .jpg) {
+            cacheImageInMemory(diskImage, key: urlKey, cache: cache, logContext: "Object cache (from disk)")
             return diskImage
         }
         return nil
     }
 
-    // MARK: - Upload Support Methods
+    /// Probe the URL-keyed byte cache directly (memory -> disk) when you have the
+    /// image URL but no `ImageCacheable` object. Matches the key `cacheAfterUpload`
+    /// writes under, so a background prefetch can dedup before re-fetching. Does
+    /// not fall back to the continuity hint and never touches the network.
+    public func imageAsync(forURL url: String) async -> UIImage? {
+        if let memoryImage = cache.object(forKey: url as NSString) {
+            return memoryImage
+        }
+        if let diskImage = await loadImageFromDisk(key: url, imageFormat: .jpg) {
+            cacheImageInMemory(diskImage, key: url, cache: cache, logContext: "URL cache (from disk)")
+            return diskImage
+        }
+        return nil
+    }
 
-    /// Prepare an image for upload by resizing/compressing and caching it
-    /// Call this before uploading to get the data, then call `cacheAfterUpload` when you know the final URL
-    /// - Parameters:
-    ///   - image: The original UIImage to prepare
-    ///   - object: The ImageCacheable object this image is for
-    /// - Returns: JPEG data ready for upload, or nil if compression fails
+    /// Remove the byte-cache entry for the object's URL, and clear its continuity
+    /// hint (explicit removal should not keep bridging to the old image).
+    public func removeImage(for object: any ImageCacheable) {
+        let identifier = object.imageCacheIdentifier
+        if let url = object.imageCacheURL {
+            let urlKey = url.absoluteString
+            cache.removeObject(forKey: urlKey as NSString)
+            Task { await removeImageFromDisk(key: urlKey) }
+            cacheUpdateSubject.send(urlKey)
+        }
+        clearStaged(for: identifier)
+        clearLastShown(for: identifier)
+        cacheUpdateSubject.send(identifier)
+    }
+
+    // MARK: - Upload Support
+
+    /// Prepare an image for upload by resizing/compressing. There is no URL yet,
+    /// so the picked image is staged into the continuity hint for the identity so
+    /// the owner sees it immediately; the byte-cache entry is created later by
+    /// `cacheAfterUpload` once the URL is known.
     public func prepareForUpload(_ image: UIImage, for object: any ImageCacheable) -> Data? {
         prepareForUpload(image, forIdentifier: object.imageCacheIdentifier)
     }
 
-    /// Identifier-based variant of `prepareForUpload(_:for:)`. Conversation
-    /// image uploads must pass the conversation's stable id directly:
-    /// `Conversation.imageCacheIdentifier` resolves to the other member's
-    /// inbox id while `imageURL` is nil, which would cache the conversation
-    /// image as that member's profile avatar.
+    /// Identifier-based variant of `prepareForUpload(_:for:)`.
     public func prepareForUpload(_ image: UIImage, forIdentifier identifier: String) -> Data? {
-        // Immediately set the cache so there is no delay showing in the UI
-        cache.setObject(image, forKey: identifier as NSString, cost: memoryCost(for: image))
-
-        // Resize and compress to JPEG
         guard let jpegData = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8) else {
             Log.error("Failed to prepare image for upload: \(identifier)")
-            cache.removeObject(forKey: identifier as NSString)
             return nil
         }
-
-        // Cache the resized image immediately (before upload completes)
-        Task {
-            guard let resizedImage = UIImage(data: jpegData) else {
-                Log.error("Failed to create UIImage from compressed data: \(identifier)")
-                return
-            }
-
-            let cost = memoryCost(for: resizedImage)
-            cache.setObject(resizedImage, forKey: identifier as NSString, cost: cost)
-            Log.debug("Cached image before upload: \(identifier)")
-
-            // Save to disk
-            await saveDataToDisk(jpegData, identifier: identifier, imageFormat: .jpg)
-
-            // Notify
-            cacheUpdateSubject.send(identifier)
-        }
-
+        let stagedImage = UIImage(data: jpegData) ?? image
+        rememberStaged(stagedImage, for: identifier)
+        cacheUpdateSubject.send(identifier)
         return jpegData
     }
 
-    /// Cache an image after upload completes, updating URL tracking
-    /// Call this after upload succeeds with the final URL from the server
-    ///
-    /// - Note: This method does NOT save to disk because `prepareForUpload` already saved
-    ///   the correctly compressed data. Re-compressing here would cause quality loss.
-    ///
-    /// - Parameters:
-    ///   - image: The uploaded image (should already be cached from prepareForUpload)
-    ///   - object: The ImageCacheable object this image is for
-    ///   - url: The final URL where the image was uploaded
+    /// Cache an image after upload completes, keyed by its final URL. `url` must
+    /// be a real URL: the byte cache is content-addressed by it. Callers that have
+    /// no URL yet (a pre-upload preview) should use `prepareForUpload` to stage by
+    /// identity instead - a non-URL string here is dropped, since nothing reads it.
     public func cacheAfterUpload(_ image: UIImage, for object: any ImageCacheable, url: String) {
-        let identifier = object.imageCacheIdentifier
-
-        // Update URL tracking with the new URL
-        Task {
-            // Track URL (but don't fail if invalid - still cache the image)
-            if let newURL = URL(string: url) {
-                let tracking = await urlTracker.track(newURL, for: identifier)
-                if tracking.changed {
-                    urlChangeSubject.send(ImageURLChange(identifier: identifier, oldURL: tracking.oldURL, newURL: newURL))
-                }
-            } else {
-                Log.error("Invalid URL for cacheAfterUpload: \(url), caching without URL tracking")
-            }
-
-            // Always cache and notify (even if URL was invalid)
-            let cost = memoryCost(for: image)
-            cache.setObject(image, forKey: identifier as NSString, cost: cost)
-
-            cacheUpdateSubject.send(identifier)
-            Log.debug("Updated URL tracking after upload: \(identifier) -> \(url)")
-        }
+        cacheAfterUpload(image, for: object.imageCacheIdentifier, url: url)
     }
 
-    /// Cache an image after fetching/decrypting, updating URL tracking
-    /// Used by prefetchers that fetch encrypted images and need to emit urlChanges
-    /// - Parameters:
-    ///   - image: The decrypted image to cache
-    ///   - identifier: The stable identifier for this image (e.g., conversationId, inboxId)
-    ///   - url: The URL the image was fetched from (used for URL tracking)
+    /// Cache an image (recompressing to JPEG) under its URL key, updating the
+    /// continuity hint for the identity.
     public func cacheAfterUpload(_ image: UIImage, for identifier: String, url: String) {
-        // Update URL tracking with the new URL
+        guard let parsedURL = URL(string: url) else {
+            Log.error("Invalid URL for cacheAfterUpload: \(url)")
+            return
+        }
+        let urlKey = parsedURL.absoluteString
         Task {
-            // Track URL (but don't fail if invalid - still cache the image)
-            if let newURL = URL(string: url) {
-                let tracking = await urlTracker.track(newURL, for: identifier)
-                if tracking.changed {
-                    urlChangeSubject.send(ImageURLChange(identifier: identifier, oldURL: tracking.oldURL, newURL: newURL))
-                    Log.debug("URL changed for \(identifier): \(tracking.oldURL?.absoluteString ?? "nil") -> \(url)")
-                }
-            } else {
-                Log.error("Invalid URL for cacheAfterUpload: \(url), caching without URL tracking")
-            }
-
-            // Cache in memory
             let cost = memoryCost(for: image)
-            cache.setObject(image, forKey: identifier as NSString, cost: cost)
+            cache.setObject(image, forKey: urlKey as NSString, cost: cost)
+            rememberLastShown(image, for: identifier, persist: true)
+            // The real upload supersedes the pre-upload staged image; clear it so
+            // a later nil URL falls through to the placeholder, not the stale stage.
+            clearStaged(for: identifier)
 
-            // Save to disk (force overwrite since we have a new image for this identifier)
             guard let jpegData = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8) else {
-                Log.error("Failed to convert image to JPEG for disk cache: \(identifier)")
-                cacheUpdateSubject.send(identifier)
+                Log.error("Failed to convert image to JPEG for disk cache: \(urlKey)")
+                publishCacheUpdate(urlKey: urlKey, identifier: identifier)
                 return
             }
-            await saveDataToDisk(jpegData, identifier: identifier, imageFormat: .jpg, forceOverwrite: true)
-
-            cacheUpdateSubject.send(identifier)
-            Log.debug("Cached image after fetch: \(identifier) -> \(url)")
+            await saveDataToDisk(jpegData, key: urlKey, imageFormat: .jpg, forceOverwrite: true)
+            publishCacheUpdate(urlKey: urlKey, identifier: identifier)
         }
     }
 
-    /// Cache pre-compressed image data after fetching/decrypting
-    /// Use this when you already have JPEG data to avoid re-compression quality loss
-    /// - Parameters:
-    ///   - imageData: Pre-compressed JPEG data
-    ///   - identifier: The stable identifier for this image
-    ///   - url: The URL the image was fetched from (used for URL tracking)
+    /// Cache pre-compressed image data (no re-compression) under its URL key.
     public func cacheAfterUpload(_ imageData: Data, for identifier: String, url: String) {
+        guard let parsedURL = URL(string: url) else {
+            Log.error("Invalid URL for cacheAfterUpload: \(url)")
+            return
+        }
+        let urlKey = parsedURL.absoluteString
         Task {
-            // Track URL (but don't fail if invalid - still cache the image)
-            if let newURL = URL(string: url) {
-                let tracking = await urlTracker.track(newURL, for: identifier)
-                if tracking.changed {
-                    urlChangeSubject.send(ImageURLChange(identifier: identifier, oldURL: tracking.oldURL, newURL: newURL))
-                }
-            } else {
-                Log.error("Invalid URL for cacheAfterUpload: \(url), caching without URL tracking")
-            }
-
-            // Create image from data for memory cache (bounded decode:
-            // the data came off the network and is sender-controlled)
             guard let image = BoundedImageDecode.image(from: imageData) else {
-                Log.error("Failed to create UIImage from data: \(identifier)")
+                Log.error("Failed to create UIImage from data: \(urlKey)")
                 return
             }
-
             let cost = memoryCost(for: image)
-            cache.setObject(image, forKey: identifier as NSString, cost: cost)
-
-            // Save data directly to disk (no re-compression)
-            await saveDataToDisk(imageData, identifier: identifier, imageFormat: .jpg, forceOverwrite: true)
-
-            cacheUpdateSubject.send(identifier)
-            Log.debug("Cached image data after fetch: \(identifier) -> \(url)")
+            cache.setObject(image, forKey: urlKey as NSString, cost: cost)
+            rememberLastShown(image, for: identifier, persist: true)
+            // The real upload supersedes the pre-upload staged image; clear it so
+            // a later nil URL falls through to the placeholder, not the stale stage.
+            clearStaged(for: identifier)
+            await saveDataToDisk(imageData, key: urlKey, imageFormat: .jpg, forceOverwrite: true)
+            publishCacheUpdate(urlKey: urlKey, identifier: identifier)
         }
     }
 
-    /// Fetch image from network with request deduplication
-    /// Multiple calls for the same URL will share a single network request
-    private func fetchImageFromNetwork(url: URL, identifier: String) async -> UIImage? {
-        // Check if there's already an in-flight request for this URL
-        let existingTask = loadingTasksLock.withLock { tasks in
-            tasks[url]
-        }
+    // MARK: - Network / decrypt fetch (URL-keyed)
 
+    private func fetchImageFromNetwork(url: URL, urlKey: String, identifier: String) async -> UIImage? {
+        let existingTask = loadingTasksLock.withLock { tasks in tasks[url] }
         if let existingTask {
-            // Wait for existing request to complete
-            return await existingTask.value
+            let image = await existingTask.value
+            if let image {
+                // The shared task only recorded the continuity hint for the first
+                // caller's identity; record it for this caller too so its own
+                // placeholder bridge survives the next render/relaunch.
+                rememberLastShown(image, for: identifier, persist: true)
+                cacheUpdateSubject.send(identifier)
+            }
+            return image
         }
 
-        // Create new loading task
         let loadingTask = Task<UIImage?, Never> {
             defer {
-                // Remove task when done
-                _ = loadingTasksLock.withLock { tasks in
-                    tasks.removeValue(forKey: url)
-                }
+                _ = loadingTasksLock.withLock { tasks in tasks.removeValue(forKey: url) }
             }
-
             do {
-                // Stream to a temporary file so the encoded payload is never
-                // fully buffered in memory, then decode with a bounded size.
                 let (tempFileURL, response) = try await URLSession.shared.download(from: url)
                 defer { try? FileManager.default.removeItem(at: tempFileURL) }
 
-                // Validate response
                 guard let httpResponse = response as? HTTPURLResponse,
                       (200...299).contains(httpResponse.statusCode) else {
                     Log.error("Failed to load image from URL: \(url) - invalid response")
                     return nil
                 }
-
                 guard let image = BoundedImageDecode.image(contentsOf: tempFileURL) else {
                     Log.error("Failed to decode image from URL: \(url)")
                     return nil
                 }
 
-                // Cache by identifier (not URL) - single entry per object
-                cacheImage(image, key: identifier, cache: cache, logContext: "loadImage (from network)", imageFormat: .jpg)
-
-                // Save to disk asynchronously
-                Task {
-                    await saveImageToDisk(image, identifier: identifier, imageFormat: .jpg)
-                }
-
-                // Emit cache update for backward compatibility
-                cacheUpdateSubject.send(identifier)
-
-                Log.debug("Successfully loaded image from network: \(identifier)")
+                cacheImage(image, key: urlKey, cache: cache, logContext: "loadImage (from network)", imageFormat: .jpg)
+                rememberLastShown(image, for: identifier, persist: true)
+                Task { await saveImageToDisk(image, key: urlKey, imageFormat: .jpg) }
+                publishCacheUpdate(urlKey: urlKey, identifier: identifier)
                 return image
             } catch {
                 Log.error("Failed to load image from URL: \(url) - \(error)")
@@ -613,31 +445,24 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             }
         }
 
-        // Store task for deduplication
-        loadingTasksLock.withLock { tasks in
-            tasks[url] = loadingTask
-        }
-
+        loadingTasksLock.withLock { tasks in tasks[url] = loadingTask }
         return await loadingTask.value
     }
 
-    /// Fetch and decrypt an encrypted image inline if all encryption parameters are available
-    /// This is used for cold start scenarios where the prefetcher hasn't run yet
     private func fetchEncryptedImageInline(
         for object: any ImageCacheable,
         url: URL,
+        urlKey: String,
         identifier: String,
         priority: EncryptedImageFetchPriority
     ) async -> UIImage? {
         guard let key = object.encryptionKey,
               let salt = object.encryptionSalt,
               let nonce = object.encryptionNonce else {
-            Log.debug("Cannot inline decrypt - missing encryption params for: \(identifier)")
+            Log.debug("Cannot inline decrypt - missing encryption params for: \(urlKey)")
             return nil
         }
-
         do {
-            Log.debug("Attempting inline encrypted fetch for: \(identifier)")
             let decryptedData = try await EncryptedImageLoader.loadAndDecrypt(
                 url: url,
                 salt: salt,
@@ -645,119 +470,115 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 groupKey: key,
                 priority: priority
             )
-
             guard let image = BoundedImageDecode.image(from: decryptedData) else {
-                Log.error("Failed to create UIImage from decrypted data: \(identifier)")
+                Log.error("Failed to create UIImage from decrypted data: \(urlKey)")
                 return nil
             }
-
-            // Cache in memory
-            cacheImage(image, key: identifier, cache: cache, logContext: "inline encrypted fetch", imageFormat: .jpg)
-
-            // Update URL tracking since we successfully fetched
-            let tracking = await urlTracker.track(url, for: identifier)
-            if tracking.changed {
-                urlChangeSubject.send(ImageURLChange(identifier: identifier, oldURL: tracking.oldURL, newURL: url))
-            }
-
-            // Save to disk asynchronously - use decryptedData directly to avoid double compression
-            Task {
-                await saveDataToDisk(decryptedData, identifier: identifier, imageFormat: .jpg, forceOverwrite: true)
-            }
-
-            cacheUpdateSubject.send(identifier)
-            Log.debug("Successfully loaded encrypted image inline: \(identifier)")
+            cacheImage(image, key: urlKey, cache: cache, logContext: "inline encrypted fetch", imageFormat: .jpg)
+            rememberLastShown(image, for: identifier, persist: true)
+            Task { await saveDataToDisk(decryptedData, key: urlKey, imageFormat: .jpg, forceOverwrite: true) }
+            publishCacheUpdate(urlKey: urlKey, identifier: identifier)
             return image
         } catch {
-            Log.error("Failed to inline decrypt image for \(identifier): \(error)")
+            Log.error("Failed to inline decrypt image for \(urlKey): \(error)")
             return nil
         }
     }
 
-    // MARK: - Generic Cache Methods
+    // MARK: - Continuity hint (identity-keyed, read-only display fallback)
 
-    /// Get cached image for any ImageCacheable object (synchronous, memory only)
-    public func image(for object: any ImageCacheable) -> UIImage? {
-        return cache.object(forKey: object.imageCacheIdentifier as NSString)
+    private func lastShownInMemory(for identifier: String) -> UIImage? {
+        lastShownLock.withLock { $0[identifier] }
     }
 
-    /// Get cached image for any ImageCacheable object (async, checks memory → disk)
-    public func imageAsync(for object: any ImageCacheable) async -> UIImage? {
-        let identifier = object.imageCacheIdentifier
-
-        // Check memory first
-        if let memoryImage = cache.object(forKey: identifier as NSString) {
-            return memoryImage
-        }
-
-        // Check disk (default to JPEG for object-based cache)
-        if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: .jpg) {
-            // Populate memory cache (image is already compressed/resized from disk)
-            cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "Object cache (from disk)")
-            return diskImage
-        }
-
-        return nil
+    private func stagedInMemory(for identifier: String) -> UIImage? {
+        stagedLock.withLock { $0[identifier] }
     }
 
-    /// Remove cached image for any ImageCacheable object (removes from both memory and disk)
-    public func removeImage(for object: any ImageCacheable) {
-        let identifier = object.imageCacheIdentifier
-        cache.removeObject(forKey: identifier as NSString)
+    private func rememberStaged(_ image: UIImage, for identifier: String) {
+        stagedLock.withLock { $0[identifier] = image }
+    }
 
-        // Remove from disk asynchronously
+    private func clearStaged(for identifier: String) {
+        stagedLock.withLock { $0.removeValue(forKey: identifier) }
+    }
+
+    /// Records the last-shown image for an identity. Memory always; disk only on
+    /// `persist` (a genuinely new image arriving), to avoid disk churn on every
+    /// render. Never fetches and never affects byte-cache truth.
+    private func rememberLastShown(_ image: UIImage, for identifier: String, persist: Bool) {
+        lastShownLock.withLock { $0[identifier] = image }
+        guard persist else { return }
+        Task { await saveLastShownToDisk(image, for: identifier) }
+    }
+
+    private func clearLastShown(for identifier: String) {
+        lastShownLock.withLock { $0.removeValue(forKey: identifier) }
         Task {
-            await removeImageFromDisk(identifier: identifier)
+            await performDiskOperation { cache in
+                let fileURL = cache.lastShownCacheURL.appendingPathComponent(
+                    cache.sanitizedFilename(for: identifier, fileExtension: ".jpg")
+                )
+                guard cache.fileManager.fileExists(atPath: fileURL.path) else { return }
+                try? cache.fileManager.removeItem(at: fileURL)
+            }
         }
-
-        cacheUpdateSubject.send(identifier)
     }
 
-    // MARK: - Identifier-based Methods
+    private func saveLastShownToDisk(_ image: UIImage, for identifier: String) async {
+        guard let data = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.7) else { return }
+        await performDiskOperation { cache in
+            let fileURL = cache.lastShownCacheURL.appendingPathComponent(
+                cache.sanitizedFilename(for: identifier, fileExtension: ".jpg")
+            )
+            do {
+                try data.write(to: fileURL, options: .atomic)
+            } catch {
+                Log.error("Failed to save continuity hint: \(identifier) - \(error)")
+            }
+        }
+    }
 
-    /// Get cached image by identifier (synchronous, memory only)
+    private func loadLastShownFromDisk(for identifier: String) async -> UIImage? {
+        let fileURL = lastShownCacheURL.appendingPathComponent(
+            sanitizedFilename(for: identifier, fileExtension: ".jpg")
+        )
+        let exists: Bool = await performDiskOperation(default: false) { cache in
+            cache.fileManager.fileExists(atPath: fileURL.path)
+        }
+        guard exists, let image = BoundedImageDecode.image(contentsOf: fileURL) else { return nil }
+        lastShownLock.withLock { storage in
+            if storage[identifier] == nil { storage[identifier] = image }
+        }
+        return image
+    }
+
+    // MARK: - Identifier-based Methods (QR codes, generated images)
+
     public func image(for identifier: String, imageFormat: ImageFormat = .jpg) -> UIImage? {
         return cache.object(forKey: identifier as NSString)
     }
 
-    /// Get cached image by identifier (async, checks memory → disk)
     public func imageAsync(for identifier: String, imageFormat: ImageFormat = .jpg) async -> UIImage? {
-        // Check memory first
         if let memoryImage = cache.object(forKey: identifier as NSString) {
             return memoryImage
         }
-
-        // Check disk
-        if let diskImage = await loadImageFromDisk(identifier: identifier, imageFormat: imageFormat) {
-            // Populate memory cache (image is already compressed/resized from disk)
+        if let diskImage = await loadImageFromDisk(key: identifier, imageFormat: imageFormat) {
             cacheImageInMemory(diskImage, key: identifier, cache: cache, logContext: "Identifier cache (from disk)")
             return diskImage
         }
-
         return nil
     }
 
-    /// Cache image by identifier (saves to both memory and disk)
     public func cacheImage(_ image: UIImage, for identifier: String, imageFormat: ImageFormat = .jpg) {
         cacheImage(image, key: identifier, cache: cache, logContext: "Identifier cache", imageFormat: imageFormat)
-
-        // Save to disk asynchronously
-        Task {
-            await saveImageToDisk(image, identifier: identifier, imageFormat: imageFormat)
-        }
-
+        Task { await saveImageToDisk(image, key: identifier, imageFormat: imageFormat) }
         cacheUpdateSubject.send(identifier)
     }
 
-    /// Remove cached image by identifier (removes from both memory and disk)
     public func removeImage(for identifier: String) {
         cache.removeObject(forKey: identifier as NSString)
-
-        // Remove from disk asynchronously
-        Task {
-            await removeImageFromDisk(identifier: identifier)
-        }
-
+        Task { await removeImageFromDisk(key: identifier) }
         cacheUpdateSubject.send(identifier)
     }
 
@@ -770,22 +591,14 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         }
         let cost = memoryCost(for: image)
         cache.setObject(image, forKey: identifier as NSString, cost: cost)
-
-        Task {
-            await saveDataToDisk(data, identifier: identifier, storageTier: storageTier)
-        }
-
+        Task { await saveDataToDisk(data, key: identifier, storageTier: storageTier) }
         cacheUpdateSubject.send(identifier)
     }
 
     public func cacheImage(_ image: UIImage, for identifier: String, storageTier: ImageStorageTier) {
         let cost = memoryCost(for: image)
         cache.setObject(image, forKey: identifier as NSString, cost: cost)
-
-        Task {
-            await saveImageToDisk(image, identifier: identifier, storageTier: storageTier)
-        }
-
+        Task { await saveImageToDisk(image, key: identifier, storageTier: storageTier) }
         cacheUpdateSubject.send(identifier)
     }
 
@@ -815,24 +628,29 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     public func removeAllPersistentImages() {
         cache.removeAllObjects()
+        // Clear the in-memory continuity hint and staged pre-upload maps too, so a
+        // delete-all reset cannot bridge to a previously shown avatar/group image.
+        lastShownLock.withLock { $0.removeAll() }
+        stagedLock.withLock { $0.removeAll() }
         Task {
             await performDiskOperation { cache in
-                guard let contents = try? cache.fileManager.contentsOfDirectory(
-                    at: cache.persistentCacheURL, includingPropertiesForKeys: nil
-                ) else { return }
-                for fileURL in contents {
-                    do { try cache.fileManager.removeItem(at: fileURL) } catch {
-                        Log.error("Failed to remove persistent image: \(fileURL.lastPathComponent) - \(error)")
+                for dir in [cache.persistentCacheURL, cache.lastShownCacheURL, cache.diskCacheURL] {
+                    guard let contents = try? cache.fileManager.contentsOfDirectory(
+                        at: dir, includingPropertiesForKeys: nil
+                    ) else { continue }
+                    for fileURL in contents {
+                        do { try cache.fileManager.removeItem(at: fileURL) } catch {
+                            Log.error("Failed to remove image: \(fileURL.lastPathComponent) - \(error)")
+                        }
                     }
+                    Log.info("Removed all images in \(dir.lastPathComponent) (\(contents.count) files)")
                 }
-                Log.info("Removed all persistent images (\(contents.count) files)")
             }
         }
     }
 
     // MARK: - Disk Cache Helpers
 
-    /// Perform an operation on the disk cache queue with proper weak self handling
     private func performDiskOperation<T: Sendable>(
         default defaultValue: T,
         _ operation: @Sendable @escaping (ImageCache) -> T
@@ -848,7 +666,6 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         }
     }
 
-    /// Perform a void operation on the disk cache queue with proper weak self handling
     private func performDiskOperation(
         _ operation: @Sendable @escaping (ImageCache) -> Void
     ) async {
@@ -866,16 +683,14 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     // MARK: - Disk Cache Methods
 
-    /// Load image from disk cache
-    private func loadImageFromDisk(identifier: String, imageFormat: ImageFormat) async -> UIImage? {
-        let filename = sanitizedFilename(for: identifier, fileExtension: imageFormat.fileExtension)
+    /// Load an image from disk by cache key (URL string for the byte cache, or an
+    /// identifier for the QR/persistent path). Checks the persistent store and the
+    /// evictable cache.
+    private func loadImageFromDisk(key: String, imageFormat: ImageFormat) async -> UIImage? {
+        let filename = sanitizedFilename(for: key, fileExtension: imageFormat.fileExtension)
         let persistentURL = persistentCacheURL.appendingPathComponent(filename)
         let cacheURL = diskCacheURL.appendingPathComponent(filename)
 
-        // Only the existence checks and access-date touches run on the serial
-        // disk queue; decodes run on the caller's task so concurrent loads
-        // (e.g. a screenful of avatars) don't serialize their decodes behind
-        // one another.
         let existingFileURLs: [URL] = await performDiskOperation(default: []) { cache in
             var existing: [URL] = []
             for fileURL in [persistentURL, cacheURL] {
@@ -889,12 +704,9 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             return existing
         }
 
-        // Decode straight from the file (bounded) instead of reading the
-        // encoded bytes into memory first. The bound matters here too:
-        // persistent-tier files store the original sender-controlled payload.
         for fileURL in existingFileURLs {
             guard let image = BoundedImageDecode.image(contentsOf: fileURL) else {
-                Log.error("Failed to decode image from disk: \(identifier)")
+                Log.error("Failed to decode image from disk: \(key)")
                 continue
             }
             return image
@@ -909,82 +721,69 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         }
     }
 
-    /// Save pre-compressed data directly to disk (avoids double compression)
     private func saveDataToDisk(
         _ data: Data,
-        identifier: String,
+        key: String,
         imageFormat: ImageFormat = .jpg,
         forceOverwrite: Bool = false,
         storageTier: ImageStorageTier = .cache
     ) async {
         let dir = directoryURL(for: storageTier)
-        let fileURL = dir.appendingPathComponent(sanitizedFilename(for: identifier, fileExtension: imageFormat.fileExtension))
-
+        let fileURL = dir.appendingPathComponent(sanitizedFilename(for: key, fileExtension: imageFormat.fileExtension))
         await performDiskOperation { cache in
             if !forceOverwrite && cache.fileManager.fileExists(atPath: fileURL.path) {
                 return
             }
-
             do {
                 try data.write(to: fileURL, options: .atomic)
                 if storageTier == .cache {
                     cache.scheduleCleanupIfNeeded()
                 }
             } catch {
-                Log.error("Failed to save image data to disk: \(identifier) - \(error)")
+                Log.error("Failed to save image data to disk: \(key) - \(error)")
             }
         }
     }
 
-    /// Save image to disk
     private func saveImageToDisk(
         _ image: UIImage,
-        identifier: String,
+        key: String,
         imageFormat: ImageFormat = .jpg,
         forceOverwrite: Bool = false,
         storageTier: ImageStorageTier = .cache
     ) async {
         await performDiskOperation { cache in
             let dir = cache.directoryURL(for: storageTier)
-            let fileURL = dir.appendingPathComponent(cache.sanitizedFilename(for: identifier, fileExtension: imageFormat.fileExtension))
-
+            let fileURL = dir.appendingPathComponent(cache.sanitizedFilename(for: key, fileExtension: imageFormat.fileExtension))
             if !forceOverwrite && cache.fileManager.fileExists(atPath: fileURL.path) {
                 return
             }
-
             let data: Data? = switch imageFormat {
             case .png: ImageCompression.resizeAndCompressToPNG(image)
             case .jpg: ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8)
             }
-
             guard let imageData = data else {
-                Log.error("Failed to resize and compress image for disk: \(identifier)")
+                Log.error("Failed to resize and compress image for disk: \(key)")
                 return
             }
-
             do {
                 try imageData.write(to: fileURL, options: .atomic)
                 if storageTier == .cache {
                     cache.scheduleCleanupIfNeeded()
                 }
             } catch {
-                Log.error("Failed to save image to disk: \(identifier) - \(error)")
+                Log.error("Failed to save image to disk: \(key) - \(error)")
             }
         }
     }
 
-    /// Remove image from both disk cache and persistent store, plus the
-    /// `.url` sidecar that the URL tracker writes alongside cached images.
-    private func removeImageFromDisk(identifier: String) async {
-        let filename = sanitizedFilename(for: identifier, fileExtension: ".jpg")
-        let pngFilename = sanitizedFilename(for: identifier, fileExtension: ".png")
-        let sidecarFilename = sanitizedFilename(for: identifier, fileExtension: ".url")
-
+    private func removeImageFromDisk(key: String) async {
+        let filename = sanitizedFilename(for: key, fileExtension: ".jpg")
+        let pngFilename = sanitizedFilename(for: key, fileExtension: ".png")
         await performDiskOperation { cache in
             let urls = [
                 cache.diskCacheURL.appendingPathComponent(filename),
                 cache.diskCacheURL.appendingPathComponent(pngFilename),
-                cache.diskCacheURL.appendingPathComponent(sidecarFilename),
                 cache.persistentCacheURL.appendingPathComponent(filename),
                 cache.persistentCacheURL.appendingPathComponent(pngFilename),
             ]
@@ -1000,26 +799,23 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         }
     }
 
-    /// Schedule cleanup if not already scheduled (coalesces multiple concurrent requests)
+    // MARK: - Cleanup
+
     private func scheduleCleanupIfNeeded() {
         _ = cleanupLock.withLock { (task: inout Task<Void, Never>?) -> Task<Void, Never>? in
             guard task == nil else { return task }
-
             task = Task {
                 await cleanupDiskCacheIfNeeded()
-                // Clear the task when done
                 _ = cleanupLock.withLock { (t: inout Task<Void, Never>?) -> Task<Void, Never>? in
                     t = nil
                     return nil
                 }
             }
-
             return task
         }
     }
 
-    /// Clean up disk cache if it exceeds size limit (LRU - removes oldest accessed files)
-    /// Processes files in batches to avoid memory pressure with large caches
+    /// LRU cleanup of the evictable byte cache when it exceeds the size limit.
     private func cleanupDiskCacheIfNeeded() async {
         struct CachedFileInfo {
             let url: URL
@@ -1029,131 +825,86 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
 
         await performDiskOperation { cache in
             do {
-                let resourceKeys: [URLResourceKey] = [.fileSizeKey, .contentAccessDateKey]
+                let resourceKeys: [URLResourceKey] = [.fileSizeKey, .contentAccessDateKey, .isRegularFileKey]
                 let fileURLs = try cache.fileManager.contentsOfDirectory(
                     at: cache.diskCacheURL,
                     includingPropertiesForKeys: resourceKeys,
                     options: .skipsHiddenFiles
                 )
-
-                // Skip .url sidecars (URLTracker metadata) from the LRU
-                // accounting and eviction list. They share their hash
-                // basename with an image file; pairing is enforced below by
-                // co-deleting the matching .url when we evict an image, so
-                // image and sidecar lifetimes stay in lockstep. Sidecars
-                // are ~50 bytes and accessed less frequently than their
-                // image, so including them in the LRU sort would falsely
-                // mark them as oldest and split pairs.
-                let evictableURLs = fileURLs.filter { $0.pathExtension != "url" }
+                let evictableURLs = fileURLs.filter { ($0.pathExtension == "jpg" || $0.pathExtension == "png") }
 
                 let batchSize = 100
                 var totalSize = 0
-                var batch: [CachedFileInfo] = []
-                batch.reserveCapacity(batchSize)
 
                 for i in stride(from: 0, to: evictableURLs.count, by: batchSize) {
                     let endIndex = min(i + batchSize, evictableURLs.count)
-                    batch.removeAll(keepingCapacity: true)
-
                     for j in i..<endIndex {
-                        let fileURL = evictableURLs[j]
-                        let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
+                        let resourceValues = try evictableURLs[j].resourceValues(forKeys: Set(resourceKeys))
                         totalSize += resourceValues.fileSize ?? 0
                     }
                 }
 
-                if totalSize > cache.maxDiskCacheSize {
-                    var oldestFiles: [CachedFileInfo] = []
+                guard totalSize > cache.maxDiskCacheSize else { return }
 
-                    for i in stride(from: 0, to: evictableURLs.count, by: batchSize) {
-                        let endIndex = min(i + batchSize, evictableURLs.count)
-                        batch.removeAll(keepingCapacity: true)
-
-                        for j in i..<endIndex {
-                            let fileURL = evictableURLs[j]
-                            let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
-                            batch.append(CachedFileInfo(
-                                url: fileURL,
-                                size: resourceValues.fileSize ?? 0,
-                                date: resourceValues.contentAccessDate ?? Date.distantPast
-                            ))
-                        }
-                        oldestFiles.append(contentsOf: batch)
+                var oldestFiles: [CachedFileInfo] = []
+                for i in stride(from: 0, to: evictableURLs.count, by: batchSize) {
+                    let endIndex = min(i + batchSize, evictableURLs.count)
+                    for j in i..<endIndex {
+                        let fileURL = evictableURLs[j]
+                        let resourceValues = try fileURL.resourceValues(forKeys: Set(resourceKeys))
+                        oldestFiles.append(CachedFileInfo(
+                            url: fileURL,
+                            size: resourceValues.fileSize ?? 0,
+                            date: resourceValues.contentAccessDate ?? Date.distantPast
+                        ))
                     }
-
-                    oldestFiles.sort { $0.date < $1.date }
-
-                    var removedSize = 0
-                    for file in oldestFiles {
-                        guard totalSize - removedSize > cache.maxDiskCacheSize else { break }
-
-                        do {
-                            try cache.fileManager.removeItem(at: file.url)
-                            // Pair: also remove the .url sidecar with the
-                            // same hash basename so URLTracker doesn't
-                            // hold stale URL state for an evicted image.
-                            let sidecarURL = file.url
-                                .deletingPathExtension()
-                                .appendingPathExtension("url")
-                            try? cache.fileManager.removeItem(at: sidecarURL)
-                            removedSize += file.size
-                            Log.debug("Removed old cached image from disk: \(file.url.lastPathComponent)")
-                        } catch {
-                            Log.error("Failed to remove cached image: \(file.url.lastPathComponent) - \(error)")
-                        }
-                    }
-
-                    Log.debug("Disk cache cleanup: removed \(removedSize) bytes")
                 }
+
+                oldestFiles.sort { $0.date < $1.date }
+
+                var removedSize = 0
+                for file in oldestFiles {
+                    guard totalSize - removedSize > cache.maxDiskCacheSize else { break }
+                    do {
+                        try cache.fileManager.removeItem(at: file.url)
+                        removedSize += file.size
+                    } catch {
+                        Log.error("Failed to remove cached image: \(file.url.lastPathComponent) - \(error)")
+                    }
+                }
+                Log.debug("Disk cache cleanup: removed \(removedSize) bytes")
             } catch {
                 Log.error("Failed to cleanup disk cache: \(error)")
             }
         }
     }
 
-    /// Sanitize identifier to create a valid filename
-    /// - Parameters:
-    ///   - identifier: The cache identifier
-    ///   - extension: File extension (default: ".jpg")
-    /// - Returns: Sanitized filename with extension
-    private func sanitizedFilename(for identifier: String, fileExtension: String = ".jpg") -> String {
-        // Use SHA256 hash for consistent, filesystem-safe filenames
-        let data = Data(identifier.utf8)
+    /// SHA256-hashed, filesystem-safe filename for a cache key.
+    private func sanitizedFilename(for key: String, fileExtension: String = ".jpg") -> String {
+        let data = Data(key.utf8)
         let hashData = data.sha256Hash()
         let hashString = hashData.map { String(format: "%02x", $0) }.joined()
         return hashString + fileExtension
     }
 
-    // MARK: - Private Methods
+    // MARK: - Memory helpers
 
-    /// Calculates memory cost in bytes for an image based on pixel dimensions
-    /// Uses CGImage pixel dimensions (not UIImage point dimensions) to account for scale factor
-    /// - Parameter image: The UIImage to calculate cost for
-    /// - Returns: Memory cost in bytes (width * height * 4 bytes per pixel for RGBA)
     private func memoryCost(for image: UIImage) -> Int {
         guard let cgImage = image.cgImage else {
-            // Fallback to point-based calculation if CGImage is unavailable
-            // Account for scale factor to get pixel dimensions (scale^2 for area)
             let scale = image.scale > 0 ? image.scale : 1.0
             return Int(image.size.width * image.size.height * scale * scale * 4)
         }
-        // Use pixel dimensions (accounts for scale factor: 1x, 2x, 3x)
         return cgImage.width * cgImage.height * 4
     }
 
-    /// Cache image in memory without compression (for images already processed, e.g., loaded from disk)
     private func cacheImageInMemory(_ image: UIImage, key: String, cache: NSCache<NSString, UIImage>, logContext: String) {
         guard image.size.width > 0 && image.size.height > 0 else {
             Log.error("Invalid image dimensions for \(logContext): \(key)")
             return
         }
-
-        let cost = memoryCost(for: image)
-        cache.setObject(image, forKey: key as NSString, cost: cost)
-        Log.debug("Successfully cached image for \(logContext): \(key)")
+        cache.setObject(image, forKey: key as NSString, cost: memoryCost(for: image))
     }
 
-    /// Resize, compress, and cache image in memory (for new/original images)
     private func cacheImage(_ image: UIImage, key: String, cache: NSCache<NSString, UIImage>, logContext: String, imageFormat: ImageFormat = .jpg) {
         let compressedData: Data?
         switch imageFormat {
@@ -1162,41 +913,19 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         case .jpg:
             compressedData = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.8)
         }
-
-        guard let imageData = compressedData else {
+        guard let imageData = compressedData, let resizedImage = UIImage(data: imageData) else {
             Log.error("Failed to resize and compress image for \(logContext): \(key)")
             return
         }
-
-        guard let resizedImage = UIImage(data: imageData) else {
-            Log.error("Failed to create UIImage from compressed data for \(logContext): \(key)")
-            return
-        }
-
         guard resizedImage.size.width > 0 && resizedImage.size.height > 0 else {
             Log.error("Failed to resize image for \(logContext): \(key) - invalid dimensions")
             return
         }
-
-        let cost = memoryCost(for: resizedImage)
-        cache.setObject(resizedImage, forKey: key as NSString, cost: cost)
-        let formatName = imageFormat == .png ? "PNG" : "JPEG"
-        Log.debug("Successfully cached resized image for \(logContext): \(key) (format: \(formatName))")
-    }
-
-    // MARK: - Testing Support
-
-    /// Track a URL for an identifier without requiring an image.
-    /// This is used by platform-independent tests to set up URL tracking state.
-    /// - Parameters:
-    ///   - url: The URL to track
-    ///   - identifier: The identifier to associate with the URL
-    internal func trackURLForTesting(_ url: URL, for identifier: String) async {
-        _ = await urlTracker.track(url, for: identifier)
+        cache.setObject(resizedImage, forKey: key as NSString, cost: memoryCost(for: resizedImage))
     }
 }
 
-// MARK: - SwiftUI View Extension for Easy Image Cache Integration
+// MARK: - SwiftUI View Extension
 
 private struct ImageCacheTaskID: Hashable {
     let identifier: String
@@ -1204,63 +933,55 @@ private struct ImageCacheTaskID: Hashable {
 }
 
 public extension View {
-    /// Complete image caching solution: loads image and observes URL changes
-    /// Handles memory → disk → network loading with automatic URL change detection
-    ///
-    /// Usage:
-    /// ```swift
-    /// @State private var cachedImage: UIImage?
-    ///
-    /// Image(uiImage: cachedImage ?? placeholder)
-    ///     .cachedImage(for: profile, into: $cachedImage)
-    /// ```
-    ///
-    /// - Parameters:
-    ///   - object: The ImageCacheable object to load an image for
-    ///   - binding: Binding to store the loaded image
-    /// - Returns: A view with image loading and observation attached
+    /// Loads an image for an `ImageCacheable` into a binding, bridging with the
+    /// continuity hint so a fresh render never blinks to a placeholder while the
+    /// authoritative URL is resolved. Reloads when the object's URL changes or
+    /// when new bytes are published for its URL or identity.
     func cachedImage(
         for object: any ImageCacheable,
         into binding: Binding<UIImage?>
     ) -> some View {
         self
             .onAppear {
-                // Check memory cache synchronously for instant display (no flicker)
                 binding.wrappedValue = ImageCache.shared.image(for: object)
             }
             .task(id: ImageCacheTaskID(identifier: object.imageCacheIdentifier, url: object.imageCacheURL)) {
-                // Then load from disk/network if needed
-                binding.wrappedValue = await ImageCache.shared.loadImage(for: object)
+                // Re-seed for the current object so a reused view that swapped to
+                // a different identity drops the previous object's image instead
+                // of briefly showing the wrong avatar. For a same-identity URL
+                // change this returns the continuity hint (the person's last
+                // image), so there is no placeholder blink. Then resolve the URL.
+                binding.wrappedValue = ImageCache.shared.image(for: object)
+                if binding.wrappedValue == nil {
+                    binding.wrappedValue = await ImageCache.shared.continuityImage(for: object)
+                }
+                if let resolved = await ImageCache.shared.loadImage(for: object) {
+                    binding.wrappedValue = resolved
+                }
             }
             .onReceive(
                 ImageCache.shared.cacheUpdates
-                    .filter { $0 == object.imageCacheIdentifier }
+                    .filter { $0 == object.imageCacheURL?.absoluteString || $0 == object.imageCacheIdentifier }
             ) { _ in
-                Task {
-                    binding.wrappedValue = await ImageCache.shared.loadImage(for: object)
-                }
+                binding.wrappedValue = ImageCache.shared.image(for: object)
             }
     }
 
-    /// Modifier that subscribes to image cache updates for a specific ImageCacheable object
-    /// (Backward compatibility - prefer `cachedImage(for:into:)` for new code)
+    /// Backward-compatibility variant that reports the current best-available
+    /// image via a closure.
     func cachedImage(
         for object: any ImageCacheable,
         onChange: @escaping (UIImage?) -> Void
     ) -> some View {
         self
             .onAppear {
-                // Load initial cached image
-                let image = ImageCache.shared.image(for: object)
-                onChange(image)
+                onChange(ImageCache.shared.image(for: object))
             }
             .onReceive(
                 ImageCache.shared.cacheUpdates
-                    .filter { $0 == object.imageCacheIdentifier }
+                    .filter { $0 == object.imageCacheURL?.absoluteString || $0 == object.imageCacheIdentifier }
             ) { _ in
-                // Update when this specific object's image changes
-                let image = ImageCache.shared.image(for: object)
-                onChange(image)
+                onChange(ImageCache.shared.image(for: object))
             }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCacheProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCacheProtocol.swift
@@ -14,8 +14,23 @@ public protocol ImageCacheProtocol: AnyObject, Sendable {
     /// Get cached image for any ImageCacheable object (synchronous, memory only)
     func image(for object: any ImageCacheable) -> ImageType?
 
-    /// Get cached image for any ImageCacheable object (async, checks memory → disk)
+    /// Get cached image for any ImageCacheable object (async, checks memory → disk).
+    /// Does NOT fall back to the continuity hint - answers "are the real bytes cached?"
     func imageAsync(for object: any ImageCacheable) async -> ImageType?
+
+    /// Probe the URL-keyed byte cache directly (memory → disk) when you have the
+    /// image URL but no object. Matches the key cacheAfterUpload writes under.
+    func imageAsync(forURL url: String) async -> ImageType?
+
+    /// Read-only continuity placeholder for the object's identity (memory hint →
+    /// disk hint). Never fetches the network. Used to bridge a fresh render while
+    /// the authoritative URL is being resolved.
+    func continuityImage(for object: any ImageCacheable) async -> ImageType?
+
+    /// Authoritative resolve with a placeholder bridge: `loadImage`, else the
+    /// continuity hint, so a failed fetch keeps the last image instead of
+    /// blanking. For callers using `loadImage` as their sole source.
+    func loadImageOrContinuity(for object: any ImageCacheable) async -> ImageType?
 
     /// Remove cached image for any ImageCacheable object
     func removeImage(for object: any ImageCacheable)
@@ -67,12 +82,6 @@ public protocol ImageCacheProtocol: AnyObject, Sendable {
 
     /// Remove all persistent images (used for "Delete All Data")
     func removeAllPersistentImages()
-
-    // MARK: - URL Change Detection
-
-    /// Check if the URL has changed for an identifier (without updating tracker)
-    /// Used by prefetcher to detect if it needs to re-fetch encrypted images
-    func hasURLChanged(_ url: String?, for identifier: String) async -> Bool
 
     // MARK: - Observation
 

--- a/ConvosCore/Sources/ConvosCore/Image Cache/MockImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/MockImageCache.swift
@@ -17,6 +17,12 @@ public final class MockImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     public func imageAsync(for object: any ImageCacheable) async -> ImageType? { nil }
 
+    public func imageAsync(forURL url: String) async -> ImageType? { nil }
+
+    public func continuityImage(for object: any ImageCacheable) async -> ImageType? { nil }
+
+    public func loadImageOrContinuity(for object: any ImageCacheable) async -> ImageType? { nil }
+
     public func removeImage(for object: any ImageCacheable) {}
 
     // MARK: - Upload Support
@@ -51,25 +57,12 @@ public final class MockImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     public func removeAllPersistentImages() {}
 
-    // MARK: - URL Change Detection
-
-    public func hasURLChanged(_ url: String?, for identifier: String) async -> Bool { false }
-
     // MARK: - Observation
 
     public var cacheUpdates: AnyPublisher<String, Never> {
         _cacheUpdates.eraseToAnyPublisher()
     }
 
-    /// Publisher that emits when an image URL changes for an identifier.
-    ///
-    /// - Important: **For testing only.** Do not use this for UI observation.
-    ///   Use `cacheUpdates` instead, which emits when an image is cached and ready to display.
-    internal var urlChanges: AnyPublisher<ImageURLChange, Never> {
-        _urlChanges.eraseToAnyPublisher()
-    }
-
     private var _cacheUpdates: CurrentValueSubject<String, Never> = .init("")
-    private var _urlChanges: PassthroughSubject<ImageURLChange, Never> = .init()
 }
 #endif

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -1222,8 +1222,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let urlString = encryptedRef.url
 
         Task.detached(priority: .background) {
-            // If URL didn't change and we already have a cached image, skip
-            if oldImageURL == nil, await ImageCacheContainer.shared.imageAsync(for: cacheId) != nil {
+            // If URL didn't change and we already have the bytes, skip. The byte
+            // cache is keyed by URL (cacheAfterUpload writes under urlString), so
+            // probe by URL - probing by cacheId hits the identifier tier and
+            // always misses, re-downloading and re-decrypting every run.
+            if oldImageURL == nil, await ImageCacheContainer.shared.imageAsync(forURL: urlString) != nil {
                 return
             }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ImageCacheTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ImageCacheTests.swift
@@ -8,7 +8,6 @@ import UIKit
 
 // MARK: - Test Configuration
 
-/// Configure required singletons before tests run
 private func configureTestEnvironment() {
     ImageCompression.resetForTesting()
     ImageCompression.configure(IOSImageCompression())
@@ -16,7 +15,7 @@ private func configureTestEnvironment() {
 
 // MARK: - Test Helpers
 
-/// A mock ImageCacheable object for testing
+/// A plain (unencrypted) ImageCacheable for tests.
 struct TestImageCacheable: ImageCacheable, Sendable {
     let imageCacheIdentifier: String
     let imageCacheURL: URL?
@@ -32,7 +31,6 @@ struct TestImageCacheable: ImageCacheable, Sendable {
     }
 }
 
-/// Creates a simple test UIImage with a solid color
 func createTestImage(width: Int = 100, height: Int = 100, color: UIColor = .red) -> UIImage {
     let size = CGSize(width: width, height: height)
     let renderer = UIGraphicsImageRenderer(size: size)
@@ -42,7 +40,13 @@ func createTestImage(width: Int = 100, height: Int = 100, color: UIColor = .red)
     }
 }
 
-// MARK: - ImageCache Tests
+private func uniqueURL() -> URL {
+    URL(string: "https://example.com/\(UUID().uuidString).jpg")!
+}
+
+private let asyncSettleNanos: UInt64 = 150_000_000
+
+// MARK: - ImageCache Tests (URL-keyed byte cache + continuity hint)
 
 @Suite("ImageCache Tests", .serialized)
 struct ImageCacheTests {
@@ -50,1313 +54,298 @@ struct ImageCacheTests {
         configureTestEnvironment()
     }
 
-    // MARK: - URLTracker Tests (via public API)
+    // MARK: Byte cache keyed by URL
 
-    @Test("URL change is detected when URL changes for an identifier")
-    func urlChangeDetected() async throws {
+    @Test("cacheAfterUpload(for:url:) then image(for:) returns the image")
+    func cacheThenRead() async throws {
         let cache = ImageCache()
-        var receivedChanges: [ImageURLChange] = []
-        let cancellable = cache.urlChanges.sink { change in
-            receivedChanges.append(change)
-        }
+        let url = uniqueURL()
+        let object = TestImageCacheable(identifier: "id-\(UUID().uuidString)", url: url)
+
+        cache.cacheAfterUpload(createTestImage(), for: object, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        #expect(cache.image(for: object) != nil)
+    }
+
+    @Test("imageAsync round-trips through disk on a fresh instance")
+    func diskRoundTrip() async throws {
+        let url = uniqueURL()
+        let object = TestImageCacheable(identifier: "id-\(UUID().uuidString)", url: url)
+
+        let writer = ImageCache()
+        writer.cacheAfterUpload(createTestImage(), for: object, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        // A second instance shares the disk directory but not memory.
+        let reader = ImageCache()
+        #expect(await reader.imageAsync(for: object) != nil)
+    }
+
+    // MARK: No-clobber regression (the whole saga)
+
+    @Test("same identity, two URLs are independent entries and never clobber")
+    func sameIdentityTwoURLsNoClobber() async throws {
+        let cache = ImageCache()
+        let identifier = "inbox-\(UUID().uuidString)"
+        let urlA = uniqueURL()
+        let urlB = uniqueURL()
+        let objectA = TestImageCacheable(identifier: identifier, url: urlA)
+        let objectB = TestImageCacheable(identifier: identifier, url: urlB)
+
+        cache.cacheAfterUpload(createTestImage(color: .red), for: objectA, url: urlA.absoluteString)
+        cache.cacheAfterUpload(createTestImage(color: .blue), for: objectB, url: urlB.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        // Both URLs resolve to their own bytes; neither overwrote the other.
+        let a = cache.image(for: objectA)
+        let b = cache.image(for: objectB)
+        #expect(a != nil)
+        #expect(b != nil)
+
+        // Loading A again must not change B's entry (no shared slot to clobber).
+        _ = await cache.loadImage(for: objectA)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        #expect(await cache.imageAsync(for: objectB) != nil)
+    }
+
+    @Test("same URL across two objects is deduped to one entry")
+    func sameURLDeduped() async throws {
+        let cache = ImageCache()
+        let url = uniqueURL()
+        let object1 = TestImageCacheable(identifier: "id1-\(UUID().uuidString)", url: url)
+        let object2 = TestImageCacheable(identifier: "id2-\(UUID().uuidString)", url: url)
+
+        cache.cacheAfterUpload(createTestImage(), for: object1, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        // object2 shares the URL, so it resolves from the same byte entry.
+        #expect(cache.image(for: object2) != nil)
+    }
+
+    // MARK: Continuity hint (identity-keyed, read-only)
+
+    @Test("continuity hint bridges an object whose current URL is not cached")
+    func continuityHintBridges() async throws {
+        let cache = ImageCache()
+        let identifier = "inbox-\(UUID().uuidString)"
+        let cachedURL = uniqueURL()
+        let cachedObject = TestImageCacheable(identifier: identifier, url: cachedURL)
+
+        // Cache an image for the identity (writes hint with persist: true).
+        cache.cacheAfterUpload(createTestImage(), for: cachedObject, url: cachedURL.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        // A new object for the same identity with a different, uncached URL:
+        // the byte cache misses, but the continuity hint bridges it.
+        let freshURL = uniqueURL()
+        let freshObject = TestImageCacheable(identifier: identifier, url: freshURL)
+
+        #expect(cache.image(for: freshObject) != nil)               // sync memory hint
+        #expect(await cache.continuityImage(for: freshObject) != nil) // memory/disk hint
+    }
+
+    @Test("continuity hint survives a fresh instance via disk")
+    func continuityHintDiskBacked() async throws {
+        let identifier = "inbox-\(UUID().uuidString)"
+        let url = uniqueURL()
+        let object = TestImageCacheable(identifier: identifier, url: url)
+
+        let writer = ImageCache()
+        writer.cacheAfterUpload(createTestImage(), for: object, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        // Fresh instance: a different uncached URL still bridges from the disk hint.
+        let reader = ImageCache()
+        let freshObject = TestImageCacheable(identifier: identifier, url: uniqueURL())
+        #expect(await reader.continuityImage(for: freshObject) != nil)
+    }
+
+    @Test("nil URL shows a staged pre-upload image, else nothing; never a stale continuity hint")
+    func nilURLStagedVersusCleared() async throws {
+        let cache = ImageCache()
+
+        // Staged pre-upload (nil URL): the explicitly staged image shows.
+        let stagedId = "inbox-\(UUID().uuidString)"
+        let stagedObject = TestImageCacheable(identifier: stagedId, url: nil)
+        _ = cache.prepareForUpload(createTestImage(), for: stagedObject)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        #expect(cache.image(for: stagedObject) != nil)
+        #expect(await cache.continuityImage(for: stagedObject) != nil)
+
+        // Cleared/never-set (nil URL) with a continuity hint from a prior real
+        // URL must show NOTHING - the hint is not consulted on a nil URL.
+        let clearedId = "inbox-\(UUID().uuidString)"
+        let url = uniqueURL()
+        let withAvatar = TestImageCacheable(identifier: clearedId, url: url)
+        cache.cacheAfterUpload(createTestImage(), for: withAvatar, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        let clearedObject = TestImageCacheable(identifier: clearedId, url: nil)
+        #expect(cache.image(for: clearedObject) == nil)
+        #expect(await cache.continuityImage(for: clearedObject) == nil)
+    }
+
+    @Test("removeImage clears the byte entry and the continuity hint")
+    func removeClearsByteAndHint() async throws {
+        let cache = ImageCache()
+        let identifier = "inbox-\(UUID().uuidString)"
+        let url = uniqueURL()
+        let object = TestImageCacheable(identifier: identifier, url: url)
+
+        cache.cacheAfterUpload(createTestImage(), for: object, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        #expect(cache.image(for: object) != nil)
+
+        cache.removeImage(for: object)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        #expect(cache.image(for: object) == nil)
+        #expect(await cache.continuityImage(for: object) == nil)
+    }
+
+    // MARK: Notifications
+
+    @Test("cacheUpdates emits the URL key on cacheAfterUpload")
+    func cacheUpdatesEmitsURLKey() async throws {
+        let cache = ImageCache()
+        let url = uniqueURL()
+        let object = TestImageCacheable(identifier: "id-\(UUID().uuidString)", url: url)
+
+        var received: [String] = []
+        let cancellable = cache.cacheUpdates.sink { received.append($0) }
         defer { cancellable.cancel() }
 
-        let identifier = "test-profile-\(UUID().uuidString)"
-        let url1 = URL(string: "https://example.com/image1.jpg")!
-        let url2 = URL(string: "https://example.com/image2.jpg")!
-        let testImage = createTestImage()
+        cache.cacheAfterUpload(createTestImage(), for: object, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
 
-        // First cache with url1
-        cache.cacheAfterUpload(testImage, for: identifier, url: url1.absoluteString)
-
-        // Wait for async Task to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Cache with url2 (URL change)
-        cache.cacheAfterUpload(testImage, for: identifier, url: url2.absoluteString)
-
-        // Wait for async Task to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Should have received two change events
-        #expect(receivedChanges.count == 2)
-
-        // First change: nil -> url1
-        #expect(receivedChanges[0].identifier == identifier)
-        #expect(receivedChanges[0].oldURL == nil)
-        #expect(receivedChanges[0].newURL == url1)
-
-        // Second change: url1 -> url2
-        #expect(receivedChanges[1].identifier == identifier)
-        #expect(receivedChanges[1].oldURL == url1)
-        #expect(receivedChanges[1].newURL == url2)
+        #expect(received.contains(url.absoluteString))
     }
 
-    @Test("No URL change event when URL stays the same")
-    func noUrlChangeWhenSameUrl() async throws {
+    @Test("cacheUpdates emits the identity key on prepareForUpload")
+    func cacheUpdatesEmitsIdentityOnStage() async throws {
         let cache = ImageCache()
-        var changeCount = 0
-        let cancellable = cache.urlChanges.sink { _ in
-            changeCount += 1
-        }
+        let identifier = "inbox-\(UUID().uuidString)"
+        let object = TestImageCacheable(identifier: identifier, url: nil)
+
+        var received: [String] = []
+        let cancellable = cache.cacheUpdates.sink { received.append($0) }
         defer { cancellable.cancel() }
 
-        let identifier = "test-profile-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/image.jpg")!
-        let testImage = createTestImage()
+        _ = cache.prepareForUpload(createTestImage(), for: object)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
 
-        // Cache with same URL twice
-        cache.cacheAfterUpload(testImage, for: identifier, url: url.absoluteString)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        cache.cacheAfterUpload(testImage, for: identifier, url: url.absoluteString)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Should only have one change event (initial tracking)
-        #expect(changeCount == 1)
+        #expect(received.contains(identifier))
     }
 
-    // MARK: - cacheAfterUpload Tests
+    // MARK: Identifier-keyed path (QR codes / generated images) is unchanged
 
-    @Test("cacheAfterUpload stores image in memory cache")
-    func cacheAfterUploadStoresInMemory() async throws {
+    @Test("identifier-keyed cache/read/remove still works")
+    func identifierPath() async throws {
         let cache = ImageCache()
-        let identifier = "test-memory-\(UUID().uuidString)"
-        let url = "https://example.com/image.jpg"
-        let testImage = createTestImage()
+        let identifier = "qr-\(UUID().uuidString)"
 
-        cache.cacheAfterUpload(testImage, for: identifier, url: url)
+        cache.cacheImage(createTestImage(), for: identifier, imageFormat: .png)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        #expect(cache.image(for: identifier, imageFormat: .png) != nil)
 
-        // Wait for async Task to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Should be retrievable from memory
-        let cached = cache.image(for: identifier)
-        #expect(cached != nil)
+        cache.removeImage(for: identifier)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        #expect(cache.image(for: identifier, imageFormat: .png) == nil)
     }
 
-    @Test("cacheAfterUpload stores image in disk cache")
-    func cacheAfterUploadStoresToDisk() async throws {
-        let identifier = "test-disk-\(UUID().uuidString)"
-        let url = "https://example.com/image.jpg"
-        let testImage = createTestImage()
+    // MARK: Persistent tier (chat photo attachments) is unchanged
 
-        // Cache in first instance
-        let cache1 = ImageCache()
-        cache1.cacheAfterUpload(testImage, for: identifier, url: url)
-
-        // Wait for async disk write to complete
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        // Create a fresh cache instance (empty memory cache, same disk location)
-        // and verify image loads from disk
-        let cache2 = ImageCache()
-
-        // Verify memory cache is empty in new instance
-        let memoryImage = cache2.image(for: identifier)
-        #expect(memoryImage == nil, "Memory cache should be empty in fresh instance")
-
-        // imageAsync should load from disk
-        let diskImage = await cache2.imageAsync(for: identifier)
-        #expect(diskImage != nil, "Image should load from disk cache")
-
-        // Cleanup
-        cache2.removeImage(for: identifier)
-    }
-
-    @Test("cacheAfterUpload emits cacheUpdates for backward compatibility")
-    func cacheAfterUploadEmitsCacheUpdates() async throws {
-        let cache = ImageCache()
-        var receivedIdentifiers: [String] = []
-        let cancellable = cache.cacheUpdates.sink { identifier in
-            receivedIdentifiers.append(identifier)
-        }
-        defer { cancellable.cancel() }
-
-        let identifier = "test-updates-\(UUID().uuidString)"
-        let url = "https://example.com/image.jpg"
-        let testImage = createTestImage()
-
-        cache.cacheAfterUpload(testImage, for: identifier, url: url)
-
-        // Wait for async Task to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(receivedIdentifiers.contains(identifier))
-    }
-
-    @Test("cacheAfterUpload with object emits urlChanges")
-    func cacheAfterUploadObjectEmitsUrlChanges() async throws {
-        let cache = ImageCache()
-        var receivedChanges: [ImageURLChange] = []
-        let cancellable = cache.urlChanges.sink { change in
-            receivedChanges.append(change)
-        }
-        defer { cancellable.cancel() }
-
-        let url = URL(string: "https://example.com/image.jpg")!
-        let cacheable = TestImageCacheable(identifier: "test-object-\(UUID().uuidString)", url: url)
-        let testImage = createTestImage()
-
-        cache.cacheAfterUpload(testImage, for: cacheable, url: url.absoluteString)
-
-        // Wait for async Task to complete
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(receivedChanges.count == 1)
-        #expect(receivedChanges[0].identifier == cacheable.imageCacheIdentifier)
-        #expect(receivedChanges[0].newURL == url)
-    }
-
-    // MARK: - loadImage Tests (Integration)
-
-    @Test("loadImage returns nil when object has no URL")
-    func loadImageNilUrl() async {
-        let cache = ImageCache()
-        let cacheable = TestImageCacheable(identifier: "no-url-\(UUID().uuidString)", url: nil)
-
-        let image = await cache.loadImage(for: cacheable)
-
-        #expect(image == nil)
-    }
-
-    @Test("loadImage emits urlChange when URL becomes nil")
-    func loadImageUrlBecomesNil() async throws {
-        let cache = ImageCache()
-        var receivedChanges: [ImageURLChange] = []
-        let cancellable = cache.urlChanges.sink { change in
-            receivedChanges.append(change)
-        }
-        defer { cancellable.cancel() }
-
-        let identifier = "test-nil-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/image.jpg")!
-
-        // First track a URL via cacheAfterUpload
-        cache.cacheAfterUpload(createTestImage(), for: identifier, url: url.absoluteString)
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Now load with nil URL (object URL changed to nil)
-        let cacheableNoUrl = TestImageCacheable(identifier: identifier, url: nil)
-        _ = await cache.loadImage(for: cacheableNoUrl)
-
-        // Wait for Combine to deliver the event
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Should emit URL change from url -> nil
-        let nilChange = receivedChanges.first { $0.oldURL == url && $0.newURL == nil }
-        #expect(nilChange != nil, "Expected URL change from \(url) to nil. Received: \(receivedChanges)")
-    }
-
-    @Test("loadImage returns cached image from memory")
-    func loadImageFromMemory() async {
-        let cache = ImageCache()
-        let identifier = "test-mem-load-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/image.jpg")!
-        let cacheable = TestImageCacheable(identifier: identifier, url: url)
-        let testImage = createTestImage()
-
-        // Pre-cache the image
-        cache.cacheImage(testImage, for: cacheable.imageCacheIdentifier)
-
-        // loadImage should return cached image
-        let loaded = await cache.loadImage(for: cacheable)
-        #expect(loaded != nil)
-    }
-
-    // MARK: - View Modifier Integration Tests
-
-    @Test("Subscriber receives urlChanges when image URL changes")
-    func subscriberReceivesUrlChanges() async throws {
-        let cache = ImageCache()
-
-        // Simulate what the view modifier does
-        let identifier = "profile-\(UUID().uuidString)"
-        var receivedURLChanges: [ImageURLChange] = []
-
-        // Subscribe to URL changes for this identifier (like the view modifier does)
-        let cancellable = cache.urlChanges
-            .filter { $0.identifier == identifier }
-            .sink { change in
-                receivedURLChanges.append(change)
-            }
-        defer { cancellable.cancel() }
-
-        // Simulate first image fetch with URL1
-        let url1 = "https://example.com/avatar-v1.jpg"
-        cache.cacheAfterUpload(createTestImage(color: .red), for: identifier, url: url1)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Simulate image URL change (like when updated from another device)
-        let url2 = "https://example.com/avatar-v2.jpg"
-        cache.cacheAfterUpload(createTestImage(color: .blue), for: identifier, url: url2)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // View should have received URL change notification
-        #expect(receivedURLChanges.count == 2)
-
-        // First: nil -> url1
-        #expect(receivedURLChanges[0].newURL?.absoluteString == url1)
-
-        // Second: url1 -> url2
-        #expect(receivedURLChanges[1].oldURL?.absoluteString == url1)
-        #expect(receivedURLChanges[1].newURL?.absoluteString == url2)
-    }
-
-    @Test("Multiple identifiers receive independent URL change events")
-    func multipleIdentifiersIndependentEvents() async throws {
-        let cache = ImageCache()
-
-        let id1 = "profile-1-\(UUID().uuidString)"
-        let id2 = "profile-2-\(UUID().uuidString)"
-
-        var changesForId1: [ImageURLChange] = []
-        var changesForId2: [ImageURLChange] = []
-
-        let cancellable1 = cache.urlChanges
-            .filter { $0.identifier == id1 }
-            .sink { changesForId1.append($0) }
-        let cancellable2 = cache.urlChanges
-            .filter { $0.identifier == id2 }
-            .sink { changesForId2.append($0) }
-        defer {
-            cancellable1.cancel()
-            cancellable2.cancel()
+    @Test("persistent tier caches and reads by identifier")
+    func persistentTier() async throws {
+        let identifier = "attachment-\(UUID().uuidString)"
+        guard let data = ImageCompression.resizeAndCompressToJPEG(createTestImage(), compressionQuality: 0.8) else {
+            Issue.record("Failed to compress test image")
+            return
         }
 
-        // Cache images for both identifiers
-        cache.cacheAfterUpload(createTestImage(), for: id1, url: "https://example.com/1.jpg")
-        cache.cacheAfterUpload(createTestImage(), for: id2, url: "https://example.com/2.jpg")
+        let writer = ImageCache()
+        writer.cacheData(data, for: identifier, storageTier: .persistent)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        let reader = ImageCache()
+        #expect(await reader.imageAsync(for: identifier) != nil)
 
-        // Change only id1's URL
-        cache.cacheAfterUpload(createTestImage(), for: id1, url: "https://example.com/1-v2.jpg")
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // id1 should have 2 changes, id2 should have 1
-        #expect(changesForId1.count == 2)
-        #expect(changesForId2.count == 1)
+        reader.removePersistentImages(for: [identifier])
     }
 
-    @Test("Full view modifier flow: loadImage + urlChanges subscription")
-    func fullViewModifierFlow() async throws {
-        let cache = ImageCache()
+    // MARK: URL probe (group-image prefetch dedup)
 
+    @Test("imageAsync(forURL:) hits the bytes cacheAfterUpload wrote, enabling dedup")
+    func urlProbeFindsCachedBytes() async throws {
+        let cache = ImageCache()
         let identifier = "conversation-\(UUID().uuidString)"
-        let url1 = URL(string: "https://example.com/group-avatar-v1.jpg")!
-        let url2 = URL(string: "https://example.com/group-avatar-v2.jpg")!
-
-        // Create immutable cacheables for each URL state
-        let cacheable1 = TestImageCacheable(identifier: identifier, url: url1)
-        let cacheable2 = TestImageCacheable(identifier: identifier, url: url2)
-
-        // Track URL changes received
-        var urlChangesReceived: [ImageURLChange] = []
-
-        // Subscribe to URL changes (like the view modifier does)
-        let cancellable = cache.urlChanges
-            .filter { $0.identifier == identifier }
-            .sink { change in
-                urlChangesReceived.append(change)
-            }
-        defer { cancellable.cancel() }
-
-        // Initial load (simulates .task modifier)
-        let initialImage = await cache.loadImage(for: cacheable1)
-
-        // Initial load with no cached image should return nil (network would fetch)
-        #expect(initialImage == nil)
-
-        // Simulate prefetcher caching the image for url1
-        let image1 = createTestImage(color: .red)
-        cache.cacheAfterUpload(image1, for: identifier, url: url1.absoluteString)
-
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Should have received URL change for url1
-        #expect(urlChangesReceived.count >= 1)
-        #expect(urlChangesReceived.first?.newURL == url1)
-
-        // Now simulate URL changing to url2 (e.g., update from another device)
-        let image2 = createTestImage(color: .blue)
-        cache.cacheAfterUpload(image2, for: identifier, url: url2.absoluteString)
-
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Should have received second URL change for url2
-        #expect(urlChangesReceived.count >= 2)
-        #expect(urlChangesReceived.last?.newURL == url2)
-
-        // Reload with new cacheable (simulates view responding to URL change)
-        let reloadedImage = await cache.loadImage(for: cacheable2)
-        #expect(reloadedImage != nil)
-    }
-
-    // MARK: - prepareForUpload Tests
-
-    @Test("prepareForUpload returns JPEG data")
-    func prepareForUploadReturnsData() async throws {
-        let cache = ImageCache()
-        let cacheable = TestImageCacheable(identifier: "upload-\(UUID().uuidString)")
-        let testImage = createTestImage()
-
-        let data = cache.prepareForUpload(testImage, for: cacheable)
-
-        #expect(data != nil)
-        #expect(data!.count > 0)
-
-        // Verify it's valid JPEG
-        let reconstructed = UIImage(data: data!)
-        #expect(reconstructed != nil)
-    }
-
-    @Test("prepareForUpload caches image immediately")
-    func prepareForUploadCachesImmediately() async throws {
-        let cache = ImageCache()
-        let identifier = "upload-cache-\(UUID().uuidString)"
-        let cacheable = TestImageCacheable(identifier: identifier)
-        let testImage = createTestImage()
-
-        _ = cache.prepareForUpload(testImage, for: cacheable)
-
-        // Wait for async caching
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let cached = cache.image(for: cacheable)
-        #expect(cached != nil)
-    }
-
-    @Test("prepareForUpload emits cacheUpdates")
-    func prepareForUploadEmitsCacheUpdates() async throws {
-        let cache = ImageCache()
-        var receivedIdentifiers: [String] = []
-        let cancellable = cache.cacheUpdates.sink { identifier in
-            receivedIdentifiers.append(identifier)
-        }
-        defer { cancellable.cancel() }
-
-        let identifier = "upload-notify-\(UUID().uuidString)"
-        let cacheable = TestImageCacheable(identifier: identifier)
-        let testImage = createTestImage()
-
-        _ = cache.prepareForUpload(testImage, for: cacheable)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(receivedIdentifiers.contains(identifier))
-    }
-
-    // MARK: - Identifier-based API Tests (for QR codes)
-
-    @Test("Identifier-based caching works without URL")
-    func identifierBasedCaching() async throws {
-        let cache = ImageCache()
-        let identifier = "qr-code-\(UUID().uuidString)"
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: identifier)
-
-        let cached = cache.image(for: identifier)
-        #expect(cached != nil)
-    }
-
-    @Test("Identifier-based caching supports PNG format")
-    func identifierBasedCachingPng() async throws {
-        let cache = ImageCache()
-        let identifier = "qr-png-\(UUID().uuidString)"
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: identifier, imageFormat: .png)
-
-        let cached = cache.image(for: identifier, imageFormat: .png)
-        #expect(cached != nil)
-    }
-
-    @Test("removeImage clears both memory and disk")
-    func removeImageClearsBothCaches() async throws {
-        let cache = ImageCache()
-        let identifier = "remove-test-\(UUID().uuidString)"
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: identifier)
-
-        // Wait for disk write
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Verify cached
-        #expect(cache.image(for: identifier) != nil)
-
-        // Remove
-        cache.removeImage(for: identifier)
-
-        // Wait for disk removal
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Should be gone from memory
-        #expect(cache.image(for: identifier) == nil)
-
-        // And from disk (new cache instance)
-        let cache2 = ImageCache()
-        let diskImage = await cache2.imageAsync(for: identifier)
-        #expect(diskImage == nil)
-    }
-
-    // MARK: - Object-based API Tests
-
-    @Test("cacheImage with object identifier stores and notifies")
-    func cacheImageWithObjectIdentifier() async throws {
-        let cache = ImageCache()
-        var receivedIdentifiers: [String] = []
-        let cancellable = cache.cacheUpdates.sink { identifier in
-            receivedIdentifiers.append(identifier)
-        }
-        defer { cancellable.cancel() }
-
-        let url = URL(string: "https://example.com/image.jpg")!
-        let cacheable = TestImageCacheable(identifier: "object-set-\(UUID().uuidString)", url: url)
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: cacheable.imageCacheIdentifier)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(cache.image(for: cacheable) != nil)
-        #expect(receivedIdentifiers.contains(cacheable.imageCacheIdentifier))
-    }
-
-    @Test("imageAsync returns disk-cached image")
-    func imageAsyncReturnsDiskCached() async throws {
-        let cache = ImageCache()
-        let identifier = "disk-async-\(UUID().uuidString)"
-        let cacheable = TestImageCacheable(identifier: identifier)
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: identifier)
-
-        // Wait for disk write
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // New cache instance (fresh memory cache)
-        let cache2 = ImageCache()
-        let loaded = await cache2.imageAsync(for: cacheable)
-
-        #expect(loaded != nil)
-    }
-
-    // MARK: - Edge Cases
-
-    @Test("Invalid URL string in cacheAfterUpload logs error but doesn't crash")
-    func invalidUrlStringHandled() async throws {
-        let cache = ImageCache()
-        let identifier = "invalid-url-\(UUID().uuidString)"
-        let testImage = createTestImage()
-
-        // This should not crash
-        cache.cacheAfterUpload(testImage, for: identifier, url: "not a valid url ::::")
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Image should still be accessible (even if URL tracking failed)
-        // Note: Current implementation may not cache if URL is invalid
-    }
-
-    @Test("Empty identifier is handled")
-    func emptyIdentifierHandled() async throws {
-        let cache = ImageCache()
-        let testImage = createTestImage()
-
-        // Should not crash with empty identifier
-        cache.cacheImage(testImage, for: "")
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let cached = cache.image(for: "")
-        #expect(cached != nil)
-    }
-
-    @Test("Very long identifier is handled")
-    func longIdentifierHandled() async throws {
-        let cache = ImageCache()
-        let longId = String(repeating: "a", count: 1000)
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: longId)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let cached = cache.image(for: longId)
-        #expect(cached != nil)
-    }
-
-    @Test("Special characters in identifier are handled")
-    func specialCharsIdentifierHandled() async throws {
-        let cache = ImageCache()
-        let specialId = "profile/user@example.com?v=1&test=true#anchor"
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: specialId)
-
-        // Wait for disk write (special chars are hashed)
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        let cached = cache.image(for: specialId)
-        #expect(cached != nil)
-
-        // Verify disk cache works with special chars (new instance)
-        let cache2 = ImageCache()
-        let diskCached = await cache2.imageAsync(for: specialId)
-        #expect(diskCached != nil)
-    }
-
-    // MARK: - Concurrent Access Tests
-
-    @Test("Concurrent cacheAfterUpload calls are safe")
-    func concurrentCacheAfterUpload() async throws {
-        let cache = ImageCache()
-        let baseId = "concurrent-\(UUID().uuidString)"
-
-        // Launch many concurrent cache operations
-        await withTaskGroup(of: Void.self) { group in
-            for i in 0..<20 {
-                group.addTask {
-                    let image = createTestImage(color: UIColor(
-                        red: CGFloat(i) / 20.0,
-                        green: 0.5,
-                        blue: 0.5,
-                        alpha: 1.0
-                    ))
-                    cache.cacheAfterUpload(
-                        image,
-                        for: "\(baseId)-\(i)",
-                        url: "https://example.com/\(i).jpg"
-                    )
-                }
-            }
+        let url = uniqueURL()
+
+        guard let data = ImageCompression.resizeAndCompressToJPEG(createTestImage(), compressionQuality: 0.8) else {
+            Issue.record("Failed to compress test image")
+            return
         }
 
-        try await Task.sleep(nanoseconds: 500_000_000)
+        // The encrypted-group-image prefetch writes by identifier + URL, then a
+        // later run dedups by probing the URL. A miss here means re-download.
+        cache.cacheAfterUpload(data, for: identifier, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
 
-        // All should be cached
-        for i in 0..<20 {
-            let cached = cache.image(for: "\(baseId)-\(i)")
-            #expect(cached != nil)
-        }
+        #expect(await cache.imageAsync(forURL: url.absoluteString) != nil)
+        #expect(await cache.imageAsync(forURL: uniqueURL().absoluteString) == nil)
     }
 
-    @Test("Concurrent URL changes for same identifier are serialized")
-    func concurrentUrlChangesForSameIdentifier() async throws {
+    // MARK: Delete-all reset clears the continuity hint
+
+    @Test("removeAllPersistentImages wipes the byte cache and continuity hint, in memory and on disk")
+    func removeAllClearsContinuityHint() async throws {
+        let identifier = "inbox-\(UUID().uuidString)"
+        let url = uniqueURL()
+        let object = TestImageCacheable(identifier: identifier, url: url)
+
         let cache = ImageCache()
-        let identifier = "same-id-\(UUID().uuidString)"
-        var receivedChanges: [ImageURLChange] = []
-        let lock = NSLock()
-
-        let cancellable = cache.urlChanges
-            .filter { $0.identifier == identifier }
-            .sink { change in
-                lock.lock()
-                receivedChanges.append(change)
-                lock.unlock()
-            }
-        defer { cancellable.cancel() }
-
-        // Rapid URL changes
-        for i in 0..<10 {
-            cache.cacheAfterUpload(
-                createTestImage(),
-                for: identifier,
-                url: "https://example.com/v\(i).jpg"
-            )
-        }
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        // Should receive change events (exact count may vary due to rapid updates)
-        #expect(receivedChanges.count >= 1)
-    }
-}
-
-// MARK: - Encrypted Image Cold Start Integration Test
-
-@Suite("Encrypted Image Cold Start Tests", .serialized)
-struct EncryptedImageColdStartTests {
-    init() {
-        configureTestEnvironment()
-    }
-
-    @Test("Cold start loadImage for encrypted image loads from disk")
-    func coldStartEncryptedImageLoadsFromDisk() async throws {
-        let cache = ImageCache()
-        let identifier = "encrypted-cold-start-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/encrypted-avatar.jpg")!
-        let testImage = createTestImage(color: .green)
-
-        // Simulate image being cached to disk (as prefetcher would do)
-        cache.cacheAfterUpload(testImage, for: identifier, url: url.absoluteString)
-
-        // Wait for disk write to complete
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        // Create a fresh cache instance (simulating cold start - empty memory, URL tracker empty)
-        let cache2 = ImageCache()
-
-        // Create a cacheable with isEncryptedImage = true
-        struct EncryptedCacheable: ImageCacheable {
-            let imageCacheIdentifier: String
-            let imageCacheURL: URL?
-            let isEncryptedImage: Bool = true
-        }
-
-        let encryptedCacheable = EncryptedCacheable(
-            imageCacheIdentifier: identifier,
-            imageCacheURL: url
-        )
-
-        // On cold start with encrypted image:
-        // - hasURLChanged() returns true (triggering prefetcher to verify)
-        // - loadImage still returns cached disk image while prefetcher runs
-        let loadedImage = await cache2.loadImage(for: encryptedCacheable)
-
-        #expect(loadedImage != nil, "Cold start should load encrypted image from disk")
-
-        // Cleanup
-        cache2.removeImage(for: identifier)
-    }
-
-    @Test("Encrypted image falls back to stale disk cache when inline fetch fails after URL change")
-    func encryptedImageFallsBackToStaleDiskCacheWhenInlineFetchFails() async throws {
-        let cache = ImageCache()
-        let identifier = "encrypted-fallback-\(UUID().uuidString)"
-        let staleURL = URL(string: "https://example.com/encrypted-avatar-v1.jpg")!
-        let newURL = URL(string: "https://example.com/encrypted-avatar-v2.jpg")!
-        let staleImage = createTestImage(color: .purple)
-
-        cache.cacheAfterUpload(staleImage, for: identifier, url: staleURL.absoluteString)
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-
-        struct EncryptedCacheable: ImageCacheable {
-            let imageCacheIdentifier: String
-            let imageCacheURL: URL?
-            let isEncryptedImage: Bool = true
-            let encryptionKey: Data? = nil
-            let encryptionSalt: Data? = nil
-            let encryptionNonce: Data? = nil
-        }
-
-        let encryptedCacheable = EncryptedCacheable(
-            imageCacheIdentifier: identifier,
-            imageCacheURL: newURL
-        )
-
-        let loadedImage = await cache2.loadImage(for: encryptedCacheable)
-
-        #expect(loadedImage != nil, "Should fall back to stale disk-cached image when inline fetch fails")
-
-        cache2.removeImage(for: identifier)
-    }
-}
-
-// MARK: - URL Tracking Behavior Tests
-
-@Suite("ImageCache URL Tracking Tests", .serialized)
-struct ImageCacheURLTrackingTests {
-    init() {
-        configureTestEnvironment()
-    }
-
-    @Test("hasURLChanged returns true when no entry exists (cold start - need to verify)")
-    func hasUrlChangedTrueWhenNoEntry() async throws {
-        let cache = ImageCache()
-        let identifier = "new-profile-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/avatar.jpg")!
-
-        // On cold start, there's no entry in the tracker but disk cache may have stale data
-        // hasURLChanged should return true to trigger verification/prefetch
-        // This ensures stale cached images get refreshed when URL changes happen while app is closed
-        let hasChanged = await cache.hasURLChanged(url.absoluteString, for: identifier)
-
-        #expect(hasChanged == true, "hasURLChanged should return true when no entry exists (cold start - need to verify)")
-    }
-
-    @Test("hasURLChanged returns true when entry exists and URL differs")
-    func hasUrlChangedTrueWhenUrlDiffers() async throws {
-        let cache = ImageCache()
-        let identifier = "profile-url-change-\(UUID().uuidString)"
-        let url1 = URL(string: "https://example.com/avatar-v1.jpg")!
-        let url2 = URL(string: "https://example.com/avatar-v2.jpg")!
-
-        // Track url1 using the test helper (no image required)
-        await cache.trackURLForTesting(url1, for: identifier)
-
-        // Now check if url2 would be considered changed
-        let hasChanged = await cache.hasURLChanged(url2.absoluteString, for: identifier)
-
-        #expect(hasChanged == true, "hasURLChanged should return true when URL differs from tracked entry")
-    }
-
-    @Test("hasURLChanged returns false when entry exists and URL is same")
-    func hasUrlChangedFalseWhenUrlSame() async throws {
-        let cache = ImageCache()
-        let identifier = "profile-same-url-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/avatar.jpg")!
-
-        // Track the URL using the test helper
-        await cache.trackURLForTesting(url, for: identifier)
-
-        // Check if the same URL would be considered changed
-        let hasChanged = await cache.hasURLChanged(url.absoluteString, for: identifier)
-
-        #expect(hasChanged == false, "hasURLChanged should return false when URL is same as tracked entry")
-    }
-
-    @Test("hasURLChanged returns true when URL is nil and entry exists")
-    func hasUrlChangedTrueWhenNilAndEntryExists() async throws {
-        let cache = ImageCache()
-        let identifier = "profile-nil-url-\(UUID().uuidString)"
-        let url = URL(string: "https://example.com/avatar.jpg")!
-
-        // Track the URL using the test helper
-        await cache.trackURLForTesting(url, for: identifier)
-
-        // Check if nil URL would be considered changed (user removed avatar)
-        let hasChanged = await cache.hasURLChanged(nil, for: identifier)
-
-        #expect(hasChanged == true, "hasURLChanged should return true when URL is nil but entry exists")
-    }
-
-    @Test("hasURLChanged returns false when URL is nil and no entry exists")
-    func hasUrlChangedFalseWhenNilAndNoEntry() async throws {
-        let cache = ImageCache()
-        let identifier = "profile-no-avatar-\(UUID().uuidString)"
-
-        // No entry tracked, URL is nil (user never had an avatar)
-        let hasChanged = await cache.hasURLChanged(nil, for: identifier)
-
-        #expect(hasChanged == false, "hasURLChanged should return false when URL is nil and no entry exists")
-    }
-}
-
-// MARK: - URLChange Flow Integration Tests
-
-@Suite("ImageCache URL Change Flow Tests", .serialized)
-struct ImageCacheURLChangeFlowTests {
-    init() {
-        configureTestEnvironment()
-    }
-
-    @Test("Complete prefetch flow emits correct URL change events")
-    func completePrefetchFlow() async throws {
-        let cache = ImageCache()
-        var changes: [ImageURLChange] = []
-        let cancellable = cache.urlChanges.sink { changes.append($0) }
-        defer { cancellable.cancel() }
-
-        let profileId = "inbox-\(UUID().uuidString)"
-        let oldUrl = "https://cdn.example.com/avatar/old.jpg"
-        let newUrl = "https://cdn.example.com/avatar/new.jpg"
-
-        // Step 1: Initial prefetch caches with old URL
-        cache.cacheAfterUpload(createTestImage(color: .red), for: profileId, url: oldUrl)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Step 2: URL changes (detected during sync)
-        // First, invalidate old cache (simulating ConversationWriter behavior)
-        cache.removeImage(for: profileId)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Step 3: Prefetch with new URL
-        cache.cacheAfterUpload(createTestImage(color: .blue), for: profileId, url: newUrl)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // Verify changes
-        let profileChanges = changes.filter { $0.identifier == profileId }
-        #expect(profileChanges.count >= 2)
-
-        // First should be nil -> oldUrl
-        #expect(profileChanges[0].oldURL == nil)
-        #expect(profileChanges[0].newURL?.absoluteString == oldUrl)
-
-        // After removal and re-cache, should see change to newUrl
-        let lastChange = profileChanges.last!
-        #expect(lastChange.newURL?.absoluteString == newUrl)
-    }
-
-    @Test("Subscriber filtering correctly isolates identifier events")
-    func subscriberFilteringIsolates() async throws {
-        let cache = ImageCache()
-
-        let profile1Id = "profile-1-\(UUID().uuidString)"
-        let profile2Id = "profile-2-\(UUID().uuidString)"
-        let convoId = "convo-\(UUID().uuidString)"
-
-        var profile1Changes: [ImageURLChange] = []
-        var profile2Changes: [ImageURLChange] = []
-        var convoChanges: [ImageURLChange] = []
-
-        let c1 = cache.urlChanges
-            .filter { $0.identifier == profile1Id }
-            .sink { profile1Changes.append($0) }
-        let c2 = cache.urlChanges
-            .filter { $0.identifier == profile2Id }
-            .sink { profile2Changes.append($0) }
-        let c3 = cache.urlChanges
-            .filter { $0.identifier == convoId }
-            .sink { convoChanges.append($0) }
-        defer {
-            c1.cancel()
-            c2.cancel()
-            c3.cancel()
-        }
-
-        // Cache for all three
-        cache.cacheAfterUpload(createTestImage(), for: profile1Id, url: "https://example.com/p1.jpg")
-        cache.cacheAfterUpload(createTestImage(), for: profile2Id, url: "https://example.com/p2.jpg")
-        cache.cacheAfterUpload(createTestImage(), for: convoId, url: "https://example.com/c.jpg")
-
-        try await Task.sleep(nanoseconds: 200_000_000)
-
-        // Update only profile1
-        cache.cacheAfterUpload(createTestImage(), for: profile1Id, url: "https://example.com/p1-v2.jpg")
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        // profile1 should have 2 changes, others should have 1
-        #expect(profile1Changes.count == 2)
-        #expect(profile2Changes.count == 1)
-        #expect(convoChanges.count == 1)
-    }
-
-    @Test("View can detect when image URL cleared")
-    func viewDetectsUrlCleared() async throws {
-        let cache = ImageCache()
-
-        let identifier = "profile-clear-\(UUID().uuidString)"
-        var hasImage = false
-
-        let cancellable = cache.urlChanges
-            .filter { $0.identifier == identifier }
-            .sink { change in
-                hasImage = change.newURL != nil
-            }
-        defer { cancellable.cancel() }
-
-        // Initial cache
-        cache.cacheAfterUpload(createTestImage(), for: identifier, url: "https://example.com/avatar.jpg")
-        try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(hasImage == true)
-
-        // Simulate loading with nil URL (user removed avatar)
-        let cacheable = TestImageCacheable(identifier: identifier, url: nil)
-        _ = await cache.loadImage(for: cacheable)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(hasImage == false)
-    }
-}
-
-// MARK: - Disk Cache Overwrite Tests
-
-@Suite("Disk Cache Overwrite Tests", .serialized)
-struct DiskCacheOverwriteTests {
-    init() {
-        configureTestEnvironment()
-    }
-
-    @Test("Disk cache is updated when URL changes (cacheAfterUpload overwrites existing file)")
-    func diskCacheUpdatedOnUrlChange() async throws {
-        let cache = ImageCache()
-        let identifier = "disk-overwrite-\(UUID().uuidString)"
-        let url1 = "https://example.com/avatar-v1.jpg"
-        let url2 = "https://example.com/avatar-v2.jpg"
-
-        // Create two different colored images
-        let redImage = createTestImage(color: .red)
-        let blueImage = createTestImage(color: .blue)
-
-        // Cache the red image with url1
-        cache.cacheAfterUpload(redImage, for: identifier, url: url1)
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // Verify red image is in cache
-        let cachedRed = await cache.imageAsync(for: identifier, imageFormat: .jpg)
-        #expect(cachedRed != nil, "Red image should be cached")
-
-        // Cache the blue image with url2 (simulates URL change)
-        cache.cacheAfterUpload(blueImage, for: identifier, url: url2)
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // Verify blue image is in cache (memory)
-        let cachedBlue = await cache.imageAsync(for: identifier, imageFormat: .jpg)
-        #expect(cachedBlue != nil, "Blue image should be cached")
-
-        // Create a fresh cache instance (simulates cold start - empty memory)
-        let cache2 = ImageCache()
-
-        // Load from disk only - should get the BLUE image, not the red one
-        let diskImage = await cache2.imageAsync(for: identifier, imageFormat: .jpg)
-        #expect(diskImage != nil, "Image should be loadable from disk after cold start")
-
-        // Cleanup
-        cache2.removeImage(for: identifier)
-    }
-
-    @Test("Cold start after URL change loads new image from disk")
-    func coldStartAfterUrlChangeLoadsNewImage() async throws {
-        let cache = ImageCache()
-        let identifier = "cold-start-url-change-\(UUID().uuidString)"
-
-        // Cache image with initial URL
-        cache.cacheAfterUpload(createTestImage(color: .green), for: identifier, url: "https://example.com/v1.jpg")
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // Update with new URL and new image
-        let newImage = createTestImage(width: 200, height: 200, color: .purple)
-        cache.cacheAfterUpload(newImage, for: identifier, url: "https://example.com/v2.jpg")
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        // Simulate cold start
-        let freshCache = ImageCache()
-
-        // Load from disk
-        let loadedImage = await freshCache.imageAsync(for: identifier, imageFormat: .jpg)
-        #expect(loadedImage != nil, "Should load image from disk after cold start")
-
-        // Cleanup
-        freshCache.removeImage(for: identifier)
-    }
-}
-
-// MARK: - Persistent Storage Tier Tests
-
-@Suite("Persistent Storage Tier Tests", .serialized)
-struct PersistentStorageTierTests {
-    init() {
-        configureTestEnvironment()
-    }
-
-    @Test("cacheData with persistent tier stores in memory")
-    func cacheDataPersistentStoresInMemory() async throws {
-        let cache = ImageCache()
-        let identifier = "persistent-data-mem-\(UUID().uuidString)"
-        let testImage = createTestImage()
-        let data = testImage.jpegData(compressionQuality: 0.8)!
-
-        cache.cacheData(data, for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let cached = cache.image(for: identifier)
-        #expect(cached != nil)
-    }
-
-    @Test("cacheImage with persistent tier stores in memory")
-    func cacheImagePersistentStoresInMemory() async throws {
-        let cache = ImageCache()
-        let identifier = "persistent-img-mem-\(UUID().uuidString)"
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let cached = cache.image(for: identifier)
-        #expect(cached != nil)
-    }
-
-    @Test("cacheData with persistent tier survives fresh cache instance")
-    func cacheDataPersistentSurvivesFreshInstance() async throws {
-        let identifier = "persistent-data-disk-\(UUID().uuidString)"
-        let testImage = createTestImage(color: .blue)
-        let data = testImage.jpegData(compressionQuality: 0.8)!
-
-        let cache1 = ImageCache()
-        cache1.cacheData(data, for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let memoryImage = cache2.image(for: identifier)
-        #expect(memoryImage == nil, "Memory cache should be empty in fresh instance")
-
-        let diskImage = await cache2.imageAsync(for: identifier)
-        #expect(diskImage != nil, "Image should load from persistent store")
-
-        cache2.removeImage(for: identifier)
-    }
-
-    @Test("cacheImage with persistent tier survives fresh cache instance")
-    func cacheImagePersistentSurvivesFreshInstance() async throws {
-        let identifier = "persistent-img-disk-\(UUID().uuidString)"
-        let testImage = createTestImage(color: .green)
-
-        let cache1 = ImageCache()
-        cache1.cacheImage(testImage, for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let diskImage = await cache2.imageAsync(for: identifier)
-        #expect(diskImage != nil, "Image should load from persistent store")
-
-        cache2.removeImage(for: identifier)
-    }
-
-    @Test("cacheData with persistent tier emits cacheUpdates")
-    func cacheDataPersistentEmitsCacheUpdates() async throws {
-        let cache = ImageCache()
-        var receivedIdentifiers: [String] = []
-        let cancellable = cache.cacheUpdates.sink { identifier in
-            receivedIdentifiers.append(identifier)
-        }
-        defer { cancellable.cancel() }
-
-        let identifier = "persistent-notify-\(UUID().uuidString)"
-        let data = createTestImage().jpegData(compressionQuality: 0.8)!
-
-        cache.cacheData(data, for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(receivedIdentifiers.contains(identifier))
-    }
-
-    @Test("cacheImage with persistent tier emits cacheUpdates")
-    func cacheImagePersistentEmitsCacheUpdates() async throws {
-        let cache = ImageCache()
-        var receivedIdentifiers: [String] = []
-        let cancellable = cache.cacheUpdates.sink { identifier in
-            receivedIdentifiers.append(identifier)
-        }
-        defer { cancellable.cancel() }
-
-        let identifier = "persistent-img-notify-\(UUID().uuidString)"
-        let testImage = createTestImage()
-
-        cache.cacheImage(testImage, for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(receivedIdentifiers.contains(identifier))
-    }
-
-    @Test("removePersistentImages removes from persistent store")
-    func removePersistentImagesRemovesFiles() async throws {
-        let cache = ImageCache()
-        let id1 = "persistent-rm-1-\(UUID().uuidString)"
-        let id2 = "persistent-rm-2-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(color: .red), for: id1, storageTier: .persistent)
-        cache.cacheImage(createTestImage(color: .blue), for: id2, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let img1Before = await cache2.imageAsync(for: id1)
-        let img2Before = await cache2.imageAsync(for: id2)
-        #expect(img1Before != nil)
-        #expect(img2Before != nil)
-
-        cache2.removePersistentImages(for: [id1, id2])
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache3 = ImageCache()
-        let img1After = await cache3.imageAsync(for: id1)
-        let img2After = await cache3.imageAsync(for: id2)
-        #expect(img1After == nil, "Image should be removed from persistent store")
-        #expect(img2After == nil, "Image should be removed from persistent store")
-    }
-
-    @Test("removePersistentImages also clears memory cache")
-    func removePersistentImagesClearsMemory() async throws {
-        let cache = ImageCache()
-        let identifier = "persistent-rm-mem-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(), for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(cache.image(for: identifier) != nil)
-
-        cache.removePersistentImages(for: [identifier])
-
-        #expect(cache.image(for: identifier) == nil)
-    }
-
-    @Test("removePersistentImages with empty array is a no-op")
-    func removePersistentImagesEmptyArray() async throws {
-        let cache = ImageCache()
-        cache.removePersistentImages(for: [])
-    }
-
-    @Test("removeAllPersistentImages clears all persistent files")
-    func removeAllPersistentImagesClears() async throws {
-        let cache = ImageCache()
-        let id1 = "persistent-all-1-\(UUID().uuidString)"
-        let id2 = "persistent-all-2-\(UUID().uuidString)"
-        let id3 = "persistent-all-3-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(color: .red), for: id1, storageTier: .persistent)
-        cache.cacheImage(createTestImage(color: .green), for: id2, storageTier: .persistent)
-        cache.cacheImage(createTestImage(color: .blue), for: id3, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
+        // Writes the URL-keyed byte cache and the continuity hint (persist: true).
+        cache.cacheAfterUpload(createTestImage(), for: object, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+
+        // A fresh object for the same identity with an uncached URL bridges via
+        // the hint before the wipe.
+        let freshObject = TestImageCacheable(identifier: identifier, url: uniqueURL())
+        #expect(await cache.continuityImage(for: freshObject) != nil)
 
         cache.removeAllPersistentImages()
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
 
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let img1 = await cache2.imageAsync(for: id1)
-        let img2 = await cache2.imageAsync(for: id2)
-        let img3 = await cache2.imageAsync(for: id3)
-        #expect(img1 == nil)
-        #expect(img2 == nil)
-        #expect(img3 == nil)
+        // In-memory hint is gone, and a new instance finds nothing on disk -
+        // neither the continuity hint nor the URL-keyed byte cache survive.
+        #expect(await cache.continuityImage(for: freshObject) == nil)
+        let reader = ImageCache()
+        #expect(await reader.continuityImage(for: freshObject) == nil)
+        #expect(await reader.imageAsync(forURL: url.absoluteString) == nil)
     }
 
-    @Test("Persistent and cache tiers are independent")
-    func persistentAndCacheTiersIndependent() async throws {
+    // MARK: Staged image is cleared once the upload is cached
+
+    @Test("cacheAfterUpload clears the staged image so a later nil URL shows nothing")
+    func cacheAfterUploadClearsStaged() async throws {
         let cache = ImageCache()
-        let persistentId = "tier-persistent-\(UUID().uuidString)"
-        let cacheId = "tier-cache-\(UUID().uuidString)"
+        let identifier = "inbox-\(UUID().uuidString)"
 
-        cache.cacheImage(createTestImage(color: .red), for: persistentId, storageTier: .persistent)
-        cache.cacheImage(createTestImage(color: .blue), for: cacheId)
+        // Stage a pre-upload image (no URL yet): a nil-URL object shows it.
+        let staging = TestImageCacheable(identifier: identifier, url: nil)
+        _ = cache.prepareForUpload(createTestImage(), for: staging)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
+        #expect(cache.image(for: staging) != nil)
 
-        try await Task.sleep(nanoseconds: 500_000_000)
+        // Upload completes under a real URL; the staged image is now superseded.
+        let url = uniqueURL()
+        let uploaded = TestImageCacheable(identifier: identifier, url: url)
+        cache.cacheAfterUpload(createTestImage(), for: uploaded, url: url.absoluteString)
+        try await Task.sleep(nanoseconds: asyncSettleNanos)
 
-        cache.removePersistentImages(for: [persistentId])
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let persistentImg = await cache2.imageAsync(for: persistentId)
-        let cacheImg = await cache2.imageAsync(for: cacheId)
-
-        #expect(persistentImg == nil, "Persistent image should be removed")
-        #expect(cacheImg != nil, "Cache image should still exist")
-
-        cache2.removeImage(for: cacheId)
-    }
-
-    @Test("loadImageFromDisk checks persistent store first")
-    func loadImageFromDiskChecksPersistentFirst() async throws {
-        let cache = ImageCache()
-        let identifier = "persistent-priority-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(color: .purple), for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let loaded = await cache2.imageAsync(for: identifier)
-        #expect(loaded != nil, "Should find image in persistent store")
-
-        cache2.removeImage(for: identifier)
-    }
-
-    @Test("removeImage clears from both persistent and cache directories")
-    func removeImageClearsBothDirectories() async throws {
-        let cache = ImageCache()
-        let identifier = "remove-both-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(), for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        cache.removeImage(for: identifier)
-
-        try await Task.sleep(nanoseconds: 300_000_000)
-
-        let cache2 = ImageCache()
-        let diskImage = await cache2.imageAsync(for: identifier)
-        #expect(diskImage == nil, "removeImage should clear from persistent store too")
-    }
-
-    @Test("Concurrent persistent cache operations are safe")
-    func concurrentPersistentCacheOperations() async throws {
-        let cache = ImageCache()
-        let baseId = "concurrent-persistent-\(UUID().uuidString)"
-
-        await withTaskGroup(of: Void.self) { group in
-            for i in 0..<15 {
-                group.addTask {
-                    let image = createTestImage(color: UIColor(
-                        red: CGFloat(i) / 15.0,
-                        green: 0.3,
-                        blue: 0.7,
-                        alpha: 1.0
-                    ))
-                    cache.cacheImage(image, for: "\(baseId)-\(i)", storageTier: .persistent)
-                }
-            }
-        }
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        for i in 0..<15 {
-            let cached = cache.image(for: "\(baseId)-\(i)")
-            #expect(cached != nil, "Concurrent persistent cache item \(i) should exist")
-        }
-
-        let identifiers = (0..<15).map { "\(baseId)-\($0)" }
-        cache.removePersistentImages(for: identifiers)
-    }
-
-    @Test("Invalid data for cacheData does not crash")
-    func invalidDataForCacheDataHandled() async throws {
-        let cache = ImageCache()
-        let identifier = "invalid-persistent-\(UUID().uuidString)"
-
-        cache.cacheData(Data([0x00, 0x01, 0x02]), for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let cached = cache.image(for: identifier)
-        #expect(cached == nil, "Invalid data should not produce a cached image")
-    }
-
-    @Test("removeAllPersistentImages clears memory cache")
-    func removeAllPersistentImagesClearsMemory() async throws {
-        let cache = ImageCache()
-        let id1 = "mem-clear-1-\(UUID().uuidString)"
-        let id2 = "mem-clear-2-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(color: .red), for: id1, storageTier: .persistent)
-        cache.cacheImage(createTestImage(color: .green), for: id2, storageTier: .persistent)
-
-        #expect(cache.image(for: id1) != nil, "Image should be in memory before removal")
-        #expect(cache.image(for: id2) != nil, "Image should be in memory before removal")
-
-        cache.removeAllPersistentImages()
-
-        #expect(cache.image(for: id1) == nil, "Memory cache should be cleared immediately")
-        #expect(cache.image(for: id2) == nil, "Memory cache should be cleared immediately")
-    }
-
-    @Test("removePersistentImages removes both jpg and png files")
-    func removePersistentImagesRemovesBothFormats() async throws {
-        let cache = ImageCache()
-        let identifier = "png-cleanup-\(UUID().uuidString)"
-
-        cache.cacheImage(createTestImage(color: .red), for: identifier, storageTier: .persistent)
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        cache.removePersistentImages(for: [identifier])
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let cache2 = ImageCache()
-        let img = await cache2.imageAsync(for: identifier)
-        #expect(img == nil, "Persistent image should be fully removed")
+        // A subsequent nil-URL object for the same identity must fall through to
+        // the placeholder (nil), not the stale staged upload.
+        #expect(cache.image(for: staging) == nil)
     }
 }
-
 #endif

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/EncryptedImageSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/EncryptedImageSyncTests.swift
@@ -97,30 +97,30 @@ struct EncryptedImageSyncTests {
         #expect(fetchedURLs.contains(charlieAvatarURL))
     }
 
-    @Test("Device A sees Device B's profile change via URL change event")
+    @Test("Two avatar URLs for one identity are independent byte entries")
     func testDeviceASeesDeviceBProfileChange() async throws {
         let cache = ImageCache()
-        var receivedChanges: [ImageURLChange] = []
-        let cancellable = cache.urlChanges
-            .filter { $0.identifier == "bob-inbox-id" }
-            .sink { change in
-                receivedChanges.append(change)
-            }
+        let identifier = "bob-inbox-\(UUID().uuidString)"
+        var received: [String] = []
+        let cancellable = cache.cacheUpdates.sink { received.append($0) }
         defer { cancellable.cancel() }
 
-        let oldAvatarURL = "https://cdn.example.com/avatars/bob-v1.enc"
-        let newAvatarURL = "https://cdn.example.com/avatars/bob-v2.enc"
+        let oldAvatarURL = "https://cdn.example.com/avatars/bob-v1-\(UUID().uuidString).enc"
+        let newAvatarURL = "https://cdn.example.com/avatars/bob-v2-\(UUID().uuidString).enc"
 
-        cache.cacheAfterUpload(createSyncTestImage(color: .blue), for: "bob-inbox-id", url: oldAvatarURL)
+        cache.cacheAfterUpload(createSyncTestImage(color: .blue), for: identifier, url: oldAvatarURL)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        cache.cacheAfterUpload(createSyncTestImage(color: .red), for: identifier, url: newAvatarURL)
         try await Task.sleep(nanoseconds: 100_000_000)
 
-        cache.cacheAfterUpload(createSyncTestImage(color: .red), for: "bob-inbox-id", url: newAvatarURL)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        #expect(receivedChanges.count == 2)
-        #expect(receivedChanges[0].newURL?.absoluteString == oldAvatarURL)
-        #expect(receivedChanges[1].oldURL?.absoluteString == oldAvatarURL)
-        #expect(receivedChanges[1].newURL?.absoluteString == newAvatarURL)
+        // Each URL is its own byte entry; cacheUpdates carries each URL key, and
+        // both resolve independently (no shared identity slot to clobber).
+        #expect(received.contains(oldAvatarURL))
+        #expect(received.contains(newAvatarURL))
+        let oldObject = TestImageCacheable(identifier: identifier, urlString: oldAvatarURL)
+        let newObject = TestImageCacheable(identifier: identifier, urlString: newAvatarURL)
+        #expect(await cache.imageAsync(for: oldObject) != nil)
+        #expect(await cache.imageAsync(for: newObject) != nil)
     }
 
     @Test("Already cached profile is not re-fetched from network")
@@ -131,14 +131,15 @@ struct EncryptedImageSyncTests {
         defer { ImageCacheContainer.shared = originalShared }
 
         let aliceInboxId = "alice-cached-\(UUID().uuidString)"
-        let aliceAvatarURL = URL(string: "https://cdn.example.com/avatars/alice-cached.enc")!
+        let aliceAvatarURL = URL(string: "https://cdn.example.com/avatars/alice-cached-\(UUID().uuidString).enc")!
 
-        testCache.cacheImage(createSyncTestImage(color: .red), for: aliceInboxId)
+        // Seed the byte cache under the avatar URL (the cache is URL-keyed).
+        testCache.cacheAfterUpload(createSyncTestImage(color: .red), for: aliceInboxId, url: aliceAvatarURL.absoluteString)
 
         try await Task.sleep(nanoseconds: 100_000_000)
 
-        let cachedImage = await testCache.imageAsync(for: aliceInboxId)
-        #expect(cachedImage != nil)
+        let aliceObject = TestImageCacheable(identifier: aliceInboxId, url: aliceAvatarURL)
+        #expect(await testCache.imageAsync(for: aliceObject) != nil)
 
         let mockLoader = MockEncryptedImageLoader()
         mockLoader.stub(url: aliceAvatarURL, with: createSyncTestImageData())

--- a/docs/plans/image-cache-url-keying.md
+++ b/docs/plans/image-cache-url-keying.md
@@ -1,0 +1,311 @@
+# Plan: split the image cache into a URL-keyed byte cache + a read-only continuity hint
+
+- Status: draft for review
+- Date: 2026-06-26
+- Related:
+  - `docs/postmortems/2026-06-26-profile-avatar-cache-pingpong.md`
+  - `docs/specs/profile-contact-identity-model.md`
+
+## Goal
+
+Today `ImageCache` is secretly **two caches fused into one identity-keyed slot**,
+and that fusion is the root of the avatar clobber / oscillation / stuck-on-old
+bug class:
+
+- It stores "the bytes" and "the latest image to show for an identity" in the
+  same place, keyed by `imageCacheIdentifier` (e.g. `inboxId`).
+- `loadImage(for: object)` reconciles that single mutable slot to whatever
+  `imageCacheURL` the caller passes. Any caller — including a stale one — can
+  overwrite the slot, and the cache has no clock or authority to know whether a
+  caller's URL is newer or older than what it holds.
+
+That single property gives us both the nice behavior (show *something* for a
+person/group instantly, even mid-update) and the bug (a stale caller drags the
+shared slot backward, and views fight over it). They are the same mechanism, so
+you cannot keep one without the other.
+
+This plan splits them apart.
+
+## The core reframing: two caches
+
+1. **Authoritative byte cache — `url -> bytes`, immutable, URL-keyed.** Owns
+   truth. A given URL always pairs with one encryption key and decrypts to the
+   same bytes, so `url -> decrypted bytes` is a pure function and a safe key.
+   Two URLs are two independent entries, so there is **no shared identity slot to
+   clobber** — a stale caller fetches its own (old) URL's entry and never touches
+   a different URL's entry. No clobber, no oscillation, no stuck-on-old, and the
+   `recentlyFetched` stopgap guard is no longer needed.
+
+2. **Read-only continuity hint — `identity -> last-shown image`, disk-backed.**
+   This is the "show the previous image until the new one downloads" behavior we
+   rely on, demoted to a pure display fallback. It is consulted **only** as the
+   placeholder while the current URL is being fetched. It is written as a side
+   effect when a URL-keyed image successfully displays for that identity. It
+   **never triggers a fetch and never decides the canonical URL.**
+
+The distinction that makes this safe: **showing a stale face as a placeholder is
+fine; fetching and installing a stale URL as the canonical entry is the bug.**
+The current cache does the latter to achieve the former. After the split, the
+byte cache does only truth (URL-keyed, immutable) and the hint does only
+continuity (read-only, never fetches).
+
+## One call surface — call sites do not change
+
+The elegant part: the `ImageCacheable` object already carries **both** keys —
+`imageCacheURL` (truth) and `imageCacheIdentifier` (continuity key). So callers
+keep expressing the same intent — "show this object's image" — and all the
+truth-vs-continuity orchestration moves *inside* the cache. No call site branches
+on `contains`, and the hundreds of `(...).cachedImage(for: object)` / `image(for:
+object)` / `loadImage(for: object)` call sites stay identical.
+
+```swift
+// Sync "what do I show right now": URL hit, else continuity placeholder.
+func image(for object: any ImageCacheable) -> UIImage? {
+    if let url = object.imageCacheURL, let img = byteCache[key(url)] {
+        lastShown[object.imageCacheIdentifier] = img   // keep the hint fresh
+        return img
+    }
+    return lastShown[object.imageCacheIdentifier]        // stale bridge (may be nil)
+}
+
+// Async authoritative resolve: URL-keyed memory -> disk -> network(+decrypt).
+func loadImage(for object: any ImageCacheable) async -> UIImage? {
+    guard let url = object.imageCacheURL else { return nil }
+    let img = await fetchByURL(url, decrypting: object)   // deduped by url
+    if let img { lastShown[object.imageCacheIdentifier] = img }
+    return img
+}
+```
+
+The `.cachedImage(for:into:)` modifier keeps its current shape; continuity falls
+out for free:
+
+```swift
+.onAppear { binding.wrappedValue = cache.image(for: object) }      // url hit OR last-shown
+.task(id: object.imageCacheURL) {
+    binding.wrappedValue = cache.image(for: object)                // re-seed on url change -> old bridges
+    if let resolved = await cache.loadImage(for: object) {
+        binding.wrappedValue = resolved                            // swap when truth arrives
+    }
+}
+.onReceive(cache.updates(for: object.imageCacheURL)) { ... }
+```
+
+Walkthrough (the group-image case the current design handles and we must
+preserve): the URL flips `g1 -> g2`, `.task` re-fires, `image(for:)` looks up
+`g2` in the byte cache -> miss -> returns `lastShown[conversationId]` = the old
+group photo -> shown instantly, no blank; then `loadImage` downloads+decrypts
+`g2` and swaps. Identical to today's UX, but the byte cache never had a shared
+slot to clobber.
+
+## Scope
+
+In scope (the re-fetchable, URL-addressable path):
+
+- `image(for:)` / `loadImage(for:)` and the `ImageCacheable.imageCacheURL` flow
+  used by avatars, conversation/group images, link previews, invite images.
+- The memory (`NSCache`) + evictable disk byte tier.
+- The new read-only continuity hint.
+- `cacheUpdates` notifications.
+- `EncryptedImagePrefetcher`.
+- The `.cachedImage(for:into:)` modifier.
+
+Out of scope (leave as-is, to bound blast radius):
+
+- The persistent attachment tier (`cacheData(_:for:storageTier:.persistent)`,
+  `removePersistentImages`, etc.). Non-re-fetchable chat photos have no shared
+  slot problem and can stay identifier-keyed.
+- Protocol/wire changes (single-`RemoteAttachment` avatar) and the Contacts
+  canonical-URL work — tracked in the identity spec; complementary, see Risks.
+
+## What gets deleted vs added
+
+Deleted (machinery that existed only to manage the identity->URL coupling):
+
+- `URLTracker` entirely: `trackedURLs`, `peek`, `track`, the `.url` sidecar
+  persistence, and the `recentlyFetched`/`recordFetched` stopgap guard. The disk
+  filename becomes the URL hash; there is nothing to "track."
+- `scheduleBackgroundRefresh` and the URL-drift branches in `loadImage` (a
+  different URL is just a miss -> fetch).
+- `urlChangeSubject` / `urlChanges` / `hasURLChanged` and the `peek.changed` /
+  `shouldRefresh` logic.
+
+Added:
+
+- The read-only `lastShown` continuity hint (`identity -> image`), disk-backed.
+
+Note these are different things: the deleted `.url` **sidecars** were
+identity->URL mappings for drift detection (part of the clobber machinery). The
+added **continuity hint** is identity->last-displayed-image, read-only for
+display. We remove the former and add the latter.
+
+Kept: `loadingTasksLock` (network dedup, already URL-keyed); disk LRU cleanup
+(operates on files regardless of key meaning; the sidecar-pairing step goes away
+with the sidecars).
+
+## Key decisions to lock before coding
+
+1. **Key format.** Proposal: `sha256(url.absoluteString)` for the disk filename;
+   `url.absoluteString` (or its hash) as the `NSCache` key. Decide whether to
+   hash the memory key too.
+2. **Encrypted + plain under one URL key space.** Both decode to bytes stored
+   under the URL key. Confirm no URL is ever fetched with two different keys
+   (true today: per-conversation URLs are 1:1 with their key); add an
+   assertion/log if a second key is seen for an already-cached URL.
+3. **Continuity hint persistence + size.** Disk-backed so cold launch after a
+   remote change still bridges with the old image. Decide format (small JPEG
+   thumbnail per identity) and that it shares the LRU/size budget sensibly.
+4. **Owner pre-upload preview.** With URL-keying there is no URL at stage time.
+   Preserve instant display of your own just-picked photo (see Edge cases).
+
+## Phased implementation
+
+**Phase 0 - Audit.** Enumerate every caller of `ImageCache` / `ImageCacheProtocol`
+and every `ImageCacheable` conformance (`Profile`, `Conversation`, `LinkPreview`,
+`MessageInvite` in `ImageCacheableExtensions.swift`, plus `Contact`). Classify
+each as URL-path (migrate) or persistent/identifier-path (leave). Output a short
+table so nothing is missed.
+
+**Phase 1 - URL-keyed byte cache.** Add `key(for url: URL)`. Convert memory cache,
+disk filenames, and the fetch paths (`fetchByURL` = the encrypted/plain
+download+decode+cache) to key by URL. Update `image(for:)` / `loadImage(for:)` /
+`imageAsync` internals to resolve the URL from the passed object and key by it.
+
+**Phase 2 - Continuity hint (required, not optional).** Add the disk-backed
+`lastShown` store keyed by `imageCacheIdentifier`. Write it on every successful
+display/resolve. Read it only as the fallback in `image(for:)`. It never fetches
+and never sets canonical state.
+
+**Phase 3 - Delete the tracker + stopgap.** Remove `URLTracker`, sidecars,
+`recentlyFetched`/`recordFetched`, `scheduleBackgroundRefresh`, drift branches,
+`urlChangeSubject`, `hasURLChanged`. Re-point `cacheUpdates` to carry the URL key.
+
+**Phase 4 - Modifier.** Update `.cachedImage(for:into:)` to the shape above:
+`onAppear`/`.task` seed from `image(for:)` (so last-shown bridges), `.task(id:)`
+keyed on `object.imageCacheURL`, `.onReceive` filtered on the URL key, never reset
+the binding to nil on a miss.
+
+**Phase 5 - Prefetcher.** Update `EncryptedImagePrefetcher` to cache/check by URL
+key instead of `hydratedProfile.imageCacheIdentifier`.
+
+**Phase 6 - Owner upload preview.** Implement the chosen instant-preview path
+(Edge cases).
+
+**Phase 7 - On-upgrade cleanup.** The disk filename scheme changes
+(`sha256(identifier)` -> `sha256(url)`), so existing byte entries become
+unreachable. One-time wipe of the evictable image cache directory on first launch
+after upgrade (persistent attachment dir untouched). The new continuity hint
+starts empty and fills as images display.
+
+**Phase 8 - Tests + cleanup.** See Testing; remove now-dead stopgap code; update
+the identity spec to reference this as the cache half of the fix.
+
+## Edge cases
+
+- **Owner pre-upload preview.** Today `prepareForUpload` caches the picked image
+  under the identifier before any URL exists. Options:
+  1. Pass the picked `UIImage` to the view as `placeholderImage` /
+     `profileImage` for the upload duration (both `ProfileAvatarView` and
+     `AvatarView` already accept a placeholder); on completion the URL load takes
+     over. Cleanest.
+  2. Seed the `lastShown` hint for that identity with the picked image at stage
+     time, so any view bridges to it immediately. Reuses the hint; also fine.
+- **Clearing an avatar (url nil).** View shows placeholder/monogram; old URL
+  bytes age out via LRU. Decide whether to also clear `lastShown` for that
+  identity on an explicit clear, so a removed avatar doesn't keep bridging to the
+  old face (probably yes for an explicit clear; no for a transient nil).
+- **Same URL, multiple objects.** Naturally deduped — one entry, one fetch.
+- **Same image, different per-conversation URLs (pre-canonicalization).** Caches
+  once per URL (up to N x M decrypted copies), bounded by the existing disk LRU
+  and memory limits. The known storage cost of URL-keying without canonical URLs;
+  this is why the canonical-URL-in-Contact work pairs with it.
+- **URL reuse with changed content.** Not possible for content-addressed avatar
+  uploads (unique UUID + fresh salt/nonce). Only `LinkPreview` has a mutable URL;
+  a stale preview for its cache lifetime is acceptable/cosmetic.
+
+## Testing
+
+- URL-keyed get / set / disk round-trip / LRU eviction with URL-hash filenames.
+- **Regression for this whole saga:** two `ImageCacheable` values with the same
+  `imageCacheIdentifier` but different URLs produce two independent byte entries;
+  loading the old URL never changes the new URL's bytes (no clobber); fetch count
+  is bounded (no oscillation).
+- **Continuity:** after a remote URL change, a *fresh* view first shows the
+  `lastShown` image for that identity (no placeholder blink), then swaps to the
+  new URL once resolved — including across a simulated cold launch (hint is
+  disk-backed).
+- **No blink on in-place change:** a view whose URL flips a->b keeps showing a
+  until b resolves.
+- Encrypted fetch+decrypt cached and re-served by URL without re-fetch.
+- `lastShown` is never consulted to choose a fetch and never overrides a resolved
+  URL image once available.
+- Clearing an avatar: placeholder, no crash, hint behavior per the decision above.
+- Owner upload: picked image visible immediately (Phase 6 path).
+- Same URL across two objects: a single network/decrypt serves both.
+
+**Per-`ImageCacheable` type coverage.** Exercise each production conformance
+through the new `image(for:)` / `loadImage(for:)` / `.cachedImage(for:)` API.
+Three are encrypted (need `key/salt/nonce` at fetch); two are plain. For a 1:1/DM
+the same person is represented by `Profile`, `Conversation`, and `Contact` at
+once, so the dedup/continuity cases must be checked across types, not just within
+one.
+
+- `Profile` — member & agent avatars, encrypted (`ImageCacheableExtensions.swift:3`):
+  correct current avatar across surfaces (message bubbles, member list, read-by
+  drawer, contact card); the no-clobber regression (two URLs for one `inboxId`);
+  continuity bridge + no blink on change; removal; dedup across many simultaneous
+  avatar views of one person.
+- `Conversation` — group images and DM peer avatars, encrypted
+  (`ImageCacheableExtensions.swift:58`): group-image continuity (old shown while
+  the new one downloads, including across a simulated cold launch); both the
+  `customImage` and `profile(member)` branches resolve; the DM case shares the
+  peer's URL (must dedup with `Profile`, not clobber).
+- `Contact` — contacts-UI default avatar, encrypted (`Contact.swift:398`):
+  renders in contacts list / picker / detail; its `contact:` identifier differs
+  from `Profile`'s, so confirm the byte cache still dedups by URL (no double
+  fetch of the same image) and the continuity hint behaves under that key.
+- `LinkPreview` — link preview image, plain/unencrypted
+  (`ImageCacheableExtensions.swift:48`): renders by URL; mutable-URL caveat — a
+  changed preview at the same link does not refresh until the entry is evicted
+  (assert no crash / no clobber; accept the staleness).
+- `MessageInvite` — invite-card image, plain/unencrypted
+  (`ImageCacheableExtensions.swift:38`): renders by URL.
+- Test conformances `TestImageCacheable` / `EncryptedCacheable`
+  (`ImageCacheTests.swift`) updated to the URL-keyed API; existing suite green.
+
+## Rollout / migration
+
+- No schema or wire migration; memory cache is ephemeral; byte cache re-fetches
+  lazily after the one-time cleanup (Phase 7); the continuity hint starts empty.
+- Optional behavior flag for one release (the cache is on every avatar render) to
+  keep a fast revert path.
+- Reversible: changes are contained to `ImageCache` + the modifier + prefetcher.
+
+## Risks
+
+- **Storage/work amplification before canonical URLs** (N x M decrypted copies +
+  redundant decrypts of the same face). Bounded by existing LRU/memory limits but
+  real until canonicalization; sequence with the Contacts canonical-URL work or
+  accept the interim cost.
+- **Continuity hint correctness.** If the hint is written from the wrong image or
+  not cleared on explicit removal, a fresh view could briefly bridge to a wrong/
+  removed face. Bounded to the pre-load placeholder window (the resolved URL image
+  always overrides), and covered by tests, but get the write/clear rules right.
+- **Owner preview / no-blink regressions** if Phase 4/6 are botched — covered by
+  tests.
+- **Reactivity is now upstream-only.** The cache no longer detects URL changes;
+  correctness depends on the `Profile`/`Conversation` re-hydrating with the new
+  URL (DB -> `ValueObservation` -> re-render), which already drives today's drift
+  detection. Confirm every avatar/image surface is driven by an observation that
+  re-emits on URL change.
+
+## Why this is the right root fix
+
+The clobber / oscillation / stuck-on-old behaviors all require a shared mutable
+slot that callers write by supplying a URL. Splitting the cache removes that
+slot: the **byte cache** is immutable and URL-keyed (truth, un-clobberable), and
+the **continuity hint** is read-only identity-keyed (the nice "show the previous
+image" behavior, with no ability to fetch or set canonical). We keep the UX,
+delete the stopgap guard and the URL tracker, and the call sites do not change.
+Canonical-URL-in-Contact then makes it storage-efficient and lets one fetch serve
+every surface — the two halves of the complete fix.


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785112178&installation_id=128169237&pr_number=1116&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1116&signature=8a2cff3be734748ebd5a223f63d1e642a3860a7e62edef41ded92ae8c84c00a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix image cache to key bytes by URL, preventing identity-keyed clobber across URL changes
> - Replaces the identity-keyed byte cache model with a dual-key model: an authoritative URL-keyed byte cache plus a stable identity-keyed "continuity hint" that bridges display gaps when a URL changes.
> - Removes `URLTracker` and `ImageURLChange`; prefetch and filter logic in `EncryptedImagePrefetcher` and `ConversationWriter` now probe by URL rather than by identifier or URL-change state.
> - Adds `continuityImage(for:)` and `loadImageOrContinuity(for:)` to serve a last-shown placeholder when authoritative bytes are unavailable, preventing avatar blanking on URL transitions.
> - SwiftUI `cachedImage` extensions now seed bindings with both the authoritative and continuity images and subscribe to updates under either the URL or identity key to reduce placeholder flicker.
> - Risk: `.url` sidecar files are no longer written or cleaned up; existing sidecars on disk are orphaned until the next LRU cleanup pass.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8be2d61.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->