### PR TITLE
feat(deeplink): route agent-template Universal Links

### DIFF
--- a/Convos/DeepLinking/DeepLinkHandler.swift
+++ b/Convos/DeepLinking/DeepLinkHandler.swift
@@ -116,19 +116,26 @@ final class DeepLinkHandler {
         return templateId
     }
 
-    /// Parses agent-template deep links of the form
-    /// `convos[-{env}]://template/<templateId>`, where `<templateId>` is
-    /// the backend's `AgentTemplate.id` (a UUID).
+    /// Parses agent-template deep links in two shapes, both carrying the
+    /// backend's `AgentTemplate.id` (a UUID):
+    ///  - custom scheme `convos[-{env}]://template/<templateId>`
+    ///  - Universal Link `https://app[-{env}].convos.org/template/<templateId>`
     ///
-    /// V1 handles the custom URL scheme only. A Universal Link form
-    /// (`https://.../<templateId>`) is a planned follow-up.
+    /// The Universal Link form opens the app from contexts a custom scheme
+    /// can't reach - notably a social app's in-app browser, which silently
+    /// drops `convos://` navigations but still hands an https associated-domain
+    /// link off to the app.
     ///
     /// See `docs/plans/agent-templates-phase-1-prd.md`.
     @MainActor
     private static func parseAgentTemplate(from url: URL) -> DeepLinkDestination? {
-        guard url.scheme == ConfigManager.shared.appUrlScheme,
-              let templateId = customSchemeAgentTemplateId(from: url),
-              isValidTemplateId(templateId) else {
+        let templateId: String?
+        if url.scheme == ConfigManager.shared.appUrlScheme {
+            templateId = customSchemeAgentTemplateId(from: url)
+        } else {
+            templateId = universalLinkAgentTemplateId(from: url)
+        }
+        guard let templateId, isValidTemplateId(templateId) else {
             return nil
         }
         return .agentTemplate(templateId: templateId)
@@ -141,6 +148,22 @@ final class DeepLinkHandler {
         let components = url.pathComponents.filter { $0 != "/" }
         guard components.count == 1 else { return nil }
         return components[0]
+    }
+
+    /// `https://app[-{env}].convos.org/template/<id>` - host is one of the
+    /// app's associated domains, first path component is `template`, second
+    /// is the id. The host is validated here, not only at `destination(for:)`,
+    /// so the QR-scanner entry point `agentTemplateId(from:)` can't extract an
+    /// id out of an unclaimed host.
+    private static func universalLinkAgentTemplateId(from url: URL) -> String? {
+        guard url.scheme == "https",
+              let host = url.host,
+              ConfigManager.shared.associatedDomains.contains(host) else {
+            return nil
+        }
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count == 2, components[0] == "template" else { return nil }
+        return components[1]
     }
 
     private static let uuidPattern: NSRegularExpression? = {

--- a/ConvosTests/DeepLinkHandlerTests.swift
+++ b/ConvosTests/DeepLinkHandlerTests.swift
@@ -186,10 +186,58 @@ final class DeepLinkHandlerTests: XCTestCase {
         }
     }
 
+    // MARK: - Agent template deep links (https universal link)
+
+    func testUniversalLinkAgentTemplate_ParsesTemplateId() throws {
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/template/\(sampleTemplateId)"))
+        let destination = DeepLinkHandler.destination(for: url)
+
+        guard case let .agentTemplate(templateId) = destination else {
+            XCTFail("Expected .agentTemplate, got \(String(describing: destination))")
+            return
+        }
+        XCTAssertEqual(templateId, sampleTemplateId)
+    }
+
+    func testUniversalLinkAgentTemplate_UppercaseTemplateIdAccepted() throws {
+        let uppercased = sampleTemplateId.uppercased()
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/template/\(uppercased)"))
+        guard case let .agentTemplate(templateId) = DeepLinkHandler.destination(for: url) else {
+            XCTFail("Expected .agentTemplate for uppercase UUID")
+            return
+        }
+        XCTAssertEqual(templateId, uppercased)
+    }
+
+    func testUniversalLinkAgentTemplate_InvalidHostReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "https://evil.example.com/template/\(sampleTemplateId)"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testUniversalLinkAgentTemplate_MissingIdReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/template/"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testUniversalLinkAgentTemplate_MalformedIdReturnsNil() throws {
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/template/not-a-uuid"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
+    func testUniversalLinkAgentTemplate_ExtraPathSegmentsRejected() throws {
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/template/\(sampleTemplateId)/extra"))
+        XCTAssertNil(DeepLinkHandler.destination(for: url))
+    }
+
     // MARK: - DeepLinkHandler.agentTemplateId(from:)
 
     func testAgentTemplateId_ReturnsTemplateIdForTemplateURL() throws {
         let url = try XCTUnwrap(URL(string: "\(appUrlScheme)://template/\(sampleTemplateId)"))
+        XCTAssertEqual(DeepLinkHandler.agentTemplateId(from: url), sampleTemplateId)
+    }
+
+    func testAgentTemplateId_ReturnsTemplateIdForUniversalLinkURL() throws {
+        let url = try XCTUnwrap(URL(string: "https://\(primaryDomain)/template/\(sampleTemplateId)"))
         XCTAssertEqual(DeepLinkHandler.agentTemplateId(from: url), sampleTemplateId)
     }
 


### PR DESCRIPTION
## Summary

Route agent-template **Universal Links** (`https://app[-env].convos.org/template/<uuid>`) into the app, alongside the existing `convos://template/<uuid>` custom scheme. `DeepLinkHandler.parseAgentTemplate` now accepts both shapes; the https form's host is validated against `ConfigManager.associatedDomains`.

## Why

The website's "Chat and personalize" CTA on the agent share page (`convos.org/a/<slug>`) is a `convos://template/<id>` custom-scheme link. Inside a social app's in-app browser (X, Instagram, Facebook) the custom scheme is silently swallowed -- the WKWebView won't load a non-https scheme and the host app doesn't forward it -- so the button does nothing, even when Convos is installed.

An https Universal Link on a **claimed associated domain** does hand off to the app from inside those in-app browsers. Verified empirically: existing Convos **invite** links (already app-handled on `app.convos.org`) open the app from inside X's in-app browser. This change gives agent templates the same path.

## The cross-repo contract

For the website to use this, the "Chat and personalize" CTA must link to:

- **prod:** `https://app.convos.org/template/<templateId>`
- **dev:** `https://app-dev.convos.org/template/<templateId>`

`app[-dev].convos.org` is the claimed associated domain (`config.{prod,dev}.json` -> `associatedDomains`), reached cross-subdomain from the `convos.org/a/<slug>` share page -- the same cross-subdomain trick convos-website's invite `app-redirect.ts` uses to trigger Universal Links. The AASA already claims `app.convos.org/*`, so no association change is needed.

> The phase-1 PRD sketched the UL as `agents-dev.convos.org/<id>`, but that host is not in `associatedDomains` (and a same-host link wouldn't fire a Universal Link anyway). The claimed app subdomain is the host that actually works.

## Sequencing

Do **not** switch the website CTA to the Universal Link until a build containing this change ships. On a current build the app claims `app.convos.org/*` but `parseAgentTemplate` returns nil for the template path, so tapping the UL would open the app to nowhere. Order: land + ship this -> then flip the website CTA.

## Tests

Added `ConvosTests/DeepLinkHandlerTests.swift` cases for the https form: parse, uppercase UUID, invalid host, missing/malformed id, extra path segments, and the `agentTemplateId(from:)` QR-scanner path.

**These app-target tests are not run by CI.** `ci/run-tests.sh --unit` only runs `swift test` on the SPM packages (ConvosCore / ConvosAppData / ConvosInvites); `ConvosTests` is xcodebuild-only. I could not build the iOS app target in my environment, so the tests are **unrun** -- please run them locally before merge:

```
xcodebuild test -scheme "Convos (Local)" -only-testing:ConvosTests/DeepLinkHandlerTests -destination "platform=iOS Simulator,name=iPhone 17"
```

The production change in `DeepLinkHandler.swift` is compiled by the firebase-pr app build. swiftlint --strict passes (local 0.62.2 matches the repo pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDCBvcruPNnu7M3RyFkZzV

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785363469&installation_id=128169237&pr_number=1121&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1121&signature=b70e0da483bb7c293890cc1605631996ffd07e59d09df5878a72d1b58470bf57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route agent-template Universal Links in `DeepLinkHandler`
> - Extends `DeepLinkHandler.parseAgentTemplate(from:)` to accept both custom-scheme URLs and `https` Universal Links, selecting the template ID source based on the URL scheme.
> - Adds `universalLinkAgentTemplateId(from:)` helper that validates the host against `ConfigManager.shared.associatedDomains` and requires an exact `/template/<uuid>` path structure.
> - Adds tests covering valid links, uppercase UUIDs, invalid hosts, missing IDs, malformed IDs, and extra path segments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73dc727.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->