### PR TITLE
feat(debug): add migration capabilities debug view with enable proposals

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "543746c5973b90ef61a028c779fba4f02c9f7a464c331be63fa1c1c188cd4d56",
+  "originHash" : "ab9adf98b174b3dddda1af96a5ab505035bb5d4b2bf723d39d30345f7fc55443",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
-        "version" : "1.36.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4b38f35946d00d8f6176fe58f96d83aba64b36c7",
-        "version" : "2.31.0"
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
-        "version" : "1.6.2"
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -630,6 +630,16 @@ extension ConversationInfoView {
             Text("Metadata")
         }
         NavigationLink {
+            MigrationCapabilitiesView(
+                loadDebugText: { await viewModel.membershipCapabilitiesDebugText() },
+                enableProposals: { force, minVersion in
+                    await viewModel.enableProposals(force: force, minVersion: minVersion)
+                }
+            )
+        } label: {
+            Text("Migration capabilities")
+        }
+        NavigationLink {
             HiddenMessagesView { try await viewModel.hiddenMessagesDebugInfo() }
         } label: {
             Text("Hidden messages")

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4108,6 +4108,38 @@ extension ConversationViewModel {
     }
 
     @MainActor
+    func membershipCapabilitiesDebugText() async -> String {
+        do {
+            let messagingService = session.messagingService()
+            let inboxResult = try await messagingService.sessionStateManager.waitForInboxReadyResult()
+            let client = inboxResult.client
+            return try await client.groupMembershipCapabilitiesDebugInfo(
+                conversationId: conversation.id
+            ).debugText
+        } catch {
+            return "Failed to load membership capabilities: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    func enableProposals(force: Bool, minVersion: String?) async -> String {
+        do {
+            let messagingService = session.messagingService()
+            let inboxResult = try await messagingService.sessionStateManager.waitForInboxReadyResult()
+            try await inboxResult.client.enableProposals(
+                conversationId: conversation.id,
+                force: force,
+                minVersion: minVersion
+            )
+            let forced = force ? " (forced)" : ""
+            let versioned = minVersion.map { " with minVersion \($0)" } ?? ""
+            return "Enabled proposals\(forced)\(versioned)."
+        } catch {
+            return "Failed to enable proposals: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
     func hiddenMessagesDebugInfo() async throws -> [HiddenMessageDebugEntry] {
         let messagingService = session.messagingService()
         let inboxResult = try await messagingService.sessionStateManager.waitForInboxReadyResult()

--- a/Convos/Conversation Detail/MigrationCapabilitiesView.swift
+++ b/Convos/Conversation Detail/MigrationCapabilitiesView.swift
@@ -1,0 +1,112 @@
+import ConvosCore
+import SwiftUI
+
+/// Debug surface for the per-member migration (proposals) capabilities plus the
+/// controls to enable proposals on the group. Mirrors the Android debug UI:
+/// an optional min libxmtp version, "Enable proposals", and a "Force enable"
+/// that bypasses the per-member capability precheck. Reloads the capabilities
+/// readout after an enable so the migrated/blocking state updates in place.
+struct MigrationCapabilitiesView: View {
+    private let loadDebugText: () async -> String
+    private let enableProposals: (_ force: Bool, _ minVersion: String?) async -> String
+
+    @State private var debugText: String = "Loading…"
+    @State private var minVersionInput: String = ""
+    @State private var actionStatus: String?
+    @State private var isEnabling: Bool = false
+
+    init(
+        loadDebugText: @escaping () async -> String,
+        enableProposals: @escaping (_ force: Bool, _ minVersion: String?) async -> String
+    ) {
+        self.loadDebugText = loadDebugText
+        self.enableProposals = enableProposals
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16.0) {
+                controls
+                Divider()
+                Text(debugText)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.colorTextPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .padding()
+        }
+        .navigationTitle("Migration capabilities")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await refresh()
+        }
+    }
+
+    @ViewBuilder
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 8.0) {
+            Text("Min libxmtp version")
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.colorTextSecondary)
+            TextField("optional, e.g. 1.11.0-dev", text: $minVersionInput)
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            HStack(spacing: 12.0) {
+                Button {
+                    enable(force: false)
+                } label: {
+                    Text("Enable proposals")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isEnabling)
+                Button {
+                    enable(force: true)
+                } label: {
+                    Text("Force enable")
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .disabled(isEnabling)
+            }
+            if let actionStatus {
+                Text(actionStatus)
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    @MainActor
+    private func enable(force: Bool) {
+        let trimmed = minVersionInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let minVersionArg: String? = trimmed.isEmpty ? nil : trimmed
+        Task {
+            isEnabling = true
+            actionStatus = "Enabling…"
+            actionStatus = await enableProposals(force, minVersionArg)
+            await refresh()
+            isEnabling = false
+        }
+    }
+
+    @MainActor
+    private func refresh() async {
+        debugText = await loadDebugText()
+    }
+}
+
+#Preview {
+    NavigationStack {
+        MigrationCapabilitiesView(
+            loadDebugText: {
+                "conversationId: preview\nmigrated (proposals enabled): no\neligible to migrate now: yes"
+            },
+            enableProposals: { force, _ in
+                "Enabled proposals\(force ? " (forced)" : "")."
+            }
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider+MembershipCapabilitiesDebug.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider+MembershipCapabilitiesDebug.swift
@@ -1,0 +1,154 @@
+import ConvosAppData
+import Foundation
+import XMTPiOS
+
+public struct GroupMembershipCapabilitiesDebugInfo: Sendable {
+    public struct InstallationEntry: Sendable {
+        public let installationId: String
+        public let isOwn: Bool
+        public let supportsProposals: Bool
+        public let capabilitiesKnown: Bool
+        public let extensions: [String]
+    }
+
+    public struct MemberEntry: Sendable {
+        public let inboxId: String
+        public let supportsProposals: Bool
+        public let installations: [InstallationEntry]
+    }
+
+    public let conversationId: String
+    public let epoch: UInt64
+    public let isActive: Bool
+    public let maybeForked: Bool
+    public let forkStatus: String
+    public let creatorInboxId: String
+    public let isMigrated: Bool
+    public let eligibleToMigrate: Bool
+    public let contextExtensions: [String]
+    public let appDataText: String
+    public let members: [MemberEntry]
+
+    public var debugText: String {
+        let blockingInboxes = members.filter { !$0.supportsProposals }.map(\.inboxId)
+        var lines: [String] = [
+            "=== group context ===",
+            "conversationId: \(conversationId)",
+            "epoch: \(epoch)",
+            "active member: \(isActive ? "yes" : "no")",
+            "forked: \(maybeForked ? "yes" : "no") (\(forkStatus))",
+            "creator inbox: \(creatorInboxId)",
+            "migrated (proposals enabled): \(isMigrated ? "yes" : "no")",
+            "eligible to migrate now: \(eligibleToMigrate ? "yes" : "no")",
+            "context extensions (types): \(displayList(contextExtensions))",
+            "blocking inboxes: \(blockingInboxes.isEmpty ? "none" : displayList(blockingInboxes))",
+            "",
+            "=== app data ===",
+            appDataText,
+            "",
+            "=== members (\(members.count)) ==="
+        ]
+        for member in members {
+            let status = member.supportsProposals ? "supports" : "blocking"
+            lines.append("  inbox \(member.inboxId) - \(status)")
+            for installation in member.installations {
+                let support = installation.supportsProposals ? "supports" : "no"
+                let own = installation.isOwn ? " (this device)" : ""
+                let known = installation.capabilitiesKnown ? "" : " (capabilities unknown)"
+                lines.append("    - \(installation.installationId): \(support)\(own)\(known)")
+                lines.append("        extensions: \(displayList(installation.extensions))")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func displayList(_ values: [String]) -> String {
+        values.isEmpty ? "<none>" : values.joined(separator: ", ")
+    }
+}
+
+public extension XMTPClientProvider {
+    /// Snapshot a group's per-member migration capabilities for the debug view.
+    ///
+    /// Reads the generic `membershipCapabilities()` surface and derives the
+    /// proposal-migration answers app-side: the group is migrated when the
+    /// context carries the app-data-dictionary extension, and an inbox blocks
+    /// migration when one of its installations does not advertise it.
+    func groupMembershipCapabilitiesDebugInfo(
+        conversationId: String
+    ) async throws -> GroupMembershipCapabilitiesDebugInfo {
+        guard let xmtpConversation = try await conversation(with: conversationId),
+              case .group(let group) = xmtpConversation else {
+            throw XMTPClientProviderError.conversationNotFound(id: conversationId)
+        }
+
+        let capabilities = try await group.membershipCapabilities()
+        let debugInfo = try? await group.getDebugInformation()
+        let isActive = (try? group.isActive()) ?? false
+        let creator = (try? await group.creatorInboxId()) ?? "<error>"
+        let rawAppData = (try? group.appData()) ?? ""
+        let appDataSnapshot = ConversationCustomMetadataDebugSnapshot(rawAppData: rawAppData)
+        let appDataDictionary: MlsExtensionType = .appDataDictionary
+
+        let members: [GroupMembershipCapabilitiesDebugInfo.MemberEntry] = capabilities.members.map { member in
+            let installations: [GroupMembershipCapabilitiesDebugInfo.InstallationEntry] = member.installations.map { installation in
+                let supports = installation.capabilitiesKnown && installation.supportedExtensions.contains(appDataDictionary)
+                return GroupMembershipCapabilitiesDebugInfo.InstallationEntry(
+                    installationId: installation.installationId.hexString,
+                    isOwn: installation.isOwn,
+                    supportsProposals: supports,
+                    capabilitiesKnown: installation.capabilitiesKnown,
+                    extensions: installation.supportedExtensions.map { String(describing: $0) }
+                )
+            }
+            let memberSupports = !installations.isEmpty && installations.allSatisfy { $0.supportsProposals }
+            return GroupMembershipCapabilitiesDebugInfo.MemberEntry(
+                inboxId: member.inboxId,
+                supportsProposals: memberSupports,
+                installations: installations
+            )
+        }
+
+        let isMigrated = capabilities.contextExtensions.contains(appDataDictionary)
+        let eligibleToMigrate = !members.isEmpty && members.allSatisfy { $0.supportsProposals }
+
+        return GroupMembershipCapabilitiesDebugInfo(
+            conversationId: conversationId,
+            epoch: debugInfo?.epoch ?? 0,
+            isActive: isActive,
+            maybeForked: debugInfo?.maybeForked ?? false,
+            forkStatus: debugInfo.map { String(describing: $0.commitLogForkStatus) } ?? "<unknown>",
+            creatorInboxId: creator,
+            isMigrated: isMigrated,
+            eligibleToMigrate: eligibleToMigrate,
+            contextExtensions: capabilities.contextExtensions.map { String(describing: $0) },
+            appDataText: appDataSnapshot.debugText,
+            members: members
+        )
+    }
+
+    /// Enable membership proposals ("migrate" the group) from the debug view.
+    ///
+    /// Wraps the SDK `Group.enableProposals(force:minVersion:)`. When set,
+    /// `minVersion` is the minimum libxmtp version an installation must run for
+    /// the migration to proceed; installations below it block it. `force`
+    /// bypasses the per-member capability precheck (the SDK otherwise hard-fails
+    /// when any member's key package can't support proposals).
+    func enableProposals(
+        conversationId: String,
+        force: Bool = false,
+        minVersion: String? = nil
+    ) async throws {
+        guard let xmtpConversation = try await conversation(with: conversationId),
+              case .group(let group) = xmtpConversation else {
+            throw XMTPClientProviderError.conversationNotFound(id: conversationId)
+        }
+        try await group.enableProposals(force: force, minVersion: minVersion)
+    }
+}
+
+private extension Data {
+    var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}


### PR DESCRIPTION
## What

Adds a per-member **migration-capabilities debug view** to the conversation info screen, with controls to **enable proposals** on the group.

It reads the generic `membershipCapabilities()` snapshot from libxmtp (`ios-4.11.0-nightly.20260630.ac662b3`, already pinned on `dev` via #1122) and derives the proposal-migration answers app-side:

- **migrated?** → group context carries the app-data-dictionary extension
- **eligible to migrate now?** → every installation advertises it
- **who's blocking?** → inboxes with an installation that doesn't

From the same screen you can **enable proposals** (migrate the group):

- an optional **min libxmtp version** gate,
- a plain **Enable proposals** action, and
- a **Force enable** that bypasses the per-member capability precheck (the SDK otherwise hard-fails with `ProposalsNotSupported` when any member's key package can't support proposals).

The readout reloads after each enable, so the migrated / blocking state updates in place. This brings iOS to parity with the Android debug UI (#86).

## Files

- `ConvosCore/.../XMTPClientProvider+MembershipCapabilitiesDebug.swift` (new) — reads the snapshot and derives the answers, plus `enableProposals(conversationId:force:minVersion:)` wrapping the SDK's `Group.enableProposals(force:minVersion:)`
- `Convos/Conversation Detail/MigrationCapabilitiesView.swift` (new) — the interactive debug screen (min-version field, Enable / Force enable, status line, auto-refresh)
- `ConversationViewModel.swift` — `membershipCapabilitiesDebugText()` and `enableProposals(force:minVersion:)` as `@MainActor` async calls surfacing human-readable results
- `ConversationInfoView.swift` — routes the "Migration capabilities" row to the new view

## Verified

- `Convos (Dev)` builds and runs on the simulator; enabling proposals (no force) migrated a live group on the XMTP dev network and the readout flipped `migrated: no → yes`.
- ConvosCore test suite green: **1351 tests / 190 suites passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRjFvtmCE3VYNQEymAUo5A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785439194&installation_id=128169237&pr_number=1127&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1127&signature=2d781a491efe066e48634dbb834419752b9e5e0830ddbe3a463bba77a2b9daf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration capabilities debug view with proposal enablement to conversation info
> - Adds a new `MigrationCapabilitiesView` debug screen (non-production only) accessible from the conversation info Support section, showing per-member migration capabilities for a group conversation.
> - Adds `groupMembershipCapabilitiesDebugInfo` to `XMTPClientProvider` to fetch membership capabilities, migration state, and installation extension support, formatted as readable debug text.
> - Adds `enableProposals` to `XMTPClientProvider` and `ConversationViewModel` to trigger proposal enablement for a group, with optional `force` and `minVersion` parameters.
> - The debug UI in [`MigrationCapabilitiesView.swift`](https://github.com/xmtplabs/convos-ios/pull/1127/files#diff-46d416f15b846cddec125e4f3322abf47e4637e546740f24f98d3f28a46b562b) allows specifying a minimum libxmtp version and shows action status feedback inline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de7459d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
