### PR TITLE
chore(skills): add /prune-xcode disk-cleanup skill

### DIFF
--- a/.claude/skills/prune-xcode/SKILL.md
+++ b/.claude/skills/prune-xcode/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: prune-xcode
+description: Reclaim Xcode and iOS-simulator disk space safely. Measures usage first, then clears the big recoverable caches (global DerivedData, per-worktree .derivedData while skipping any active build, module caches, old iOS DeviceSupport) and offers simulator cleanup (unavailable + duplicate + orphaned custom sims). Shows before/after free space; confirms destructive simulator/Archive deletions. Use when the user asks to free disk, prune DerivedData, clean Xcode/simulator storage, or "my disk is full".
+---
+
+# prune-xcode
+
+Reclaim disk from Xcode / iOS build artifacts. Everything here EXCEPT simulator and Archive deletion is recoverable cache (it rebuilds), so the cache steps are safe to run unattended. Simulator/Archive deletion needs explicit confirmation (sims hold test state; Archives are submitted-build dSYMs/IPAs that don't rebuild).
+
+## 0. Measure first (always)
+
+Show the user where the space is BEFORE deleting anything:
+
+```bash
+df -h /System/Volumes/Data | tail -1
+du -sh ~/Library/Developer/Xcode/DerivedData 2>/dev/null
+du -sh ~/Library/Developer/Xcode/iOS\ DeviceSupport 2>/dev/null
+du -sh ~/Library/Developer/CoreSimulator/Devices 2>/dev/null
+du -sh ~/Library/Developer/Xcode/Archives 2>/dev/null
+du -sh ~/Library/Caches/com.apple.dt.Xcode 2>/dev/null
+# per-worktree caches (repos that build with -derivedDataPath .derivedData):
+find ~/dev -maxdepth 4 -name .derivedData -type d -exec du -sh {} \; 2>/dev/null
+```
+
+Present a table + the total reclaimable, then act.
+
+## 1. DerivedData -- the usual monster (safe, recoverable)
+
+Global DerivedData lives at `~/Library/Developer/Xcode/DerivedData`. It is pure build cache; Xcode rebuilds it on the next build. It is routinely 100s of GB.
+
+- It has 100k+ files, so deleting it is SLOW -- ALWAYS run the delete in the background (run_in_background: true) or it times out and gets killed mid-sweep, leaving "Directory not empty" residue:
+  ```bash
+  rm -rf ~/Library/Developer/Xcode/DerivedData
+  ```
+- For a clean sweep the user should QUIT Xcode first -- an open Xcode keeps writing to DerivedData (you'll see "Directory not empty" if it recreates files mid-delete). If Xcode must stay open, just re-run the rm afterward; residual is harmless.
+
+### Per-worktree .derivedData
+Some repos build with `-derivedDataPath .derivedData` (a local cache per worktree). Delete the inactive ones, but SKIP any worktree with an active build:
+
+```bash
+pgrep -fl xcodebuild   # is a build running, and which derivedDataPath?
+```
+Skip the `.derivedData` of any path an active `xcodebuild` is using (or whose `.derivedData` was modified in the last few minutes). Delete the rest in the background:
+```bash
+rm -rf <worktree>/.derivedData
+```
+
+## 2. iOS DeviceSupport -- recoverable (re-extracted on device connect)
+
+`~/Library/Developer/Xcode/iOS DeviceSupport/` holds per-iOS-version debug symbols for physical devices (several GB each). Keep the latest 1-2 OS versions, delete older:
+```bash
+ls -1 ~/Library/Developer/Xcode/iOS\ DeviceSupport/
+rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/<old-version>
+```
+Reconnecting a device on a deleted version re-extracts it (slow but automatic). If unsure which to keep, ask.
+
+## 3. Simulators -- CONFIRM before deleting (may hold test state)
+
+```bash
+xcrun simctl shutdown all 2>/dev/null
+xcrun simctl delete unavailable        # safe: removes sims whose runtime you no longer have
+```
+For duplicate models / orphaned custom (per-task) sims:
+- List: `xcrun simctl list devices`
+- Identify duplicate models (keep one of each) + orphaned custom sims named after dead branches/tasks.
+- CONFIRM the deletion list with the user, then delete each: `xcrun simctl delete <udid>`
+- To reclaim a sim's DATA without deleting the device: `xcrun simctl erase <udid>`
+
+## 4. Other caches (optional, smaller)
+
+```bash
+rm -rf ~/Library/Caches/com.apple.dt.Xcode      # safe
+```
+Do NOT delete `~/Library/Developer/Xcode/Archives` unless the user confirms -- those are submitted-build artifacts, not recoverable.
+
+## 5. Report
+
+Show `df -h /System/Volumes/Data` before vs after and the GB reclaimed.
+
+## Safety rules
+- Delete CACHE / build output only -- never source, worktrees, or `Archives` (without confirmation).
+- Skip the `.derivedData` of any worktree with an active/in-flight build.
+- Large deletes (DerivedData) MUST run in the background to avoid timeouts.
+- Confirm before deleting simulators or DeviceSupport versions.


### PR DESCRIPTION
Adds a `/prune-xcode` Claude Code skill that safely reclaims Xcode / iOS-simulator disk space.

## Why
Xcode's global DerivedData (`~/Library/Developer/Xcode/DerivedData`) plus the per-worktree `.derivedData` caches this project uses accumulate to hundreds of GB. This skill turns reclaiming that space into a one-command, safe operation (a single sweep here freed ~120 GB).

## What it does
- Measures first (`df` + `du` across DerivedData, DeviceSupport, simulators, per-worktree caches) and shows a breakdown before deleting anything.
- Clears the safe, recoverable caches in the background (global DerivedData, inactive worktree `.derivedData`, Xcode caches) -- skipping any worktree with an in-flight build (`pgrep xcodebuild` guard).
- Trims old iOS DeviceSupport, keeping the latest 1-2 versions.
- Offers simulator cleanup (`simctl delete unavailable` + duplicate / orphaned per-task sims) with confirmation, since sims can hold test state.
- Reports GB reclaimed (before/after free space).

Cache-only by default; simulator and `Archives` deletions require explicit confirmation (they don't rebuild).

## Usage
`/prune-xcode`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785406334&installation_id=128169237&pr_number=1123&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1123&signature=a28ceefccdc44d25dc50a8e33d7ab120963b680c82d801544b21fcddb68bca29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `prune-xcode` disk-cleanup skill for Xcode cache and simulator management
> Adds [SKILL.md](.claude/skills/prune-xcode/SKILL.md) defining procedures for measuring and reclaiming disk space used by Xcode. The skill covers deleting DerivedData (global and per-worktree), pruning iOS DeviceSupport directories, and safely erasing or deleting simulators with confirmation steps. It also defines safety rules, such as never deleting Archives without explicit confirmation and always reporting reclaimed space after cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f96bf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->