### PR TITLE
fix(attachments): emit encrypted contentLength on all send paths (CON-436)

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Messaging/PhotoAttachmentService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/PhotoAttachmentService.swift
@@ -31,6 +31,7 @@ public struct PreparedBackgroundUpload: Sendable {
     public let encryptionNonce: Data
     public let contentDigest: String
     public let filename: String
+    public let encryptedContentLength: UInt32
 
     public init(
         taskId: String,
@@ -41,7 +42,8 @@ public struct PreparedBackgroundUpload: Sendable {
         encryptionSalt: Data,
         encryptionNonce: Data,
         contentDigest: String,
-        filename: String
+        filename: String,
+        encryptedContentLength: UInt32
     ) {
         self.taskId = taskId
         self.encryptedFileURL = encryptedFileURL
@@ -52,6 +54,7 @@ public struct PreparedBackgroundUpload: Sendable {
         self.encryptionNonce = encryptionNonce
         self.contentDigest = contentDigest
         self.filename = filename
+        self.encryptedContentLength = encryptedContentLength
     }
 }
 
@@ -189,7 +192,8 @@ public final class PhotoAttachmentService: PhotoAttachmentServiceProtocol, Senda
             encryptionSalt: encrypted.salt,
             encryptionNonce: encrypted.nonce,
             contentDigest: encrypted.digest,
-            filename: filename
+            filename: filename,
+            encryptedContentLength: UInt32(encrypted.payload.count)
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/RemoteAttachmentInfo+Builder.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/RemoteAttachmentInfo+Builder.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XMTPiOS
+
+extension MultiRemoteAttachment.RemoteAttachmentInfo {
+    /// Build the wire attachment info from an encrypted-upload descriptor.
+    /// `contentLength` is the encrypted payload byte count (per the XMTP proto),
+    /// so no send path can emit 0/nil/plaintext.
+    init(from prepared: PreparedBackgroundUpload) {
+        self.init(
+            url: prepared.assetURL,
+            filename: prepared.filename,
+            contentLength: prepared.encryptedContentLength,
+            contentDigest: prepared.contentDigest,
+            nonce: prepared.encryptionNonce,
+            scheme: "https",
+            salt: prepared.encryptionSalt,
+            secret: prepared.encryptionSecret
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -1321,16 +1321,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         }
         if let error = state.uploadError { throw error }
         let prepared = state.prepared
-        let info = MultiRemoteAttachment.RemoteAttachmentInfo(
-            url: prepared.assetURL,
-            filename: prepared.filename,
-            contentLength: 0,
-            contentDigest: prepared.contentDigest,
-            nonce: prepared.encryptionNonce,
-            scheme: "https",
-            salt: prepared.encryptionSalt,
-            secret: prepared.encryptionSecret
-        )
+        let info = MultiRemoteAttachment.RemoteAttachmentInfo(from: prepared)
         // Embed a chip-sized thumbnail in the stored JSON, mirroring the
         // video path's `state.thumbnailData` below. The agent-builder summary
         // card renders bundle chips straight from this JSON (`hydrateAttachment`
@@ -1373,7 +1364,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let info = MultiRemoteAttachment.RemoteAttachmentInfo(
             url: prepared.assetURL,
             filename: state.filename,
-            contentLength: 0,
+            contentLength: prepared.encryptedContentLength,
             contentDigest: prepared.contentDigest,
             nonce: prepared.encryptionNonce,
             scheme: "https",
@@ -1513,7 +1504,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let info = MultiRemoteAttachment.RemoteAttachmentInfo(
             url: presigned.assetURL,
             filename: filename,
-            contentLength: UInt32(clamping: fileData.count),
+            contentLength: UInt32(encrypted.payload.count),
             contentDigest: encrypted.digest,
             nonce: encrypted.nonce,
             scheme: "https",
@@ -1693,7 +1684,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 encryptionSalt: encrypted.salt,
                 encryptionNonce: encrypted.nonce,
                 contentDigest: encrypted.digest,
-                filename: state.filename
+                filename: state.filename,
+                encryptedContentLength: UInt32(encrypted.payload.count)
             )
 
             // Publish prepared + compressed URL into the shared state BEFORE the
@@ -1866,6 +1858,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         _ = try await publishAttachment(
             storedAttachment: storedAttachment,
+            contentLength: prepared.encryptedContentLength,
             clientMessageId: state.clientMessageId,
             trackingKey: trackingKey,
             thumbnailImage: thumbnailImage,
@@ -2008,6 +2001,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
             let messageId = try await publishAttachment(
                 storedAttachment: storedAttachment,
+                contentLength: UInt32(encrypted.payload.count),
                 clientMessageId: clientMessageId,
                 trackingKey: trackingKey,
                 thumbnailImage: params.thumbnailData.flatMap { ImageType(data: $0) },
@@ -2051,6 +2045,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
     private func publishAttachment(
         storedAttachment: StoredRemoteAttachment,
+        contentLength: UInt32,
         clientMessageId: String,
         trackingKey: String,
         thumbnailImage: ImageType?,
@@ -2072,7 +2067,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             salt: storedAttachment.salt,
             nonce: storedAttachment.nonce,
             scheme: .https,
-            contentLength: nil,
+            contentLength: Int(contentLength),
             filename: storedAttachment.filename
         )
 
@@ -2614,6 +2609,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         let messageId = try await publishAttachment(
             storedAttachment: storedAttachment,
+            contentLength: UInt32(encrypted.payload.count),
             clientMessageId: queued.clientMessageId,
             trackingKey: queued.trackingKey,
             thumbnailImage: thumbnailImage,
@@ -2693,6 +2689,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
         let messageId = try await publishAttachment(
             storedAttachment: storedAttachment,
+            contentLength: UInt32(encrypted.payload.count),
             clientMessageId: queued.clientMessageId,
             trackingKey: queued.trackingKey,
             thumbnailImage: nil,
@@ -2727,6 +2724,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         do {
             messageId = try await publishAttachment(
                 storedAttachment: storedAttachment,
+                contentLength: prepared.encryptedContentLength,
                 clientMessageId: queued.clientMessageId,
                 trackingKey: trackingKey,
                 thumbnailImage: queued.image,

--- a/ConvosCore/Tests/ConvosCoreTests/RemoteAttachmentContentLengthTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/RemoteAttachmentContentLengthTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import XMTPiOS
+@testable import ConvosCore
+
+@Suite("Remote attachment contentLength")
+struct RemoteAttachmentContentLengthTests {
+    @Test("PreparedBackgroundUpload carries the encrypted size")
+    func preparedCarriesEncryptedSize() {
+        let prepared = PreparedBackgroundUpload(
+            taskId: "t",
+            encryptedFileURL: URL(fileURLWithPath: "/tmp/x.bin"),
+            presignedUploadURL: URL(string: "https://example.com/up")!,
+            assetURL: "https://example.com/x.bin",
+            encryptionSecret: Data(repeating: 1, count: 32),
+            encryptionSalt: Data(repeating: 2, count: 32),
+            encryptionNonce: Data(repeating: 3, count: 12),
+            contentDigest: "deadbeef",
+            filename: "x.bin",
+            encryptedContentLength: 4096
+        )
+        #expect(prepared.encryptedContentLength == 4096)
+    }
+
+    @Test("builder sets contentLength from the descriptor")
+    func builderSetsContentLength() {
+        let prepared = PreparedBackgroundUpload(
+            taskId: "t",
+            encryptedFileURL: URL(fileURLWithPath: "/tmp/x.bin"),
+            presignedUploadURL: URL(string: "https://example.com/up")!,
+            assetURL: "https://example.com/x.bin",
+            encryptionSecret: Data(repeating: 1, count: 32),
+            encryptionSalt: Data(repeating: 2, count: 32),
+            encryptionNonce: Data(repeating: 3, count: 12),
+            contentDigest: "deadbeef",
+            filename: "x.bin",
+            encryptedContentLength: 4096
+        )
+        let info = MultiRemoteAttachment.RemoteAttachmentInfo(from: prepared)
+        #expect(info.contentLength == 4096)
+        #expect(info.url == "https://example.com/x.bin")
+        #expect(info.contentDigest == "deadbeef")
+    }
+
+    @Test("descriptor-built info never has zero contentLength for a real upload")
+    func bundleInfoNotZero() {
+        let prepared = PreparedBackgroundUpload(
+            taskId: "t",
+            encryptedFileURL: URL(fileURLWithPath: "/tmp/x.bin"),
+            presignedUploadURL: URL(string: "https://example.com/up")!,
+            assetURL: "https://example.com/x.bin",
+            encryptionSecret: Data(repeating: 1, count: 32),
+            encryptionSalt: Data(repeating: 2, count: 32),
+            encryptionNonce: Data(repeating: 3, count: 12),
+            contentDigest: "deadbeef",
+            filename: "x.bin",
+            encryptedContentLength: 7777
+        )
+        let info = MultiRemoteAttachment.RemoteAttachmentInfo(from: prepared)
+        #expect(info.contentLength == 7777)
+        #expect(info.contentLength != 0)
+    }
+
+    @Test("encrypted ciphertext size differs from plaintext (guards voice/file plaintext bug)")
+    func ciphertextSizeDiffersFromPlaintext() throws {
+        // AES-GCM ciphertext = plaintext + 16-byte tag, so they always differ.
+        // This documents why contentLength must use encrypted.payload.count,
+        // not the plaintext fileData.count, at the voice/file bundle site.
+        let plaintext = 1000
+        let ciphertextWithTag = plaintext + 16
+        #expect(UInt32(ciphertextWithTag) != UInt32(plaintext))
+    }
+
+    @Test("RemoteAttachment Int? contentLength accepts the encrypted UInt32 size")
+    func intContentLengthFromUInt32() {
+        let encryptedSize: UInt32 = 5000
+        let asInt = Int(encryptedSize)
+        #expect(asInt == 5000)
+    }
+}


### PR DESCRIPTION
The remoteStaticAttachment `contentLength` was wrong on every iOS send path, which downstream renders as the `(-1 bytes)` signal in [CON-436](https://linear.app/convos/issue/CON-436):

- eager photo/video **bundles** hardcoded `contentLength: 0`
- voice/file bundle used the **plaintext** size (`UInt32(clamping: fileData.count)`)
- single sends passed `nil` → the XMTPiOS codec encodes that as `-1`

Per the proto, `contentLength` is the **encrypted** payload byte size.

## Changes
- `PreparedBackgroundUpload` carries `encryptedContentLength` (set from `UInt32(encrypted.payload.count)` at prepare).
- New `MultiRemoteAttachment.RemoteAttachmentInfo(from:)` builder centralizes wire-info construction so no path can emit 0/nil.
- Eager photo→builder, video→descriptor size (dropped `0`).
- Voice/file bundle uses `encrypted.payload.count` (dropped plaintext).
- `publishAttachment` takes `contentLength`; all 5 callers pass the encrypted size from their own descriptor (dropped `nil`).

No change to the persisted `StoredRemoteAttachment` (no migration).

## Tests
New `RemoteAttachmentContentLengthTests` (swift-testing) assert the descriptor/builder carry the encrypted size and never 0; all pass on macOS (Xcode 26.4 / Swift 6.3).

## Related
- libxmtp SDK root-cause fix (encoder no longer defaults nil→-1; ctor + multi codec derive size): xmtp/libxmtp#3796 (merged).
- convos-client (Kotlin) sibling fix: xmtplabs/convos-client (same CON-436).
- This is the metadata-correctness part of CON-436; the disconnect bound is herald-lite #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785355151&installation_id=128169237&pr_number=1119&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1119&signature=26b1dfb2ead61fdc18b066fb1446fb373c012024a6d4fd9d3aac5f9390ef0a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix encrypted `contentLength` to emit the ciphertext size on all attachment send paths
> - Previously, `contentLength` in `RemoteAttachment` and `RemoteAttachmentInfo` was either `nil`, `0`, or set to the plaintext size rather than the encrypted ciphertext size.
> - Adds `encryptedContentLength: UInt32` to `PreparedBackgroundUpload` and a new `RemoteAttachmentInfo(from:)` builder initializer in [`RemoteAttachmentInfo+Builder.swift`](https://github.com/xmtplabs/convos-ios/pull/1119/files#diff-f7308239e3446c2a9a5500b9207c32ce3b54047bd1789af53ac628277df3ef4f) to propagate the encrypted size consistently.
> - Updates all send paths in [`OutgoingMessageWriter.swift`](https://github.com/xmtplabs/convos-ios/pull/1119/files#diff-2ba8cf409a96f2eb22ac537fb59817aae89c4fdf4a953c1683a27be30a6107b6) — photo, video, file, and voice — to supply `UInt32(encrypted.payload.count)` rather than `0` or plaintext length.
> - Adds a new test suite in [`RemoteAttachmentContentLengthTests.swift`](https://github.com/xmtplabs/convos-ios/pull/1119/files#diff-272f20a137ab33aef4f56cf9a44e91ff0a257bf30d28da8b50a6c91e07880753) verifying the encrypted length is carried through each path and differs from plaintext.
> - Behavioral Change: `RemoteAttachment.contentLength` is now always non-nil and reflects ciphertext size; receivers previously seeing `nil` or `0` will now see the real encrypted byte count.
>
> #### 🖇️ Linked Issues
> Addresses [CON-436](ticket:linear/CON-436).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c49f4fe. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->