### PR TITLE
feat(share): share agent HTML artifacts as the .html file (PNG as preview only)

### DIFF
--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -181,7 +181,14 @@ struct AttachmentSharePayload {
     /// Recipients receive only this HTML file; the rendered image is preview
     /// metadata, never a shared item.
     private static func writeShareHTML(fileURL: URL, basename: String, attachmentKey: String) async -> URL? {
-        let ext: String = fileURL.pathExtension.isEmpty ? "html" : fileURL.pathExtension
+        // `isHTMLFile` can be true from the MIME type alone, so the cached
+        // file's on-disk extension may be missing or non-html (e.g.
+        // `report.txt`). Force `html` for the shared copy unless the existing
+        // extension is already a valid HTML one, so recipients never get an
+        // HTML payload that opens as plain text.
+        let htmlExtensions: Set<String> = ["html", "htm"]
+        let rawExtension: String = fileURL.pathExtension.lowercased()
+        let ext: String = htmlExtensions.contains(rawExtension) ? rawExtension : "html"
         // Namespace by attachment key so same-named attachments cannot
         // overwrite each other's armed share payload.
         let url: URL = FileManager.default.temporaryDirectory

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -5,10 +5,11 @@ import UIKit
 
 /// The resolved share content for an HTML or Markdown attachment, shared by
 /// `AttachmentShareLink` and the message context menu's Share action so the
-/// payload stays identical everywhere. HTML shares the full-page rendered
-/// image only (the share sheet preview stays the square tile); Markdown
-/// shares the underlying file, adding the rendered thumbnail image once it
-/// resolves.
+/// payload stays identical everywhere. HTML shares the underlying `.html`
+/// file (copied to a title-named temp file so the raw on-disk filename is
+/// never exposed); the rendered tile image rides along only as the share
+/// sheet preview thumbnail, never as a second shared file. Markdown shares
+/// the underlying file, adding the rendered thumbnail image once it resolves.
 struct AttachmentSharePayload {
     let items: [URL]
     let title: String
@@ -67,27 +68,16 @@ struct AttachmentSharePayload {
             fileURL: fileURL,
             appearance: appearance
         )
-        // Share the full-page render when available; the square tile stays
-        // the share sheet preview so it reads as a card, not a tall sliver.
-        // The PNG is rendered once and disk-cached, so re-sharing arms
-        // instantly.
-        let fullPageURL: URL? = await HTMLThumbnailRenderer.shared.fullPagePNGURL(
-            for: attachment.key,
-            fileURL: fileURL,
-            appearance: appearance,
-            basename: basename
-        )
-        if let fullPageURL {
-            // Arm even when the tile thumbnail failed - the share sheet
-            // then shows a title-only preview instead of staying dimmed.
-            return AttachmentSharePayload(items: [fullPageURL], title: title, previewImage: thumbnail)
-        }
-        // Full-page render failed; fall back to sharing the tile image.
-        guard let thumbnail,
-              let fallbackURL = await writeSharePNG(image: thumbnail, basename: basename, attachmentKey: attachment.key) else {
+        // Share the actual `.html` file. Copy it to a title-named temp file so
+        // recipients never see the raw on-disk filename, then hand that single
+        // file over as the shared item. The rendered tile rides along only as
+        // the share sheet preview thumbnail (never a second shared file), so
+        // sharing arms as soon as the HTML exists - no wait on the slow
+        // full-page render.
+        guard let htmlURL = await writeShareHTML(fileURL: fileURL, basename: basename, attachmentKey: attachment.key) else {
             return nil
         }
-        return AttachmentSharePayload(items: [fallbackURL], title: title, previewImage: thumbnail)
+        return AttachmentSharePayload(items: [htmlURL], title: title, previewImage: thumbnail)
     }
 
     @MainActor
@@ -185,6 +175,36 @@ struct AttachmentSharePayload {
         }.value
         return written ? url : nil
     }
+
+    /// Copies the cached `.html` attachment to a title-named temp file so the
+    /// shared item carries the artifact's name, not the raw on-disk filename.
+    /// Recipients receive only this HTML file; the rendered image is preview
+    /// metadata, never a shared item.
+    private static func writeShareHTML(fileURL: URL, basename: String, attachmentKey: String) async -> URL? {
+        let ext: String = fileURL.pathExtension.isEmpty ? "html" : fileURL.pathExtension
+        // Namespace by attachment key so same-named attachments cannot
+        // overwrite each other's armed share payload.
+        let url: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-" + HTMLThumbnailRenderer.stableKeyComponent(for: attachmentKey), isDirectory: true)
+            .appendingPathComponent("\(basename).\(ext)")
+        let written: Bool = await Task.detached(priority: .utility) {
+            do {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try FileManager.default.removeItem(at: url)
+                }
+                try FileManager.default.copyItem(at: fileURL, to: url)
+                return true
+            } catch {
+                Log.error("AttachmentSharePayload: failed to copy share HTML: \(error)")
+                return false
+            }
+        }.value
+        return written ? url : nil
+    }
 }
 
 /// Share button for HTML and Markdown attachments, used by both the
@@ -240,10 +260,13 @@ struct AttachmentShareLink: View {
                 })
             }
         } else if attachment.isHTMLFile {
-            // HTML shares only the rendered image, so there is nothing to
-            // share until the full-page render lands.
-            Image(systemName: "square.and.arrow.up")
-                .foregroundStyle(.secondary)
+            // The HTML file already exists, so arm sharing immediately on the
+            // raw file rather than dimming while the preview thumbnail and
+            // title-named copy resolve. The richer payload (title-named file +
+            // preview image) swaps in once `resolve` finishes.
+            ShareLink(item: fileURL, preview: SharePreview(fallbackTitle ?? "Attachment")) {
+                Image(systemName: "square.and.arrow.up")
+            }
         } else {
             ShareLink(items: [fileURL], preview: { (_: URL) in
                 SharePreview(attachment.filename ?? fallbackTitle ?? "Attachment")

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -190,7 +190,13 @@ struct AttachmentSharePayload {
         fileURL: URL,
         fallbackTitle: String?
     ) async -> URL? {
-        let basename: String = sanitizeFilename(fallbackTitle ?? String(attachment.key.prefix(32)))
+        // Prefer the already-cached page title so the immediate-arm filename
+        // matches what the resolved payload would use; only when no title has
+        // resolved yet do we fall back to the supplied title, then the key
+        // prefix. The cached lookup is synchronous (no render), so sharing
+        // still arms as soon as the HTML exists.
+        let cachedTitle: String? = HTMLPageMetadata.shared.cachedTitle(for: attachment.key)
+        let basename: String = sanitizeFilename(cachedTitle ?? fallbackTitle ?? String(attachment.key.prefix(32)))
         return await writeShareHTML(fileURL: fileURL, basename: basename, attachmentKey: attachment.key)
     }
 

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -263,8 +263,9 @@ struct AttachmentShareLink: View {
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var payload: AttachmentSharePayload?
     /// A correctly `.html`-extensioned copy of the raw file, armed before the
-    /// slow render so the immediate-share fallback never hands over a
-    /// wrong-extension file.
+    /// slow render. The immediate (pre-resolve) HTML share stays disabled until
+    /// this lands, so a share is never armed with the raw cached file, whose
+    /// on-disk extension may be missing or non-html.
     @State private var immediateURL: URL?
 
     static func canShare(_ attachment: HydratedAttachment) -> Bool {
@@ -314,22 +315,31 @@ struct AttachmentShareLink: View {
                 })
             }
         } else if attachment.isHTMLFile {
-            // The HTML file already exists, so arm sharing immediately rather
-            // than dimming while the preview thumbnail and title-named copy
-            // resolve. Prefer the correctly `.html`-extensioned copy; fall back
-            // to the raw file only until that fast copy lands, so the share is
-            // never unavailable. The richer payload (title-named file + preview
-            // image) swaps in once `resolve` finishes.
-            let immediateItem: URL = immediateURL ?? fileURL
-            ShareLink(item: immediateItem, preview: SharePreview(fallbackTitle ?? "Attachment")) {
-                Image(systemName: "square.and.arrow.up")
-            }
+            htmlImmediateShareLink
         } else {
             ShareLink(items: [fileURL], preview: { (_: URL) in
                 SharePreview(attachment.filename ?? fallbackTitle ?? "Attachment")
             }, label: {
                 Image(systemName: "square.and.arrow.up")
             })
+        }
+    }
+
+    /// The pre-resolve HTML share affordance. It only arms once the correctly
+    /// `.html`-extensioned copy exists (`immediateURL`); until then it shows a
+    /// dimmed, non-tappable placeholder rather than sharing the raw cached
+    /// file, whose on-disk extension may be missing or non-html and would be
+    /// delivered as plain text. The copy is fast (no render), so this state is
+    /// brief, and the richer payload swaps in once `resolve` finishes.
+    @ViewBuilder
+    private var htmlImmediateShareLink: some View {
+        if let immediateURL {
+            ShareLink(item: immediateURL, preview: SharePreview(fallbackTitle ?? "Attachment")) {
+                Image(systemName: "square.and.arrow.up")
+            }
+        } else {
+            Image(systemName: "square.and.arrow.up")
+                .opacity(0.4)
         }
     }
 }

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -205,25 +205,31 @@ struct AttachmentSharePayload {
         return await writeShareHTML(fileURL: fileURL, basename: basename, attachmentKey: attachment.key)
     }
 
+    /// The on-disk extension to give a shared HTML copy. `isHTMLFile` can be
+    /// true from the MIME type alone, so the cached file's extension may be
+    /// missing or non-html (e.g. `report.txt`); force `html` unless the source
+    /// already carries a valid HTML extension, so recipients never get an HTML
+    /// payload that opens as plain text.
+    static func htmlShareExtension(for fileURL: URL) -> String {
+        let htmlExtensions: Set<String> = ["html", "htm"]
+        let rawExtension: String = fileURL.pathExtension.lowercased()
+        return htmlExtensions.contains(rawExtension) ? rawExtension : "html"
+    }
+
     /// Copies the cached `.html` attachment to a title-named temp file so the
     /// shared item carries the artifact's name, not the raw on-disk filename.
     /// Recipients receive only this HTML file; the rendered image is preview
     /// metadata, never a shared item.
     private static func writeShareHTML(fileURL: URL, basename: String, attachmentKey: String) async -> URL? {
-        // `isHTMLFile` can be true from the MIME type alone, so the cached
-        // file's on-disk extension may be missing or non-html (e.g.
-        // `report.txt`). Force `html` for the shared copy unless the existing
-        // extension is already a valid HTML one, so recipients never get an
-        // HTML payload that opens as plain text.
-        let htmlExtensions: Set<String> = ["html", "htm"]
-        let rawExtension: String = fileURL.pathExtension.lowercased()
-        let ext: String = htmlExtensions.contains(rawExtension) ? rawExtension : "html"
+        let ext: String = htmlShareExtension(for: fileURL)
         // Namespace by attachment key so same-named attachments cannot
         // overwrite each other's armed share payload.
         let url: URL = FileManager.default.temporaryDirectory
             .appendingPathComponent("share-" + HTMLThumbnailRenderer.stableKeyComponent(for: attachmentKey), isDirectory: true)
             .appendingPathComponent("\(basename).\(ext)")
-        let written: Bool = await Task.detached(priority: .utility) {
+        // Sharing is a direct user action on a small file, so copy at
+        // user-initiated priority rather than letting it sit behind utility work.
+        let written: Bool = await Task.detached(priority: .userInitiated) {
             do {
                 try FileManager.default.createDirectory(
                     at: url.deletingLastPathComponent(),

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -137,15 +137,20 @@ struct AttachmentSharePayload {
         return result.image
     }
 
-    private static func sanitizeFilename(_ raw: String) -> String {
+    static func sanitizeFilename(_ raw: String) -> String {
         let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_. "))
         var output: String = ""
         for scalar in raw.unicodeScalars {
             output.append(allowed.contains(scalar) ? Character(scalar) : "_")
         }
-        let trimmed: String = output.trimmingCharacters(in: .whitespaces)
-        let fallback: String = trimmed.isEmpty ? "image" : trimmed
-        return String(fallback.prefix(64))
+        // Trim whitespace plus any leading or trailing dots and underscores so a
+        // title like ".secret" cannot produce a hidden file (".secret.html") or
+        // a trailing-dot name that some filesystems mangle. Cap, then trim once
+        // more in case the cap re-introduced a trailing dot.
+        let strippable: CharacterSet = CharacterSet(charactersIn: "._").union(.whitespaces)
+        let capped: String = String(output.trimmingCharacters(in: strippable).prefix(64))
+        let cleaned: String = capped.trimmingCharacters(in: strippable)
+        return cleaned.isEmpty ? "attachment" : cleaned
     }
 
     private static func writeSharePNG(image: UIImage, basename: String, attachmentKey: String) async -> URL? {

--- a/Convos/Shared Views/AttachmentShareLink.swift
+++ b/Convos/Shared Views/AttachmentShareLink.swift
@@ -176,6 +176,24 @@ struct AttachmentSharePayload {
         return written ? url : nil
     }
 
+    /// Arms the immediate (pre-resolve) HTML share with a correctly
+    /// `.html`-extensioned copy. The raw cached file may carry a missing or
+    /// non-html on-disk extension (when `isHTMLFile` is MIME-only), so sharing
+    /// it directly would deliver a file the recipient's OS opens as plain
+    /// text. This reuses the same copy/extension-forcing as the resolved
+    /// payload, using the fallback title (or the attachment key) as the
+    /// basename. The copy is fast (no render), so sharing still arms as soon
+    /// as the HTML exists.
+    @MainActor
+    static func immediateHTMLShareURL(
+        attachment: HydratedAttachment,
+        fileURL: URL,
+        fallbackTitle: String?
+    ) async -> URL? {
+        let basename: String = sanitizeFilename(fallbackTitle ?? String(attachment.key.prefix(32)))
+        return await writeShareHTML(fileURL: fileURL, basename: basename, attachmentKey: attachment.key)
+    }
+
     /// Copies the cached `.html` attachment to a title-named temp file so the
     /// shared item carries the artifact's name, not the raw on-disk filename.
     /// Recipients receive only this HTML file; the rendered image is preview
@@ -227,6 +245,10 @@ struct AttachmentShareLink: View {
 
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var payload: AttachmentSharePayload?
+    /// A correctly `.html`-extensioned copy of the raw file, armed before the
+    /// slow render so the immediate-share fallback never hands over a
+    /// wrong-extension file.
+    @State private var immediateURL: URL?
 
     static func canShare(_ attachment: HydratedAttachment) -> Bool {
         attachment.isHTMLFile || attachment.isMarkdownFile
@@ -240,6 +262,14 @@ struct AttachmentShareLink: View {
             .accessibilityLabel("Share")
             .task(id: "\(attachment.key)-\(appearanceSuffix)") {
                 payload = nil
+                immediateURL = nil
+                if attachment.isHTMLFile {
+                    immediateURL = await AttachmentSharePayload.immediateHTMLShareURL(
+                        attachment: attachment,
+                        fileURL: fileURL,
+                        fallbackTitle: fallbackTitle
+                    )
+                }
                 payload = await AttachmentSharePayload.resolve(
                     attachment: attachment,
                     fileURL: fileURL,
@@ -267,11 +297,14 @@ struct AttachmentShareLink: View {
                 })
             }
         } else if attachment.isHTMLFile {
-            // The HTML file already exists, so arm sharing immediately on the
-            // raw file rather than dimming while the preview thumbnail and
-            // title-named copy resolve. The richer payload (title-named file +
-            // preview image) swaps in once `resolve` finishes.
-            ShareLink(item: fileURL, preview: SharePreview(fallbackTitle ?? "Attachment")) {
+            // The HTML file already exists, so arm sharing immediately rather
+            // than dimming while the preview thumbnail and title-named copy
+            // resolve. Prefer the correctly `.html`-extensioned copy; fall back
+            // to the raw file only until that fast copy lands, so the share is
+            // never unavailable. The richer payload (title-named file + preview
+            // image) swaps in once `resolve` finishes.
+            let immediateItem: URL = immediateURL ?? fileURL
+            ShareLink(item: immediateItem, preview: SharePreview(fallbackTitle ?? "Attachment")) {
                 Image(systemName: "square.and.arrow.up")
             }
         } else {

--- a/ConvosTests/AttachmentSharePayloadTests.swift
+++ b/ConvosTests/AttachmentSharePayloadTests.swift
@@ -1,0 +1,78 @@
+@testable import Convos
+import XCTest
+
+final class AttachmentSharePayloadTests: XCTestCase {
+    // MARK: - sanitizeFilename
+
+    func testLeadingDotDoesNotProduceHiddenFile() {
+        let result = AttachmentSharePayload.sanitizeFilename(".secret")
+        XCTAssertFalse(result.hasPrefix("."), "Sanitized name must not start with a dot")
+        XCTAssertEqual(result, "secret")
+    }
+
+    func testTrailingDotIsStripped() {
+        XCTAssertEqual(AttachmentSharePayload.sanitizeFilename("report."), "report")
+    }
+
+    func testLeadingAndTrailingUnderscoresAreStripped() {
+        XCTAssertEqual(AttachmentSharePayload.sanitizeFilename("__draft__"), "draft")
+    }
+
+    func testEmptyInputFallsBackToAttachment() {
+        XCTAssertEqual(AttachmentSharePayload.sanitizeFilename(""), "attachment")
+    }
+
+    func testAllStrippableInputFallsBackToAttachment() {
+        XCTAssertEqual(AttachmentSharePayload.sanitizeFilename("..__  "), "attachment")
+    }
+
+    func testNormalTitleIsPreserved() {
+        XCTAssertEqual(AttachmentSharePayload.sanitizeFilename("My Report"), "My Report")
+    }
+
+    func testDisallowedCharactersBecomeUnderscores() {
+        XCTAssertEqual(AttachmentSharePayload.sanitizeFilename("Q3/Results"), "Q3_Results")
+    }
+
+    func testLengthIsCappedAndNotLeftWithTrailingDot() {
+        let raw = String(repeating: "a", count: 63) + ".tail"
+        let result = AttachmentSharePayload.sanitizeFilename(raw)
+        XCTAssertLessThanOrEqual(result.count, 64)
+        XCTAssertFalse(result.hasSuffix("."), "Capping must not leave a trailing dot")
+    }
+
+    // MARK: - htmlShareExtension
+
+    func testHTMLExtensionIsPreserved() {
+        let url = URL(fileURLWithPath: "/tmp/report.html")
+        XCTAssertEqual(AttachmentSharePayload.htmlShareExtension(for: url), "html")
+    }
+
+    func testHTMExtensionIsPreserved() {
+        let url = URL(fileURLWithPath: "/tmp/report.htm")
+        XCTAssertEqual(AttachmentSharePayload.htmlShareExtension(for: url), "htm")
+    }
+
+    func testUppercaseHTMLExtensionIsNormalized() {
+        let url = URL(fileURLWithPath: "/tmp/report.HTML")
+        XCTAssertEqual(AttachmentSharePayload.htmlShareExtension(for: url), "html")
+    }
+
+    func testNonHTMLExtensionIsForcedToHTML() {
+        let url = URL(fileURLWithPath: "/tmp/report.txt")
+        XCTAssertEqual(AttachmentSharePayload.htmlShareExtension(for: url), "html")
+    }
+
+    func testMissingExtensionIsForcedToHTML() {
+        let url = URL(fileURLWithPath: "/tmp/report")
+        XCTAssertEqual(AttachmentSharePayload.htmlShareExtension(for: url), "html")
+    }
+
+    // MARK: - Combined share filename
+
+    func testHiddenTitleWithTextSourceYieldsVisibleHTMLName() {
+        let basename = AttachmentSharePayload.sanitizeFilename(".secret")
+        let ext = AttachmentSharePayload.htmlShareExtension(for: URL(fileURLWithPath: "/tmp/report.txt"))
+        XCTAssertEqual("\(basename).\(ext)", "secret.html")
+    }
+}


### PR DESCRIPTION
Re-enables sharing agent HTML "artifacts" as the actual `.html` file, with the rendered PNG used only as the share-sheet preview thumbnail (not a second shared file).

## Why
Sharing currently hands the recipient a rendered PNG snapshot instead of the artifact itself (changed in #823, to avoid dumping the raw file). This restores HTML sharing while keeping the visual preview.

## What
- `AttachmentSharePayload.resolveHTML` now shares `items: [htmlURL]` (the actual `.html`); the PNG moves to the preview slot only.
- ShareLink surfaces use `ShareLink(item: htmlURL, preview: SharePreview(title, image: png))`; the context-menu `UIActivityViewController` supplies the PNG as the `LPLinkMetadata` thumbnail (not a shared item). The recipient gets only the HTML.
- The shared filename is sanitized from the artifact title (the raw on-disk filename is never exposed).
- The share arms immediately (the HTML already exists) -- the ~5s PNG render is dropped from the share path; the preview thumbnail fills in when ready.
- Markdown sharing and non-HTML image sharing are unchanged.

## Note
This reverses the deliberate image-swap from #823 -- worth a heads-up to that change's author. `HTMLThumbnailRenderer.fullPagePNGURL` is now unused (left in place; removing it is larger renderer surgery, out of scope).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785422822&installation_id=128169237&pr_number=1125&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1125&signature=6a75b0be41d869f8edb5c1343af18cba5ce4ea45c2dafc593f18567609f2977c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share agent HTML artifacts as .html files with tile image as share-sheet preview only
> - HTML attachments are now shared as a title-named `.html` file copied to a temp directory, replacing the previous flow that waited for a full-page PNG render before enabling sharing.
> - A new `immediateHTMLShareURL` helper prepares the share URL before full payload resolution, so the share button becomes tappable sooner.
> - `sanitizeFilename` is tightened to strip leading/trailing dots and underscores, cap at 64 characters, and return `"attachment"` for empty input; a new `htmlShareExtension` helper forces `.html` when the cached file has a non-browser extension.
> - New tests in [AttachmentSharePayloadTests.swift](https://github.com/xmtplabs/convos-ios/pull/1125/files#diff-66dec47d0c583745998eef4aa7ed75126ca991cf0d724ab21c06b0a097da77c7) cover sanitization edge cases and extension normalization.
> - Behavioral Change: the tile image is used only as the share-sheet preview thumbnail; the shared file is always the `.html` source, never a rendered PNG.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 146be25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->