### PR TITLE
feat(variants): agent variant selector, three-call plumbing + in-app markers (CON-583)

### DIFF
--- a/Convos/Agent Builder/AgentBuilderView.swift
+++ b/Convos/Agent Builder/AgentBuilderView.swift
@@ -418,6 +418,12 @@ struct AgentBuilderView: View {
                 .padding(.bottom, DesignConstants.Spacing.step3x)
                 .opacity(viewModel.isRecordingVoiceMemo ? 0 : 1)
 
+            if FeatureFlags.shared.isAgentVariantSelectorEnabled, !viewModel.isRecordingVoiceMemo {
+                AgentVariantSelector()
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+                    .padding(.top, DesignConstants.Spacing.step3x)
+            }
+
             if viewModel.isRecordingVoiceMemo {
                 Spacer(minLength: 0)
                 recordingControls(focusState: focusState)

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -261,6 +261,13 @@ final class AgentBuilderViewModel: Identifiable {
     /// the repository. Cleared once the generation has been kicked off.
     @ObservationIgnored
     private var pendingDirectPrompt: String?
+    /// Direct-builder only: the dev variant slug captured at Make (`nil` when no
+    /// variant is selected), held alongside the prompt and handed to the
+    /// repository with it. Capturing once at Make -- not re-reading the device
+    /// selection when the deferred generation finally starts -- is what keeps a
+    /// mid-build variant switch from splitting generation and routing.
+    @ObservationIgnored
+    private var pendingDirectVariantId: String?
     @ObservationIgnored
     private var didStartDirectGeneration: Bool = false
     @ObservationIgnored
@@ -652,7 +659,12 @@ final class AgentBuilderViewModel: Identifiable {
         // chat without the reveal tail; the home flow runs the reveal/visibility
         // tail below so the chat animates in and the agent's contact card
         // appears once it joins.
-        startDirectGeneration(prompt: textToSend)
+        // Capture the active variant once, here at Make. Reading the device
+        // selection now (rather than when the deferred generation starts) is the
+        // split-brain guard: a mid-build switch can't generate under one variant
+        // and route/stamp under another.
+        let variantId = FeatureFlags.shared.selectedAgentVariant?.slug
+        startDirectGeneration(prompt: textToSend, variantId: variantId)
         if targetsExistingConversation { return }
 
         Task { @MainActor [weak self] in
@@ -774,8 +786,9 @@ extension AgentBuilderViewModel {
     /// Capture the prompt and start the generation as soon as the conversation
     /// has an invite slug. If Make was tapped before the conversation was
     /// ready, `onReachedReady` re-invokes `startDirectGenerationIfReady()`.
-    private func startDirectGeneration(prompt: String) {
+    private func startDirectGeneration(prompt: String, variantId: String?) {
         pendingDirectPrompt = prompt
+        pendingDirectVariantId = variantId
         startDirectGenerationIfReady()
     }
 
@@ -796,6 +809,8 @@ extension AgentBuilderViewModel {
         }
         didStartDirectGeneration = true
         pendingDirectPrompt = nil
+        let variantId = pendingDirectVariantId
+        pendingDirectVariantId = nil
         let conversationId = conversation.id
         let photos: [PendingPhotoAttachment] = directBuildPhotos()
         var attachmentInputs: [AgentBuildAttachmentInput] = []
@@ -849,7 +864,8 @@ extension AgentBuilderViewModel {
             conversationId: conversationId,
             slug: slug,
             attachments: attachmentInputs,
-            connections: connectionServiceIds
+            connections: connectionServiceIds,
+            variantId: variantId
         )
         var bundledIds: Set<String> = []
         if let promptMessageId { bundledIds.insert(promptMessageId) }

--- a/Convos/Agent Builder/AgentBuilderViewModel.swift
+++ b/Convos/Agent Builder/AgentBuilderViewModel.swift
@@ -662,8 +662,12 @@ final class AgentBuilderViewModel: Identifiable {
         // Capture the active variant once, here at Make. Reading the device
         // selection now (rather than when the deferred generation starts) is the
         // split-brain guard: a mid-build switch can't generate under one variant
-        // and route/stamp under another.
-        let variantId = FeatureFlags.shared.selectedAgentVariant?.slug
+        // and route/stamp under another. Gated on the selector flag so a stale
+        // persisted selection can't silently route builds once the dev toggle is
+        // turned back off (disabling it only hides the UI, not the cached value).
+        let variantId = FeatureFlags.shared.isAgentVariantSelectorEnabled
+            ? FeatureFlags.shared.selectedAgentVariant?.slug
+            : nil
         startDirectGeneration(prompt: textToSend, variantId: variantId)
         if targetsExistingConversation { return }
 

--- a/Convos/Agent Builder/AgentVariantSelector.swift
+++ b/Convos/Agent Builder/AgentVariantSelector.swift
@@ -78,25 +78,35 @@ struct AgentVariantSelector: View {
 
     private var menu: some View {
         Menu {
-            let selectNone = { viewModel.select(nil) }
-            Button(action: selectNone) {
-                menuItemLabel(title: "No variant", selected: viewModel.selectedVariant == nil)
-            }
-            switch viewModel.loadState {
-            case .loaded:
-                ForEach(viewModel.variants) { variant in
-                    let selectVariant = { viewModel.select(variant) }
-                    Button(action: selectVariant) {
-                        menuItemLabel(title: variant.label, selected: viewModel.isSelected(variant))
-                    }
-                }
-            case .loading:
-                Text("Loading variants...")
-            case .failed:
-                Text("Couldn't load variants")
-            }
+            menuContent
         } label: {
             menuButtonLabel
+        }
+    }
+
+    @ViewBuilder
+    private var menuContent: some View {
+        let selectNone = { viewModel.select(nil) }
+        Button(action: selectNone) {
+            menuItemLabel(title: "No variant", selected: viewModel.selectedVariant == nil)
+        }
+        loadedVariantsOrPlaceholder
+    }
+
+    @ViewBuilder
+    private var loadedVariantsOrPlaceholder: some View {
+        switch viewModel.loadState {
+        case .loaded:
+            ForEach(viewModel.variants) { variant in
+                let selectVariant = { viewModel.select(variant) }
+                Button(action: selectVariant) {
+                    menuItemLabel(title: variant.label, selected: viewModel.isSelected(variant))
+                }
+            }
+        case .loading:
+            Text("Loading variants...")
+        case .failed:
+            Text("Couldn't load variants")
         }
     }
 

--- a/Convos/Agent Builder/AgentVariantSelector.swift
+++ b/Convos/Agent Builder/AgentVariantSelector.swift
@@ -1,0 +1,134 @@
+import ConvosCore
+import SwiftUI
+
+/// Loads the dev variant registry (`GET /v2/agent-variants`) and tracks the
+/// chosen one, mirrored into `FeatureFlags.selectedAgentVariant` so `commit()`
+/// can thread its slug through the build. A persisted selection whose slug is
+/// gone from the live registry silently falls back to no variant.
+@MainActor
+@Observable
+final class AgentVariantSelectorViewModel {
+    enum LoadState {
+        case loading
+        case loaded
+        case failed
+    }
+
+    private(set) var variants: [ConvosAPI.AgentVariant] = []
+    private(set) var loadState: LoadState = .loading
+    /// The chosen variant (`nil` = none). A stored mirror of
+    /// `FeatureFlags.selectedAgentVariant` so the view reacts to selection.
+    private(set) var selectedVariant: ConvosAPI.AgentVariant?
+
+    private let apiClient: any ConvosAPIClientProtocol
+
+    init(apiClient: any ConvosAPIClientProtocol = ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)) {
+        self.apiClient = apiClient
+        self.selectedVariant = FeatureFlags.shared.selectedAgentVariant
+    }
+
+    func isSelected(_ variant: ConvosAPI.AgentVariant) -> Bool {
+        selectedVariant?.slug == variant.slug
+    }
+
+    func load() async {
+        loadState = .loading
+        do {
+            let fetched = try await apiClient.getAgentVariants()
+            variants = fetched
+            reconcileSelection(against: fetched)
+            loadState = .loaded
+        } catch {
+            Log.error("AgentVariantSelector: failed to load variants: \(error.localizedDescription)")
+            loadState = .failed
+        }
+    }
+
+    func select(_ variant: ConvosAPI.AgentVariant?) {
+        FeatureFlags.shared.selectedAgentVariant = variant
+        selectedVariant = variant
+    }
+
+    private func reconcileSelection(against fetched: [ConvosAPI.AgentVariant]) {
+        guard let slug = selectedVariant?.slug else { return }
+        guard !fetched.contains(where: { $0.slug == slug }) else { return }
+        FeatureFlags.shared.selectedAgentVariant = nil
+        selectedVariant = nil
+    }
+}
+
+/// Dev-only variant selector for the make-an-agent composer, gated by
+/// `FeatureFlags.isAgentVariantSelectorEnabled`. A dropdown of variant labels
+/// ("No variant" plus the live registry); the chosen one's full what-to-test
+/// renders below via `ConversationVariantBanner` so the builder reviews it
+/// before Make.
+struct AgentVariantSelector: View {
+    @State private var viewModel: AgentVariantSelectorViewModel = AgentVariantSelectorViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step3x) {
+            menu
+            if let selected = viewModel.selectedVariant {
+                ConversationVariantBanner(variant: selected.stamp)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task { await viewModel.load() }
+    }
+
+    private var menu: some View {
+        Menu {
+            let selectNone = { viewModel.select(nil) }
+            Button(action: selectNone) {
+                menuItemLabel(title: "No variant", selected: viewModel.selectedVariant == nil)
+            }
+            switch viewModel.loadState {
+            case .loaded:
+                ForEach(viewModel.variants) { variant in
+                    let selectVariant = { viewModel.select(variant) }
+                    Button(action: selectVariant) {
+                        menuItemLabel(title: variant.label, selected: viewModel.isSelected(variant))
+                    }
+                }
+            case .loading:
+                Text("Loading variants...")
+            case .failed:
+                Text("Couldn't load variants")
+            }
+        } label: {
+            menuButtonLabel
+        }
+    }
+
+    @ViewBuilder
+    private func menuItemLabel(title: String, selected: Bool) -> some View {
+        if selected {
+            Label(title, systemImage: "checkmark")
+        } else {
+            Text(title)
+        }
+    }
+
+    private var menuTitle: String {
+        guard let variant = viewModel.selectedVariant else { return "No variant" }
+        return "🧪 \(variant.label)"
+    }
+
+    private var menuButtonLabel: some View {
+        HStack(spacing: DesignConstants.Spacing.stepX) {
+            Text(menuTitle)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.colorTextPrimary)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.caption2)
+                .foregroundStyle(.colorTextSecondary)
+            Spacer(minLength: 0.0)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.vertical, DesignConstants.Spacing.step3x)
+        .background(
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
+                .fill(.colorFillMinimal)
+        )
+    }
+}

--- a/Convos/Assets.xcassets/colorWarning.colorset/Contents.json
+++ b/Convos/Assets.xcassets/colorWarning.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xC4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -31,6 +31,12 @@ final class FeatureFlags {
         set {
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
             UserDefaults.standard.set(newValue, forKey: Constant.agentVariantSelectorEnabledKey)
+            // Clear any cached selection when the feature is turned off so a
+            // stale variant can't resurface on re-enable. Reads are already
+            // gated on this flag; clearing keeps the persisted state honest too.
+            if !newValue {
+                selectedAgentVariant = nil
+            }
         }
     }
 

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -20,6 +20,20 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- gates the dev-only agent variant selector that appears
+    /// in the make-an-agent composer. Toggle from App Settings -> Debug. Hard-
+    /// locked off in production so the selector can never surface for end users.
+    var isAgentVariantSelectorEnabled: Bool {
+        get {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+            return UserDefaults.standard.bool(forKey: Constant.agentVariantSelectorEnabledKey)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            UserDefaults.standard.set(newValue, forKey: Constant.agentVariantSelectorEnabledKey)
+        }
+    }
+
     /// Mock credits/subscription state used by the in-app paywall preview surface
     /// in the Debug menu. Non-production only; defaults to `.plusAmple`.
     var mockCreditsPreset: CreditsStatePreset {
@@ -33,8 +47,32 @@ final class FeatureFlags {
         }
     }
 
+    /// Dev-only agent variant chosen in the make-an-agent composer's selector.
+    /// The full bundle is cached (not just the slug) so the selected detail
+    /// renders without a fetch; the selector reconciles it against the live
+    /// registry. The build reads `slug` once at Make and carries it through all
+    /// three calls. Hard-locked to `nil` in production builds so a leaked value
+    /// can never route an end user to a variant runtime.
+    var selectedAgentVariant: ConvosAPI.AgentVariant? {
+        get {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return nil }
+            guard let data = UserDefaults.standard.data(forKey: Constant.selectedAgentVariantKey) else { return nil }
+            return try? JSONDecoder().decode(ConvosAPI.AgentVariant.self, from: data)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            guard let newValue, let data = try? JSONEncoder().encode(newValue) else {
+                UserDefaults.standard.removeObject(forKey: Constant.selectedAgentVariantKey)
+                return
+            }
+            UserDefaults.standard.set(data, forKey: Constant.selectedAgentVariantKey)
+        }
+    }
+
     private enum Constant {
         static let debugInjectorEnabledKey: String = "featureFlags.debugInjectorEnabled"
         static let mockCreditsPresetKey: String = "featureFlags.mockCreditsPreset"
+        static let selectedAgentVariantKey: String = "featureFlags.selectedAgentVariant"
+        static let agentVariantSelectorEnabledKey: String = "featureFlags.agentVariantSelectorEnabled"
     }
 }

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -45,6 +45,10 @@ import SwiftUI
 /// entry-point mapping and section visibility rules.
 struct ContactDetailView: View {
     let contact: Contact
+    /// Dev-only variant marker, passed from the live member profile at the
+    /// chat-side entry point (`nil` elsewhere). Drives the 🧪 variant card on
+    /// the agent profile, mirroring the in-chat ribbon.
+    let variantStamp: AgentVariantStamp?
     let mode: ContactDetailMode
     /// True when the view should render its own X close button in the
     /// nav-bar's cancellation slot. Sheet entry points (where there is no
@@ -106,6 +110,7 @@ struct ContactDetailView: View {
 
     init(
         contact: Contact,
+        variantStamp: AgentVariantStamp? = nil,
         mode: ContactDetailMode = .standalone,
         contactsWriter: any ContactsWriterProtocol,
         contactsRepository: any ContactsRepositoryProtocol,
@@ -117,6 +122,7 @@ struct ContactDetailView: View {
         onRemove: (() -> Void)? = nil
     ) {
         self.contact = contact
+        self.variantStamp = variantStamp
         self.mode = mode
         self.contactsWriter = contactsWriter
         self.contactsRepository = contactsRepository
@@ -325,6 +331,11 @@ struct ContactDetailView: View {
                     .padding(.top, DesignConstants.Spacing.step2x)
                 }
                 headerBadge
+                if !ConfigManager.shared.currentEnvironment.isProduction, let variant = variantStamp {
+                    ConversationVariantBanner(variant: variant)
+                        .padding(.top, DesignConstants.Spacing.step6x)
+                        .padding(.horizontal, DesignConstants.Spacing.step4x)
+                }
                 ContactDetailActions(
                     isBlocked: isBlocked,
                     isApplyingBlockChange: isApplyingBlockChange,

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -140,11 +140,20 @@ struct ContactsPickerView: View {
             }
         }
         .safeAreaBar(edge: .bottom) {
-            ContactsPickerConfirmButton(
-                title: viewModel.confirmButtonTitle,
-                isEnabled: viewModel.canConfirm,
-                onTap: handleConfirm
-            )
+            VStack(spacing: DesignConstants.Spacing.step3x) {
+                // Dev-only: choose the variant the picked agent(s) build under.
+                // Shown only once an agent is in the selection; the slug is read
+                // at join time via FeatureFlags, so no plumbing through confirm.
+                if FeatureFlags.shared.isAgentVariantSelectorEnabled, !viewModel.selectedAgentTemplateIds.isEmpty {
+                    AgentVariantSelector()
+                        .padding(.horizontal, DesignConstants.Spacing.step4x)
+                }
+                ContactsPickerConfirmButton(
+                    title: viewModel.confirmButtonTitle,
+                    isEnabled: viewModel.canConfirm,
+                    onTap: handleConfirm
+                )
+            }
         }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -753,6 +753,7 @@ struct MemberContactDetailSheetContent: View {
         NavigationStack {
             ContactDetailView(
                 contact: resolvedContact,
+                variantStamp: member.profile.variant,
                 mode: .scopedToConversation(
                     conversationId: viewModel.conversation.id,
                     canRemoveMembers: viewModel.canRemoveMembers,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3738,11 +3738,13 @@ extension ConversationViewModel {
         let taskId = requestId
         let session = self.session
         let actions: any CoreActions = coreActions
+        let variantId = Self.selectedAgentVariantSlug()
         agentJoinTask = Task { [weak self] in
             let outcome = await Self.performAgentJoinCall(
                 templateId: templateId,
                 conversationId: conversationId,
                 requestId: requestId,
+                variantId: variantId,
                 forceErrorCode: forceErrorCode,
                 session: session
             )
@@ -3828,6 +3830,7 @@ extension ConversationViewModel {
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
         let session = self.session
+        let variantId = Self.selectedAgentVariantSlug()
         Task { [weak self] in
             var failed: [AgentJoinAttempt] = []
             var anySucceeded = false
@@ -3842,6 +3845,7 @@ extension ConversationViewModel {
                     templateId: join.templateId,
                     conversationId: conversationId,
                     requestId: join.requestId,
+                    variantId: variantId,
                     forceErrorCode: forceErrorCode,
                     session: session
                 )
@@ -3959,10 +3963,20 @@ extension ConversationViewModel {
     /// `.noAgentsAvailable`) on error. Static + parameterized so both the
     /// single-flight and batched callers can share the same body without
     /// holding `self`.
+    /// The dev-selected agent variant slug to route an agent join, or `nil`.
+    /// Gated on the selector flag so a stale persisted selection can't route
+    /// joins once the dev toggle is off (mirrors `AgentBuilderViewModel.commit`).
+    private static func selectedAgentVariantSlug() -> String? {
+        FeatureFlags.shared.isAgentVariantSelectorEnabled
+            ? FeatureFlags.shared.selectedAgentVariant?.slug
+            : nil
+    }
+
     private static func performAgentJoinCall(
         templateId: String?,
         conversationId: String,
         requestId: String,
+        variantId: String?,
         forceErrorCode: Int?,
         session: any SessionManagerProtocol
     ) async -> AgentJoinOutcome {
@@ -3973,10 +3987,13 @@ extension ConversationViewModel {
         )
         Log.info("performAgentJoinCall about to POST agents/join templateId=\(templateId ?? "nil") requestId=\(requestId)")
         do {
+            let options: ConvosAPI.AgentJoinOptions? = variantId.map {
+                ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0)
+            }
             _ = try await session.addAgentToConversation(
                 conversationId: conversationId,
                 templateId: templateId,
-                options: nil,
+                options: options,
                 forceErrorCode: forceErrorCode
             )
             Log.info("performAgentJoinCall succeeded templateId=\(templateId ?? "nil") requestId=\(requestId)")

--- a/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConversationVariantBanner.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/Messages List Items/ConversationVariantBanner.swift
@@ -1,0 +1,85 @@
+import ConvosCore
+import SwiftUI
+
+/// The shared dev-only variant ribbon: `🧪 <label> · PR #<n>` on a soft yellow
+/// surface, with the PR number linking to the pull request. Rendered as a plain
+/// rectangle; the host shapes its corners. Used in two places so they read as
+/// the same thing: overlaid across the top of the in-chat agent contact card
+/// (clipped to the card's top corners), and as the header of the agent
+/// profile's variant card, with the full what-to-test expanded below it.
+struct AgentVariantRibbon: View {
+    let variant: AgentVariantStamp
+    /// Vertical inset of the ribbon bar. The in-chat overlay uses a tighter
+    /// value so more of the contact card's top padding stays visible beneath it.
+    var verticalPadding: CGFloat = DesignConstants.Spacing.step2x
+
+    var body: some View {
+        let prURL: URL? = variant.prUrl.flatMap { URL(string: $0) }
+        let prNumber: String? = variant.prUrl.flatMap { Self.prNumber(from: $0) }
+        HStack(spacing: DesignConstants.Spacing.stepHalf) {
+            Text("🧪 \(variant.label)")
+                .lineLimit(1)
+            if let prURL, let prNumber {
+                Text("·")
+                    .foregroundStyle(.colorTextSecondary)
+                Link("PR #\(prNumber)", destination: prURL)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0.0)
+        }
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(.colorTextPrimary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.vertical, verticalPadding)
+        .background(.colorWarning.opacity(0.18))
+    }
+
+    static func prNumber(from prUrl: String) -> String? {
+        guard let number = prUrl.split(separator: "/").last, !number.isEmpty else { return nil }
+        return String(number)
+    }
+}
+
+/// The agent profile's variant card: the shared `AgentVariantRibbon` as a header
+/// (so it matches the in-chat ribbon) plus the full what-to-test below. Dev-only;
+/// gated to non-production at the call site.
+struct ConversationVariantBanner: View {
+    let variant: AgentVariantStamp
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0.0) {
+            AgentVariantRibbon(variant: variant)
+            Text(variant.whatToTest)
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(DesignConstants.Spacing.step4x)
+        }
+        .background(Color.colorBackgroundRaised)
+        .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Variant \(variant.label). \(variant.whatToTest)")
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        AgentVariantRibbon(
+            variant: AgentVariantStamp(
+                slug: "pr-1234", label: "Mixture of Agents",
+                whatToTest: "Every reply runs through Mixture of Agents.",
+                prUrl: "https://github.com/xmtplabs/convos-assistants/pull/2334"
+            )
+        )
+        ConversationVariantBanner(
+            variant: AgentVariantStamp(
+                slug: "pr-1234", label: "Mixture of Agents",
+                whatToTest: "Every reply runs through Mixture of Agents — GLM-5.2 + DeepSeek V4 Pro + Kimi K2.6 synthesized by a Claude Opus 4.8 aggregator.",
+                prUrl: "https://github.com/xmtplabs/convos-assistants/pull/2334"
+            )
+        )
+    }
+    .padding()
+    .background(Color.colorBackgroundRaisedSecondary)
+}

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -323,8 +323,9 @@ struct MessagesGroupView: View {
     }
 
     /// Dev-only variant ribbon overlaid on the agent contact card's top, clipped
-    /// to its own top corners so the card stays untouched. The PR-number link
-    /// taps through to the PR; taps elsewhere fall to the card.
+    /// to its own top corners so the card stays untouched. Non-interactive so
+    /// taps pass through to the card's gesture and open the agent profile, which
+    /// carries the full detail and a working PR link.
     @ViewBuilder
     private var variantRibbonOverlay: some View {
         if !ConfigManager.shared.currentEnvironment.isProduction,
@@ -339,6 +340,7 @@ struct MessagesGroupView: View {
                         topTrailingRadius: 24.0
                     )
                 )
+                .allowsHitTesting(false)
         }
     }
 

--- a/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesListView/MessagesGroupView.swift
@@ -322,6 +322,26 @@ struct MessagesGroupView: View {
         .id("merged-thinking-receipt-\(message.differenceIdentifier)")
     }
 
+    /// Dev-only variant ribbon overlaid on the agent contact card's top, clipped
+    /// to its own top corners so the card stays untouched. The PR-number link
+    /// taps through to the PR; taps elsewhere fall to the card.
+    @ViewBuilder
+    private var variantRibbonOverlay: some View {
+        if !ConfigManager.shared.currentEnvironment.isProduction,
+           let variant = displayGroup.sender.profile.variant {
+            // Top corners match AgentContactCardView's 24pt card radius.
+            AgentVariantRibbon(variant: variant, verticalPadding: DesignConstants.Spacing.stepX)
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 24.0,
+                        bottomLeadingRadius: 0.0,
+                        bottomTrailingRadius: 0.0,
+                        topTrailingRadius: 24.0
+                    )
+                )
+        }
+    }
+
     @ViewBuilder
     private func contactCardRow(card: AgentContactCardInfo) -> some View {
         // The card shows its own bottom-leading avatar only when it is the
@@ -353,6 +373,9 @@ struct MessagesGroupView: View {
                         if cardIsLast && !displayGroup.sender.isCurrentUser {
                             avatarOverlay { onTapSender(displayGroup.sender) }
                         }
+                    }
+                    .overlay(alignment: .top) {
+                        variantRibbonOverlay
                     }
 
                 Spacer()

--- a/Convos/Conversations List/ConversationsListItem.swift
+++ b/Convos/Conversations List/ConversationsListItem.swift
@@ -82,7 +82,13 @@ struct ConversationsListItem: View {
     @Environment(\.memberNameOverride) private var memberNameOverride: @Sendable (String) -> String?
 
     // Extract computed values to prevent unnecessary recalculations
-    private var title: String { conversation.title(memberNameOverride: memberNameOverride) }
+    private var title: String {
+        let base: String = conversation.title(memberNameOverride: memberNameOverride)
+        guard !ConfigManager.shared.currentEnvironment.isProduction, conversation.agentVariant != nil else {
+            return base
+        }
+        return "🧪 \(base)"
+    }
     private var isMuted: Bool { conversation.isMuted }
     private var isUnread: Bool { conversation.isUnread }
     private var lastMessage: MessagePreview? { conversation.lastMessage }

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -72,6 +72,7 @@ struct DebugViewSection: View {
     private var featuresSection: some View {
         Section("Features") {
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
+            Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
 
             let showInfoAction = { showingAgentsInfoSheet = true }
             Button(action: showInfoAction) {

--- a/Convos/Shared Views/ConversationToolbarButton.swift
+++ b/Convos/Shared Views/ConversationToolbarButton.swift
@@ -38,10 +38,11 @@ struct ConversationToolbarButton: View {
     }
 
     var title: String {
-        guard !conversationName.isEmpty else {
-            return placeholderName
+        let base: String = conversationName.isEmpty ? placeholderName : conversationName
+        guard !ConfigManager.shared.currentEnvironment.isProduction, conversation.agentVariant != nil else {
+            return base
         }
-        return conversationName
+        return "🧪 \(base)"
     }
 
     @ViewBuilder

--- a/ConvosCore/Sources/ConvosCore/API/AgentTemplateGenerationModels.swift
+++ b/ConvosCore/Sources/ConvosCore/API/AgentTemplateGenerationModels.swift
@@ -50,13 +50,20 @@ public extension ConvosAPI {
         /// directory), matching the website create flow. Always encoded; when the
         /// field is absent the backend defaults to a listed/public template.
         public let publishStatus: String
+        /// Dev-only agent variant slug. A top-level envelope field (sibling of
+        /// `source`/`inputs`, not nested in `inputs`) selecting the variant's
+        /// builder prompt server-side. Omitted from the encoded body when `nil`
+        /// (via `encodeIfPresent`) so default builds stay byte-identical; the
+        /// backend schema is `.strict()`, so the key only belongs at top level.
+        public let variantId: String?
 
-        public init(source: String, inputs: Inputs, connections: [String]? = nil, clientDeviceId: String?, publishStatus: String) {
+        public init(source: String, inputs: Inputs, connections: [String]? = nil, clientDeviceId: String?, publishStatus: String, variantId: String? = nil) {
             self.source = source
             self.inputs = inputs
             self.connections = connections
             self.clientDeviceId = clientDeviceId
             self.publishStatus = publishStatus
+            self.variantId = variantId
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/AgentVariantModels.swift
+++ b/ConvosCore/Sources/ConvosCore/API/AgentVariantModels.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public extension ConvosAPI {
+    /// A registered dev-only agent variant from the backend registry
+    /// (`GET /v2/agent-variants`). A named bundle pinning an ephemeral runtime
+    /// (`assistantWorkerUrl`, Axis A) and/or a builder prompt
+    /// (`builderPromptSlug`, Axis B); the app selects one by `slug` and carries
+    /// that slug through the generation, join, and join-status-poll calls.
+    struct AgentVariant: Codable, Sendable, Equatable, Identifiable {
+        public let slug: String
+        public let label: String
+        public let whatToTest: String
+        /// Registry lifecycle, e.g. `building` | `ready`. Kept a string (not an
+        /// enum) so an unknown backend status never fails decoding.
+        public let status: String
+        /// Ephemeral worker host (Axis A); `nil` for a default-runtime variant.
+        public let assistantWorkerUrl: String?
+        /// Bench/Braintrust builder-prompt slug (Axis B); `nil` for the canonical
+        /// generator prompt.
+        public let builderPromptSlug: String?
+        public let prUrl: String?
+        public let branch: String?
+        public let commit: String?
+
+        public var id: String { slug }
+
+        public init(
+            slug: String,
+            label: String,
+            whatToTest: String,
+            status: String,
+            assistantWorkerUrl: String? = nil,
+            builderPromptSlug: String? = nil,
+            prUrl: String? = nil,
+            branch: String? = nil,
+            commit: String? = nil
+        ) {
+            self.slug = slug
+            self.label = label
+            self.whatToTest = whatToTest
+            self.status = status
+            self.assistantWorkerUrl = assistantWorkerUrl
+            self.builderPromptSlug = builderPromptSlug
+            self.prUrl = prUrl
+            self.branch = branch
+            self.commit = commit
+        }
+    }
+
+    /// Envelope for `GET /v2/agent-variants` -- the registry returns
+    /// `{ data: [ ... ] }`, not a bare array.
+    struct AgentVariantsResponse: Codable, Sendable {
+        public let data: [AgentVariant]
+
+        public init(data: [AgentVariant]) {
+            self.data = data
+        }
+    }
+}
+
+public extension ConvosAPI.AgentVariant {
+    /// The profile-stamp projection of this registry variant, so the pre-Make
+    /// selector can preview a chosen variant with the same `AgentVariantStamp`-
+    /// driven views the built agent shows.
+    var stamp: AgentVariantStamp {
+        AgentVariantStamp(slug: slug, label: label, whatToTest: whatToTest, prUrl: prUrl)
+    }
+}
+
+/// The variant marker stamped onto a variant-built agent's XMTP profile
+/// (`Profile.metadata["variant"]`), written by the assistants worker at join as
+/// `JSON.stringify({ slug, label, whatToTest, prUrl })`. Read by the dev variant
+/// ribbon, profile card, and name/header badges. A smaller, distinct shape from
+/// the registry `ConvosAPI.AgentVariant`: only these four fields ride the profile.
+public struct AgentVariantStamp: Codable, Sendable, Equatable, Hashable {
+    public let slug: String
+    public let label: String
+    public let whatToTest: String
+    public let prUrl: String?
+
+    public init(slug: String, label: String, whatToTest: String, prUrl: String? = nil) {
+        self.slug = slug
+        self.label = label
+        self.whatToTest = whatToTest
+        self.prUrl = prUrl
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -212,9 +212,17 @@ public enum ConvosAPI {
     /// the generic chat persona.
     public struct AgentJoinOptions: Codable, Sendable {
         public let onboarding: String?
+        /// Dev-only agent variant slug, routing the join to the variant's
+        /// ephemeral worker (`variant.assistantWorkerUrl`) server-side. Nested
+        /// here (not top-level) because the join schema is `.strict()`; omitted
+        /// from the encoded body when `nil` (via `encodeIfPresent`) so default
+        /// joins stay byte-identical. The backend strips it before forwarding to
+        /// the worker.
+        public let variantId: String?
 
-        public init(onboarding: String?) {
+        public init(onboarding: String?, variantId: String? = nil) {
             self.onboarding = onboarding
+            self.variantId = variantId
         }
 
         public static let agentBuilder: AgentJoinOptions = AgentJoinOptions(onboarding: "agent-builder")

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -887,12 +887,16 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // `timezone` is the creator's device IANA timezone, captured on the main
         // actor by the caller. It seeds the agent's baseline/default zone and is
         // distinct from the per-sender ProfileUpdate "timezone" metadata key.
+        // Prod backstop: strip a leaked dev variant slug from the join options.
+        let safeOptions = options.map {
+            ConvosAPI.AgentJoinOptions(onboarding: $0.onboarding, variantId: prodSafeVariantId($0.variantId))
+        }
         request.httpBody = try JSONEncoder().encode(
             ConvosAPI.AgentJoinRequest(
                 slug: slug,
                 conversationId: conversationId,
                 templateId: templateId,
-                options: options,
+                options: safeOptions,
                 timezone: timezone
             )
         )
@@ -929,7 +933,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // `variantId` is load-bearing here: the backend only routes the poll to
         // the variant's ephemeral worker when it is present, so a variant-built
         // agent whose poll omits it stalls against the default worker.
-        let queryParameters: [String: String]? = variantId.map { ["variantId": $0] }
+        let queryParameters = Self.agentJoinStatusQueryParameters(variantId: prodSafeVariantId(variantId))
         var request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET", queryParameters: queryParameters)
         // Bound a single poll: without this a hung GET stalls the caller's
         // registration loop indefinitely, since the loop's own deadline is
@@ -1012,7 +1016,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
                 connections: connections.isEmpty ? nil : connections,
                 clientDeviceId: clientDeviceId,
                 publishStatus: "unlisted",
-                variantId: variantId
+                variantId: prodSafeVariantId(variantId)
             )
         )
         request.httpBody = body
@@ -1200,6 +1204,21 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 // MARK: - Agent template generation (split out to keep the class body length in check)
 
 extension ConvosAPIClient {
+    /// Defense-in-depth: drop any dev variant slug in production. The invariant
+    /// is enforced at the source (FeatureFlags hard-locks the selection to nil in
+    /// prod), so nothing should reach here; this keeps the client honest even if
+    /// a future caller isn't gated.
+    func prodSafeVariantId(_ slug: String?) -> String? {
+        environment.isProduction ? nil : slug
+    }
+
+    /// Query parameters for the join-status poll. The dev `variantId` is the
+    /// load-bearing routing key; omitted entirely when nil so a default poll
+    /// stays byte-identical to the pre-variant shape.
+    static func agentJoinStatusQueryParameters(variantId: String?) -> [String: String]? {
+        variantId.map { ["variantId": $0] }
+    }
+
     func getAgentTemplateAttachmentPresignedURL(
         contentType: String,
         contentLength: Int

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -139,11 +139,10 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// `getAgentTemplateGeneration` for the terminal state. `idempotencyKey`
     /// must be a UUID and is reused across retries of the same submit.
     func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse
@@ -262,11 +261,10 @@ extension ConvosAPIClientProtocol {
     /// have to stub these. The real `ConvosAPIClient` and `MockAPIClient`
     /// override both.
     func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
@@ -991,11 +989,10 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
@@ -1005,7 +1002,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         let body = try JSONEncoder().encode(
             ConvosAPI.AgentTemplateGenerationRequest(
                 source: source,
-                inputs: .init(text: text, attachments: attachments.isEmpty ? nil : attachments),
+                inputs: inputs,
                 connections: connections.isEmpty ? nil : connections,
                 clientDeviceId: clientDeviceId,
                 publishStatus: "unlisted",

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -985,6 +985,12 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // route serves an empty list.
         let request = try authenticatedRequest(for: "v2/agent-variants")
         let response: ConvosAPI.AgentVariantsResponse = try await performRequest(request)
+        if response.data.isEmpty {
+            // A throw would mean a transport/auth failure; an empty list is the
+            // route's intended prod response (or no open variants in dev). Log so
+            // the two are distinguishable when the picker shows nothing.
+            Log.info("getAgentVariants: registry returned an empty list")
+        }
         return response.data
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -101,7 +101,11 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 
     /// Polls a dispatched agent's provisioning status. Direct-add callers
     /// use it to obtain `inboxId` when the join response didn't carry one.
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse
+    /// `variantId` (dev-only) is appended as a `?variantId=` query param; it is
+    /// load-bearing for variant-built agents because the backend only routes the
+    /// poll to the variant's ephemeral worker when present, so omitting it makes
+    /// the poll hit the default worker, which has no record of the instance.
+    func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse
 
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
@@ -125,6 +129,11 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// `getFeaturedAgentTemplates`.
     func getAgentPromptHints() async throws -> [String]
 
+    /// Lists registered dev-only agent variants (`GET /v2/agent-variants`).
+    /// Authenticated (user JWT) and served only by the dev backend -- elsewhere
+    /// it returns an empty list. Backs the Debug-menu variant picker.
+    func getAgentVariants() async throws -> [ConvosAPI.AgentVariant]
+
     /// Submits an async template generation (`POST /v2/agent-templates/generations`).
     /// Returns 202 with `status: pending` by default; the caller polls
     /// `getAgentTemplateGeneration` for the terminal state. `idempotencyKey`
@@ -135,7 +144,8 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse
 
     /// Polls a generation's status (`GET /v2/agent-templates/generations/:id`).
@@ -257,7 +267,8 @@ extension ConvosAPIClientProtocol {
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         throw APIError.invalidRequest
     }
@@ -915,9 +926,13 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         }
     }
 
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+    func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse {
         let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
-        var request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET")
+        // `variantId` is load-bearing here: the backend only routes the poll to
+        // the variant's ephemeral worker when it is present, so a variant-built
+        // agent whose poll omits it stalls against the default worker.
+        let queryParameters: [String: String]? = variantId.map { ["variantId": $0] }
+        var request = try authenticatedRequest(for: "v2/agents/join/\(encoded)", method: "GET", queryParameters: queryParameters)
         // Bound a single poll: without this a hung GET stalls the caller's
         // registration loop indefinitely, since the loop's own deadline is
         // only checked between iterations and can't interrupt an in-flight
@@ -966,13 +981,23 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         return response.hints
     }
 
+    func getAgentVariants() async throws -> [ConvosAPI.AgentVariant] {
+        // Authenticated GET -- the registry is dev-gated and sends the user JWT.
+        // The response is enveloped (`{ data: [...] }`); on the prod backend the
+        // route serves an empty list.
+        let request = try authenticatedRequest(for: "v2/agent-variants")
+        let response: ConvosAPI.AgentVariantsResponse = try await performRequest(request)
+        return response.data
+    }
+
     func createAgentTemplateGeneration(
         text: String,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         var request = try authenticatedRequest(for: "v2/agent-templates/generations", method: "POST")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -983,7 +1008,8 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
                 inputs: .init(text: text, attachments: attachments.isEmpty ? nil : attachments),
                 connections: connections.isEmpty ? nil : connections,
                 clientDeviceId: clientDeviceId,
-                publishStatus: "unlisted"
+                publishStatus: "unlisted",
+                variantId: variantId
             )
         )
         request.httpBody = body

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -106,7 +106,7 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")
     }
 
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+    func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse {
         // A registered, joined agent — a coherent terminal state (joined ⇒
         // inbox present), not "starting" paired with an inbox, which masks the
         // poll loop and can't be told apart from a real in-flight state.
@@ -151,13 +151,36 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         ]
     }
 
+    func getAgentVariants() async throws -> [ConvosAPI.AgentVariant] {
+        [
+            .init(
+                slug: "pr-1234",
+                label: "Q+A",
+                whatToTest: "Agent asks clarifying questions before building. Check it doesn't over-ask.",
+                status: "ready",
+                assistantWorkerUrl: "https://ephemeral-pr-1234.convos.fun",
+                builderPromptSlug: "qa-flow-v2",
+                prUrl: "https://github.com/xmtplabs/convos-assistants/pull/1234",
+                branch: "saul/qa-flow",
+                commit: "b9adb65"
+            ),
+            .init(
+                slug: "pr-1251",
+                label: "Artifact",
+                whatToTest: "Replies with an artifact card -- check rendering.",
+                status: "building"
+            ),
+        ]
+    }
+
     func createAgentTemplateGeneration(
         text: String,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         .init(generationId: UUID().uuidString, status: .pending, templateId: nil, error: nil)
     }

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -174,11 +174,10 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
@@ -46,7 +46,7 @@ public struct AgentTemplateGeneration: Sendable, Equatable {
 /// `SessionManager.addAgentToConversation` (not the raw API client) so the
 /// direct-add provision/add runs and the agent is added to the conversation
 /// the build targeted.
-public typealias AgentTemplateJoinHandler = @Sendable (_ conversationId: String, _ templateId: String) async throws -> Void
+public typealias AgentTemplateJoinHandler = @Sendable (_ conversationId: String, _ templateId: String, _ variantId: String?) async throws -> Void
 
 /// Errors an `AgentTemplateJoinHandler` can throw when it cannot perform the
 /// join. Surfacing these as thrown errors (rather than returning) keeps the
@@ -79,7 +79,10 @@ public protocol AgentTemplateRepositoryProtocol: Sendable {
     /// in the background. Safe to call once per build; the persisted row makes it
     /// idempotent across relaunch. `connections` are neutral service ids sent
     /// for generation awareness; post-join grants are driven separately.
-    func startGeneration(prompt: String, conversationId: String, slug: String, attachments: [AgentBuildAttachmentInput], connections: [String])
+    /// `variantId` is the dev-only agent variant slug captured once at build
+    /// start (`nil` for default builds); it is persisted on the row and reused
+    /// for the generation, join, and join-status-poll calls.
+    func startGeneration(prompt: String, conversationId: String, slug: String, attachments: [AgentBuildAttachmentInput], connections: [String], variantId: String?)
 
     /// Latest generation for a conversation, observed reactively.
     func generationPublisher(conversationId: String) -> AnyPublisher<AgentTemplateGeneration?, Never>
@@ -103,7 +106,7 @@ public protocol AgentTemplateRepositoryProtocol: Sendable {
 public extension AgentTemplateRepositoryProtocol {
     /// Text-only convenience for callers with no attachments or connections.
     func startGeneration(prompt: String, conversationId: String, slug: String) {
-        startGeneration(prompt: prompt, conversationId: conversationId, slug: slug, attachments: [], connections: [])
+        startGeneration(prompt: prompt, conversationId: conversationId, slug: slug, attachments: [], connections: [], variantId: nil)
     }
 }
 
@@ -151,7 +154,7 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
         joinHandler.withLock { $0 = handler }
     }
 
-    public func startGeneration(prompt: String, conversationId: String, slug: String, attachments: [AgentBuildAttachmentInput], connections: [String]) {
+    public func startGeneration(prompt: String, conversationId: String, slug: String, attachments: [AgentBuildAttachmentInput], connections: [String], variantId: String?) {
         let idempotencyKey: String = UUID().uuidString
         let now: Date = Date()
         let storedAttachments: [StoredGenerationAttachment]
@@ -172,6 +175,7 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
             errorMessage: nil,
             attachments: Self.encodeAttachments(storedAttachments),
             connections: Self.encodeConnections(connections),
+            variantId: variantId,
             createdAt: now,
             updatedAt: now
         )
@@ -298,7 +302,8 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                     clientDeviceId: clientDeviceIdProvider(),
                     idempotencyKey: row.idempotencyKey,
                     attachments: Self.attachmentRefs(from: row),
-                    connections: Self.decodeConnections(row.connections)
+                    connections: Self.decodeConnections(row.connections),
+                    variantId: row.variantId
                 )
                 return await applyResponse(response, to: row.idempotencyKey)
             } catch let error as AgentGenerationError {
@@ -373,13 +378,14 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                 // to the raw client when unset (tests).
                 let handler = joinHandler.withLock { $0 }
                 if let handler {
-                    try await handler(row.conversationId, templateId)
+                    try await handler(row.conversationId, templateId, row.variantId)
                 } else {
+                    let options = row.variantId.map { ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0) }
                     _ = try await apiClient.requestAgentJoin(
                         slug: nil,
                         conversationId: row.conversationId,
                         templateId: templateId,
-                        options: nil,
+                        options: options,
                         timezone: nil,
                         forceErrorCode: nil
                     )
@@ -625,7 +631,7 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
 /// No-op repository used as the `SessionManagerProtocol` default so test mocks
 /// and non-builder conformers don't need bespoke wiring.
 public final class NoOpAgentTemplateRepository: AgentTemplateRepositoryProtocol {
-    public func startGeneration(prompt: String, conversationId: String, slug: String, attachments: [AgentBuildAttachmentInput], connections: [String]) {}
+    public func startGeneration(prompt: String, conversationId: String, slug: String, attachments: [AgentBuildAttachmentInput], connections: [String], variantId: String?) {}
 
     public init() {}
 

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
@@ -296,12 +296,12 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
         var attempt: Int = 0
         while attempt < Constant.maxSubmitAttempts {
             do {
+                let attachmentRefs = Self.attachmentRefs(from: row)
                 let response = try await apiClient.createAgentTemplateGeneration(
-                    text: row.prompt,
+                    inputs: .init(text: row.prompt, attachments: attachmentRefs.isEmpty ? nil : attachmentRefs),
                     source: source,
                     clientDeviceId: clientDeviceIdProvider(),
                     idempotencyKey: row.idempotencyKey,
-                    attachments: Self.attachmentRefs(from: row),
                     connections: Self.decodeConnections(row.connections),
                     variantId: row.variantId
                 )

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1154,7 +1154,7 @@ extension SessionManager {
                     forceErrorCode: forceErrorCode
                 )
             },
-            fetchStatus: { try await self.apiClient.getAgentJoinStatus(instanceId: $0) }
+            fetchStatus: { try await self.apiClient.getAgentJoinStatus(instanceId: $0, variantId: options?.variantId) }
         )
         let instanceId = resolved.instanceId
         let agentInboxId = resolved.inboxId
@@ -1330,13 +1330,17 @@ extension SessionManager {
     /// provision/add runs, then resume any in-flight generations persisted
     /// across a relaunch.
     func wireAgentTemplateRepository() {
-        agentTemplateRepositoryInstance.configureJoinHandler { [weak self] conversationId, templateId in
+        agentTemplateRepositoryInstance.configureJoinHandler { [weak self] conversationId, templateId, variantId in
             // Throw rather than letting optional chaining return a silent `nil`:
             // the invite step only detects failure via thrown errors, so a
             // no-op `nil` would be recorded as a false `.invited` with no agent
             // actually added.
             guard let self else { throw AgentTemplateJoinError.sessionUnavailable }
-            _ = try await self.addAgentToConversation(conversationId: conversationId, templateId: templateId, options: nil)
+            // A nil variantId leaves options nil so default builds stay
+            // byte-identical; when set, the same slug carries the join routing
+            // and (via options.variantId) the load-bearing join-status poll.
+            let options = variantId.map { ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0) }
+            _ = try await self.addAgentToConversation(conversationId: conversationId, templateId: templateId, options: options)
         }
         agentTemplateRepositoryInstance.resumePendingGenerations()
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateGeneration.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateGeneration.swift
@@ -41,6 +41,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         static let progressPhrases: Column = Column(CodingKeys.progressPhrases)
         static let attachments: Column = Column(CodingKeys.attachments)
         static let connections: Column = Column(CodingKeys.connections)
+        static let variantId: Column = Column(CodingKeys.variantId)
         static let createdAt: Column = Column(CodingKeys.createdAt)
         static let updatedAt: Column = Column(CodingKeys.updatedAt)
     }
@@ -86,6 +87,12 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
     /// generation request. Persisted so a resumed/retried submit sends an
     /// identical body and dedupes. `nil` when no connections.
     var connections: String?
+    /// Dev-only agent variant slug captured once at build start. The same value
+    /// rides the generation (top-level field), join (`options.variantId`), and
+    /// join-status poll (`?variantId=`) calls; reading it off the row keeps all
+    /// three consistent even when the build resumes after a relaunch. `nil` for
+    /// default builds.
+    let variantId: String?
     let createdAt: Date
     var updatedAt: Date
 
@@ -94,7 +101,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         case templateId, prompt
         case errorMessage = "error"
         case previewAgentName, previewEmoji, previewDescription, progressPhrases
-        case attachments, connections
+        case attachments, connections, variantId
         case createdAt, updatedAt
     }
 
@@ -113,6 +120,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         progressPhrases: String? = nil,
         attachments: String? = nil,
         connections: String? = nil,
+        variantId: String? = nil,
         createdAt: Date,
         updatedAt: Date
     ) {
@@ -130,6 +138,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         self.progressPhrases = progressPhrases
         self.attachments = attachments
         self.connections = connections
+        self.variantId = variantId
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -68,6 +68,16 @@ public extension Conversation {
         members.filter { !$0.isCurrentUser }
     }
 
+    /// The variant marker of this conversation's variant-built agent member, if
+    /// any. Drives the dev-only 🧪 name badge (conversations list) and header
+    /// badge; `nil` for default agents and human-only conversations. The stamp
+    /// itself is the signal -- only a variant-built agent carries
+    /// `profile.variant` -- so the internal-build gate is applied at the call
+    /// site, not here.
+    var agentVariant: AgentVariantStamp? {
+        members.first(where: { $0.profile.variant != nil })?.profile.variant
+    }
+
     /// Copy of this conversation with `members` replaced. Used by the
     /// optimistic contacts-picker flows to overlay synthetic members onto
     /// a DB-emitted conversation so the chat header keeps rendering the

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -210,6 +210,7 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let publishedURLKey: String = "publishedUrl"
         static let instanceIdKey: String = "instanceId"
         static let emailKey: String = "email"
+        static let variantKey: String = "variant"
     }
 }
 
@@ -281,6 +282,20 @@ extension Profile {
     /// the published agent keyset. `nil` when no attestation is present.
     public var agentAttestationKid: String? {
         metadata?["attestation_kid"]?.stringValue
+    }
+
+    /// The dev-only variant marker stamped onto a variant-built agent's profile
+    /// metadata by the assistants worker at join -- a JSON string of
+    /// `{ slug, label, whatToTest, prUrl }`. Drives the dev-only variant ribbon,
+    /// profile card, and name/header badges. nil for default agents and humans;
+    /// decoding is defensive so a malformed or partial stamp reads as nil rather
+    /// than throwing.
+    public var variant: AgentVariantStamp? {
+        guard let json = metadata?[Constant.variantKey]?.stringValue,
+              let data = json.data(using: .utf8) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(AgentVariantStamp.self, from: data)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -268,6 +268,17 @@ extension SharedDatabaseMigrator {
         }
     }
 
+    /// Additive, nullable column holding the dev-only agent variant slug the
+    /// build was captured under. Persisted on the row so the same value rides
+    /// the generation, join, and join-status-poll calls even across a relaunch
+    /// resume, instead of re-reading the device selection mid-build. `nil` for
+    /// default (non-variant) builds, so existing rows are unaffected.
+    private static func addAgentTemplateGenerationVariant(_ db: Database) throws {
+        try db.alter(table: "agentTemplateGeneration") { t in
+            t.add(column: "variantId", .text)
+        }
+    }
+
     /// Registers the join-request ledger and the direct-builder generation
     /// table, in this order. Grouped into a helper to keep `makeMigrator`
     /// under the function-length budget; the registration position (last,
@@ -278,6 +289,7 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addAgentTemplateGenerationPreview", migrate: Self.addAgentTemplateGenerationPreview)
         migrator.registerMigration("addAgentTemplateGenerationAttachments", migrate: Self.addAgentTemplateGenerationAttachments)
         migrator.registerMigration("addAgentTemplateGenerationConnections", migrate: Self.addAgentTemplateGenerationConnections)
+        migrator.registerMigration("addAgentTemplateGenerationVariant", migrate: Self.addAgentTemplateGenerationVariant)
     }
 
     /// In-flight (or finished) agent-template generation kicked off by the

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
@@ -99,7 +99,8 @@ struct AgentTemplateRepositoryTests {
             conversationId: "convo-3",
             slug: "chef.abcd",
             attachments: [attachment],
-            connections: []
+            connections: [],
+            variantId: nil
         )
 
         let row = try await waitForStatus(.failed, conversationId: "convo-3", in: database)
@@ -131,7 +132,8 @@ private final class HappyStubAPIClient: TestStubAPIClient {
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         ConvosAPI.AgentTemplateGenerationResponse(
             generationId: "gen-1",
@@ -181,7 +183,8 @@ private final class ModeratedStubAPIClient: TestStubAPIClient {
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         throw AgentGenerationError.moderationBlocked("not allowed")
     }
@@ -222,7 +225,8 @@ private final class AttachmentUploadFailingStubAPIClient: TestStubAPIClient {
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         lock.withLock { generationCallCount += 1 }
         return ConvosAPI.AgentTemplateGenerationResponse(

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
@@ -127,11 +127,10 @@ private final class HappyStubAPIClient: TestStubAPIClient {
     var joinedConversationId: String? { lock.withLock { capturedConversationId } }
 
     override func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
@@ -178,11 +177,10 @@ private final class ModeratedStubAPIClient: TestStubAPIClient {
     var joinCalls: Int { lock.withLock { joinCallCount } }
 
     override func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
@@ -220,11 +218,10 @@ private final class AttachmentUploadFailingStubAPIClient: TestStubAPIClient {
     }
 
     override func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {

--- a/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
@@ -67,8 +67,15 @@ struct AgentVariantPlumbingTests {
 
     // MARK: - Join-status poll query param
 
-    @Test("Join-status poll path carries the load-bearing variantId query param")
-    func joinStatusPollCarriesVariantIdQueryParam() throws {
+    @Test("Join-status poll query carries the persisted variantId, omitted when nil")
+    func joinStatusPollThreadsPersistedVariantId() throws {
+        // The slug persisted on the row (carried through the join options) is what
+        // getAgentJoinStatus turns into the load-bearing `?variantId=` query param.
+        #expect(ConvosAPIClient.agentJoinStatusQueryParameters(variantId: "pr-1234") == ["variantId": "pr-1234"])
+        // No selection -> no query param, so a default poll stays byte-identical.
+        #expect(ConvosAPIClient.agentJoinStatusQueryParameters(variantId: nil) == nil)
+
+        // And the constructed parameters actually land in the request URL.
         let api = ConvosAPIClientFactory.client(
             environment: .local(config: ConvosConfiguration(
                 apiBaseURL: "https://api.example.com",
@@ -80,7 +87,7 @@ struct AgentVariantPlumbingTests {
         let request = try api.request(
             for: "v2/agents/join/inst-1",
             method: "GET",
-            queryParameters: ["variantId": "pr-1234"]
+            queryParameters: ConvosAPIClient.agentJoinStatusQueryParameters(variantId: "pr-1234")
         )
         #expect(request.url?.query?.contains("variantId=pr-1234") == true)
     }

--- a/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
@@ -199,11 +199,10 @@ private final class VariantRecordingStubAPIClient: TestStubAPIClient {
     var joinVariantId: String? { lock.withLock { capturedJoinVariantId } }
 
     override func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {

--- a/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
@@ -1,0 +1,241 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Covers the dev-only agent-variant three-call plumbing: the same `variantId`
+/// captured at build start must ride the generation call (top-level body
+/// field), the join call (`options.variantId`), and the join-status poll
+/// (`?variantId=` query param), each in its own shape, with no split-brain.
+///
+/// The generation and join legs are threaded from the persisted row and are
+/// asserted end-to-end via a recording client. The join-status poll leg lives
+/// in `SessionManager.addAgentToConversation` (outside the extracted, unit-
+/// testable `awaitProvisionedAgentInbox` helper, for the same reason
+/// `DirectAddProvisionPollTests` exists), so it is exercised in the E2E pass;
+/// here we lock the query-param shape it relies on.
+@Suite("Agent variant three-call plumbing")
+struct AgentVariantPlumbingTests {
+    // MARK: - Wire shapes (`.strict()` placement)
+
+    @Test("Generation request encodes variantId as a top-level field, never under inputs")
+    func generationRequestTopLevelVariantId() throws {
+        let request = ConvosAPI.AgentTemplateGenerationRequest(
+            source: "ios-app",
+            inputs: .init(text: "build me a chef"),
+            clientDeviceId: "dev-1",
+            publishStatus: "unlisted",
+            variantId: "pr-1234"
+        )
+        let object = try Self.jsonObject(request)
+        #expect(object["variantId"] as? String == "pr-1234")
+        let inputs = object["inputs"] as? [String: Any]
+        #expect(inputs?["variantId"] == nil)
+    }
+
+    @Test("Generation request omits variantId when nil so default builds stay byte-identical")
+    func generationRequestOmitsNilVariantId() throws {
+        let request = ConvosAPI.AgentTemplateGenerationRequest(
+            source: "ios-app",
+            inputs: .init(text: "build me a chef"),
+            clientDeviceId: "dev-1",
+            publishStatus: "unlisted"
+        )
+        let object = try Self.jsonObject(request)
+        #expect(object.keys.contains("variantId") == false)
+    }
+
+    @Test("Join request nests variantId under options, not at the top level")
+    func joinRequestNestsVariantIdUnderOptions() throws {
+        let request = ConvosAPI.AgentJoinRequest(
+            conversationId: "convo-1",
+            templateId: "tmpl-1",
+            options: ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: "pr-1234")
+        )
+        let object = try Self.jsonObject(request)
+        #expect(object["variantId"] == nil)
+        let options = object["options"] as? [String: Any]
+        #expect(options?["variantId"] as? String == "pr-1234")
+    }
+
+    @Test("Join options omit variantId when nil")
+    func joinOptionsOmitNilVariantId() throws {
+        let object = try Self.jsonObject(ConvosAPI.AgentJoinOptions(onboarding: "agent-builder"))
+        #expect(object.keys.contains("variantId") == false)
+        #expect(object["onboarding"] as? String == "agent-builder")
+    }
+
+    // MARK: - Join-status poll query param
+
+    @Test("Join-status poll path carries the load-bearing variantId query param")
+    func joinStatusPollCarriesVariantIdQueryParam() throws {
+        let api = ConvosAPIClientFactory.client(
+            environment: .local(config: ConvosConfiguration(
+                apiBaseURL: "https://api.example.com",
+                appGroupIdentifier: "group.test",
+                relyingPartyIdentifier: "example.com",
+                siweConfiguration: SIWEConfiguration(domain: "example.com", uri: "https://example.com", chainId: 1)
+            ))
+        )
+        let request = try api.request(
+            for: "v2/agents/join/inst-1",
+            method: "GET",
+            queryParameters: ["variantId": "pr-1234"]
+        )
+        #expect(request.url?.query?.contains("variantId=pr-1234") == true)
+    }
+
+    // MARK: - Profile variant stamp (banner/badge source)
+
+    @Test("Profile.variant decodes the worker-stamped JSON marker")
+    func profileVariantDecodesStamp() {
+        let json = #"{"slug":"pr-1234","label":"Q+A","whatToTest":"asks clarifying Qs","prUrl":"https://github.com/x/pull/1234"}"#
+        let profile = Profile(
+            inboxId: "agent-inbox",
+            conversationId: "convo-1",
+            name: "Q+A Agent",
+            avatar: nil,
+            isAgent: true,
+            metadata: ["variant": .string(json)]
+        )
+        let stamp = profile.variant
+        #expect(stamp?.slug == "pr-1234")
+        #expect(stamp?.label == "Q+A")
+        #expect(stamp?.whatToTest == "asks clarifying Qs")
+        #expect(stamp?.prUrl == "https://github.com/x/pull/1234")
+    }
+
+    @Test("Profile.variant is nil for an absent, malformed, or partial marker")
+    func profileVariantDefensiveDecode() {
+        let absent = Profile(inboxId: "a", conversationId: "c", name: nil, avatar: nil, metadata: [:])
+        #expect(absent.variant == nil)
+        let malformed = Profile(inboxId: "a", conversationId: "c", name: nil, avatar: nil, metadata: ["variant": .string("{not json")])
+        #expect(malformed.variant == nil)
+        let partial = Profile(inboxId: "a", conversationId: "c", name: nil, avatar: nil, metadata: ["variant": .string(#"{"slug":"pr-1"}"#)])
+        #expect(partial.variant == nil)
+    }
+
+    // MARK: - Capture-once threading (generation + join read the same row value)
+
+    @Test("variantId persisted on the row reaches both the generation and join calls unchanged")
+    func variantIdThreadsFromRowToGenerationAndJoin() async throws {
+        let database = try Self.makeDatabase()
+        let api = VariantRecordingStubAPIClient()
+        let repository = Self.makeRepository(database: database, apiClient: api)
+        repository.startGeneration(
+            prompt: "build me a chef",
+            conversationId: "convo-1",
+            slug: "chef.abcd",
+            attachments: [],
+            connections: [],
+            variantId: "pr-1234"
+        )
+        let row = try await Self.waitForInvited(conversationId: "convo-1", in: database)
+        #expect(row?.statusValue == .invited)
+        #expect(api.generationVariantId == "pr-1234")
+        #expect(api.joinVariantId == "pr-1234")
+    }
+
+    // MARK: - Helpers
+
+    private static func jsonObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try #require(object)
+    }
+
+    private static func makeDatabase() throws -> DatabaseQueue {
+        let dbQueue = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: dbQueue)
+        return dbQueue
+    }
+
+    private static func makeRepository(
+        database: DatabaseQueue,
+        apiClient: any ConvosAPIClientProtocol
+    ) -> AgentTemplateRepository {
+        AgentTemplateRepository(
+            apiClient: apiClient,
+            databaseWriter: database,
+            databaseReader: database,
+            source: "test",
+            clientDeviceIdProvider: { "test-device" }
+        )
+    }
+
+    private static func waitForInvited(
+        conversationId: String,
+        in database: DatabaseQueue,
+        timeout: TimeInterval = 20
+    ) async throws -> DBAgentTemplateGeneration? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let row = try await database.read { db in
+                try DBAgentTemplateGeneration
+                    .filter(DBAgentTemplateGeneration.Columns.conversationId == conversationId)
+                    .fetchOne(db)
+            }
+            if let row, row.statusValue == .invited { return row }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return try await database.read { db in
+            try DBAgentTemplateGeneration
+                .filter(DBAgentTemplateGeneration.Columns.conversationId == conversationId)
+                .fetchOne(db)
+        }
+    }
+}
+
+/// Records the `variantId` handed to the generation and join calls so the test
+/// can assert the same captured value rides both. With no join handler
+/// configured, the repository's invite step falls back to the raw API client,
+/// which derives the join `options` from the persisted row.
+private final class VariantRecordingStubAPIClient: TestStubAPIClient {
+    private let lock: NSLock = NSLock()
+    private var capturedGenerationVariantId: String?
+    private var capturedJoinVariantId: String?
+
+    var generationVariantId: String? { lock.withLock { capturedGenerationVariantId } }
+    var joinVariantId: String? { lock.withLock { capturedJoinVariantId } }
+
+    override func createAgentTemplateGeneration(
+        text: String,
+        source: String,
+        clientDeviceId: String?,
+        idempotencyKey: String,
+        attachments: [ConvosAPI.AttachmentRef],
+        connections: [String],
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
+        lock.withLock { capturedGenerationVariantId = variantId }
+        return ConvosAPI.AgentTemplateGenerationResponse(
+            generationId: "gen-1",
+            status: .pending,
+            templateId: nil,
+            error: nil
+        )
+    }
+
+    override func getAgentTemplateGeneration(
+        generationId: String
+    ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
+        ConvosAPI.AgentTemplateGenerationResponse(
+            generationId: generationId,
+            status: .done,
+            templateId: "tmpl-1",
+            error: nil
+        )
+    }
+
+    override func requestAgentJoin(
+        slug: String?,
+        conversationId: String?,
+        templateId: String?,
+        options: ConvosAPI.AgentJoinOptions?,
+        timezone: String?,
+        forceErrorCode: Int?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        lock.withLock { capturedJoinVariantId = options?.variantId }
+        return ConvosAPI.AgentJoinResponse(success: true, joined: true)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -218,11 +218,10 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
     }
 
     func createAgentTemplateGeneration(
-        text: String,
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
         source: String,
         clientDeviceId: String?,
         idempotencyKey: String,
-        attachments: [ConvosAPI.AttachmentRef],
         connections: [String],
         variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -56,7 +56,7 @@ extension ConvosAPIClientProtocol {
     /// unrelated tests don't iterate the poll loop. Tests that exercise the
     /// poll specifically program their own status sequence (see
     /// DirectAddProvisionPollTests).
-    func getAgentJoinStatus(instanceId: String) async throws -> ConvosAPI.AgentJoinStatusResponse {
+    func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse {
         ConvosAPI.AgentJoinStatusResponse(
             success: true,
             instanceId: instanceId,
@@ -64,6 +64,12 @@ extension ConvosAPIClientProtocol {
             joined: true,
             inboxId: "test-agent-inbox"
         )
+    }
+
+    /// Default for the dev-only variant registry so stubs that don't exercise
+    /// the picker don't have to re-stub it. Empty == no variants registered.
+    func getAgentVariants() async throws -> [ConvosAPI.AgentVariant] {
+        []
     }
 
     /// Default for the public agent-template detail fetch used by the
@@ -217,7 +223,8 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
         clientDeviceId: String?,
         idempotencyKey: String,
         attachments: [ConvosAPI.AttachmentRef],
-        connections: [String]
+        connections: [String],
+        variantId: String?
     ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
         ConvosAPI.AgentTemplateGenerationResponse(
             generationId: UUID().uuidString,


### PR DESCRIPTION
## CON-583 — iOS slice of Per-PR Agent Variants

Internal/dev-builds-only feature for selecting a per-PR agent variant at build time and seeing it marked across the app. Hard-gated to non-production throughout.

### What's in it
- **Variant selector** in the make-an-agent composer, gated by a new **"Agent variant selector"** toggle in Debug → Features. A dropdown of the live registry (`GET /v2/agent-variants`) plus "No variant"; selecting one renders its full what-to-test inline before Make.
- **Three-call `variantId` plumbing**, each a distinct shape (backend schemas are `.strict()`, so placement matters):
  - generation request — **top-level** field
  - join request — nested under **`options`**
  - join-status poll — the **load-bearing `?variantId=`** query param (the poll silently stalls against the default worker without it)

  Captured once at build start and persisted on the generation row so all three calls stay consistent across a mid-build switch.
- **In-app markers** from the agent's `profile.variant` stamp: a yellow ribbon on the in-chat contact card, a matching ribbon-headed card on the agent profile, and 🧪 name/header badges.
- **GRDB additive migration** for the `variantId` column; defensive decode of the worker-stamped profile marker (malformed/partial → nil, never throws).

### Testing
- `AgentVariantPlumbingTests` (8 tests) — the three call shapes, the byte-identical default-build path, the poll query param, row→calls threading, and the profile-marker decode.
- Full ConvosCore suite green (1354 tests / 190 suites), SwiftLint clean.

### Demo
Paired with a backend variant (convos-assistants #2317, "Pirate Talk") that makes the built agent greet in pirate speak: enable the Debug toggle, pick the variant in the composer, build, and the agent's welcome lands in pirate speak — proving the per-PR variant routed the build end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zCW7kUGbuatc4hZKM2Bs2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785353942&installation_id=128169237&pr_number=1118&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1118&signature=c1a31153ca10d467be7642eb0a93557786ce0969e73cda094435c792b80a9c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dev-only agent variant selector with end-to-end plumbing through generation, join, and in-app markers
> - Adds `AgentVariantSelector` UI (behind `FeatureFlags.isAgentVariantSelectorEnabled`) to the agent builder and contacts picker, letting developers pick a variant fetched from the new `GET v2/agent-variants` endpoint.
> - Threads the selected `variantId` through three API calls: `createAgentTemplateGeneration`, `getAgentJoinStatus`, and `requestAgentJoin`, persisting it on the `agentTemplateGeneration` DB row via a new `variantId` migration.
> - Adds `ConversationVariantBanner` and `AgentVariantRibbon` views that surface variant label, what-to-test text, and PR link in the message list, contact detail, and conversation toolbar (non-production only, prefixed with 🧪).
> - Reads variant stamp from `Profile` metadata via a new `profile.variant` computed property and exposes it on `Conversation.agentVariant` for display logic.
> - Risk: database migration adds a nullable `variantId` column to `agentTemplateGeneration`; existing rows receive `NULL`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1118 opened
>
> - Modified `ConvosAPIClient` agent join request method, `ConvosAPIClient.getAgentJoinStatus`, and `ConvosAPIClient.createAgentTemplateGeneration` to conditionally suppress `variantId` values in production environments [ad88952]
> - Added `ConvosAPIClient.prodSafeVariantId` instance method and `ConvosAPIClient.agentJoinStatusQueryParameters` static helper method to support environment-aware variant ID handling [ad88952]
> - Updated `AgentVariantPlumbingTests.joinStatusPollThreadsPersistedVariantId` test to verify the new `ConvosAPIClient.agentJoinStatusQueryParameters` helper method [ad88952]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2e0702.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->