### PR TITLE
feat(variants): variant selector when adding an agent from contacts

### DIFF
--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -140,11 +140,20 @@ struct ContactsPickerView: View {
             }
         }
         .safeAreaBar(edge: .bottom) {
-            ContactsPickerConfirmButton(
-                title: viewModel.confirmButtonTitle,
-                isEnabled: viewModel.canConfirm,
-                onTap: handleConfirm
-            )
+            VStack(spacing: DesignConstants.Spacing.step3x) {
+                // Dev-only: choose the variant the picked agent(s) build under.
+                // Shown only once an agent is in the selection; the slug is read
+                // at join time via FeatureFlags, so no plumbing through confirm.
+                if FeatureFlags.shared.isAgentVariantSelectorEnabled, !viewModel.selectedAgentTemplateIds.isEmpty {
+                    AgentVariantSelector()
+                        .padding(.horizontal, DesignConstants.Spacing.step4x)
+                }
+                ContactsPickerConfirmButton(
+                    title: viewModel.confirmButtonTitle,
+                    isEnabled: viewModel.canConfirm,
+                    onTap: handleConfirm
+                )
+            }
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -3738,11 +3738,13 @@ extension ConversationViewModel {
         let taskId = requestId
         let session = self.session
         let actions: any CoreActions = coreActions
+        let variantId = Self.selectedAgentVariantSlug()
         agentJoinTask = Task { [weak self] in
             let outcome = await Self.performAgentJoinCall(
                 templateId: templateId,
                 conversationId: conversationId,
                 requestId: requestId,
+                variantId: variantId,
                 forceErrorCode: forceErrorCode,
                 session: session
             )
@@ -3828,6 +3830,7 @@ extension ConversationViewModel {
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
         let session = self.session
+        let variantId = Self.selectedAgentVariantSlug()
         Task { [weak self] in
             var failed: [AgentJoinAttempt] = []
             var anySucceeded = false
@@ -3842,6 +3845,7 @@ extension ConversationViewModel {
                     templateId: join.templateId,
                     conversationId: conversationId,
                     requestId: join.requestId,
+                    variantId: variantId,
                     forceErrorCode: forceErrorCode,
                     session: session
                 )
@@ -3959,10 +3963,20 @@ extension ConversationViewModel {
     /// `.noAgentsAvailable`) on error. Static + parameterized so both the
     /// single-flight and batched callers can share the same body without
     /// holding `self`.
+    /// The dev-selected agent variant slug to route an agent join, or `nil`.
+    /// Gated on the selector flag so a stale persisted selection can't route
+    /// joins once the dev toggle is off (mirrors `AgentBuilderViewModel.commit`).
+    private static func selectedAgentVariantSlug() -> String? {
+        FeatureFlags.shared.isAgentVariantSelectorEnabled
+            ? FeatureFlags.shared.selectedAgentVariant?.slug
+            : nil
+    }
+
     private static func performAgentJoinCall(
         templateId: String?,
         conversationId: String,
         requestId: String,
+        variantId: String?,
         forceErrorCode: Int?,
         session: any SessionManagerProtocol
     ) async -> AgentJoinOutcome {
@@ -3973,10 +3987,13 @@ extension ConversationViewModel {
         )
         Log.info("performAgentJoinCall about to POST agents/join templateId=\(templateId ?? "nil") requestId=\(requestId)")
         do {
+            let options: ConvosAPI.AgentJoinOptions? = variantId.map {
+                ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0)
+            }
             _ = try await session.addAgentToConversation(
                 conversationId: conversationId,
                 templateId: templateId,
-                options: nil,
+                options: options,
                 forceErrorCode: forceErrorCode
             )
             Log.info("performAgentJoinCall succeeded templateId=\(templateId ?? "nil") requestId=\(requestId)")


### PR DESCRIPTION
## Variant selector when adding an agent from contacts

Stacked on #1118. Extends the dev-only agent variant feature to the **add-an-agent-from-contacts** flow.

Unlike the make-an-agent composer (which *generates* an agent from a prompt), adding from contacts is a **template join** — every entry point funnels into `ConversationViewModel.performAgentJoinCall → session.addAgentToConversation(... options:)`. The join wire model (`AgentJoinOptions.variantId`) already existed but no caller populated it.

### Changes
- **`ConversationViewModel`** — thread a gated variant slug into `performAgentJoinCall` (the single choke point for both the single-join `requestAgentJoin` and the batch `requestAgentJoins`/`runSequentialAgentJoins` paths), building `AgentJoinOptions(variantId:)` instead of `options: nil`. Captured via `selectedAgentVariantSlug()`, gated on `isAgentVariantSelectorEnabled` so a stale persisted selection can't route joins after the toggle is off (same guard added to the builder in #1118).
- **`ContactsPickerView`** — render the same `AgentVariantSelector` in the bottom bar when the flag is on and an agent template is selected.

### Testing
Debug → Features → enable **Agent variant selector**, open the contacts picker (compose `+`, a contact's "Send a message", or in-chat "Add from Contacts"), select a suggested agent → the variant selector appears above Continue; the joined agent routes to the chosen variant (e.g. the "Pirate Talk" ephemeral).

App builds, SwiftLint clean. No ConvosCore changes (the join wire model already supported `variantId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zCW7kUGbuatc4hZKM2Bs2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785356300&installation_id=128169237&pr_number=1120&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1120&signature=dfdf99480a3a21bffb3df7153f49f30627bbc47de47e066c5ca0610ac9d79876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add variant selector when adding an agent from the contacts picker
> - Shows an `AgentVariantSelector` above the confirm button in [ContactsPickerView.swift](https://github.com/xmtplabs/convos-ios/pull/1120/files#diff-2578e38453bafa6d5ec984c48564cbc8f5d2f353d811cdbeac6aef49a58e5e2b) when the `isAgentVariantSelectorEnabled` dev flag is on and at least one agent is selected.
> - Passes the selected variant slug to `performAgentJoinCall` in [ConversationViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/1120/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) for both single and batched agent joins, constructing `AgentJoinOptions` with the variant ID when available.
> - When the feature flag is off or no variant is selected, all behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 758a28e. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->