### PR TITLE
feat(groups): leave a group (self-removal) + super-admin succession

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -491,7 +491,9 @@ struct ConversationInfoView: View {
                 ConversationConnectionsSection(viewModel: connectionsViewModel)
             }
 
-            leaveSection
+            if viewModel.canLeaveConversation {
+                leaveSection
+            }
 
             debugInfoSection
         }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -97,6 +97,7 @@ struct ConversationInfoView: View {
     @State private var metadataDebugText: String = "Loading…"
     @State private var showingRestoreInviteTagAlert: Bool = false
     @State private var restoreInviteTagText: String = ""
+    @State private var showingLeaveConfirmation: Bool = false
     /// "New Agent" builder, presented from here so it stacks on top of the
     /// Info sheet rather than racing the chat view's own builder sheet.
     @State private var presentingAgentBuilder: AgentBuilderViewModel?
@@ -490,7 +491,25 @@ struct ConversationInfoView: View {
                 ConversationConnectionsSection(viewModel: connectionsViewModel)
             }
 
+            leaveSection
+
             debugInfoSection
+        }
+    }
+
+    private var leaveSection: some View {
+        Section {
+            let action = { showingLeaveConfirmation = true }
+            Button(action: action) {
+                HStack {
+                    Text("Leave")
+                        .foregroundStyle(.colorCaution)
+                    Spacer()
+                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                        .foregroundStyle(.colorCaution)
+                }
+            }
+            .accessibilityIdentifier("leave-conversation-button")
         }
     }
 
@@ -561,6 +580,14 @@ struct ConversationInfoView: View {
                     }
                 } message: {
                     Text("Only use this if you know the expected invite tag for this convo.")
+                }
+                .alert("Leave conversation?", isPresented: $showingLeaveConfirmation) {
+                    Button("Cancel", role: .cancel) {}
+                    Button("Leave", role: .destructive) {
+                        viewModel.leaveGroupConvo()
+                    }
+                } message: {
+                    Text("You'll be removed from this conversation and stop receiving its messages.")
                 }
                 .scrollContentBackground(.hidden)
                 .background(.colorBackgroundRaisedSecondary)

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4277,10 +4277,10 @@ extension ConversationViewModel {
                 )
                 self.finishLeave()
             } catch ConversationLeaveError.hideFailedAfterLeave(_, let underlying) {
-                // The MLS self-removal committed; only the local consent-hide
-                // failed afterwards. The user is off the group either way, so
-                // surface the leave and let a later consent sync converge the
-                // hide.
+                // The user's membership already ended (the MLS self-removal
+                // committed, or it was already over or pending); only the
+                // local consent-hide failed afterwards. Surface the leave and
+                // let a later consent sync converge the hide.
                 Log.error("Left convo but hiding it failed: \(underlying.localizedDescription)")
                 self.finishLeave()
             } catch {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -300,6 +300,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     private let localStateWriter: any ConversationLocalStateWriterProtocol
     private let metadataWriter: any ConversationMetadataWriterProtocol
     private let explosionWriter: any ConversationExplosionWriterProtocol
+    private let leaveWriter: any ConversationLeaveWriterProtocol
     private let reactionWriter: any ReactionWriterProtocol
     let readReceiptWriter: any ReadReceiptWriterProtocol
     private let conversationRepository: any ConversationRepositoryProtocol
@@ -1317,6 +1318,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         self.localStateWriter = conversationStateManager.conversationLocalStateWriter
         self.metadataWriter = conversationStateManager.conversationMetadataWriter
         self.explosionWriter = messagingService.conversationExplosionWriter()
+        self.leaveWriter = messagingService.conversationLeaveWriter()
         self.reactionWriter = messagingService.reactionWriter()
         self.readReceiptWriter = messagingService.readReceiptWriter()
 
@@ -1414,6 +1416,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         self.localStateWriter = conversationStateManager.conversationLocalStateWriter
         self.metadataWriter = conversationStateManager.conversationMetadataWriter
         self.explosionWriter = messagingService.conversationExplosionWriter()
+        self.leaveWriter = messagingService.conversationLeaveWriter()
         self.reactionWriter = messagingService.reactionWriter()
         self.readReceiptWriter = messagingService.readReceiptWriter()
 
@@ -4245,6 +4248,50 @@ extension ConversationViewModel {
                 Log.error("Error blocking and leaving convo: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Self-removes the current user from this group: `leaveGroup()` plus the
+    /// optimistic consent-hide (consent `.denied` + push-topic unsubscribe +
+    /// local hide) so the conversation vanishes immediately while the MLS
+    /// remove-commit finalizes async. When the current user is the sole super
+    /// admin, the leave writer transfers super admin to the longest-tenured
+    /// remaining member first.
+    func leaveGroupConvo() {
+        let leaveWriter = leaveWriter
+        let conversation = conversation
+        let successorInboxIds = leaveSuccessorInboxIds()
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await leaveWriter.leave(
+                    conversation: conversation,
+                    tenureOrderedSuccessorInboxIds: successorInboxIds
+                )
+                await MainActor.run {
+                    self.presentingConversationSettings = false
+                    self.conversation.postLeftConversationNotification()
+                }
+            } catch {
+                Log.error("Error leaving convo: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Remaining members (excluding the current user) ordered longest-tenured
+    /// first, used by the leave writer to pick a super-admin successor when the
+    /// leaver is the sole super admin. Members with an unknown `joinedAt` sort
+    /// last so known-tenure members are preferred.
+    private func leaveSuccessorInboxIds() -> [String] {
+        let remaining = conversation.members.filter { !$0.isCurrentUser }
+        let sorted = remaining.sorted { (lhs: ConversationMember, rhs: ConversationMember) -> Bool in
+            switch (lhs.joinedAt, rhs.joinedAt) {
+            case let (left?, right?): return left < right
+            case (nil, _?): return false
+            case (_?, nil): return true
+            case (nil, nil): return false
+            }
+        }
+        return sorted.map { $0.profile.inboxId }
     }
 
     @MainActor

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4285,10 +4285,12 @@ extension ConversationViewModel {
     /// Remaining members (excluding the current user) as super-admin successor
     /// candidates. The leave writer applies the human-preferred, agent-fallback
     /// tenure policy; here we only surface each member's agent flag and join
-    /// time.
+    /// time. Optimistic agent members are presentation-only sentinels overlaid
+    /// while agent instances provision -- their inbox ids don't exist on the
+    /// network, so promoting one would fail and abort the leave.
     private func leaveSuccessorCandidates() -> [LeaveSuccessorCandidate] {
         conversation.members
-            .filter { !$0.isCurrentUser }
+            .filter { !$0.isCurrentUser && !$0.isOptimisticAgentMember }
             .map { (member: ConversationMember) -> LeaveSuccessorCandidate in
                 LeaveSuccessorCandidate(
                     inboxId: member.profile.inboxId,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -929,6 +929,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     var canRemoveMembers: Bool {
         conversation.creator.isCurrentUser
     }
+    /// Self-removal is a group-only operation (the protocol forbids leaving
+    /// a DM); gates the Leave affordance in the info view.
+    var canLeaveConversation: Bool {
+        conversation.kind == .group
+    }
     var isUpdatingPublicPreview: Bool = false
     private var _editingIncludeInfoInPublicPreview: Bool?
     var includeInfoInPublicPreview: Bool {

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4264,22 +4264,36 @@ extension ConversationViewModel {
     func leaveGroupConvo() {
         let leaveWriter = leaveWriter
         let conversation = conversation
-        let successorCandidates = leaveSuccessorCandidates()
         Task { [weak self] in
             guard let self else { return }
+            // Derived at execution time rather than at tap time so the
+            // writer sees the freshest membership when picking a super-admin
+            // successor.
+            let successorCandidates = self.leaveSuccessorCandidates()
             do {
                 try await leaveWriter.leave(
                     conversation: conversation,
                     successorCandidates: successorCandidates
                 )
-                await MainActor.run {
-                    self.presentingConversationSettings = false
-                    self.conversation.postLeftConversationNotification()
-                }
+                self.finishLeave()
+            } catch ConversationLeaveError.hideFailedAfterLeave(_, let underlying) {
+                // The MLS self-removal committed; only the local consent-hide
+                // failed afterwards. The user is off the group either way, so
+                // surface the leave and let a later consent sync converge the
+                // hide.
+                Log.error("Left convo but hiding it failed: \(underlying.localizedDescription)")
+                self.finishLeave()
             } catch {
                 Log.error("Error leaving convo: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Dismisses settings and announces the departure once the leave is
+    /// effective on the MLS side.
+    private func finishLeave() {
+        presentingConversationSettings = false
+        conversation.postLeftConversationNotification()
     }
 
     /// Remaining members (excluding the current user) as super-admin successor

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4255,17 +4255,17 @@ extension ConversationViewModel {
     /// local hide) so the conversation vanishes immediately while the MLS
     /// remove-commit finalizes async. When the current user is the sole super
     /// admin, the leave writer transfers super admin to the longest-tenured
-    /// remaining member first.
+    /// remaining human member first (agents only as a fallback).
     func leaveGroupConvo() {
         let leaveWriter = leaveWriter
         let conversation = conversation
-        let successorInboxIds = leaveSuccessorInboxIds()
+        let successorCandidates = leaveSuccessorCandidates()
         Task { [weak self] in
             guard let self else { return }
             do {
                 try await leaveWriter.leave(
                     conversation: conversation,
-                    tenureOrderedSuccessorInboxIds: successorInboxIds
+                    successorCandidates: successorCandidates
                 )
                 await MainActor.run {
                     self.presentingConversationSettings = false
@@ -4277,21 +4277,20 @@ extension ConversationViewModel {
         }
     }
 
-    /// Remaining members (excluding the current user) ordered longest-tenured
-    /// first, used by the leave writer to pick a super-admin successor when the
-    /// leaver is the sole super admin. Members with an unknown `joinedAt` sort
-    /// last so known-tenure members are preferred.
-    private func leaveSuccessorInboxIds() -> [String] {
-        let remaining = conversation.members.filter { !$0.isCurrentUser }
-        let sorted = remaining.sorted { (lhs: ConversationMember, rhs: ConversationMember) -> Bool in
-            switch (lhs.joinedAt, rhs.joinedAt) {
-            case let (left?, right?): return left < right
-            case (nil, _?): return false
-            case (_?, nil): return true
-            case (nil, nil): return false
+    /// Remaining members (excluding the current user) as super-admin successor
+    /// candidates. The leave writer applies the human-preferred, agent-fallback
+    /// tenure policy; here we only surface each member's agent flag and join
+    /// time.
+    private func leaveSuccessorCandidates() -> [LeaveSuccessorCandidate] {
+        conversation.members
+            .filter { !$0.isCurrentUser }
+            .map { (member: ConversationMember) -> LeaveSuccessorCandidate in
+                LeaveSuccessorCandidate(
+                    inboxId: member.profile.inboxId,
+                    isAgent: member.isAgent,
+                    joinedAt: member.joinedAt
+                )
             }
-        }
-        return sorted.map { $0.profile.inboxId }
     }
 
     @MainActor

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1112,6 +1112,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                 RemoteAttachmentCodec(),
                 MultiRemoteAttachmentCodec(),
                 GroupUpdatedCodec(),
+                LeaveRequestCodec(),
                 ExplodeSettingsCodec(),
                 InviteJoinErrorCodec(),
                 InviteJoinHandledCodec(),

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -385,7 +385,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     func conversationLeaveWriter() -> any ConversationLeaveWriterProtocol {
         ConversationLeaveWriter(
             operations: XMTPLeaveGroupOperations(sessionStateManager: sessionStateManager),
-            consentWriter: conversationConsentWriter()
+            consentWriter: conversationConsentWriter(),
+            databaseReader: databaseReader
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -382,6 +382,13 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         )
     }
 
+    func conversationLeaveWriter() -> any ConversationLeaveWriterProtocol {
+        ConversationLeaveWriter(
+            operations: XMTPLeaveGroupOperations(sessionStateManager: sessionStateManager),
+            consentWriter: conversationConsentWriter()
+        )
+    }
+
     func conversationPermissionsRepository() -> any ConversationPermissionsRepositoryProtocol {
         ConversationPermissionsRepository(sessionStateManager: sessionStateManager,
                                           databaseReader: databaseReader)

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingServiceProtocol.swift
@@ -83,6 +83,7 @@ public protocol MessagingServiceProtocol: AnyObject, Sendable, PostPairBroadcast
 
     func conversationMetadataWriter() -> any ConversationMetadataWriterProtocol
     func conversationExplosionWriter() -> any ConversationExplosionWriterProtocol
+    func conversationLeaveWriter() -> any ConversationLeaveWriterProtocol
     func conversationPermissionsRepository() -> any ConversationPermissionsRepositoryProtocol
     func profileMetadataWriter() -> any ProfileMetadataWriterProtocol
     func connectionGrantWriter() -> any CloudConnectionGrantWriterProtocol

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationLeaveWriter.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Mock implementation of `ConversationLeaveWriterProtocol` for testing.
+public final class MockConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked Sendable {
+    public struct LeaveRecord: Sendable {
+        public let conversation: Conversation
+        public let tenureOrderedSuccessorInboxIds: [String]
+    }
+
+    public var leftConversations: [LeaveRecord] = []
+    public var leaveError: Error?
+
+    public init() {}
+
+    public func leave(
+        conversation: Conversation,
+        tenureOrderedSuccessorInboxIds: [String]
+    ) async throws {
+        if let leaveError {
+            throw leaveError
+        }
+        leftConversations.append(
+            LeaveRecord(
+                conversation: conversation,
+                tenureOrderedSuccessorInboxIds: tenureOrderedSuccessorInboxIds
+            )
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationLeaveWriter.swift
@@ -4,7 +4,7 @@ import Foundation
 public final class MockConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked Sendable {
     public struct LeaveRecord: Sendable {
         public let conversation: Conversation
-        public let tenureOrderedSuccessorInboxIds: [String]
+        public let successorCandidates: [LeaveSuccessorCandidate]
     }
 
     public var leftConversations: [LeaveRecord] = []
@@ -14,7 +14,7 @@ public final class MockConversationLeaveWriter: ConversationLeaveWriterProtocol,
 
     public func leave(
         conversation: Conversation,
-        tenureOrderedSuccessorInboxIds: [String]
+        successorCandidates: [LeaveSuccessorCandidate]
     ) async throws {
         if let leaveError {
             throw leaveError
@@ -22,7 +22,7 @@ public final class MockConversationLeaveWriter: ConversationLeaveWriterProtocol,
         leftConversations.append(
             LeaveRecord(
                 conversation: conversation,
-                tenureOrderedSuccessorInboxIds: tenureOrderedSuccessorInboxIds
+                successorCandidates: successorCandidates
             )
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
@@ -4,12 +4,13 @@ import os
 /// In-memory stub for `LeaveGroupOperationsProtocol`. Records the sequence of
 /// MLS-level calls the leave writer makes and lets tests inject the super-admin
 /// roster and per-step failures, enough to assert the super-admin-transfer ->
-/// leaveGroup flow without standing up a real XMTP group.
+/// self-demotion -> leaveGroup flow without standing up a real XMTP group.
 final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked Sendable {
     enum Call: Equatable, Sendable {
         case currentInboxId
         case superAdminInboxIds(conversationId: String)
         case promoteToSuperAdmin(inboxId: String, conversationId: String)
+        case demoteFromSuperAdmin(inboxId: String, conversationId: String)
         case leaveGroup(conversationId: String)
     }
 
@@ -20,6 +21,7 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
         var inboxId: String = "inbox-self"
         var superAdmins: [String] = []
         var promoteError: (any Error)?
+        var demoteError: (any Error)?
         var leaveError: (any Error)?
     }
 
@@ -35,6 +37,10 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
 
     func failPromote(with error: any Error) {
         lock.withLock { $0.promoteError = error }
+    }
+
+    func failDemote(with error: any Error) {
+        lock.withLock { $0.demoteError = error }
     }
 
     func failLeave(with error: any Error) {
@@ -59,6 +65,14 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
         let error: (any Error)? = lock.withLock { state in
             state.calls.append(.promoteToSuperAdmin(inboxId: inboxId, conversationId: conversationId))
             return state.promoteError
+        }
+        if let error { throw error }
+    }
+
+    func demoteFromSuperAdmin(inboxId: String, conversationId: String) async throws {
+        let error: (any Error)? = lock.withLock { state in
+            state.calls.append(.demoteFromSuperAdmin(inboxId: inboxId, conversationId: conversationId))
+            return state.demoteError
         }
         if let error { throw error }
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
@@ -20,6 +20,7 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
         var calls: [Call] = []
         var inboxId: String = "inbox-self"
         var superAdmins: [String] = []
+        var superAdminsError: (any Error)?
         var promoteError: (any Error)?
         var demoteError: (any Error)?
         var leaveError: (any Error)?
@@ -33,6 +34,10 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
 
     func setSuperAdmins(_ ids: [String]) {
         lock.withLock { $0.superAdmins = ids }
+    }
+
+    func failSuperAdmins(with error: any Error) {
+        lock.withLock { $0.superAdminsError = error }
     }
 
     func failPromote(with error: any Error) {
@@ -55,10 +60,14 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
     }
 
     func superAdminInboxIds(conversationId: String) async throws -> [String] {
-        lock.withLock { state in
+        let result: Result<[String], any Error> = lock.withLock { state in
             state.calls.append(.superAdminInboxIds(conversationId: conversationId))
-            return state.superAdmins
+            if let error = state.superAdminsError {
+                return .failure(error)
+            }
+            return .success(state.superAdmins)
         }
+        return try result.get()
     }
 
     func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
@@ -22,6 +22,7 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
         var superAdmins: [String] = []
         var superAdminsError: (any Error)?
         var promoteError: (any Error)?
+        var promoteErrorsByInboxId: [String: any Error] = [:]
         var demoteError: (any Error)?
         var leaveError: (any Error)?
     }
@@ -42,6 +43,10 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
 
     func failPromote(with error: any Error) {
         lock.withLock { $0.promoteError = error }
+    }
+
+    func failPromote(forInboxId inboxId: String, with error: any Error) {
+        lock.withLock { $0.promoteErrorsByInboxId[inboxId] = error }
     }
 
     func failDemote(with error: any Error) {
@@ -73,7 +78,7 @@ final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked S
     func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws {
         let error: (any Error)? = lock.withLock { state in
             state.calls.append(.promoteToSuperAdmin(inboxId: inboxId, conversationId: conversationId))
-            return state.promoteError
+            return state.promoteErrorsByInboxId[inboxId] ?? state.promoteError
         }
         if let error { throw error }
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockLeaveGroupOperations.swift
@@ -1,0 +1,73 @@
+import Foundation
+import os
+
+/// In-memory stub for `LeaveGroupOperationsProtocol`. Records the sequence of
+/// MLS-level calls the leave writer makes and lets tests inject the super-admin
+/// roster and per-step failures, enough to assert the super-admin-transfer ->
+/// leaveGroup flow without standing up a real XMTP group.
+final class MockLeaveGroupOperations: LeaveGroupOperationsProtocol, @unchecked Sendable {
+    enum Call: Equatable, Sendable {
+        case currentInboxId
+        case superAdminInboxIds(conversationId: String)
+        case promoteToSuperAdmin(inboxId: String, conversationId: String)
+        case leaveGroup(conversationId: String)
+    }
+
+    private let lock: OSAllocatedUnfairLock<State> = .init(initialState: State())
+
+    private struct State {
+        var calls: [Call] = []
+        var inboxId: String = "inbox-self"
+        var superAdmins: [String] = []
+        var promoteError: (any Error)?
+        var leaveError: (any Error)?
+    }
+
+    var calls: [Call] { lock.withLock { $0.calls } }
+
+    func setInboxId(_ inboxId: String) {
+        lock.withLock { $0.inboxId = inboxId }
+    }
+
+    func setSuperAdmins(_ ids: [String]) {
+        lock.withLock { $0.superAdmins = ids }
+    }
+
+    func failPromote(with error: any Error) {
+        lock.withLock { $0.promoteError = error }
+    }
+
+    func failLeave(with error: any Error) {
+        lock.withLock { $0.leaveError = error }
+    }
+
+    func currentInboxId() async throws -> String {
+        lock.withLock { state in
+            state.calls.append(.currentInboxId)
+            return state.inboxId
+        }
+    }
+
+    func superAdminInboxIds(conversationId: String) async throws -> [String] {
+        lock.withLock { state in
+            state.calls.append(.superAdminInboxIds(conversationId: conversationId))
+            return state.superAdmins
+        }
+    }
+
+    func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws {
+        let error: (any Error)? = lock.withLock { state in
+            state.calls.append(.promoteToSuperAdmin(inboxId: inboxId, conversationId: conversationId))
+            return state.promoteError
+        }
+        if let error { throw error }
+    }
+
+    func leaveGroup(conversationId: String) async throws {
+        let error: (any Error)? = lock.withLock { state in
+            state.calls.append(.leaveGroup(conversationId: conversationId))
+            return state.leaveError
+        }
+        if let error { throw error }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessagingService.swift
@@ -20,6 +20,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
     private let _conversationLocalStateWriter: any ConversationLocalStateWriterProtocol
     private let _conversationMetadataWriter: any ConversationMetadataWriterProtocol
     private let _conversationExplosionWriter: any ConversationExplosionWriterProtocol
+    private let _conversationLeaveWriter: any ConversationLeaveWriterProtocol
     private let _conversationPermissionsRepository: any ConversationPermissionsRepositoryProtocol
     private let _outgoingMessageWriter: any OutgoingMessageWriterProtocol
     private let _reactionWriter: any ReactionWriterProtocol
@@ -45,6 +46,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         conversationLocalStateWriter: (any ConversationLocalStateWriterProtocol)? = nil,
         conversationMetadataWriter: (any ConversationMetadataWriterProtocol)? = nil,
         conversationExplosionWriter: (any ConversationExplosionWriterProtocol)? = nil,
+        conversationLeaveWriter: (any ConversationLeaveWriterProtocol)? = nil,
         conversationPermissionsRepository: (any ConversationPermissionsRepositoryProtocol)? = nil,
         outgoingMessageWriter: (any OutgoingMessageWriterProtocol)? = nil,
         reactionWriter: (any ReactionWriterProtocol)? = nil,
@@ -57,6 +59,7 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
         self._conversationLocalStateWriter = conversationLocalStateWriter ?? MockConversationLocalStateWriter()
         self._conversationMetadataWriter = conversationMetadataWriter ?? MockConversationMetadataWriter()
         self._conversationExplosionWriter = conversationExplosionWriter ?? MockConversationExplosionWriter()
+        self._conversationLeaveWriter = conversationLeaveWriter ?? MockConversationLeaveWriter()
         self._conversationPermissionsRepository = conversationPermissionsRepository ?? MockConversationPermissionsRepository()
         self._outgoingMessageWriter = outgoingMessageWriter ?? MockOutgoingMessageWriter()
         self._reactionWriter = reactionWriter ?? MockReactionWriter()
@@ -141,6 +144,10 @@ public final class MockMessagingService: MessagingServiceProtocol, @unchecked Se
 
     public func conversationExplosionWriter() -> any ConversationExplosionWriterProtocol {
         _conversationExplosionWriter
+    }
+
+    public func conversationLeaveWriter() -> any ConversationLeaveWriterProtocol {
+        _conversationLeaveWriter
     }
 
     public func conversationPermissionsRepository() -> any ConversationPermissionsRepositoryProtocol {

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -459,13 +459,18 @@ public extension ConversationUpdate {
             return metaSummary
         } else if !removedMembers.isEmpty {
             if removedMembers.count == 1, let member = removedMembers.first {
+                // A self-leave stores the leaver as both initiator and removed
+                // member (see the leave-request ingest); anything else is an
+                // admin-initiated removal and credits the remover.
+                let isSelfLeave = member.profile.inboxId == creator.profile.inboxId
                 if member.isCurrentUser {
-                    return "You left the convo"
+                    return isSelfLeave ? "You left the convo" : "You were removed from the convo"
                 }
-                if member.isAgent {
-                    return "\(resolvedMemberDisplayName(member, memberNameOverride: memberNameOverride)) left · Removed by \(creatorDisplayName)"
+                let memberName = resolvedMemberDisplayName(member, memberNameOverride: memberNameOverride)
+                if isSelfLeave {
+                    return "\(memberName) left"
                 }
-                return "\(resolvedMemberDisplayName(member, memberNameOverride: memberNameOverride)) left"
+                return "\(memberName) left · Removed by \(creatorDisplayName)"
             }
             let removed = removedMembers.formattedNamesString(memberNameOverride: memberNameOverride)
             return "\(removed) left"

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -986,6 +986,7 @@ extension SessionManager {
         try DBAgentTemplate.deleteAll(db)
         try DBMessage.deleteAll(db)
         try DBMemberProfile.deleteAll(db)
+        try DBMemberDeparture.deleteAll(db)
         try DBConversationMember.deleteAll(db)
         try DBContact.deleteAll(db)
         try DBMember.deleteAll(db)

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationDetails.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversationDetails.swift
@@ -5,7 +5,11 @@ import GRDB
 
 struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hashable {
     let conversation: DBConversation
-    let conversationCreator: DBConversationMemberProfileWithRole
+    /// Nil when the creator's `conversation_members` row is gone -- a creator
+    /// who left the group. The conversation must still hydrate for the
+    /// remaining members; hydration falls back to a minimal member built from
+    /// `conversation.creatorId`.
+    let conversationCreator: DBConversationMemberProfileWithRole?
     let conversationMembers: [DBConversationMemberProfileWithRole]
     let conversationLastMessageWithSource: DBLastMessageWithSource?
     let conversationLocalState: ConversationLocalState
@@ -22,7 +26,7 @@ struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hasha
 
     init(
         conversation: DBConversation,
-        conversationCreator: DBConversationMemberProfileWithRole,
+        conversationCreator: DBConversationMemberProfileWithRole?,
         conversationMembers: [DBConversationMemberProfileWithRole],
         conversationLastMessageWithSource: DBLastMessageWithSource?,
         conversationLocalState: ConversationLocalState,
@@ -43,7 +47,15 @@ struct DBConversationDetails: Codable, FetchableRecord, PersistableRecord, Hasha
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.conversation = try container.decode(DBConversation.self, forKey: .conversation)
-        self.conversationCreator = try container.decode(DBConversationMemberProfileWithRole.self, forKey: .conversationCreator)
+        // Lenient: the creator scope is joined optionally (a departed
+        // creator has no member row), and a partially-null scope (member row
+        // without its profile row) must degrade to the fallback creator
+        // rather than fail the whole conversations fetch.
+        do {
+            self.conversationCreator = try container.decodeIfPresent(DBConversationMemberProfileWithRole.self, forKey: .conversationCreator)
+        } catch {
+            self.conversationCreator = nil
+        }
         self.conversationMembers = try container.decode([DBConversationMemberProfileWithRole].self, forKey: .conversationMembers)
         self.conversationLastMessageWithSource = try container.decodeIfPresent(DBLastMessageWithSource.self, forKey: .conversationLastMessageWithSource)
         self.conversationLocalState = try container.decode(ConversationLocalState.self, forKey: .conversationLocalState)

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberDeparture.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMemberDeparture.swift
@@ -1,0 +1,34 @@
+import Foundation
+import GRDB
+
+// MARK: - DBMemberDeparture
+
+/// Marks a member who announced they are leaving a conversation (via the
+/// protocol's leave-request message) but whose MLS remove-commit hasn't been
+/// finalized yet. While the marker exists the member is excluded from the
+/// persisted member rows, so every member-list surface drops the leaver
+/// promptly instead of waiting for an authorized client to finalize the
+/// removal.
+///
+/// Lifecycle:
+/// - Written by `IncomingMessageWriter` when a leave-request message is
+///   ingested (any ingest path: stream, catch-up, batch, notification
+///   extension).
+/// - Deleted by `ConversationWriter.persist` once a synced MLS member list
+///   no longer contains the inbox (the removal finalized, the marker has
+///   done its job).
+/// - Deleted by `IncomingMessageWriter` when a membership change re-adds the
+///   inbox (rejoin via invite after the removal finalized).
+struct DBMemberDeparture: Codable, FetchableRecord, PersistableRecord, Hashable {
+    static var databaseTableName: String { "member_departure" }
+
+    enum Columns {
+        static let conversationId: Column = Column(CodingKeys.conversationId)
+        static let inboxId: Column = Column(CodingKeys.inboxId)
+        static let dateNs: Column = Column(CodingKeys.dateNs)
+    }
+
+    let conversationId: String
+    let inboxId: String
+    let dateNs: Int64
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -16,7 +16,7 @@ extension DBConversationDetails {
             contactNameResolver: contactNameResolver
         )
         let members = hydrateConversationMembers(currentInboxId: currentInboxId)
-        let creator = conversationCreator.hydrateConversationMember(currentInboxId: currentInboxId)
+        let creator = hydrateCreator(currentInboxId: currentInboxId)
 
         let otherMember: ConversationMember?
         if conversation.kind == .dm,
@@ -84,6 +84,23 @@ extension DBConversationDetails {
             agentJoinStatus: agentJoinStatus,
             hasHadVerifiedAgent: conversation.hasHadVerifiedAgent,
             wasCreatedFromAgentBuilder: conversationAgentBuilderSummary != nil
+        )
+    }
+
+    /// The creator's `conversation_members` row is deleted when they leave the
+    /// group, so `conversationCreator` can be nil. Consumers only rely on the
+    /// creator's identity (`isCurrentUser` checks), so fall back to a minimal
+    /// member built from the stored `creatorId` -- the same shape
+    /// `MessagesRepository.fetchLightweightConversation` synthesizes for a
+    /// missing creator, so both hydration paths agree.
+    private func hydrateCreator(currentInboxId: String) -> ConversationMember {
+        if let conversationCreator {
+            return conversationCreator.hydrateConversationMember(currentInboxId: currentInboxId)
+        }
+        return ConversationMember(
+            profile: .empty(inboxId: conversation.creatorId),
+            role: .superAdmin,
+            isCurrentUser: conversation.creatorId == currentInboxId
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -235,8 +235,14 @@ extension QueryInterfaceRequest where RowDecoder == DBConversation {
 
         return self
             .including(all: DBConversation.invites)
+            // Optional join: a creator who left the group has no
+            // conversation_members row anymore, and a required join would
+            // silently drop the conversation from every list and detail
+            // query on the remaining members' devices. The nested profile
+            // joins must also be optional -- GRDB cannot chain a required
+            // association behind an optional one.
             .including(
-                required: DBConversation.creator
+                optional: DBConversation.creator
                     .forKey("conversationCreator")
                     .select([
                         DBConversationMember.Columns.conversationId,

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -179,22 +179,7 @@ extension SharedDatabaseMigrator {
         // schema, so an upgrade migrates in place.
         Self.registerAgentTemplateContactMigrations(on: &migrator)
 
-        // Filter set of agent-builder bundle message ids hidden from every
-        // client's chat. Intentionally no foreign key to `conversation`: a
-        // manifest can be processed before its conversation row is stored (the
-        // stream routes supplementals ahead of `conversationWriter.store`, and
-        // catch-up can deliver a manifest before the initial conversation sync
-        // lands); a FK would make those inserts fail and silently drop the hidden
-        // ids, leaving the brief visible. A stray row for an absent conversation
-        // matches nothing and is harmless. Teardown clears the table explicitly
-        // in `SessionManager.deleteAllInboxes` (no cascade).
-        migrator.registerMigration("createBuilderBundleHiddenMessage") { db in
-            try db.create(table: "builder_bundle_hidden_message") { t in
-                t.column("conversationId", .text).notNull()
-                t.column("messageId", .text).notNull()
-                t.primaryKey(["conversationId", "messageId"])
-            }
-        }
+        Self.registerBuilderBundleHiddenMessageMigrations(on: &migrator)
 
         migrator.registerMigration("backfillContactAgentTemplateFieldsFromMemberProfiles",
                                    migrate: Self.backfillContactAgentTemplateFieldsFromMemberProfiles)
@@ -205,6 +190,7 @@ extension SharedDatabaseMigrator {
         Self.registerConnectionGrantMigrations(on: &migrator)
         Self.registerJoinAndGenerationMigrations(on: &migrator)
         Self.registerTailMigrations(on: &migrator)
+        Self.registerMemberDepartureMigrations(on: &migrator)
 
         return migrator
     }
@@ -249,6 +235,41 @@ extension SharedDatabaseMigrator {
                 WHERE inboxId NOT IN (SELECT inboxId FROM inbox)
             )
             """)
+    }
+
+    /// Filter set of agent-builder bundle message ids hidden from every
+    /// client's chat. Intentionally no foreign key to `conversation`: a
+    /// manifest can be processed before its conversation row is stored (the
+    /// stream routes supplementals ahead of `conversationWriter.store`, and
+    /// catch-up can deliver a manifest before the initial conversation sync
+    /// lands); a FK would make those inserts fail and silently drop the hidden
+    /// ids, leaving the brief visible. A stray row for an absent conversation
+    /// matches nothing and is harmless. Teardown clears the table explicitly
+    /// in `SessionManager.deleteAllInboxes` (no cascade).
+    private static func registerBuilderBundleHiddenMessageMigrations(on migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("createBuilderBundleHiddenMessage") { db in
+            try db.create(table: "builder_bundle_hidden_message") { t in
+                t.column("conversationId", .text).notNull()
+                t.column("messageId", .text).notNull()
+                t.primaryKey(["conversationId", "messageId"])
+            }
+        }
+    }
+
+    /// Pending-leave markers for members who announced a self-removal that
+    /// hasn't been finalized yet. No foreign key to `conversation` for the
+    /// same reason as `builder_bundle_hidden_message`: a leave-request can
+    /// be ingested before the conversation row lands, and a stray row for
+    /// an absent conversation matches nothing and is harmless.
+    private static func registerMemberDepartureMigrations(on migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("createMemberDeparture") { db in
+            try db.create(table: "member_departure") { t in
+                t.column("conversationId", .text).notNull()
+                t.column("inboxId", .text).notNull()
+                t.column("dateNs", .integer).notNull()
+                t.primaryKey(["conversationId", "inboxId"])
+            }
+        }
     }
 
     private static func registerConnectionGrantMigrations(on migrator: inout DatabaseMigrator) {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 @preconcurrency import XMTPiOS
 
 public protocol ConversationLeaveWriterProtocol: Sendable {
@@ -51,11 +52,18 @@ protocol LeaveGroupOperationsProtocol: Sendable {
 public enum ConversationLeaveError: LocalizedError {
     case conversationNotFound(String)
     case notGroupConversation(String)
-    /// The MLS self-removal already committed (or was benignly unnecessary),
-    /// but the optimistic consent-hide failed afterwards. The user is off the
-    /// group either way, so callers should treat the conversation as left;
-    /// the hide converges on a later consent sync.
+    /// The MLS self-removal committed in this call, but the optimistic
+    /// consent-hide failed afterwards. The user is off the group, so callers
+    /// should treat the conversation as left; the hide converges on a later
+    /// consent sync. Not thrown when the leave was benignly swallowed (the
+    /// raw hide error propagates instead, so the leave reads as failed and
+    /// stays retryable).
     case hideFailedAfterLeave(String, underlying: any Error)
+    /// The leaver is the sole super admin and no successor could be promoted:
+    /// every candidate announced their own departure since the candidate
+    /// snapshot was taken. The leave aborts so the group is not left with a
+    /// departing member as its only super admin.
+    case noViableSuccessor(String)
 
     public var errorDescription: String? {
         switch self {
@@ -65,6 +73,8 @@ public enum ConversationLeaveError: LocalizedError {
             return "Cannot leave non-group conversation: \(id)"
         case let .hideFailedAfterLeave(id, underlying):
             return "Left conversation \(id) but hiding it failed: \(underlying.localizedDescription)"
+        case .noViableSuccessor(let id):
+            return "No viable super-admin successor remains in conversation: \(id)"
         }
     }
 }
@@ -113,18 +123,21 @@ struct XMTPLeaveGroupOperations: LeaveGroupOperationsProtocol {
     }
 }
 
-/// @unchecked Sendable: both stored properties are immutable Sendable
+/// @unchecked Sendable: all stored properties are immutable Sendable
 /// references and every method is async with no shared mutable state.
 final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked Sendable {
     private let operations: any LeaveGroupOperationsProtocol
     private let consentWriter: any ConversationConsentWriterProtocol
+    private let databaseReader: any DatabaseReader
 
     init(
         operations: any LeaveGroupOperationsProtocol,
-        consentWriter: any ConversationConsentWriterProtocol
+        consentWriter: any ConversationConsentWriterProtocol,
+        databaseReader: any DatabaseReader
     ) {
         self.operations = operations
         self.consentWriter = consentWriter
+        self.databaseReader = databaseReader
     }
 
     func leave(
@@ -141,6 +154,7 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
         // The benign filter covers the whole flow because the not-found case
         // also surfaces from the pre-leave super-admin lookup, not just from
         // leaveGroup itself.
+        var leaveCommitted = true
         do {
             let myInboxId = try await operations.currentInboxId()
             try await relinquishSuperAdminIfNeeded(
@@ -151,18 +165,24 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
             try await operations.leaveGroup(conversationId: conversation.id)
         } catch {
             guard Self.isBenignLeaveError(error) else { throw error }
+            leaveCommitted = false
             Log.info("Leave skipped for \(conversation.id): \(error.localizedDescription)")
         }
 
         // Optimistic hide, reusing the existing consent-hide path: consent
         // `.denied` + push-topic unsubscribe + local row hide. The MLS
         // remove-commit is finalized async by an authorized admin/agent.
-        // A failure here happens after the self-removal committed, so it is
-        // surfaced as a typed error: the caller must still treat the
-        // conversation as left rather than as a failed leave.
+        // When the self-removal committed above, a failure here is surfaced
+        // as a typed error: the caller must still treat the conversation as
+        // left rather than as a failed leave. When the leave was benignly
+        // swallowed instead, nothing committed in this call, so the raw hide
+        // error propagates and the leave reads as failed and retryable;
+        // announcing a completed leave here could be false (a single-member
+        // rejection leaves the user a member of a still-visible group).
         do {
             try await consentWriter.delete(conversation: conversation)
         } catch {
+            guard leaveCommitted else { throw error }
             throw ConversationLeaveError.hideFailedAfterLeave(conversation.id, underlying: error)
         }
     }
@@ -203,14 +223,22 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
     /// candidates is taken before the leave runs, so a candidate can have
     /// left the group meanwhile and their promotion is rejected; falling
     /// back to the next candidate keeps a valid leave from aborting on a
-    /// stale snapshot. Only when every promotion fails does the last error
-    /// propagate, aborting the leave to protect the super-admin invariant.
+    /// stale snapshot. A candidate can also have announced their own
+    /// departure since the snapshot; libxmtp still accepts a pending leaver
+    /// in the admin list, so the departure markers are re-checked right
+    /// before each attempt and marked candidates are skipped. Only when no
+    /// candidate can be promoted does an error propagate, aborting the leave
+    /// to protect the super-admin invariant.
     private func promoteFirstViableSuccessor(
         from orderedInboxIds: [String],
         conversationId: String
     ) async throws {
         var lastError: (any Error)?
         for inboxId in orderedInboxIds {
+            guard try await !hasAnnouncedDeparture(inboxId: inboxId, conversationId: conversationId) else {
+                Log.info("Skipping successor \(inboxId) in \(conversationId): departure announced since the candidate snapshot")
+                continue
+            }
             do {
                 try await operations.promoteToSuperAdmin(inboxId: inboxId, conversationId: conversationId)
                 Log.info("Transferred super admin to \(inboxId) before leaving \(conversationId)")
@@ -221,8 +249,24 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
             }
         }
         // Callers guarantee a non-empty candidate list, so reaching this
-        // point means every promotion attempt failed.
+        // point means every promotion attempt failed or was skipped.
         if let lastError { throw lastError }
+        throw ConversationLeaveError.noViableSuccessor(conversationId)
+    }
+
+    /// True when a local departure marker exists for the inbox: the member
+    /// announced they are leaving and their remove-commit hasn't finalized,
+    /// so they must not become the group's super admin.
+    private func hasAnnouncedDeparture(
+        inboxId: String,
+        conversationId: String
+    ) async throws -> Bool {
+        try await databaseReader.read { db in
+            try DBMemberDeparture
+                .filter(DBMemberDeparture.Columns.conversationId == conversationId)
+                .filter(DBMemberDeparture.Columns.inboxId == inboxId)
+                .fetchCount(db) > 0
+        }
     }
 
     /// Successor inbox ids in promotion-preference order. Human members come

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -8,14 +8,29 @@ public protocol ConversationLeaveWriterProtocol: Sendable {
     /// the MLS remove-commit finalizes async.
     ///
     /// When the leaver is the sole super admin, the super-admin role is first
-    /// transferred to the longest-tenured remaining member so the group always
-    /// keeps at least one super admin. `tenureOrderedSuccessorInboxIds` is the
-    /// remaining membership (excluding the leaver) ordered longest-tenured
-    /// first; the writer promotes the first entry when a transfer is needed.
+    /// transferred to a remaining member so the group always keeps at least
+    /// one super admin. `successorCandidates` is the remaining membership
+    /// (excluding the leaver); the writer applies a human-preferred,
+    /// agent-fallback tenure policy to pick who to promote.
     func leave(
         conversation: Conversation,
-        tenureOrderedSuccessorInboxIds: [String]
+        successorCandidates: [LeaveSuccessorCandidate]
     ) async throws
+}
+
+/// A remaining group member the leave writer may promote to super admin when
+/// the leaver is the sole super admin. Carries just enough for the
+/// human-preferred, agent-fallback tenure policy.
+public struct LeaveSuccessorCandidate: Sendable {
+    public let inboxId: String
+    public let isAgent: Bool
+    public let joinedAt: Date?
+
+    public init(inboxId: String, isAgent: Bool, joinedAt: Date?) {
+        self.inboxId = inboxId
+        self.isAgent = isAgent
+        self.joinedAt = joinedAt
+    }
 }
 
 /// The MLS-level operations the leave writer reaches through to the XMTP SDK.
@@ -99,14 +114,14 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
 
     func leave(
         conversation: Conversation,
-        tenureOrderedSuccessorInboxIds: [String]
+        successorCandidates: [LeaveSuccessorCandidate]
     ) async throws {
         let myInboxId = try await operations.currentInboxId()
 
         try await transferSuperAdminIfNeeded(
             conversationId: conversation.id,
             myInboxId: myInboxId,
-            tenureOrderedSuccessorInboxIds: tenureOrderedSuccessorInboxIds
+            successorCandidates: successorCandidates
         )
 
         // Self-remove from the MLS roster. Benign outcomes are logged and
@@ -129,25 +144,55 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
 
     /// Protects the "group always keeps at least one super admin" invariant.
     /// Only acts when the leaver is the sole super admin, then promotes the
-    /// longest-tenured remaining member before leaving. Awaited rather than
-    /// best-effort: if the transfer can't land we abort the leave rather than
-    /// strand the group with no super admin.
+    /// preferred successor before leaving. Awaited rather than best-effort: if
+    /// the transfer can't land we abort the leave rather than strand the group
+    /// with no super admin.
     private func transferSuperAdminIfNeeded(
         conversationId: String,
         myInboxId: String,
-        tenureOrderedSuccessorInboxIds: [String]
+        successorCandidates: [LeaveSuccessorCandidate]
     ) async throws {
         let superAdmins = try await operations.superAdminInboxIds(conversationId: conversationId)
         let isSoleSuperAdmin = superAdmins.contains(myInboxId) && superAdmins.count == 1
         guard isSoleSuperAdmin else { return }
 
-        guard let successor = tenureOrderedSuccessorInboxIds.first(where: { $0 != myInboxId }) else {
+        let ordered = Self.orderedSuccessorInboxIds(from: successorCandidates, excluding: myInboxId)
+        guard let successor = ordered.first else {
             Log.warning("Leaving \(conversationId) as sole super admin with no successor to promote")
             return
         }
 
         try await operations.promoteToSuperAdmin(inboxId: successor, conversationId: conversationId)
         Log.info("Transferred super admin to \(successor) before leaving \(conversationId)")
+    }
+
+    /// Successor inbox ids in promotion-preference order. Human members come
+    /// first, longest-tenured first (by `joinedAt`, unknown tenure last).
+    /// Agents are only used as a fallback so a creator can still leave a group
+    /// whose only remaining members are agents while the "at least one super
+    /// admin" invariant holds.
+    private static func orderedSuccessorInboxIds(
+        from candidates: [LeaveSuccessorCandidate],
+        excluding myInboxId: String
+    ) -> [String] {
+        let eligible = candidates.filter { $0.inboxId != myInboxId }
+        let humans = eligible.filter { !$0.isAgent }.sorted(by: isLongerTenured)
+        let agents = eligible.filter { $0.isAgent }.sorted(by: isLongerTenured)
+        return (humans + agents).map { $0.inboxId }
+    }
+
+    /// Orders longest-tenured first; a known `joinedAt` always precedes an
+    /// unknown one.
+    private static func isLongerTenured(
+        _ lhs: LeaveSuccessorCandidate,
+        _ rhs: LeaveSuccessorCandidate
+    ) -> Bool {
+        switch (lhs.joinedAt, rhs.joinedAt) {
+        case let (left?, right?): return left < right
+        case (nil, _?): return false
+        case (_?, nil): return true
+        case (nil, nil): return false
+        }
     }
 
     /// libxmtp surfaces MLS failures as FFI errors whose full message is only

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -48,16 +48,23 @@ protocol LeaveGroupOperationsProtocol: Sendable {
     func leaveGroup(conversationId: String) async throws
 }
 
-enum ConversationLeaveError: LocalizedError {
+public enum ConversationLeaveError: LocalizedError {
     case conversationNotFound(String)
     case notGroupConversation(String)
+    /// The MLS self-removal already committed (or was benignly unnecessary),
+    /// but the optimistic consent-hide failed afterwards. The user is off the
+    /// group either way, so callers should treat the conversation as left;
+    /// the hide converges on a later consent sync.
+    case hideFailedAfterLeave(String, underlying: any Error)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .conversationNotFound(let id):
             return "Conversation not found: \(id)"
         case .notGroupConversation(let id):
             return "Cannot leave non-group conversation: \(id)"
+        case let .hideFailedAfterLeave(id, underlying):
+            return "Left conversation \(id) but hiding it failed: \(underlying.localizedDescription)"
         }
     }
 }
@@ -150,7 +157,14 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
         // Optimistic hide, reusing the existing consent-hide path: consent
         // `.denied` + push-topic unsubscribe + local row hide. The MLS
         // remove-commit is finalized async by an authorized admin/agent.
-        try await consentWriter.delete(conversation: conversation)
+        // A failure here happens after the self-removal committed, so it is
+        // surfaced as a typed error: the caller must still treat the
+        // conversation as left rather than as a failed leave.
+        do {
+            try await consentWriter.delete(conversation: conversation)
+        } catch {
+            throw ConversationLeaveError.hideFailedAfterLeave(conversation.id, underlying: error)
+        }
     }
 
     /// The protocol rejects `leaveGroup()` while the leaver is a super admin
@@ -171,19 +185,44 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
 
         if superAdmins.count == 1 {
             let ordered = Self.orderedSuccessorInboxIds(from: successorCandidates, excluding: myInboxId)
-            guard let successor = ordered.first else {
+            guard !ordered.isEmpty else {
                 // No one left to promote: the leaver is effectively the last
                 // member, so keep the role and let `leaveGroup()` resolve it
                 // (the 1 -> 0 commit is rejected as a benign error).
                 Log.warning("Leaving \(conversationId) as sole super admin with no successor to promote")
                 return
             }
-            try await operations.promoteToSuperAdmin(inboxId: successor, conversationId: conversationId)
-            Log.info("Transferred super admin to \(successor) before leaving \(conversationId)")
+            try await promoteFirstViableSuccessor(from: ordered, conversationId: conversationId)
         }
 
         try await operations.demoteFromSuperAdmin(inboxId: myInboxId, conversationId: conversationId)
         Log.info("Demoted self from super admin before leaving \(conversationId)")
+    }
+
+    /// Tries candidates in preference order. The snapshot behind the
+    /// candidates is taken before the leave runs, so a candidate can have
+    /// left the group meanwhile and their promotion is rejected; falling
+    /// back to the next candidate keeps a valid leave from aborting on a
+    /// stale snapshot. Only when every promotion fails does the last error
+    /// propagate, aborting the leave to protect the super-admin invariant.
+    private func promoteFirstViableSuccessor(
+        from orderedInboxIds: [String],
+        conversationId: String
+    ) async throws {
+        var lastError: (any Error)?
+        for inboxId in orderedInboxIds {
+            do {
+                try await operations.promoteToSuperAdmin(inboxId: inboxId, conversationId: conversationId)
+                Log.info("Transferred super admin to \(inboxId) before leaving \(conversationId)")
+                return
+            } catch {
+                Log.warning("Promotion of \(inboxId) in \(conversationId) failed, trying next candidate: \(error.localizedDescription)")
+                lastError = error
+            }
+        }
+        // Callers guarantee a non-empty candidate list, so reaching this
+        // point means every promotion attempt failed.
+        if let lastError { throw lastError }
     }
 
     /// Successor inbox ids in promotion-preference order. Human members come
@@ -216,10 +255,19 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
     }
 
     /// libxmtp surfaces MLS failures as FFI errors whose full message is only
-    /// visible via `String(describing:)`. Benign cases on self-leave:
-    /// - `LeaveCantProcessed` / "only one member": we're the last member and
-    ///   the 1 -> 0 invariant rejects the commit.
-    /// - `NotFound::MlsGroup`: a concurrent remove already took us out.
+    /// visible via `String(describing:)`. `LeaveCantProcessed` is the wrapper
+    /// for every leave validation failure - including super-admin and DM
+    /// rejections that mean the user is still a member - so matching on the
+    /// wrapper name alone would turn those into a silent local hide. Only the
+    /// specific rejections whose goal is already achieved (or unachievable by
+    /// protocol) are benign, matched by their stable libxmtp messages:
+    /// - "only one member": we're the last member and the 1 -> 0 invariant
+    ///   rejects the commit; the group is dead by protocol.
+    /// - "only a member of the group can send a leave request": a concurrent
+    ///   removal already took us out before the leave-request landed.
+    /// - "already exists in the pending leave list": a leave-request from a
+    ///   retry or another installation is already awaiting finalization.
+    /// - `NotFound::MlsGroup`: a concurrent remove already deleted the group.
     /// - `conversationNotFound`: the client no longer has the group at all
     ///   (another admin removed us and the welcome/group was purged); the
     ///   local hide is all that's left to do.
@@ -228,8 +276,12 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
             return true
         }
         let description = String(describing: error)
-        return description.contains("LeaveCantProcessed")
-            || description.contains("cannot leave a group that has only one member")
-            || description.contains("NotFound::MlsGroup")
+        let benignFragments = [
+            "cannot leave a group that has only one member",
+            "only a member of the group can send a leave request",
+            "inbox ID already exists in the pending leave list",
+            "NotFound::MlsGroup",
+        ]
+        return benignFragments.contains { description.contains($0) }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -124,20 +124,23 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
         conversation: Conversation,
         successorCandidates: [LeaveSuccessorCandidate]
     ) async throws {
-        let myInboxId = try await operations.currentInboxId()
-
-        try await relinquishSuperAdminIfNeeded(
-            conversationId: conversation.id,
-            myInboxId: myInboxId,
-            successorCandidates: successorCandidates
-        )
-
         // Self-remove from the MLS roster. Benign outcomes are logged and
         // swallowed so the optimistic consent-hide below still runs and the
         // conversation leaves the UI regardless:
         // - we're the last member, so libxmtp rejects the 1 -> 0 commit,
-        // - a concurrent remove already took us out of the group.
+        // - the group is already gone locally or another admin removed us
+        //   first (conversationNotFound / NotFound::MlsGroup) -- the leave's
+        //   goal is already achieved, only the local hide remains.
+        // The benign filter covers the whole flow because the not-found case
+        // also surfaces from the pre-leave super-admin lookup, not just from
+        // leaveGroup itself.
         do {
+            let myInboxId = try await operations.currentInboxId()
+            try await relinquishSuperAdminIfNeeded(
+                conversationId: conversation.id,
+                myInboxId: myInboxId,
+                successorCandidates: successorCandidates
+            )
             try await operations.leaveGroup(conversationId: conversation.id)
         } catch {
             guard Self.isBenignLeaveError(error) else { throw error }
@@ -213,11 +216,17 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
     }
 
     /// libxmtp surfaces MLS failures as FFI errors whose full message is only
-    /// visible via `String(describing:)`. Two benign cases on self-leave:
+    /// visible via `String(describing:)`. Benign cases on self-leave:
     /// - `LeaveCantProcessed` / "only one member": we're the last member and
     ///   the 1 -> 0 invariant rejects the commit.
     /// - `NotFound::MlsGroup`: a concurrent remove already took us out.
+    /// - `conversationNotFound`: the client no longer has the group at all
+    ///   (another admin removed us and the welcome/group was purged); the
+    ///   local hide is all that's left to do.
     private static func isBenignLeaveError(_ error: any Error) -> Bool {
+        if case ConversationLeaveError.conversationNotFound = error {
+            return true
+        }
         let description = String(describing: error)
         return description.contains("LeaveCantProcessed")
             || description.contains("cannot leave a group that has only one member")

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -1,0 +1,164 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+public protocol ConversationLeaveWriterProtocol: Sendable {
+    /// Self-removes the current user from the group via `leaveGroup()`, then
+    /// applies the optimistic consent-hide (consent `.denied` + push-topic
+    /// unsubscribe + local row hide) so the conversation leaves the UI while
+    /// the MLS remove-commit finalizes async.
+    ///
+    /// When the leaver is the sole super admin, the super-admin role is first
+    /// transferred to the longest-tenured remaining member so the group always
+    /// keeps at least one super admin. `tenureOrderedSuccessorInboxIds` is the
+    /// remaining membership (excluding the leaver) ordered longest-tenured
+    /// first; the writer promotes the first entry when a transfer is needed.
+    func leave(
+        conversation: Conversation,
+        tenureOrderedSuccessorInboxIds: [String]
+    ) async throws
+}
+
+/// The MLS-level operations the leave writer reaches through to the XMTP SDK.
+/// Factored out so tests can assert the call sequence (super-admin transfer ->
+/// `leaveGroup`) without standing up a real MLS group. Production
+/// implementation is `XMTPLeaveGroupOperations`; `MockLeaveGroupOperations`
+/// backs the unit tests.
+protocol LeaveGroupOperationsProtocol: Sendable {
+    func currentInboxId() async throws -> String
+    func superAdminInboxIds(conversationId: String) async throws -> [String]
+    func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws
+    func leaveGroup(conversationId: String) async throws
+}
+
+enum ConversationLeaveError: LocalizedError {
+    case conversationNotFound(String)
+    case notGroupConversation(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .conversationNotFound(let id):
+            return "Conversation not found: \(id)"
+        case .notGroupConversation(let id):
+            return "Cannot leave non-group conversation: \(id)"
+        }
+    }
+}
+
+struct XMTPLeaveGroupOperations: LeaveGroupOperationsProtocol {
+    let sessionStateManager: any SessionStateManagerProtocol
+
+    func currentInboxId() async throws -> String {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        return inboxReady.client.inboxId
+    }
+
+    func superAdminInboxIds(conversationId: String) async throws -> [String] {
+        let (_, group) = try await findGroupConversation(conversationId: conversationId)
+        return try group.listSuperAdmins()
+    }
+
+    func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws {
+        let (_, group) = try await findGroupConversation(conversationId: conversationId)
+        try await group.addSuperAdmin(inboxId: inboxId)
+    }
+
+    func leaveGroup(conversationId: String) async throws {
+        let (_, group) = try await findGroupConversation(conversationId: conversationId)
+        try await group.leaveGroup()
+    }
+
+    private func findGroupConversation(
+        conversationId: String
+    ) async throws -> (XMTPiOS.Conversation, Group) {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        guard let xmtpConversation = try await inboxReady.client.conversationsProvider.findConversation(
+            conversationId: conversationId
+        ) else {
+            throw ConversationLeaveError.conversationNotFound(conversationId)
+        }
+        guard case .group(let group) = xmtpConversation else {
+            throw ConversationLeaveError.notGroupConversation(conversationId)
+        }
+        return (xmtpConversation, group)
+    }
+}
+
+/// @unchecked Sendable: both stored properties are immutable Sendable
+/// references and every method is async with no shared mutable state.
+final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked Sendable {
+    private let operations: any LeaveGroupOperationsProtocol
+    private let consentWriter: any ConversationConsentWriterProtocol
+
+    init(
+        operations: any LeaveGroupOperationsProtocol,
+        consentWriter: any ConversationConsentWriterProtocol
+    ) {
+        self.operations = operations
+        self.consentWriter = consentWriter
+    }
+
+    func leave(
+        conversation: Conversation,
+        tenureOrderedSuccessorInboxIds: [String]
+    ) async throws {
+        let myInboxId = try await operations.currentInboxId()
+
+        try await transferSuperAdminIfNeeded(
+            conversationId: conversation.id,
+            myInboxId: myInboxId,
+            tenureOrderedSuccessorInboxIds: tenureOrderedSuccessorInboxIds
+        )
+
+        // Self-remove from the MLS roster. Benign outcomes are logged and
+        // swallowed so the optimistic consent-hide below still runs and the
+        // conversation leaves the UI regardless:
+        // - we're the last member, so libxmtp rejects the 1 -> 0 commit,
+        // - a concurrent remove already took us out of the group.
+        do {
+            try await operations.leaveGroup(conversationId: conversation.id)
+        } catch {
+            guard Self.isBenignLeaveError(error) else { throw error }
+            Log.info("Leave skipped for \(conversation.id): \(error.localizedDescription)")
+        }
+
+        // Optimistic hide, reusing the existing consent-hide path: consent
+        // `.denied` + push-topic unsubscribe + local row hide. The MLS
+        // remove-commit is finalized async by an authorized admin/agent.
+        try await consentWriter.delete(conversation: conversation)
+    }
+
+    /// Protects the "group always keeps at least one super admin" invariant.
+    /// Only acts when the leaver is the sole super admin, then promotes the
+    /// longest-tenured remaining member before leaving. Awaited rather than
+    /// best-effort: if the transfer can't land we abort the leave rather than
+    /// strand the group with no super admin.
+    private func transferSuperAdminIfNeeded(
+        conversationId: String,
+        myInboxId: String,
+        tenureOrderedSuccessorInboxIds: [String]
+    ) async throws {
+        let superAdmins = try await operations.superAdminInboxIds(conversationId: conversationId)
+        let isSoleSuperAdmin = superAdmins.contains(myInboxId) && superAdmins.count == 1
+        guard isSoleSuperAdmin else { return }
+
+        guard let successor = tenureOrderedSuccessorInboxIds.first(where: { $0 != myInboxId }) else {
+            Log.warning("Leaving \(conversationId) as sole super admin with no successor to promote")
+            return
+        }
+
+        try await operations.promoteToSuperAdmin(inboxId: successor, conversationId: conversationId)
+        Log.info("Transferred super admin to \(successor) before leaving \(conversationId)")
+    }
+
+    /// libxmtp surfaces MLS failures as FFI errors whose full message is only
+    /// visible via `String(describing:)`. Two benign cases on self-leave:
+    /// - `LeaveCantProcessed` / "only one member": we're the last member and
+    ///   the 1 -> 0 invariant rejects the commit.
+    /// - `NotFound::MlsGroup`: a concurrent remove already took us out.
+    private static func isBenignLeaveError(_ error: any Error) -> Bool {
+        let description = String(describing: error)
+        return description.contains("LeaveCantProcessed")
+            || description.contains("cannot leave a group that has only one member")
+            || description.contains("NotFound::MlsGroup")
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -7,9 +7,11 @@ public protocol ConversationLeaveWriterProtocol: Sendable {
     /// unsubscribe + local row hide) so the conversation leaves the UI while
     /// the MLS remove-commit finalizes async.
     ///
-    /// When the leaver is the sole super admin, the super-admin role is first
-    /// transferred to a remaining member so the group always keeps at least
-    /// one super admin. `successorCandidates` is the remaining membership
+    /// The protocol forbids a super admin from leaving (and from being
+    /// removed), so a super-admin leaver is demoted first. When the leaver is
+    /// also the sole super admin, the role is transferred to a remaining
+    /// member before the demotion so the group always keeps at least one
+    /// super admin. `successorCandidates` is the remaining membership
     /// (excluding the leaver); the writer applies a human-preferred,
     /// agent-fallback tenure policy to pick who to promote.
     func leave(
@@ -35,13 +37,14 @@ public struct LeaveSuccessorCandidate: Sendable {
 
 /// The MLS-level operations the leave writer reaches through to the XMTP SDK.
 /// Factored out so tests can assert the call sequence (super-admin transfer ->
-/// `leaveGroup`) without standing up a real MLS group. Production
-/// implementation is `XMTPLeaveGroupOperations`; `MockLeaveGroupOperations`
-/// backs the unit tests.
+/// self-demotion -> `leaveGroup`) without standing up a real MLS group.
+/// Production implementation is `XMTPLeaveGroupOperations`;
+/// `MockLeaveGroupOperations` backs the unit tests.
 protocol LeaveGroupOperationsProtocol: Sendable {
     func currentInboxId() async throws -> String
     func superAdminInboxIds(conversationId: String) async throws -> [String]
     func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws
+    func demoteFromSuperAdmin(inboxId: String, conversationId: String) async throws
     func leaveGroup(conversationId: String) async throws
 }
 
@@ -75,6 +78,11 @@ struct XMTPLeaveGroupOperations: LeaveGroupOperationsProtocol {
     func promoteToSuperAdmin(inboxId: String, conversationId: String) async throws {
         let (_, group) = try await findGroupConversation(conversationId: conversationId)
         try await group.addSuperAdmin(inboxId: inboxId)
+    }
+
+    func demoteFromSuperAdmin(inboxId: String, conversationId: String) async throws {
+        let (_, group) = try await findGroupConversation(conversationId: conversationId)
+        try await group.removeSuperAdmin(inboxId: inboxId)
     }
 
     func leaveGroup(conversationId: String) async throws {
@@ -118,7 +126,7 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
     ) async throws {
         let myInboxId = try await operations.currentInboxId()
 
-        try await transferSuperAdminIfNeeded(
+        try await relinquishSuperAdminIfNeeded(
             conversationId: conversation.id,
             myInboxId: myInboxId,
             successorCandidates: successorCandidates
@@ -142,28 +150,37 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
         try await consentWriter.delete(conversation: conversation)
     }
 
-    /// Protects the "group always keeps at least one super admin" invariant.
-    /// Only acts when the leaver is the sole super admin, then promotes the
-    /// preferred successor before leaving. Awaited rather than best-effort: if
-    /// the transfer can't land we abort the leave rather than strand the group
-    /// with no super admin.
-    private func transferSuperAdminIfNeeded(
+    /// The protocol rejects `leaveGroup()` while the leaver is a super admin
+    /// (super admins cannot be removed), so a super-admin leaver must be
+    /// demoted before the leave. Protects the "group always keeps at least
+    /// one super admin" invariant: when the leaver is the sole super admin,
+    /// the preferred successor is promoted before the self-demotion. Awaited
+    /// rather than best-effort: if the transfer or demotion can't land we
+    /// abort the leave rather than strand the group with no super admin or
+    /// fail the leave at the MLS layer.
+    private func relinquishSuperAdminIfNeeded(
         conversationId: String,
         myInboxId: String,
         successorCandidates: [LeaveSuccessorCandidate]
     ) async throws {
         let superAdmins = try await operations.superAdminInboxIds(conversationId: conversationId)
-        let isSoleSuperAdmin = superAdmins.contains(myInboxId) && superAdmins.count == 1
-        guard isSoleSuperAdmin else { return }
+        guard superAdmins.contains(myInboxId) else { return }
 
-        let ordered = Self.orderedSuccessorInboxIds(from: successorCandidates, excluding: myInboxId)
-        guard let successor = ordered.first else {
-            Log.warning("Leaving \(conversationId) as sole super admin with no successor to promote")
-            return
+        if superAdmins.count == 1 {
+            let ordered = Self.orderedSuccessorInboxIds(from: successorCandidates, excluding: myInboxId)
+            guard let successor = ordered.first else {
+                // No one left to promote: the leaver is effectively the last
+                // member, so keep the role and let `leaveGroup()` resolve it
+                // (the 1 -> 0 commit is rejected as a benign error).
+                Log.warning("Leaving \(conversationId) as sole super admin with no successor to promote")
+                return
+            }
+            try await operations.promoteToSuperAdmin(inboxId: successor, conversationId: conversationId)
+            Log.info("Transferred super admin to \(successor) before leaving \(conversationId)")
         }
 
-        try await operations.promoteToSuperAdmin(inboxId: successor, conversationId: conversationId)
-        Log.info("Transferred super admin to \(successor) before leaving \(conversationId)")
+        try await operations.demoteFromSuperAdmin(inboxId: myInboxId, conversationId: conversationId)
+        Log.info("Demoted self from super admin before leaving \(conversationId)")
     }
 
     /// Successor inbox ids in promotion-preference order. Human members come

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLeaveWriter.swift
@@ -9,12 +9,14 @@ public protocol ConversationLeaveWriterProtocol: Sendable {
     /// the MLS remove-commit finalizes async.
     ///
     /// The protocol forbids a super admin from leaving (and from being
-    /// removed), so a super-admin leaver is demoted first. When the leaver is
-    /// also the sole super admin, the role is transferred to a remaining
-    /// member before the demotion so the group always keeps at least one
-    /// super admin. `successorCandidates` is the remaining membership
-    /// (excluding the leaver); the writer applies a human-preferred,
-    /// agent-fallback tenure policy to pick who to promote.
+    /// removed), so a super-admin leaver is demoted first. When no other
+    /// super admin would remain after the demotion (the leaver is the sole
+    /// super admin, or every other super admin has announced their own
+    /// departure), the role is transferred to a remaining member before the
+    /// demotion so the group always keeps at least one super admin.
+    /// `successorCandidates` is the remaining membership (excluding the
+    /// leaver); the writer applies a human-preferred, agent-fallback tenure
+    /// policy to pick who to promote.
     func leave(
         conversation: Conversation,
         successorCandidates: [LeaveSuccessorCandidate]
@@ -52,17 +54,20 @@ protocol LeaveGroupOperationsProtocol: Sendable {
 public enum ConversationLeaveError: LocalizedError {
     case conversationNotFound(String)
     case notGroupConversation(String)
-    /// The MLS self-removal committed in this call, but the optimistic
-    /// consent-hide failed afterwards. The user is off the group, so callers
-    /// should treat the conversation as left; the hide converges on a later
-    /// consent sync. Not thrown when the leave was benignly swallowed (the
-    /// raw hide error propagates instead, so the leave reads as failed and
-    /// stays retryable).
+    /// The user's membership already ended (the MLS self-removal committed
+    /// in this call, or a benign rejection showed it was already over or
+    /// already pending), but the optimistic consent-hide failed afterwards.
+    /// The user is off the group either way, so callers should treat the
+    /// conversation as left; the hide converges on a later consent sync. Not
+    /// thrown for the one benign rejection that keeps the user a member (the
+    /// single-member group): there the raw hide error propagates instead, so
+    /// the leave reads as failed and stays retryable.
     case hideFailedAfterLeave(String, underlying: any Error)
-    /// The leaver is the sole super admin and no successor could be promoted:
-    /// every candidate announced their own departure since the candidate
-    /// snapshot was taken. The leave aborts so the group is not left with a
-    /// departing member as its only super admin.
+    /// The leaver is the last super admin not already departing, and no
+    /// successor could be promoted: every candidate announced their own
+    /// departure since the candidate snapshot was taken, or none remains.
+    /// The leave aborts so the group is not left without an active super
+    /// admin.
     case noViableSuccessor(String)
 
     public var errorDescription: String? {
@@ -146,15 +151,13 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
     ) async throws {
         // Self-remove from the MLS roster. Benign outcomes are logged and
         // swallowed so the optimistic consent-hide below still runs and the
-        // conversation leaves the UI regardless:
-        // - we're the last member, so libxmtp rejects the 1 -> 0 commit,
-        // - the group is already gone locally or another admin removed us
-        //   first (conversationNotFound / NotFound::MlsGroup) -- the leave's
-        //   goal is already achieved, only the local hide remains.
-        // The benign filter covers the whole flow because the not-found case
-        // also surfaces from the pre-leave super-admin lookup, not just from
-        // leaveGroup itself.
-        var leaveCommitted = true
+        // conversation leaves the UI regardless. Each benign case is also
+        // classified by what it implies for the membership (see
+        // `benignLeaveOutcome(for:)`) because that decides what a hide
+        // failure afterwards means. The benign filter covers the whole flow
+        // because the not-found case also surfaces from the pre-leave
+        // super-admin lookup, not just from leaveGroup itself.
+        var membershipEnded = true
         do {
             let myInboxId = try await operations.currentInboxId()
             try await relinquishSuperAdminIfNeeded(
@@ -164,25 +167,25 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
             )
             try await operations.leaveGroup(conversationId: conversation.id)
         } catch {
-            guard Self.isBenignLeaveError(error) else { throw error }
-            leaveCommitted = false
+            guard let outcome = Self.benignLeaveOutcome(for: error) else { throw error }
+            membershipEnded = outcome == .membershipEnded
             Log.info("Leave skipped for \(conversation.id): \(error.localizedDescription)")
         }
 
         // Optimistic hide, reusing the existing consent-hide path: consent
         // `.denied` + push-topic unsubscribe + local row hide. The MLS
         // remove-commit is finalized async by an authorized admin/agent.
-        // When the self-removal committed above, a failure here is surfaced
-        // as a typed error: the caller must still treat the conversation as
-        // left rather than as a failed leave. When the leave was benignly
-        // swallowed instead, nothing committed in this call, so the raw hide
-        // error propagates and the leave reads as failed and retryable;
-        // announcing a completed leave here could be false (a single-member
-        // rejection leaves the user a member of a still-visible group).
+        // When the membership already ended above (the self-removal
+        // committed, or a benign rejection showed it was already over), a
+        // failure here is surfaced as a typed error: the caller must still
+        // treat the conversation as left rather than as a failed leave. When
+        // the user is still a member instead (the single-member rejection),
+        // the raw hide error propagates and the leave reads as failed and
+        // retryable; announcing a completed leave there would be false.
         do {
             try await consentWriter.delete(conversation: conversation)
         } catch {
-            guard leaveCommitted else { throw error }
+            guard membershipEnded else { throw error }
             throw ConversationLeaveError.hideFailedAfterLeave(conversation.id, underlying: error)
         }
     }
@@ -190,7 +193,8 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
     /// The protocol rejects `leaveGroup()` while the leaver is a super admin
     /// (super admins cannot be removed), so a super-admin leaver must be
     /// demoted before the leave. Protects the "group always keeps at least
-    /// one super admin" invariant: when the leaver is the sole super admin,
+    /// one super admin" invariant: when no other super admin remains viable -
+    /// there is none, or every other one has announced their own departure -
     /// the preferred successor is promoted before the self-demotion. Awaited
     /// rather than best-effort: if the transfer or demotion can't land we
     /// abort the leave rather than strand the group with no super admin or
@@ -203,20 +207,47 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
         let superAdmins = try await operations.superAdminInboxIds(conversationId: conversationId)
         guard superAdmins.contains(myInboxId) else { return }
 
-        if superAdmins.count == 1 {
+        let otherSuperAdmins = superAdmins.filter { $0 != myInboxId }
+        let keepsAViableSuperAdmin: Bool = try await hasViableOtherSuperAdmin(
+            among: otherSuperAdmins,
+            conversationId: conversationId
+        )
+        if !keepsAViableSuperAdmin {
             let ordered = Self.orderedSuccessorInboxIds(from: successorCandidates, excluding: myInboxId)
-            guard !ordered.isEmpty else {
+            if ordered.isEmpty && otherSuperAdmins.isEmpty {
                 // No one left to promote: the leaver is effectively the last
                 // member, so keep the role and let `leaveGroup()` resolve it
                 // (the 1 -> 0 commit is rejected as a benign error).
                 Log.warning("Leaving \(conversationId) as sole super admin with no successor to promote")
                 return
             }
+            guard !ordered.isEmpty else {
+                // Every other super admin announced their own departure and
+                // no other member remains to promote: demoting self would let
+                // the group finalize into zero super admins once those leaves
+                // complete.
+                throw ConversationLeaveError.noViableSuccessor(conversationId)
+            }
             try await promoteFirstViableSuccessor(from: ordered, conversationId: conversationId)
         }
 
         try await operations.demoteFromSuperAdmin(inboxId: myInboxId, conversationId: conversationId)
         Log.info("Demoted self from super admin before leaving \(conversationId)")
+    }
+
+    /// True when at least one of the other super admins has not announced
+    /// their own departure, so the group still has a super admin after the
+    /// leaver's self-demotion. A departing super admin does not count: their
+    /// pending removal would finalize the group into zero super admins.
+    private func hasViableOtherSuperAdmin(
+        among inboxIds: [String],
+        conversationId: String
+    ) async throws -> Bool {
+        for inboxId in inboxIds {
+            let departing = try await hasAnnouncedDeparture(inboxId: inboxId, conversationId: conversationId)
+            if !departing { return true }
+        }
+        return false
     }
 
     /// Tries candidates in preference order. The snapshot behind the
@@ -298,34 +329,61 @@ final class ConversationLeaveWriter: ConversationLeaveWriterProtocol, @unchecked
         }
     }
 
+    /// What a benign leave rejection implies for the user's membership. The
+    /// distinction decides what a subsequent consent-hide failure means for
+    /// the caller.
+    private enum BenignLeaveOutcome {
+        /// The membership is already over, or its removal is already pending
+        /// finalization - the same state a successful `leaveGroup()` leaves
+        /// behind. A hide failure afterwards still means the user is off the
+        /// group.
+        case membershipEnded
+        /// The rejection keeps the user a member: they are the group's sole
+        /// member and libxmtp forbids the 1 -> 0 commit. Only the local hide
+        /// ends this membership, so a hide failure means the leave failed.
+        case stillMember
+    }
+
     /// libxmtp surfaces MLS failures as FFI errors whose full message is only
     /// visible via `String(describing:)`. `LeaveCantProcessed` is the wrapper
     /// for every leave validation failure - including super-admin and DM
     /// rejections that mean the user is still a member - so matching on the
     /// wrapper name alone would turn those into a silent local hide. Only the
     /// specific rejections whose goal is already achieved (or unachievable by
-    /// protocol) are benign, matched by their stable libxmtp messages:
-    /// - "only one member": we're the last member and the 1 -> 0 invariant
-    ///   rejects the commit; the group is dead by protocol.
-    /// - "only a member of the group can send a leave request": a concurrent
-    ///   removal already took us out before the leave-request landed.
-    /// - "already exists in the pending leave list": a leave-request from a
-    ///   retry or another installation is already awaiting finalization.
-    /// - `NotFound::MlsGroup`: a concurrent remove already deleted the group.
-    /// - `conversationNotFound`: the client no longer has the group at all
-    ///   (another admin removed us and the welcome/group was purged); the
-    ///   local hide is all that's left to do.
-    private static func isBenignLeaveError(_ error: any Error) -> Bool {
+    /// protocol) are benign, matched by their stable libxmtp messages, and
+    /// each carries what it implies for the membership:
+    /// - "only one member" (still a member): libxmtp raises it only when the
+    ///   user is a member and the sole occupant; the 1 -> 0 invariant rejects
+    ///   the commit and the group is dead by protocol, but only the local
+    ///   hide removes it from view.
+    /// - "only a member of the group can send a leave request" (ended): a
+    ///   concurrent removal already took us out before the leave-request
+    ///   landed.
+    /// - "already exists in the pending leave list" (ended): a leave-request
+    ///   from a retry or another installation is already awaiting
+    ///   finalization.
+    /// - `NotFound::MlsGroup` (ended): a concurrent remove already deleted
+    ///   the group.
+    /// - `conversationNotFound` (ended): the client no longer has the group
+    ///   at all (another admin removed us and the welcome/group was purged);
+    ///   the local hide is all that's left to do.
+    /// Returns nil for any other error: not benign, the leave failed.
+    private static func benignLeaveOutcome(for error: any Error) -> BenignLeaveOutcome? {
         if case ConversationLeaveError.conversationNotFound = error {
-            return true
+            return .membershipEnded
         }
         let description = String(describing: error)
-        let benignFragments = [
-            "cannot leave a group that has only one member",
+        if description.contains("cannot leave a group that has only one member") {
+            return .stillMember
+        }
+        let membershipEndedFragments = [
             "only a member of the group can send a leave request",
             "inbox ID already exists in the pending leave list",
             "NotFound::MlsGroup",
         ]
-        return benignFragments.contains { description.contains($0) }
+        if membershipEndedFragments.contains(where: { description.contains($0) }) {
+            return .membershipEnded
+        }
+        return nil
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -354,8 +354,20 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         )
         try localState.insert(db, onConflict: .ignore)
 
+        // A member with a pending-leave marker is still in the MLS roster
+        // until an authorized client finalizes their remove-commit, but the
+        // UI must treat them as gone; exclude them from the persisted rows
+        // so a re-sync can't resurrect a leaver the ingest path dropped.
+        let mlsMemberInboxIds = Set(prepared.dbMembers.map(\.inboxId))
+        let departedInboxIds = try Self.reconcileMemberDepartures(
+            conversationId: prepared.dbConversation.id,
+            mlsMemberInboxIds: mlsMemberInboxIds,
+            in: db
+        )
+        let activeMembers = prepared.dbMembers.filter { !departedInboxIds.contains($0.inboxId) }
+
         // Remove conversation_members rows for members no longer in the group
-        let currentMemberInboxIds = Set(prepared.dbMembers.map(\.inboxId))
+        let currentMemberInboxIds = Set(activeMembers.map(\.inboxId))
         if !currentMemberInboxIds.isEmpty {
             try DBConversationMember
                 .filter(DBConversationMember.Columns.conversationId == prepared.dbConversation.id)
@@ -375,7 +387,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             in: db
         )
 
-        try saveMembers(prepared.dbMembers, in: db)
+        try saveMembers(activeMembers, in: db)
 
         // Fill gaps from the group's app-data profiles. The canonical write is
         // what rendering reads; the legacy `DBMemberProfile` write is kept
@@ -474,6 +486,34 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         if let mergedAvatar, mergedAvatar != existingAvatar {
             try mergedAvatar.save(db)
         }
+    }
+
+    /// Reconciles pending-leave markers against a freshly synced MLS member
+    /// list. Markers whose inbox is no longer in the roster have served their
+    /// purpose (the remove-commit finalized) and are deleted so a later
+    /// rejoin can't be masked by a stale marker. The remaining markers name
+    /// leavers whose removal is still pending; their inbox ids are returned
+    /// so the caller can exclude them from the persisted member rows. Static
+    /// so the marker lifecycle is unit-testable without constructing the full
+    /// writer.
+    static func reconcileMemberDepartures(
+        conversationId: String,
+        mlsMemberInboxIds: Set<String>,
+        in db: Database
+    ) throws -> Set<String> {
+        let departures = try DBMemberDeparture
+            .filter(DBMemberDeparture.Columns.conversationId == conversationId)
+            .fetchAll(db)
+        guard !departures.isEmpty else { return [] }
+
+        let staleInboxIds = departures.map(\.inboxId).filter { !mlsMemberInboxIds.contains($0) }
+        if !staleInboxIds.isEmpty {
+            try DBMemberDeparture
+                .filter(DBMemberDeparture.Columns.conversationId == conversationId)
+                .filter(staleInboxIds.contains(DBMemberDeparture.Columns.inboxId))
+                .deleteAll(db)
+        }
+        return Set(departures.map(\.inboxId)).intersection(mlsMemberInboxIds)
     }
 
     /// Clears a persisted removed marker once a synced member list proves the

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -381,9 +381,13 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             in: db
         )
 
+        // The engagement latch reads the raw MLS roster, not the
+        // departure-filtered one: a pending leaver was genuinely a member,
+        // so a joined-then-left conversation must still count as having had
+        // another member even though the leaver's row is excluded above.
         try Self.markHasHadOtherMembersIfNeeded(
             conversationId: prepared.dbConversation.id,
-            currentMemberInboxIds: currentMemberInboxIds,
+            currentMemberInboxIds: mlsMemberInboxIds,
             in: db
         )
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -100,15 +100,11 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
 
         let messageExistsInDB = try DBMessage.exists(db, key: message.id)
         let localInboxId = try DBInbox.currentInboxId(db)
-        let wasRemovedFromConversation: Bool = {
-            guard let localInboxId, let update = message.update else { return false }
-            // A self-leave echo (leave-request the local user sent) names the
-            // local inbox as both initiator and removed member; it must not
-            // set the removed-by-someone-else marker -- the leave flow already
-            // hid the conversation via the consent path.
-            guard update.initiatedByInboxId != localInboxId else { return false }
-            return update.removedInboxIds.contains(localInboxId)
-        }()
+        let wasRemovedFromConversation = Self.isRemovedFromConversation(
+            update: message.update,
+            localInboxId: localInboxId,
+            conversationConsent: conversation.consent
+        )
 
         Log.debug("Storing incoming message \(message.id) localId \(message.clientMessageId) echoDateNs=\(message.dateNs)")
         if !message.attachmentUrls.isEmpty {
@@ -220,6 +216,31 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
             wasRemovedFromConversation: wasRemovedFromConversation,
             messageAlreadyExists: messageExistsInDB
         )
+    }
+
+    /// True when the update removes the local user from the conversation, so
+    /// the removed marker and the live-hide notification must fire.
+    ///
+    /// A self-leave echo (leave-request the local user's inbox sent) names
+    /// the local inbox as both initiator and removed member. On the
+    /// installation that initiated the leave, the leave flow already hid the
+    /// conversation via the consent path, so the echo must not re-mark it.
+    /// A paired sibling installation of the same inbox receives the identical
+    /// echo but never ran the local leave flow, and the finalization commit
+    /// reports self-leaves via `leftInboxes`, which is deliberately not
+    /// mapped -- the echo is the only removal signal the sibling gets before
+    /// consent sync converges. The conversation's consent state is the
+    /// discriminator: the initiator is already denied when the echo lands,
+    /// while a sibling is still allowed and must process the removal.
+    static func isRemovedFromConversation(
+        update: DBMessage.Update?,
+        localInboxId: String?,
+        conversationConsent: Consent
+    ) -> Bool {
+        guard let localInboxId, let update else { return false }
+        guard update.removedInboxIds.contains(localInboxId) else { return false }
+        guard update.initiatedByInboxId == localInboxId else { return true }
+        return conversationConsent != .denied
     }
 
     /// Marks the conversation as removed-for-the-local-user. Idempotent and

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -101,8 +101,13 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
         let messageExistsInDB = try DBMessage.exists(db, key: message.id)
         let localInboxId = try DBInbox.currentInboxId(db)
         let wasRemovedFromConversation: Bool = {
-            guard let localInboxId, let removedInboxIds = message.update?.removedInboxIds else { return false }
-            return removedInboxIds.contains(localInboxId)
+            guard let localInboxId, let update = message.update else { return false }
+            // A self-leave echo (leave-request the local user sent) names the
+            // local inbox as both initiator and removed member; it must not
+            // set the removed-by-someone-else marker -- the leave flow already
+            // hid the conversation via the consent path.
+            guard update.initiatedByInboxId != localInboxId else { return false }
+            return update.removedInboxIds.contains(localInboxId)
         }()
 
         Log.debug("Storing incoming message \(message.id) localId \(message.clientMessageId) echoDateNs=\(message.dateNs)")
@@ -180,6 +185,30 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
                     .filter(DBConversationMember.Columns.invitedByInboxId == nil)
                     .updateAll(db, DBConversationMember.Columns.invitedByInboxId.set(to: update.initiatedByInboxId))
             }
+            // A membership add supersedes any pending-leave marker the same
+            // inbox announced before it (rejoin after an earlier departure
+            // finalized). Bounded by the add's timestamp because backlog
+            // catch-up processes newest-first: an older add ingested late
+            // must not clear the marker of a leave that happened after it.
+            try Self.clearMemberDepartures(
+                conversationId: conversation.id,
+                inboxIds: update.addedInboxIds,
+                beforeNs: message.dateNs,
+                in: db
+            )
+        }
+
+        // Gated on first ingest: the message row and the departure write
+        // commit in the same transaction, so a re-encounter (NSE and main
+        // app share the database) means the departure was already applied.
+        // Re-applying would wrongly re-mark a member who has since rejoined.
+        if encodedContentType == ContentTypeLeaveRequest, !messageExistsInDB {
+            try Self.applyMemberDeparture(
+                conversationId: conversation.id,
+                inboxId: source.senderInboxId,
+                dateNs: message.dateNs,
+                in: db
+            )
         }
 
         if wasRemovedFromConversation {
@@ -225,6 +254,83 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
             .with(isPinned: false)
             .with(pinnedOrder: nil)
             .save(db)
+    }
+
+    /// Records a member's announced departure and drops their member row so
+    /// every member-list surface loses the leaver promptly. The departure
+    /// marker keeps `ConversationWriter.persist` from re-adding the row while
+    /// the MLS roster still lists the leaver (the remove-commit is finalized
+    /// asynchronously by an authorized client). Idempotent: re-ingesting the
+    /// same leave-request (NSE + main app) upserts the same marker.
+    ///
+    /// Order-aware: backlog catch-up processes messages newest-first, so a
+    /// rejoin-add can already be stored when an older leave-request is first
+    /// ingested. Applying that stale leave would hide a current member behind
+    /// a marker no later event clears, so it is skipped when a newer
+    /// membership add for the same inbox exists.
+    static func applyMemberDeparture(
+        conversationId: String,
+        inboxId: String,
+        dateNs: Int64,
+        in db: Database
+    ) throws {
+        guard try !hasNewerMembershipAdd(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            afterNs: dateNs,
+            in: db
+        ) else {
+            Log.info("Skipping stale leave-request for \(inboxId) in \(conversationId): a newer membership add exists")
+            return
+        }
+        try DBMemberDeparture(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            dateNs: dateNs
+        ).save(db)
+        try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .filter(DBConversationMember.Columns.inboxId == inboxId)
+            .deleteAll(db)
+    }
+
+    /// Clears pending-leave markers for inboxes a membership change re-added.
+    /// Without this a member who left and later rejoined would stay filtered
+    /// out of the member list by their stale departure marker. Only markers
+    /// older than the add event (`beforeNs`) are cleared: with newest-first
+    /// backlog processing an older add can be ingested after a newer leave,
+    /// and it must not erase that leave's marker.
+    static func clearMemberDepartures(
+        conversationId: String,
+        inboxIds: [String],
+        beforeNs: Int64,
+        in db: Database
+    ) throws {
+        try DBMemberDeparture
+            .filter(DBMemberDeparture.Columns.conversationId == conversationId)
+            .filter(inboxIds.contains(DBMemberDeparture.Columns.inboxId))
+            .filter(DBMemberDeparture.Columns.dateNs < beforeNs)
+            .deleteAll(db)
+    }
+
+    /// True when a stored membership update newer than `afterNs` added the
+    /// inbox to the conversation -- the signal that a leave-request being
+    /// ingested is stale (the member has since rejoined). Scans stored
+    /// update-type messages because the `update` payload lives in a JSON
+    /// column; updates newer than a given message are rare, and the cost is
+    /// only paid on leave-request ingest.
+    private static func hasNewerMembershipAdd(
+        conversationId: String,
+        inboxId: String,
+        afterNs: Int64,
+        in db: Database
+    ) throws -> Bool {
+        let newerUpdates = try DBMessage
+            .filter(DBMessage.Columns.conversationId == conversationId)
+            .filter(DBMessage.Columns.contentType == MessageContentType.update.rawValue)
+            .filter(DBMessage.Columns.dateNs > afterNs)
+            .fetchAll(db)
+        return newerUpdates.contains { $0.update?.addedInboxIds.contains(inboxId) == true }
     }
 
     func store(message: DecodedMessage,

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -65,6 +65,8 @@ extension XMTPiOS.DecodedMessage {
             components = try handleRemoteAttachmentContent()
         case ContentTypeGroupUpdated:
             components = try handleGroupUpdatedContent()
+        case ContentTypeLeaveRequest:
+            components = handleLeaveRequestContent()
         case ContentTypeExplodeSettings:
             components = try handleExplodeSettingsContent()
         case ContentTypeAgentJoinRequest:
@@ -88,7 +90,7 @@ extension XMTPiOS.DecodedMessage {
         default:
             // Read receipts are dropped silently above because of their volume;
             // anything else without a registered codec gets a trace so unknown
-            // inbound traffic (e.g. LeaveRequest) is visible in exported logs.
+            // inbound traffic is visible in exported logs.
             let version = "\(encodedContentType.versionMajor).\(encodedContentType.versionMinor)"
             Log.warning(
                 "Dropping message \(id) (dateNs=\(sentAtNs)) in conversation \(conversationId) from \(senderInboxId): "
@@ -477,11 +479,46 @@ extension XMTPiOS.DecodedMessage {
                     )
                 }
             }
+        // `groupUpdated.leftInboxes` (self-removals finalized by an authorized
+        // client) is deliberately not mapped: the leaver's earlier
+        // leave-request message already produced the visible "left" update
+        // (see `handleLeaveRequestContent`), so rendering the finalization
+        // commit too would duplicate the transcript row. `removedInboxes`
+        // only carries admin-initiated removals.
         let update = DBMessage.Update(
             initiatedByInboxId: groupUpdated.initiatedByInboxID,
             addedInboxIds: groupUpdated.addedInboxes.map { $0.inboxID },
             removedInboxIds: groupUpdated.removedInboxes.map { $0.inboxID },
             metadataChanges: metadataFieldChanges,
+            expiresAt: nil
+        )
+        return DBMessageComponents(
+            messageType: .original,
+            contentType: .update,
+            sourceMessageId: nil,
+            emoji: nil,
+            attachmentUrls: [],
+            text: nil,
+            update: update
+        )
+    }
+
+    /// A leave-request message is the sender announcing their own departure.
+    /// The MLS remove-commit that actually drops them from the roster is
+    /// finalized later by an authorized client, so this message is the prompt
+    /// signal remote devices key the "left" transcript row and member-list
+    /// drop off. Stored as a membership update where the sender both
+    /// initiated the change and is the removed member -- that identity is how
+    /// rendering distinguishes a self-leave from an admin removal. The later
+    /// finalization commit reports the leaver via `leftInboxes`, which is
+    /// deliberately not rendered (see `handleGroupUpdatedContent`), so the
+    /// transcript never shows the departure twice.
+    private func handleLeaveRequestContent() -> DBMessageComponents {
+        let update = DBMessage.Update(
+            initiatedByInboxId: senderInboxId,
+            addedInboxIds: [],
+            removedInboxIds: [senderInboxId],
+            metadataChanges: [],
             expiresAt: nil
         )
         return DBMessageComponents(

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -3,10 +3,11 @@ import Foundation
 import Testing
 
 /// Self-removal flow coverage: transfer super admin when the leaver is the
-/// sole super admin, self-remove via `leaveGroup`, then apply the optimistic
-/// consent-hide. These tests pin the call sequence, the super-admin invariant,
-/// and the human-preferred / agent-fallback successor policy without standing
-/// up a real MLS group.
+/// sole super admin, demote a super-admin leaver (the protocol rejects a
+/// super admin's `leaveGroup`), self-remove via `leaveGroup`, then apply the
+/// optimistic consent-hide. These tests pin the call sequence, the
+/// super-admin invariant, and the human-preferred / agent-fallback successor
+/// policy without standing up a real MLS group.
 @Suite("ConversationLeaveWriter — transfer-and-leave flow", .serialized)
 struct ConversationLeaveWriterTests {
     private let conversationId = "conv-leave-1"
@@ -25,7 +26,7 @@ struct ConversationLeaveWriterTests {
         LeaveSuccessorCandidate(inboxId: inboxId, isAgent: true, joinedAt: joinedAt)
     }
 
-    @Test("Not sole super admin: leave + consent-hide, no super-admin transfer")
+    @Test("Not sole super admin: demote self + leave + consent-hide, no transfer")
     func noTransferWhenAnotherSuperAdminExists() async throws {
         let fixtures = Fixtures()
         fixtures.operations.setSuperAdmins([selfInboxId, elder])
@@ -40,12 +41,15 @@ struct ConversationLeaveWriterTests {
             return false
         }
         #expect(!hasPromote)
+        #expect(fixtures.operations.calls.contains(
+            .demoteFromSuperAdmin(inboxId: selfInboxId, conversationId: conversationId)
+        ))
         #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
         #expect(fixtures.consentWriter.deletedConversations.first?.id == conversationId)
     }
 
-    @Test("Not a super admin: leave + consent-hide, no transfer")
+    @Test("Not a super admin: leave + consent-hide, no transfer, no demotion")
     func noTransferWhenNotSuperAdmin() async throws {
         let fixtures = Fixtures()
         fixtures.operations.setSuperAdmins([elder])
@@ -59,11 +63,16 @@ struct ConversationLeaveWriterTests {
             if case .promoteToSuperAdmin = call { return true }
             return false
         }
+        let hasDemote = fixtures.operations.calls.contains { call in
+            if case .demoteFromSuperAdmin = call { return true }
+            return false
+        }
         #expect(!hasPromote)
+        #expect(!hasDemote)
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
 
-    @Test("Sole super admin: promotes longest-tenured human before leaving")
+    @Test("Sole super admin: promotes longest-tenured human, demotes self, then leaves")
     func transfersToLongestTenuredBeforeLeaving() async throws {
         let fixtures = Fixtures()
         fixtures.operations.setSuperAdmins([selfInboxId])
@@ -79,6 +88,7 @@ struct ConversationLeaveWriterTests {
             .currentInboxId,
             .superAdminInboxIds(conversationId: conversationId),
             .promoteToSuperAdmin(inboxId: elder, conversationId: conversationId),
+            .demoteFromSuperAdmin(inboxId: selfInboxId, conversationId: conversationId),
             .leaveGroup(conversationId: conversationId)
         ])
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
@@ -117,7 +127,7 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
 
-    @Test("Sole super admin with no successor: leaves without transfer")
+    @Test("Sole super admin with no successor: leaves without transfer or demotion")
     func soleSuperAdminNoSuccessor() async throws {
         let fixtures = Fixtures()
         fixtures.operations.setSuperAdmins([selfInboxId])
@@ -131,7 +141,12 @@ struct ConversationLeaveWriterTests {
             if case .promoteToSuperAdmin = call { return true }
             return false
         }
+        let hasDemote = fixtures.operations.calls.contains { call in
+            if case .demoteFromSuperAdmin = call { return true }
+            return false
+        }
         #expect(!hasPromote)
+        #expect(!hasDemote)
         #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
@@ -185,6 +200,24 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.consentWriter.deletedConversations.isEmpty)
     }
 
+    @Test("Self-demotion failure aborts the leave before leaveGroup")
+    func demoteFailureAbortsLeave() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId, elder])
+        fixtures.operations.failDemote(with: StubError.demoteFailed)
+
+        await #expect(throws: StubError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+        }
+
+        let hasLeave = fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId))
+        #expect(!hasLeave)
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
     // MARK: - Fixtures
 
     private final class Fixtures {
@@ -209,6 +242,7 @@ struct ConversationLeaveWriterTests {
     private enum StubError: Error {
         case leaveFailed
         case promoteFailed
+        case demoteFailed
     }
 
     private struct BenignLeaveError: Error, CustomStringConvertible {

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -217,6 +217,120 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
 
+    @Test("Concurrent removal (not a group member) is benign; consent-hide still runs")
+    func notAGroupMemberStillHides() async throws {
+        // We were removed between the roster snapshot and the leave-request;
+        // the leave's goal is already achieved.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "[GroupError::LeaveCantProcessed] Group error: only a member of the group can send a leave request or retract a leave request"
+        ))
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [human(elder, joinedAt: earliest)]
+        )
+
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Leave already pending (retry or another installation) is benign; consent-hide still runs")
+    func leaveAlreadyPendingStillHides() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "[GroupError::LeaveCantProcessed] Group error: inbox ID already exists in the pending leave list"
+        ))
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [human(elder, joinedAt: earliest)]
+        )
+
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("A super-admin leave rejection is not benign: it propagates and skips the hide")
+    func superAdminRejectionPropagates() async throws {
+        // If this fires the pre-leave demotion did not land and the user is
+        // still a member; hiding the conversation would fake a leave.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "[GroupError::LeaveCantProcessed] Group error: super-admin cannot leave a group; must be demoted first"
+        ))
+
+        await #expect(throws: BenignLeaveError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+        }
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
+    @Test("A DM leave rejection is not benign: it propagates and skips the hide")
+    func dmRejectionPropagates() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "[GroupError::LeaveCantProcessed] Group error: cannot leave a DM conversation"
+        ))
+
+        await #expect(throws: BenignLeaveError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+        }
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
+    @Test("Consent-hide failure after a committed leave surfaces the typed post-leave error")
+    func hideFailureAfterLeaveSurfacesTypedError() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.consentWriter.deleteError = StubError.hideFailed
+
+        do {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+            Issue.record("Expected hideFailedAfterLeave to be thrown")
+        } catch ConversationLeaveError.hideFailedAfterLeave(let id, _) {
+            #expect(id == conversationId)
+        }
+
+        // The MLS self-removal did commit; the caller must treat the
+        // conversation as left despite the error.
+        #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
+    }
+
+    @Test("Stale first successor falls back to the next candidate")
+    func promoteFallsBackToNextCandidate() async throws {
+        // The candidate snapshot is taken before the leave executes; the
+        // preferred successor can have left meanwhile. Their rejected
+        // promotion must not abort the leave while valid candidates remain.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+        fixtures.operations.failPromote(forInboxId: elder, with: StubError.promoteFailed)
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [
+                human(elder, joinedAt: earliest),
+                human(younger, joinedAt: latest),
+            ]
+        )
+
+        #expect(fixtures.operations.calls.contains(.promoteToSuperAdmin(inboxId: elder, conversationId: conversationId)))
+        #expect(fixtures.operations.calls.contains(.promoteToSuperAdmin(inboxId: younger, conversationId: conversationId)))
+        #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
     @Test("Non-benign leaveGroup error propagates and skips the consent-hide")
     func nonBenignLeaveErrorPropagates() async throws {
         let fixtures = Fixtures()
@@ -293,6 +407,7 @@ struct ConversationLeaveWriterTests {
         case leaveFailed
         case promoteFailed
         case demoteFailed
+        case hideFailed
     }
 
     private struct BenignLeaveError: Error, CustomStringConvertible {

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -1,5 +1,6 @@
 @testable import ConvosCore
 import Foundation
+import GRDB
 import Testing
 
 /// Self-removal flow coverage: transfer super admin when the leaver is the
@@ -308,6 +309,82 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
     }
 
+    @Test("Hide failure after a benign-swallowed leave propagates the raw error, not the post-leave case")
+    func hideFailureAfterBenignLeavePropagatesRawError() async throws {
+        // The single-member rejection means the leave never committed and the
+        // user is still a member; wrapping the hide failure as
+        // hideFailedAfterLeave would make the caller announce a completed
+        // leave that did not happen.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "[GroupError::LeaveCantProcessed] Group error: cannot leave a group that has only one member"
+        ))
+        fixtures.consentWriter.deleteError = StubError.hideFailed
+
+        await #expect(throws: StubError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+        }
+    }
+
+    @Test("A successor who announced departure after the snapshot is skipped, not promoted")
+    func promoteSkipsCandidateWithAnnouncedDeparture() async throws {
+        // libxmtp accepts a pending leaver in the admin list, so the
+        // promotion-rejection fallback alone cannot catch this; the departure
+        // markers must be re-checked right before each promotion attempt.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+        try fixtures.markDeparture(inboxId: elder, conversationId: conversationId)
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [
+                human(elder, joinedAt: earliest),
+                human(younger, joinedAt: latest),
+            ]
+        )
+
+        let hasElderPromote = fixtures.operations.calls.contains(
+            .promoteToSuperAdmin(inboxId: elder, conversationId: conversationId)
+        )
+        #expect(!hasElderPromote)
+        #expect(fixtures.operations.calls.contains(
+            .promoteToSuperAdmin(inboxId: younger, conversationId: conversationId)
+        ))
+        #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Every successor announced departure: the leave aborts with no promotion")
+    func allSuccessorsDepartedAbortsLeave() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+        try fixtures.markDeparture(inboxId: elder, conversationId: conversationId)
+        try fixtures.markDeparture(inboxId: younger, conversationId: conversationId)
+
+        await #expect(throws: ConversationLeaveError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [
+                    human(elder, joinedAt: earliest),
+                    human(younger, joinedAt: latest),
+                ]
+            )
+        }
+
+        let hasPromote = fixtures.operations.calls.contains { call in
+            if case .promoteToSuperAdmin = call { return true }
+            return false
+        }
+        #expect(!hasPromote)
+        let hasLeave = fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId))
+        #expect(!hasLeave)
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
     @Test("Stale first successor falls back to the next candidate")
     func promoteFallsBackToNextCandidate() async throws {
         // The candidate snapshot is taken before the leave executes; the
@@ -387,6 +464,7 @@ struct ConversationLeaveWriterTests {
     private final class Fixtures {
         let operations: MockLeaveGroupOperations
         let consentWriter: MockConversationConsentWriter
+        let database: MockDatabaseManager
         let writer: ConversationLeaveWriter
 
         init() {
@@ -394,12 +472,27 @@ struct ConversationLeaveWriterTests {
             let ops = MockLeaveGroupOperations()
             ops.setInboxId("inbox-self")
             let consent = MockConversationConsentWriter()
+            let database = MockDatabaseManager.makeTestDatabase()
             self.operations = ops
             self.consentWriter = consent
+            self.database = database
             self.writer = ConversationLeaveWriter(
                 operations: ops,
-                consentWriter: consent
+                consentWriter: consent,
+                databaseReader: database.dbReader
             )
+        }
+
+        /// Seeds a departure marker: the state a candidate gains when their
+        /// leave-request is ingested after the successor snapshot was taken.
+        func markDeparture(inboxId: String, conversationId: String) throws {
+            try database.dbWriter.write { db in
+                try DBMemberDeparture(
+                    conversationId: conversationId,
+                    inboxId: inboxId,
+                    dateNs: 1
+                ).save(db)
+            }
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -167,6 +167,56 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
 
+    @Test("Group already gone at leaveGroup: consent-hide still runs")
+    func conversationNotFoundOnLeaveStillHides() async throws {
+        // Another admin removed us first (or the group was purged); the
+        // leave's goal is already achieved and only the local hide remains.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: ConversationLeaveError.conversationNotFound(conversationId))
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [human(elder, joinedAt: earliest)]
+        )
+
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+        #expect(fixtures.consentWriter.deletedConversations.first?.id == conversationId)
+    }
+
+    @Test("Group already gone at the super-admin lookup: consent-hide still runs")
+    func conversationNotFoundOnSuperAdminLookupStillHides() async throws {
+        // The not-found can surface from the pre-leave super-admin check,
+        // before leaveGroup is ever reached; it must be benign there too.
+        let fixtures = Fixtures()
+        fixtures.operations.failSuperAdmins(with: ConversationLeaveError.conversationNotFound(conversationId))
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [human(elder, joinedAt: earliest)]
+        )
+
+        let hasLeave = fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId))
+        #expect(!hasLeave)
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Concurrent removal (NotFound::MlsGroup) is benign; consent-hide still runs")
+    func concurrentRemovalStillHides() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "GenericError: GroupError NotFound::MlsGroup"
+        ))
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [human(elder, joinedAt: earliest)]
+        )
+
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
     @Test("Non-benign leaveGroup error propagates and skips the consent-hide")
     func nonBenignLeaveErrorPropagates() async throws {
         let fixtures = Fixtures()

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -1,0 +1,172 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Self-removal flow coverage: transfer super admin when the leaver is the
+/// sole super admin, self-remove via `leaveGroup`, then apply the optimistic
+/// consent-hide. These tests pin the call sequence and the super-admin
+/// invariant without standing up a real MLS group.
+@Suite("ConversationLeaveWriter — transfer-and-leave flow", .serialized)
+struct ConversationLeaveWriterTests {
+    private let conversationId = "conv-leave-1"
+    private let selfInboxId = "inbox-self"
+    private let elder = "inbox-elder"
+    private let younger = "inbox-younger"
+
+    @Test("Not sole super admin: leave + consent-hide, no super-admin transfer")
+    func noTransferWhenAnotherSuperAdminExists() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId, elder])
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            tenureOrderedSuccessorInboxIds: [elder, younger]
+        )
+
+        let hasPromote = fixtures.operations.calls.contains { call in
+            if case .promoteToSuperAdmin = call { return true }
+            return false
+        }
+        #expect(!hasPromote)
+        #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+        #expect(fixtures.consentWriter.deletedConversations.first?.id == conversationId)
+    }
+
+    @Test("Not a super admin: leave + consent-hide, no transfer")
+    func noTransferWhenNotSuperAdmin() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            tenureOrderedSuccessorInboxIds: [elder, younger]
+        )
+
+        let hasPromote = fixtures.operations.calls.contains { call in
+            if case .promoteToSuperAdmin = call { return true }
+            return false
+        }
+        #expect(!hasPromote)
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Sole super admin: promotes longest-tenured successor before leaving")
+    func transfersToLongestTenuredBeforeLeaving() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            tenureOrderedSuccessorInboxIds: [elder, younger]
+        )
+
+        // Order matters: super-admin lookup, promote the first (longest-tenured)
+        // successor, then leave. The consent-hide follows.
+        #expect(fixtures.operations.calls == [
+            .currentInboxId,
+            .superAdminInboxIds(conversationId: conversationId),
+            .promoteToSuperAdmin(inboxId: elder, conversationId: conversationId),
+            .leaveGroup(conversationId: conversationId)
+        ])
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Sole super admin with no successor: leaves without transfer")
+    func soleSuperAdminNoSuccessor() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            tenureOrderedSuccessorInboxIds: []
+        )
+
+        let hasPromote = fixtures.operations.calls.contains { call in
+            if case .promoteToSuperAdmin = call { return true }
+            return false
+        }
+        #expect(!hasPromote)
+        #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Benign leaveGroup error is swallowed; consent-hide still runs")
+    func benignLeaveErrorStillHides() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "GroupError: LeaveCantProcessed cannot leave a group that has only one member"
+        ))
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            tenureOrderedSuccessorInboxIds: [elder]
+        )
+
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Non-benign leaveGroup error propagates and skips the consent-hide")
+    func nonBenignLeaveErrorPropagates() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: StubError.leaveFailed)
+
+        await #expect(throws: StubError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                tenureOrderedSuccessorInboxIds: [elder]
+            )
+        }
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
+    @Test("Super-admin transfer failure aborts the leave to protect the invariant")
+    func promoteFailureAbortsLeave() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+        fixtures.operations.failPromote(with: StubError.promoteFailed)
+
+        await #expect(throws: StubError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                tenureOrderedSuccessorInboxIds: [elder]
+            )
+        }
+
+        let hasLeave = fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId))
+        #expect(!hasLeave)
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
+    // MARK: - Fixtures
+
+    private final class Fixtures {
+        let operations: MockLeaveGroupOperations
+        let consentWriter: MockConversationConsentWriter
+        let writer: ConversationLeaveWriter
+
+        init() {
+            ConvosLog.configure(environment: .tests)
+            let ops = MockLeaveGroupOperations()
+            ops.setInboxId("inbox-self")
+            let consent = MockConversationConsentWriter()
+            self.operations = ops
+            self.consentWriter = consent
+            self.writer = ConversationLeaveWriter(
+                operations: ops,
+                consentWriter: consent
+            )
+        }
+    }
+
+    private enum StubError: Error {
+        case leaveFailed
+        case promoteFailed
+    }
+
+    private struct BenignLeaveError: Error, CustomStringConvertible {
+        let description: String
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -4,14 +4,26 @@ import Testing
 
 /// Self-removal flow coverage: transfer super admin when the leaver is the
 /// sole super admin, self-remove via `leaveGroup`, then apply the optimistic
-/// consent-hide. These tests pin the call sequence and the super-admin
-/// invariant without standing up a real MLS group.
+/// consent-hide. These tests pin the call sequence, the super-admin invariant,
+/// and the human-preferred / agent-fallback successor policy without standing
+/// up a real MLS group.
 @Suite("ConversationLeaveWriter — transfer-and-leave flow", .serialized)
 struct ConversationLeaveWriterTests {
     private let conversationId = "conv-leave-1"
     private let selfInboxId = "inbox-self"
     private let elder = "inbox-elder"
     private let younger = "inbox-younger"
+
+    private let earliest = Date(timeIntervalSince1970: 1_000)
+    private let latest = Date(timeIntervalSince1970: 3_000)
+
+    private func human(_ inboxId: String, joinedAt: Date?) -> LeaveSuccessorCandidate {
+        LeaveSuccessorCandidate(inboxId: inboxId, isAgent: false, joinedAt: joinedAt)
+    }
+
+    private func agent(_ inboxId: String, joinedAt: Date?) -> LeaveSuccessorCandidate {
+        LeaveSuccessorCandidate(inboxId: inboxId, isAgent: true, joinedAt: joinedAt)
+    }
 
     @Test("Not sole super admin: leave + consent-hide, no super-admin transfer")
     func noTransferWhenAnotherSuperAdminExists() async throws {
@@ -20,7 +32,7 @@ struct ConversationLeaveWriterTests {
 
         try await fixtures.writer.leave(
             conversation: .mock(id: conversationId),
-            tenureOrderedSuccessorInboxIds: [elder, younger]
+            successorCandidates: [human(elder, joinedAt: earliest), human(younger, joinedAt: latest)]
         )
 
         let hasPromote = fixtures.operations.calls.contains { call in
@@ -40,7 +52,7 @@ struct ConversationLeaveWriterTests {
 
         try await fixtures.writer.leave(
             conversation: .mock(id: conversationId),
-            tenureOrderedSuccessorInboxIds: [elder, younger]
+            successorCandidates: [human(elder, joinedAt: earliest)]
         )
 
         let hasPromote = fixtures.operations.calls.contains { call in
@@ -51,24 +63,57 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
 
-    @Test("Sole super admin: promotes longest-tenured successor before leaving")
+    @Test("Sole super admin: promotes longest-tenured human before leaving")
     func transfersToLongestTenuredBeforeLeaving() async throws {
         let fixtures = Fixtures()
         fixtures.operations.setSuperAdmins([selfInboxId])
 
+        // Input order is younger-first; the writer must still pick the
+        // earlier-joined (longest-tenured) human, elder.
         try await fixtures.writer.leave(
             conversation: .mock(id: conversationId),
-            tenureOrderedSuccessorInboxIds: [elder, younger]
+            successorCandidates: [human(younger, joinedAt: latest), human(elder, joinedAt: earliest)]
         )
 
-        // Order matters: super-admin lookup, promote the first (longest-tenured)
-        // successor, then leave. The consent-hide follows.
         #expect(fixtures.operations.calls == [
             .currentInboxId,
             .superAdminInboxIds(conversationId: conversationId),
             .promoteToSuperAdmin(inboxId: elder, conversationId: conversationId),
             .leaveGroup(conversationId: conversationId)
         ])
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Sole super admin: a human wins over a longer-tenured agent")
+    func humanPreferredOverLongerTenuredAgent() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+
+        // The agent joined earliest, but a human must still be promoted.
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [agent("inbox-agent", joinedAt: earliest), human(younger, joinedAt: latest)]
+        )
+
+        #expect(fixtures.operations.calls.contains(
+            .promoteToSuperAdmin(inboxId: younger, conversationId: conversationId)
+        ))
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Sole super admin with only agents left: falls back to longest-tenured agent")
+    func agentFallbackWhenNoHumansRemain() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId])
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [agent("inbox-agent-new", joinedAt: latest), agent("inbox-agent-old", joinedAt: earliest)]
+        )
+
+        #expect(fixtures.operations.calls.contains(
+            .promoteToSuperAdmin(inboxId: "inbox-agent-old", conversationId: conversationId)
+        ))
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
     }
 
@@ -79,7 +124,7 @@ struct ConversationLeaveWriterTests {
 
         try await fixtures.writer.leave(
             conversation: .mock(id: conversationId),
-            tenureOrderedSuccessorInboxIds: []
+            successorCandidates: []
         )
 
         let hasPromote = fixtures.operations.calls.contains { call in
@@ -101,7 +146,7 @@ struct ConversationLeaveWriterTests {
 
         try await fixtures.writer.leave(
             conversation: .mock(id: conversationId),
-            tenureOrderedSuccessorInboxIds: [elder]
+            successorCandidates: [human(elder, joinedAt: earliest)]
         )
 
         #expect(fixtures.consentWriter.deletedConversations.count == 1)
@@ -116,7 +161,7 @@ struct ConversationLeaveWriterTests {
         await #expect(throws: StubError.self) {
             try await fixtures.writer.leave(
                 conversation: .mock(id: conversationId),
-                tenureOrderedSuccessorInboxIds: [elder]
+                successorCandidates: [human(elder, joinedAt: earliest)]
             )
         }
         #expect(fixtures.consentWriter.deletedConversations.isEmpty)
@@ -131,7 +176,7 @@ struct ConversationLeaveWriterTests {
         await #expect(throws: StubError.self) {
             try await fixtures.writer.leave(
                 conversation: .mock(id: conversationId),
-                tenureOrderedSuccessorInboxIds: [elder]
+                successorCandidates: [human(elder, joinedAt: earliest)]
             )
         }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLeaveWriterTests.swift
@@ -309,12 +309,12 @@ struct ConversationLeaveWriterTests {
         #expect(fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId)))
     }
 
-    @Test("Hide failure after a benign-swallowed leave propagates the raw error, not the post-leave case")
+    @Test("Hide failure after the still-a-member benign rejection propagates the raw error")
     func hideFailureAfterBenignLeavePropagatesRawError() async throws {
-        // The single-member rejection means the leave never committed and the
-        // user is still a member; wrapping the hide failure as
-        // hideFailedAfterLeave would make the caller announce a completed
-        // leave that did not happen.
+        // The single-member rejection is the one benign case that keeps the
+        // user a member; wrapping the hide failure as hideFailedAfterLeave
+        // would make the caller announce a completed leave that did not
+        // happen.
         let fixtures = Fixtures()
         fixtures.operations.setSuperAdmins([elder])
         fixtures.operations.failLeave(with: BenignLeaveError(
@@ -327,6 +327,46 @@ struct ConversationLeaveWriterTests {
                 conversation: .mock(id: conversationId),
                 successorCandidates: [human(elder, joinedAt: earliest)]
             )
+        }
+    }
+
+    @Test("Hide failure after an already-out benign rejection surfaces the post-leave error")
+    func hideFailureAfterAlreadyOutRejectionIsPostLeave() async throws {
+        // A concurrent removal already ended the membership; the hide failing
+        // must not read as a failed leave, or the caller would keep a group
+        // the user is no longer in onscreen without announcing the departure.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([elder])
+        fixtures.operations.failLeave(with: BenignLeaveError(
+            description: "[GroupError::LeaveCantProcessed] Group error: only a member of the group can send a leave request or retract a leave request"
+        ))
+        fixtures.consentWriter.deleteError = StubError.hideFailed
+
+        do {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+            Issue.record("Expected hideFailedAfterLeave to be thrown")
+        } catch ConversationLeaveError.hideFailedAfterLeave(let id, _) {
+            #expect(id == conversationId)
+        }
+    }
+
+    @Test("Hide failure after the group is already gone surfaces the post-leave error")
+    func hideFailureAfterConversationNotFoundIsPostLeave() async throws {
+        let fixtures = Fixtures()
+        fixtures.operations.failSuperAdmins(with: ConversationLeaveError.conversationNotFound(conversationId))
+        fixtures.consentWriter.deleteError = StubError.hideFailed
+
+        do {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: [human(elder, joinedAt: earliest)]
+            )
+            Issue.record("Expected hideFailedAfterLeave to be thrown")
+        } catch ConversationLeaveError.hideFailedAfterLeave(let id, _) {
+            #expect(id == conversationId)
         }
     }
 
@@ -380,6 +420,56 @@ struct ConversationLeaveWriterTests {
             return false
         }
         #expect(!hasPromote)
+        let hasLeave = fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId))
+        #expect(!hasLeave)
+        #expect(fixtures.consentWriter.deletedConversations.isEmpty)
+    }
+
+    @Test("Co-super-admin with announced departure: a successor is promoted before self-demotion")
+    func departingCoSuperAdminTriggersSuccessorPromotion() async throws {
+        // The other super admin is on their way out; without a promotion the
+        // group would finalize into zero super admins once their leave
+        // completes. The departing super admin is marker-excluded from the
+        // member rows, so the candidates only carry the remaining members.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId, elder])
+        try fixtures.markDeparture(inboxId: elder, conversationId: conversationId)
+
+        try await fixtures.writer.leave(
+            conversation: .mock(id: conversationId),
+            successorCandidates: [human(younger, joinedAt: latest)]
+        )
+
+        #expect(fixtures.operations.calls == [
+            .currentInboxId,
+            .superAdminInboxIds(conversationId: conversationId),
+            .promoteToSuperAdmin(inboxId: younger, conversationId: conversationId),
+            .demoteFromSuperAdmin(inboxId: selfInboxId, conversationId: conversationId),
+            .leaveGroup(conversationId: conversationId)
+        ])
+        #expect(fixtures.consentWriter.deletedConversations.count == 1)
+    }
+
+    @Test("Co-super-admin departing with no candidate to promote: the leave aborts")
+    func departingCoSuperAdminWithNoCandidateAbortsLeave() async throws {
+        // Demoting self here would leave only a departing super admin behind;
+        // aborting keeps the group from finalizing into zero super admins.
+        let fixtures = Fixtures()
+        fixtures.operations.setSuperAdmins([selfInboxId, elder])
+        try fixtures.markDeparture(inboxId: elder, conversationId: conversationId)
+
+        await #expect(throws: ConversationLeaveError.self) {
+            try await fixtures.writer.leave(
+                conversation: .mock(id: conversationId),
+                successorCandidates: []
+            )
+        }
+
+        let hasDemote = fixtures.operations.calls.contains { call in
+            if case .demoteFromSuperAdmin = call { return true }
+            return false
+        }
+        #expect(!hasDemote)
         let hasLeave = fixtures.operations.calls.contains(.leaveGroup(conversationId: conversationId))
         #expect(!hasLeave)
         #expect(fixtures.consentWriter.deletedConversations.isEmpty)

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationRemovedStateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationRemovedStateTests.swift
@@ -98,6 +98,79 @@ struct ConversationRemovedStateTests {
             .fetchOne(db)
     }
 
+    // MARK: - isRemovedFromConversation
+
+    private static func membershipUpdate(
+        initiatedBy: String,
+        removed: [String]
+    ) -> DBMessage.Update {
+        DBMessage.Update(
+            initiatedByInboxId: initiatedBy,
+            addedInboxIds: [],
+            removedInboxIds: removed,
+            metadataChanges: [],
+            expiresAt: nil
+        )
+    }
+
+    @Test("Admin removal naming the local inbox is processed as a removal")
+    func testAdminRemovalIsProcessed() throws {
+        let removed = IncomingMessageWriter.isRemovedFromConversation(
+            update: Self.membershipUpdate(initiatedBy: Self.otherInboxId, removed: [Self.currentInboxId]),
+            localInboxId: Self.currentInboxId,
+            conversationConsent: .allowed
+        )
+        #expect(removed)
+    }
+
+    @Test("Self-leave echo on a sibling installation (consent still allowed) is processed as a removal")
+    func testSelfLeaveEchoOnSiblingInstallationIsProcessed() throws {
+        // Device pairing puts the same inbox on multiple installations. The
+        // sibling never ran the local leave flow, and the finalization commit
+        // is not mapped for self-leaves, so the echo must set the marker or
+        // the conversation stays visible until consent sync converges.
+        let removed = IncomingMessageWriter.isRemovedFromConversation(
+            update: Self.membershipUpdate(initiatedBy: Self.currentInboxId, removed: [Self.currentInboxId]),
+            localInboxId: Self.currentInboxId,
+            conversationConsent: .allowed
+        )
+        #expect(removed)
+    }
+
+    @Test("Self-leave echo on the initiating installation (consent already denied) stays skipped")
+    func testSelfLeaveEchoOnInitiatorIsSkipped() throws {
+        // The leave flow already hid the conversation via the consent path;
+        // the echo must not re-mark it.
+        let removed = IncomingMessageWriter.isRemovedFromConversation(
+            update: Self.membershipUpdate(initiatedBy: Self.currentInboxId, removed: [Self.currentInboxId]),
+            localInboxId: Self.currentInboxId,
+            conversationConsent: .denied
+        )
+        #expect(!removed)
+    }
+
+    @Test("Updates that do not remove the local inbox never mark a removal")
+    func testUnrelatedUpdateIsIgnored() throws {
+        let removed = IncomingMessageWriter.isRemovedFromConversation(
+            update: Self.membershipUpdate(initiatedBy: Self.otherInboxId, removed: [Self.otherInboxId]),
+            localInboxId: Self.currentInboxId,
+            conversationConsent: .allowed
+        )
+        #expect(!removed)
+        let noUpdate = IncomingMessageWriter.isRemovedFromConversation(
+            update: nil,
+            localInboxId: Self.currentInboxId,
+            conversationConsent: .allowed
+        )
+        #expect(!noUpdate)
+        let noInbox = IncomingMessageWriter.isRemovedFromConversation(
+            update: Self.membershipUpdate(initiatedBy: Self.otherInboxId, removed: [Self.currentInboxId]),
+            localInboxId: nil,
+            conversationConsent: .allowed
+        )
+        #expect(!noInbox)
+    }
+
     // MARK: - persistRemovedMarker
 
     @Test("Marks the conversation removed and unpins it")

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationUpdateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationUpdateTests.swift
@@ -139,4 +139,66 @@ struct ConversationUpdateTests {
         let update = metadataUpdate(creator: creator, field: .description, newValue: "")
         #expect(update.summary == "You removed the convo description")
     }
+
+    // MARK: - summary for removals: self-leave vs admin removal
+
+    private func member(
+        inboxId: String,
+        name: String?,
+        isCurrentUser: Bool = false
+    ) -> ConversationMember {
+        ConversationMember(
+            profile: Profile(
+                inboxId: inboxId,
+                conversationId: "convo-1",
+                name: name,
+                avatar: nil
+            ),
+            role: .member,
+            isCurrentUser: isCurrentUser
+        )
+    }
+
+    private func removalUpdate(
+        creator: ConversationMember,
+        removed: ConversationMember
+    ) -> ConversationUpdate {
+        ConversationUpdate(
+            creator: creator,
+            addedMembers: [],
+            removedMembers: [removed],
+            metadataChanges: []
+        )
+    }
+
+    @Test("summary renders a plain 'left' for another member's self-leave")
+    func summarySelfLeaveByOtherMember() {
+        // A self-leave stores the leaver as both initiator and removed member.
+        let bob = member(inboxId: "bob", name: "Bob")
+        let update = removalUpdate(creator: bob, removed: bob)
+        #expect(update.summary == "Bob left")
+    }
+
+    @Test("summary credits the remover for an admin removal")
+    func summaryAdminRemovalCreditsRemover() {
+        let admin = member(inboxId: "admin", name: "Alice")
+        let bob = member(inboxId: "bob", name: "Bob")
+        let update = removalUpdate(creator: admin, removed: bob)
+        #expect(update.summary == "Bob left · Removed by Alice")
+    }
+
+    @Test("summary renders 'You left the convo' for the current user's self-leave")
+    func summarySelfLeaveByCurrentUser() {
+        let me = member(inboxId: "me", name: "Me", isCurrentUser: true)
+        let update = removalUpdate(creator: me, removed: me)
+        #expect(update.summary == "You left the convo")
+    }
+
+    @Test("summary renders 'You were removed' when an admin removes the current user")
+    func summaryAdminRemovalOfCurrentUser() {
+        let admin = member(inboxId: "admin", name: "Alice")
+        let me = member(inboxId: "me", name: "Me", isCurrentUser: true)
+        let update = removalUpdate(creator: admin, removed: me)
+        #expect(update.summary == "You were removed from the convo")
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
@@ -1,5 +1,6 @@
 @testable import ConvosCore
 import Foundation
+import GRDB
 import Testing
 @preconcurrency import XMTPiOS
 
@@ -82,5 +83,212 @@ struct LeaveRequestIntegrationTests {
         #expect(dbMessage.update?.initiatedByInboxId == leaverClient.inboxId)
         #expect(dbMessage.update?.removedInboxIds == [leaverClient.inboxId])
         #expect(dbMessage.update?.addedInboxIds.isEmpty == true)
+    }
+
+    /// The user-observed critical scenario: a two-member group whose creator
+    /// (sole super admin) leaves via the writer's promote -> demote -> leave
+    /// order. The remaining member must keep the conversation, see the "left"
+    /// update, and hold the transferred super admin role. This drives the real
+    /// ingest path (IncomingMessageWriter + departure reconciliation) against
+    /// the messages the remaining member's client actually receives.
+    @Test("creator leaving a two-member group leaves the other member promoted with the conversation intact")
+    func creatorLeaveKeepsConversationForRemainingMember() async throws {
+        let creatorClient = try await createClient()
+        let memberClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? memberClient.deleteLocalDatabase()
+        }
+
+        let creatorGroup = try await creatorClient.conversations.newGroup(with: [memberClient.inboxId])
+
+        _ = try await memberClient.conversations.syncAllConversations(consentStates: nil)
+        let memberConversation = try await memberClient.conversations.findConversation(conversationId: creatorGroup.id)
+        guard case .group(let memberGroup) = try #require(memberConversation) else {
+            Issue.record("Remaining member's conversation is not a group")
+            return
+        }
+        let membershipStateBeforeLeave = try memberGroup.membershipState
+
+        // The writer's operation order for a sole-super-admin leaver.
+        try await creatorGroup.addSuperAdmin(inboxId: memberClient.inboxId)
+        try await creatorGroup.removeSuperAdmin(inboxId: creatorClient.inboxId)
+        try await creatorGroup.leaveGroup()
+
+        // The remaining member's client processes the commits and the
+        // leave-request; as the new super admin it may also finalize the
+        // creator's removal.
+        try await memberGroup.sync()
+        _ = try await memberGroup.members
+
+        // Promotion is visible on the remaining member's device.
+        #expect(try memberGroup.listSuperAdmins().contains(memberClient.inboxId))
+        // The remaining member's own membership is untouched by the creator's
+        // leave (a raw SDK client that never consented stays `.pending`; it
+        // must never flip to `.pendingRemove`).
+        #expect(try memberGroup.membershipState == membershipStateBeforeLeave)
+        #expect(try memberGroup.isActive())
+
+        // Drive the real ingest path with everything the member received.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let conversationId = memberGroup.id
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(
+                db: db,
+                id: conversationId,
+                currentInboxId: memberClient.inboxId,
+                otherInboxId: creatorClient.inboxId
+            )
+        }
+
+        let dbConversation = try await dbManager.dbWriter.read { db in
+            try #require(try DBConversation.fetchOne(db, key: conversationId))
+        }
+
+        let messageWriter = IncomingMessageWriter(databaseWriter: dbManager.dbWriter)
+        let messages = try await memberGroup.messages(direction: .ascending)
+        var sawRemovedFromConversation = false
+        for message in messages {
+            guard let contentType = try? message.encodedContent.type,
+                  contentType == ContentTypeGroupUpdated || contentType == ContentTypeLeaveRequest else {
+                continue
+            }
+            let result = try await messageWriter.store(message: message, for: dbConversation)
+            if result.wasRemovedFromConversation {
+                sawRemovedFromConversation = true
+            }
+        }
+
+        // No message the remaining member receives may mark THEM as removed.
+        #expect(!sawRemovedFromConversation)
+
+        let roster = try await memberGroup.members.map(\.inboxId)
+        try await dbManager.dbWriter.write { db in
+            _ = try ConversationWriter.reconcileMemberDepartures(
+                conversationId: conversationId,
+                mlsMemberInboxIds: Set(roster),
+                in: db
+            )
+        }
+
+        let creatorInboxId = creatorClient.inboxId
+        let memberInboxId = memberClient.inboxId
+        try await dbManager.dbReader.read { db in
+            // The conversation row survives, unhidden.
+            let conversation = try DBConversation.fetchOne(db, key: conversationId)
+            #expect(conversation != nil)
+            #expect(conversation?.consent == .allowed)
+            let localState = try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == conversationId)
+                .fetchOne(db)
+            #expect(localState?.wasRemoved != true)
+
+            // The regression the user hit: the conversations-list query joins
+            // the creator's member row, and the departure ingest deletes that
+            // row when the creator leaves. The conversation must still come
+            // back from the detailed query and hydrate with a fallback
+            // creator.
+            let details = try DBConversation
+                .filter(DBConversation.Columns.id == conversationId)
+                .detailedConversationQuery()
+                .fetchOne(db)
+            let hydrated = try #require(details?.hydrateConversation(currentInboxId: memberInboxId))
+            #expect(hydrated.creator.profile.inboxId == creatorInboxId)
+            #expect(!hydrated.creator.isCurrentUser)
+            #expect(hydrated.members.map(\.profile.inboxId) == [memberInboxId])
+
+            // The leaver's member row is gone; the remaining member's stays.
+            let creatorRow = try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == conversationId)
+                .filter(DBConversationMember.Columns.inboxId == creatorClient.inboxId)
+                .fetchOne(db)
+            #expect(creatorRow == nil)
+            let memberRow = try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == conversationId)
+                .filter(DBConversationMember.Columns.inboxId == memberClient.inboxId)
+                .fetchOne(db)
+            #expect(memberRow != nil)
+
+            // Exactly one visible "left" transcript row: the self-leave shape
+            // (initiator == removed member == the creator).
+            let updates = try DBMessage
+                .filter(DBMessage.Columns.conversationId == conversationId)
+                .filter(DBMessage.Columns.contentType == MessageContentType.update.rawValue)
+                .fetchAll(db)
+            let leaveUpdates = updates.filter { message in
+                guard let update = message.update else { return false }
+                return update.removedInboxIds == [creatorClient.inboxId]
+                    && update.initiatedByInboxId == creatorClient.inboxId
+            }
+            #expect(leaveUpdates.count == 1)
+        }
+    }
+
+    private static func seedConversation(
+        db: Database,
+        id: String,
+        currentInboxId: String,
+        otherInboxId: String
+    ) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+        try DBMember(inboxId: otherInboxId).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: otherInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: Date(),
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            wasRemoved: false
+        ).insert(db)
+
+        for inboxId in [currentInboxId, otherInboxId] {
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: inboxId == otherInboxId ? .superAdmin : .member,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            ).insert(db)
+            try DBMemberProfile(
+                conversationId: id,
+                inboxId: inboxId,
+                name: nil,
+                avatar: nil
+            ).insert(db)
+        }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
@@ -273,7 +273,9 @@ struct LeaveRequestIntegrationTests {
             hidesInviteCard: false,
             leftHostedInviteSession: false,
             wasRemoved: false,
-            hasHadOtherMembers: false,
+            // True to mirror what the real writer persists for a two-member
+            // conversation (the latch sets as soon as another inbox syncs).
+            hasHadOtherMembers: true,
             hasSharedInvite: false
         ).insert(db)
 

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
@@ -1,0 +1,86 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+/// Integration coverage for the self-leave signal against a local XMTP node
+/// (`./dev/up`). `leaveGroup()` publishes a leave-request message rather than
+/// removing the member directly; the remove-commit is finalized later by an
+/// authorized client. These tests pin the protocol behavior the departure
+/// pipeline is built on: the leave-request reaches the other members with
+/// normal message latency, our ingest maps it to a self-leave membership
+/// update, and the MLS roster still lists the leaver until finalization.
+@Suite("Leave request Integration Tests", .serialized)
+struct LeaveRequestIntegrationTests {
+    private func createClient() async throws -> Client {
+        var keyBytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, 32, &keyBytes)
+        let dbKey = Data(keyBytes)
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let options = ClientOptions(
+            api: .init(env: .local, appVersion: "convos-tests/1.0.0"),
+            codecs: [
+                TextCodec(),
+                GroupUpdatedCodec(),
+                LeaveRequestCodec(),
+            ],
+            dbEncryptionKey: dbKey,
+            dbDirectory: tmpDir.path
+        )
+        return try await Client.create(
+            account: try PrivateKey.generate(),
+            options: options
+        )
+    }
+
+    @Test("leaveGroup publishes a leave-request other members ingest as a self-leave update")
+    func leaveRequestReachesOtherMembers() async throws {
+        let creatorClient = try await createClient()
+        let leaverClient = try await createClient()
+        defer {
+            try? creatorClient.deleteLocalDatabase()
+            try? leaverClient.deleteLocalDatabase()
+        }
+
+        let group = try await creatorClient.conversations.newGroup(with: [leaverClient.inboxId])
+
+        _ = try await leaverClient.conversations.syncAllConversations(consentStates: nil)
+        let leaverConversation = try await leaverClient.conversations.findConversation(conversationId: group.id)
+        guard case .group(let leaverGroup) = try #require(leaverConversation) else {
+            Issue.record("Leaver's conversation is not a group")
+            return
+        }
+
+        // The leaver is a regular member (the creator holds super admin), so
+        // the protocol accepts the self-leave.
+        try await leaverGroup.leaveGroup()
+
+        // The leaver's own client can't commit its own removal: it stays in
+        // the roster in a pending-remove state until an authorized client
+        // finalizes the commit.
+        try await leaverGroup.sync()
+        #expect(try leaverGroup.membershipState == .pendingRemove)
+        let leaverRoster = try await leaverGroup.members.map(\.inboxId)
+        #expect(leaverRoster.contains(leaverClient.inboxId))
+
+        // The creator receives the leave-request as an ordinary message.
+        try await group.sync()
+        let messages = try await group.messages()
+        let leaveRequest = try #require(
+            messages.first { (try? $0.encodedContent.type) == ContentTypeLeaveRequest },
+            "Creator should receive the leave-request message"
+        )
+        #expect(leaveRequest.senderInboxId == leaverClient.inboxId)
+
+        // Ingest maps it to a membership update naming the sender as both
+        // initiator and removed member -- the self-leave shape the transcript
+        // renders as "<name> left" and the member-list drop keys off.
+        let dbMessage = try leaveRequest.dbRepresentation()
+        #expect(dbMessage.contentType == .update)
+        #expect(dbMessage.update?.initiatedByInboxId == leaverClient.inboxId)
+        #expect(dbMessage.update?.removedInboxIds == [leaverClient.inboxId])
+        #expect(dbMessage.update?.addedInboxIds.isEmpty == true)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/Integration/LeaveRequestIntegrationTests.swift
@@ -271,7 +271,10 @@ struct LeaveRequestIntegrationTests {
             isMuted: false,
             pinnedOrder: nil,
             hidesInviteCard: false,
-            wasRemoved: false
+            leftHostedInviteSession: false,
+            wasRemoved: false,
+            hasHadOtherMembers: false,
+            hasSharedInvite: false
         ).insert(db)
 
         for inboxId in [currentInboxId, otherInboxId] {

--- a/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
@@ -1,0 +1,331 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the pending-leave marker lifecycle: written when a
+/// leave-request message is ingested (`IncomingMessageWriter.applyMemberDeparture`),
+/// used by `ConversationWriter.reconcileMemberDepartures` to keep a leaver out
+/// of the persisted member rows while the MLS roster still lists them, and
+/// cleared when the removal finalizes or a membership add re-admits the inbox.
+@Suite("Member departure marker Tests", .serialized)
+struct MemberDepartureTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let leaverInboxId: String = "inbox-leaver"
+
+    // MARK: - Seeding
+
+    private static func seedConversation(db: Database, id: String) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+        try DBMember(inboxId: leaverInboxId).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        for inboxId in [currentInboxId, leaverInboxId] {
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: .member,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            ).insert(db)
+        }
+    }
+
+    private static func memberRow(db: Database, conversationId: String, inboxId: String) throws -> DBConversationMember? {
+        try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .filter(DBConversationMember.Columns.inboxId == inboxId)
+            .fetchOne(db)
+    }
+
+    private static func departureRows(db: Database, conversationId: String) throws -> [DBMemberDeparture] {
+        try DBMemberDeparture
+            .filter(DBMemberDeparture.Columns.conversationId == conversationId)
+            .fetchAll(db)
+    }
+
+    /// Stores a membership-add update message, the shape a rejoin's
+    /// GroupUpdated commit produces on ingest.
+    private static func storeMembershipAdd(
+        db: Database,
+        conversationId: String,
+        addedInboxId: String,
+        dateNs: Int64
+    ) throws {
+        try DBMessage(
+            id: "msg-add-\(dateNs)",
+            clientMessageId: "msg-add-\(dateNs)",
+            conversationId: conversationId,
+            senderId: currentInboxId,
+            dateNs: dateNs,
+            date: Date(),
+            sortId: dateNs,
+            status: .published,
+            messageType: .original,
+            contentType: .update,
+            text: nil,
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            attachmentUrls: [],
+            update: DBMessage.Update(
+                initiatedByInboxId: currentInboxId,
+                addedInboxIds: [addedInboxId],
+                removedInboxIds: [],
+                metadataChanges: [],
+                expiresAt: nil
+            )
+        ).insert(db)
+    }
+
+    // MARK: - applyMemberDeparture
+
+    @Test("Departure drops the member row and records the marker")
+    func testDepartureDropsMemberRowAndRecordsMarker() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo")
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo",
+                inboxId: Self.leaverInboxId,
+                dateNs: 1_000,
+                in: db
+            )
+        }
+
+        try dbManager.dbReader.read { db in
+            let member = try Self.memberRow(db: db, conversationId: "convo", inboxId: Self.leaverInboxId)
+            #expect(member == nil)
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.map(\.inboxId) == [Self.leaverInboxId])
+            let remaining = try Self.memberRow(db: db, conversationId: "convo", inboxId: Self.currentInboxId)
+            #expect(remaining != nil)
+        }
+    }
+
+    @Test("Departure is idempotent across re-ingested leave requests")
+    func testDepartureIsIdempotent() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo")
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+        }
+
+        try dbManager.dbReader.read { db in
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.count == 1)
+        }
+    }
+
+    @Test("Stale leave-request after a stored rejoin-add is skipped")
+    func testStaleLeaveAfterRejoinAddIsSkipped() throws {
+        // Backlog catch-up processes newest-first: while this device was
+        // offline the member left, the removal finalized, and they were
+        // re-added. The rejoin-add (newer) is ingested before the old
+        // leave-request; applying that stale leave would hide a current
+        // member behind a marker nothing later clears.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let departed = try dbManager.dbWriter.write { db -> Set<String> in
+            try Self.seedConversation(db: db, id: "convo")
+            try Self.storeMembershipAdd(
+                db: db,
+                conversationId: "convo",
+                addedInboxId: Self.leaverInboxId,
+                dateNs: 2_000
+            )
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+            return try ConversationWriter.reconcileMemberDepartures(
+                conversationId: "convo",
+                mlsMemberInboxIds: [Self.currentInboxId, Self.leaverInboxId],
+                in: db
+            )
+        }
+
+        #expect(departed.isEmpty)
+        try dbManager.dbReader.read { db in
+            let member = try Self.memberRow(db: db, conversationId: "convo", inboxId: Self.leaverInboxId)
+            #expect(member != nil)
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.isEmpty)
+        }
+    }
+
+    @Test("Leave-request newer than a stored add still applies")
+    func testLeaveNewerThanStoredAddStillApplies() throws {
+        // The inverse ordering: the stored add predates the leave, so the
+        // member really did leave after (re)joining and must be marked.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo")
+            try Self.storeMembershipAdd(
+                db: db,
+                conversationId: "convo",
+                addedInboxId: Self.leaverInboxId,
+                dateNs: 1_000
+            )
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 2_000, in: db
+            )
+        }
+
+        try dbManager.dbReader.read { db in
+            let member = try Self.memberRow(db: db, conversationId: "convo", inboxId: Self.leaverInboxId)
+            #expect(member == nil)
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.map(\.inboxId) == [Self.leaverInboxId])
+        }
+    }
+
+    // MARK: - clearMemberDepartures
+
+    @Test("Membership add clears the marker for the re-added inbox only")
+    func testAddClearsMarkerForReAddedInbox() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo")
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: "inbox-other-leaver", dateNs: 1_100, in: db
+            )
+            try IncomingMessageWriter.clearMemberDepartures(
+                conversationId: "convo",
+                inboxIds: [Self.leaverInboxId],
+                beforeNs: 5_000,
+                in: db
+            )
+        }
+
+        try dbManager.dbReader.read { db in
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.map(\.inboxId) == ["inbox-other-leaver"])
+        }
+    }
+
+    @Test("An add older than the marker does not clear it")
+    func testOlderAddKeepsNewerMarker() throws {
+        // Newest-first backlog ordering can ingest an old add after a newer
+        // leave. The leave happened last, so its marker must survive.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo")
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 3_000, in: db
+            )
+            try IncomingMessageWriter.clearMemberDepartures(
+                conversationId: "convo",
+                inboxIds: [Self.leaverInboxId],
+                beforeNs: 1_000,
+                in: db
+            )
+        }
+
+        try dbManager.dbReader.read { db in
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.map(\.inboxId) == [Self.leaverInboxId])
+        }
+    }
+
+    // MARK: - reconcileMemberDepartures
+
+    @Test("Leaver still in the MLS roster stays excluded and keeps the marker")
+    func testPendingLeaverStaysExcluded() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let departed = try dbManager.dbWriter.write { db -> Set<String> in
+            try Self.seedConversation(db: db, id: "convo")
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+            // The remove-commit hasn't finalized: the synced roster still
+            // lists the leaver.
+            return try ConversationWriter.reconcileMemberDepartures(
+                conversationId: "convo",
+                mlsMemberInboxIds: [Self.currentInboxId, Self.leaverInboxId],
+                in: db
+            )
+        }
+
+        #expect(departed == [Self.leaverInboxId])
+        try dbManager.dbReader.read { db in
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.count == 1)
+        }
+    }
+
+    @Test("Finalized removal deletes the marker and returns no exclusions")
+    func testFinalizedRemovalDeletesMarker() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let departed = try dbManager.dbWriter.write { db -> Set<String> in
+            try Self.seedConversation(db: db, id: "convo")
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+            // The remove-commit finalized: the synced roster no longer lists
+            // the leaver, so the marker has done its job.
+            return try ConversationWriter.reconcileMemberDepartures(
+                conversationId: "convo",
+                mlsMemberInboxIds: [Self.currentInboxId],
+                in: db
+            )
+        }
+
+        #expect(departed.isEmpty)
+        try dbManager.dbReader.read { db in
+            let departures = try Self.departureRows(db: db, conversationId: "convo")
+            #expect(departures.isEmpty)
+        }
+    }
+
+    @Test("No markers means no exclusions")
+    func testNoMarkersNoExclusions() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let departed = try dbManager.dbWriter.write { db -> Set<String> in
+            try Self.seedConversation(db: db, id: "convo")
+            return try ConversationWriter.reconcileMemberDepartures(
+                conversationId: "convo",
+                mlsMemberInboxIds: [Self.currentInboxId, Self.leaverInboxId],
+                in: db
+            )
+        }
+        #expect(departed.isEmpty)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
@@ -329,6 +329,62 @@ struct MemberDepartureTests {
         #expect(departed.isEmpty)
     }
 
+    // MARK: - persist engagement latch
+
+    @Test("Persist latches hasHadOtherMembers when the only other member is a pending leaver")
+    func testPersistLatchesEngagementForPendingLeaver() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = ConversationWriter(
+            identityStore: MockKeychainIdentityStore(),
+            databaseWriter: dbManager.dbWriter,
+            messageWriter: MockIncomingMessageWriter()
+        )
+
+        let conversation = try dbManager.dbWriter.write { db -> DBConversation? in
+            try Self.seedConversation(db: db, id: "convo")
+            // The leave-request ingest already dropped the leaver's row and
+            // recorded the pending-leave marker.
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo", inboxId: Self.leaverInboxId, dateNs: 1_000, in: db
+            )
+            return try DBConversation.fetchOne(db, id: "convo")
+        }
+        let dbConversation = try #require(conversation)
+
+        // Next roster sync: MLS still lists the leaver because their
+        // remove-commit has not finalized.
+        let prepared = ConversationWriter.PreparedConversation(
+            dbConversation: dbConversation,
+            dbMembers: [Self.currentInboxId, Self.leaverInboxId].map { inboxId in
+                DBConversationMember(
+                    conversationId: "convo",
+                    inboxId: inboxId,
+                    role: .member,
+                    consent: .allowed,
+                    createdAt: Date(),
+                    invitedByInboxId: nil
+                )
+            },
+            memberProfiles: []
+        )
+        try dbManager.dbWriter.write { db in
+            _ = try writer.persist(prepared, in: db)
+        }
+
+        try dbManager.dbReader.read { db in
+            // The leaver stays excluded from the persisted member rows...
+            let leaverRow = try Self.memberRow(db: db, conversationId: "convo", inboxId: Self.leaverInboxId)
+            #expect(leaverRow == nil)
+            // ...but the engagement latch reads the raw roster: the pending
+            // leaver was genuinely a member, so the joined-then-left
+            // conversation must not be judged an untouched draft.
+            let state = try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == "convo")
+                .fetchOne(db)
+            #expect(state?.hasHadOtherMembers == true)
+        }
+    }
+
     // MARK: - Creator departure
 
     @Test("Creator departure keeps the conversation visible in the detailed query")
@@ -383,7 +439,10 @@ struct MemberDepartureTests {
                 hidesInviteCard: false,
                 leftHostedInviteSession: false,
                 wasRemoved: false,
-                hasHadOtherMembers: false,
+                // True to mirror what the real writer persists for a
+                // two-member conversation (the latch sets as soon as another
+                // inbox syncs).
+                hasHadOtherMembers: true,
                 hasSharedInvite: false
             ).insert(db)
             for inboxId in [Self.currentInboxId, Self.leaverInboxId] {

--- a/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
@@ -381,7 +381,10 @@ struct MemberDepartureTests {
                 isMuted: false,
                 pinnedOrder: nil,
                 hidesInviteCard: false,
-                wasRemoved: false
+                leftHostedInviteSession: false,
+                wasRemoved: false,
+                hasHadOtherMembers: false,
+                hasSharedInvite: false
             ).insert(db)
             for inboxId in [Self.currentInboxId, Self.leaverInboxId] {
                 try DBConversationMember(

--- a/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberDepartureTests.swift
@@ -328,4 +328,95 @@ struct MemberDepartureTests {
         }
         #expect(departed.isEmpty)
     }
+
+    // MARK: - Creator departure
+
+    @Test("Creator departure keeps the conversation visible in the detailed query")
+    func testCreatorDepartureKeepsConversationVisible() throws {
+        // The detailed conversation query joins the creator's member row.
+        // When the creator self-leaves, the departure ingest deletes that row
+        // on every other member's device; the join must be optional or the
+        // conversation silently disappears from the list and detail views
+        // (the user-visible "conversation was deleted" bug).
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            // seedConversation sets creatorId to currentInboxId; here the
+            // leaver must be the creator, so seed with the creator flipped.
+            try DBMember(inboxId: Self.currentInboxId).save(db, onConflict: .ignore)
+            try DBInbox(
+                inboxId: Self.currentInboxId,
+                clientId: "client-current",
+                createdAt: Date()
+            ).save(db, onConflict: .ignore)
+            try DBMember(inboxId: Self.leaverInboxId).save(db, onConflict: .ignore)
+            try DBConversation(
+                id: "convo",
+                clientConversationId: "client-convo",
+                inviteTag: "tag-convo",
+                creatorId: Self.leaverInboxId,
+                kind: .group,
+                consent: .allowed,
+                createdAt: Date(),
+                name: nil,
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAgent: false
+            ).insert(db)
+            try ConversationLocalState(
+                conversationId: "convo",
+                isPinned: false,
+                isUnread: false,
+                isUnreadUpdatedAt: Date(),
+                isMuted: false,
+                pinnedOrder: nil,
+                hidesInviteCard: false,
+                wasRemoved: false
+            ).insert(db)
+            for inboxId in [Self.currentInboxId, Self.leaverInboxId] {
+                try DBConversationMember(
+                    conversationId: "convo",
+                    inboxId: inboxId,
+                    role: inboxId == Self.leaverInboxId ? .superAdmin : .member,
+                    consent: .allowed,
+                    createdAt: Date(),
+                    invitedByInboxId: nil
+                ).insert(db)
+                try DBMemberProfile(
+                    conversationId: "convo",
+                    inboxId: inboxId,
+                    name: nil,
+                    avatar: nil
+                ).insert(db)
+            }
+
+            try IncomingMessageWriter.applyMemberDeparture(
+                conversationId: "convo",
+                inboxId: Self.leaverInboxId,
+                dateNs: 1_000,
+                in: db
+            )
+        }
+
+        try dbManager.dbReader.read { db in
+            let details = try DBConversation
+                .filter(DBConversation.Columns.id == "convo")
+                .detailedConversationQuery()
+                .fetchOne(db)
+            let hydrated = try #require(details?.hydrateConversation(currentInboxId: Self.currentInboxId))
+            #expect(hydrated.creator.profile.inboxId == Self.leaverInboxId)
+            #expect(!hydrated.creator.isCurrentUser)
+            #expect(hydrated.members.map(\.profile.inboxId) == [Self.currentInboxId])
+        }
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/MemberNameOverrideTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MemberNameOverrideTests.swift
@@ -157,7 +157,7 @@ struct MemberNameOverrideTests {
         let result = update.summary { inboxId in
             inboxId == "removed" ? "Bob" : nil
         }
-        #expect(result == "Bob left")
+        #expect(result == "Bob left · Removed by Admin")
     }
 
     @Test("Self-joiner shows You regardless of override")

--- a/ConvosTests/ConversationViewModelLeaveSuccessorTests.swift
+++ b/ConvosTests/ConversationViewModelLeaveSuccessorTests.swift
@@ -1,0 +1,53 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Coverage for the successor-candidate selection feeding
+/// `ConversationLeaveWriter`: `leaveGroupConvo()` must not offer optimistic
+/// agent sentinels as super-admin successors. Those members are
+/// presentation-only overlays shown while agent instances provision; their
+/// inbox ids don't exist on the network, so promoting one would fail and
+/// abort the leave.
+@MainActor
+final class ConversationViewModelLeaveSuccessorTests: XCTestCase {
+    func testLeaveExcludesOptimisticAgentMembersFromSuccessors() async throws {
+        let human = ConversationMember.mock(isCurrentUser: false, name: "Alice")
+        let sentinel = ConversationMember(
+            profile: .mock(
+                inboxId: AgentShareInfo.optimisticInboxIdPrefix + "template-1",
+                name: "Pending Agent"
+            ),
+            role: .member,
+            isCurrentUser: false,
+            isAgent: true
+        )
+        XCTAssertTrue(sentinel.isOptimisticAgentMember)
+
+        let group = Conversation.mock(
+            id: "test-group",
+            members: [.mock(isCurrentUser: true), human, sentinel]
+        )
+        XCTAssertEqual(group.kind, .group)
+
+        let leaveWriter = MockConversationLeaveWriter()
+        let viewModel = ConversationViewModel(
+            conversation: group,
+            session: MockInboxesService(),
+            messagingService: MockMessagingService(conversationLeaveWriter: leaveWriter),
+            applyGlobalDefaultsForNewConversation: false
+        )
+
+        viewModel.leaveGroupConvo()
+
+        // leaveGroupConvo performs the leave in a detached task; poll until
+        // the mock records it.
+        for _ in 0..<100 where leaveWriter.leftConversations.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        let record = try XCTUnwrap(leaveWriter.leftConversations.first)
+        XCTAssertEqual(record.successorCandidates.map(\.inboxId),
+                       [human.profile.inboxId],
+                       "Only real members may be offered as super-admin successors")
+    }
+}

--- a/ConvosTests/ConversationViewModelLeaveTests.swift
+++ b/ConvosTests/ConversationViewModelLeaveTests.swift
@@ -1,0 +1,52 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Coverage for the leave affordance gating: `canLeaveConversation` limits
+/// the Leave section in the conversation info view to group conversations.
+/// Self-removal is a group-only operation -- the protocol rejects leaving a
+/// DM -- so the affordance must never be offered there.
+@MainActor
+final class ConversationViewModelLeaveTests: XCTestCase {
+    func testCanLeaveConversationFalseForDM() {
+        // Conversation.mock derives kind == .dm from a two-member roster.
+        let dm = Conversation.mock(
+            id: "test-dm",
+            members: [
+                .mock(isCurrentUser: true),
+                .mock(isCurrentUser: false, name: "Alice"),
+            ]
+        )
+        XCTAssertEqual(dm.kind, .dm)
+
+        let viewModel = makeViewModel(conversation: dm)
+        XCTAssertFalse(viewModel.canLeaveConversation,
+                       "The Leave affordance must not be offered for a DM")
+    }
+
+    func testCanLeaveConversationTrueForGroup() {
+        let group = Conversation.mock(
+            id: "test-group",
+            members: [
+                .mock(isCurrentUser: true),
+                .mock(isCurrentUser: false, name: "Alice"),
+                .mock(isCurrentUser: false, name: "Bob"),
+            ]
+        )
+        XCTAssertEqual(group.kind, .group)
+
+        let viewModel = makeViewModel(conversation: group)
+        XCTAssertTrue(viewModel.canLeaveConversation)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(conversation: Conversation) -> ConversationViewModel {
+        ConversationViewModel(
+            conversation: conversation,
+            session: MockInboxesService(),
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+    }
+}

--- a/docs/plans/leave-a-group.md
+++ b/docs/plans/leave-a-group.md
@@ -1,0 +1,28 @@
+# Leave a Group
+
+Lets a member remove themselves from a group conversation -- a true self-removal, not just a local hide. This is a platform-agnostic behavior spec (iOS + Android parity).
+
+## Behavior
+
+Entry point: a **Leave** button on the Group Info screen -> confirmation -> the leave action.
+
+The leave action:
+1. Removes the current user from the group via the MLS self-removal primitive (`leaveGroup()`).
+2. Optimistically hides the conversation locally -- marks it denied/hidden and stops its notifications immediately, so it disappears from the UI while the removal finalizes. The MLS remove-commit may be finalized asynchronously by an authorized client; the UX assumes success.
+
+## Super-admin succession
+
+A group must always keep at least one super admin. If the leaving member is the sole super admin:
+
+1. Before leaving, transfer the super-admin role to another member -- the longest-tenured remaining member, preferring a human; fall back to an agent only if no human members remain.
+2. If the transfer fails, abort the leave (never leave a group without a super admin).
+
+## Pending state
+
+The removal can stay pending until an authorized client finalizes the remove-commit. While pending, exclude the group from push subscriptions so the user stops receiving its notifications right away.
+
+## Notes for implementers
+
+- The optimistic hide reuses the same local hide + push-unsubscribe already used when declining/hiding a conversation; leaving simply adds the real `leaveGroup()` call on top.
+- "Longest-tenured" uses local member join order (the protocol member exposes no join timestamp).
+- Distinguishing a self-leave from being removed by an admin (for UI copy) is a follow-up.

--- a/docs/plans/leave-a-group.md
+++ b/docs/plans/leave-a-group.md
@@ -10,19 +10,48 @@ The leave action:
 1. Removes the current user from the group via the MLS self-removal primitive (`leaveGroup()`).
 2. Optimistically hides the conversation locally -- marks it denied/hidden and stops its notifications immediately, so it disappears from the UI while the removal finalizes. The MLS remove-commit may be finalized asynchronously by an authorized client; the UX assumes success.
 
-## Super-admin succession
+## Super-admin succession and demotion
 
-A group must always keep at least one super admin. If the leaving member is the sole super admin:
+The protocol rejects `leaveGroup()` while the leaver is a super admin (super admins cannot be removed from a group). A group must also always keep at least one super admin. So, before leaving:
 
-1. Before leaving, transfer the super-admin role to another member -- the longest-tenured remaining member, preferring a human; fall back to an agent only if no human members remain.
-2. If the transfer fails, abort the leave (never leave a group without a super admin).
+1. If the leaving member is the **sole** super admin, transfer the super-admin role to another member -- the longest-tenured remaining member, preferring a human; fall back to an agent only if no human members remain.
+2. If the leaving member is a super admin (sole or not), demote them from super admin.
+3. If the transfer or the demotion fails, abort the leave (never leave a group without a super admin, and never call `leaveGroup()` as a super admin -- the protocol rejects it).
+
+Exception: a sole super admin with no other member to promote is effectively the last member; keep the role and let `leaveGroup()` resolve it (the protocol rejects a 1 -> 0 commit as a benign error and the local hide still applies).
+
+## How the leave propagates (remote visibility)
+
+`leaveGroup()` does not remove the member directly. It publishes a **leave-request message** into the group (content type `xmtp.org/leave_request`); the MLS remove-commit is created later by an authorized client (a super admin's device) when it processes the request. Until that commit lands, the leaver is still in the MLS roster on every device.
+
+Clients therefore key the user-visible departure off the leave-request message, which arrives with normal message latency:
+
+- **Transcript row**: ingest the leave-request as a membership-change update where the sender is both the initiator and the removed member. Render it as "<name> left" ("You left the convo" for the leaver's own devices).
+- **Member list**: on ingest, drop the leaver from the local member rows and record a pending-leave marker for `(conversation, inbox)`. Membership re-syncs while the removal is pending must not resurrect the leaver: filter any synced roster against the pending-leave markers.
+- **Marker lifecycle**: delete the marker once a synced roster no longer contains the inbox (the removal finalized), and delete it when a membership change re-adds the inbox (rejoin via invite after the removal finalized).
+
+When the remove-commit finalizes, the resulting membership-change message reports the leaver in a dedicated "left" list, separate from admin-initiated removals. Do not render that finalization event: the leave-request already produced the visible row, and rendering both would duplicate the departure in the transcript.
+
+## Self-leave vs admin removal (copy)
+
+The two removal paths stay distinguishable end to end:
+
+| Event | Signal | Copy (other members) | Copy (affected member) |
+|---|---|---|---|
+| Self-leave | leave-request message (sender == removed member) | "<name> left" | "You left the convo" |
+| Admin removal | membership-change commit with removed members (initiator != removed member) | "<name> left · Removed by <initiator>" | "You were removed from the convo" |
+
+A self-leave echo on the leaver's own devices must not set the "removed by someone else" state -- the leave flow already hid the conversation locally.
 
 ## Pending state
 
-The removal can stay pending until an authorized client finalizes the remove-commit. While pending, exclude the group from push subscriptions so the user stops receiving its notifications right away.
+The removal can stay pending until an authorized client finalizes the remove-commit. While pending:
+
+- Exclude the group from push subscriptions so the leaver stops receiving its notifications right away.
+- Other members' devices already render the leaver as gone (see above); no UI should depend on the finalization time.
 
 ## Notes for implementers
 
 - The optimistic hide reuses the same local hide + push-unsubscribe already used when declining/hiding a conversation; leaving simply adds the real `leaveGroup()` call on top.
 - "Longest-tenured" uses local member join order (the protocol member exposes no join timestamp).
-- Distinguishing a self-leave from being removed by an admin (for UI copy) is a follow-up.
+- The protocol's roster query does not filter pending leavers -- the pending-leave marker layer is what keeps member lists consistent between the request and the finalization.

--- a/docs/plans/leave-a-group.md
+++ b/docs/plans/leave-a-group.md
@@ -55,3 +55,7 @@ The removal can stay pending until an authorized client finalizes the remove-com
 - The optimistic hide reuses the same local hide + push-unsubscribe already used when declining/hiding a conversation; leaving simply adds the real `leaveGroup()` call on top.
 - "Longest-tenured" uses local member join order (the protocol member exposes no join timestamp).
 - The protocol's roster query does not filter pending leavers -- the pending-leave marker layer is what keeps member lists consistent between the request and the finalization.
+- The conversation must stay fully usable for the remaining members after the creator leaves. No query or hydration path may require the creator to still be a member: dropping the creator's member row must degrade to a placeholder creator identity, never hide the conversation.
+- If the group is already gone when the leave runs (another admin removed the user first, or the local group was purged), treat it as success: skip the protocol calls and complete the local hide.
+- Only real, committed members are eligible super-admin successors. Presentation-only placeholders (for example optimistic agent members still provisioning) have no network identity and must be excluded from the candidate list.
+- Leaving applies to groups only; the affordance is hidden for DMs (the protocol rejects a DM leave).


### PR DESCRIPTION
Real "leave a group" (self-removal): a Leave button on Group Info that removes the user from the MLS group, with an optimistic hide and automatic super-admin succession.

Draft -- the core is implemented + unit-tested (9/9); real-device QA and a couple of follow-up chunks remain (below).

## What
- A **Leave** button on the Group Info screen -> confirmation -> leaves the group.
- Uses `group.leaveGroup()` (the true self-removal primitive), then reuses the existing consent-hide path (denied + push-unsubscribe + local hide) so the conversation vanishes and stops notifications immediately -- optimistic while the MLS remove-commit finalizes.
- **Super-admin succession:** if the leaver is the sole super admin, auto-transfer the role to the longest-tenured remaining **human** member (agent only as a fallback if no humans remain) *before* leaving, preserving the ">= 1 super admin" invariant. Aborts the leave if the transfer fails.

## How
- New `ConversationLeaveWriter` (protocol + XMTP impl + mocks) in ConvosCore -- keeps leave logic out of the view and testable; does not modify the existing consent `delete` path, so non-leave flows are unchanged.
- Wired via `MessagingServiceProtocol.conversationLeaveWriter()`.
- 9/9 unit tests (transfer order, sole-super-admin, no-successor, human-preferred vs agent-fallback, benign vs fatal leave errors, promote-failure aborts).

## Follow-up (not in this PR)
- Exclude pending-leave groups from push subscription deltas.
- Distinguish self-leave vs. being kicked (for UI copy).
- Confirm the backend/agent finalizes the remove-commit so leaves don't hang.
- Real-device QA (leave / creator-leave-with-succession / rejoin).

Platform-agnostic behavior spec for Android parity: `docs/plans/leave-a-group.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785503960&installation_id=128169237&pr_number=1132&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1132&signature=a4aa68b6c6252de0384200e90c2969c465977d97a68e0a4efe49a66a930d0dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add group leave with super-admin succession and pending-departure tracking
> - Adds a `ConversationLeaveWriter` that handles MLS self-removal, transferring super-admin to the longest-tenured human successor if the leaver is the sole super-admin, then applies an optimistic local hide.
> - Introduces a `DBMemberDeparture` table and migration to track pending departures; `ConversationWriter` and `IncomingMessageWriter` use these markers to exclude pending leavers from member lists and reconcile stale markers against the live MLS roster.
> - Surfaces a Leave button in `ConversationInfoView` (groups only) with a destructive confirmation alert; `ConversationViewModel.leaveGroupConvo()` drives the flow and posts a left-conversation notification on success.
> - Decodes `ContentTypeLeaveRequest` messages into `DBMessage.Update` records so leave-request events appear as membership updates for other members.
> - Fixes `detailedConversationQuery` and `DBConversationDetails` hydration to return conversations even when the creator's member row is absent (e.g. after the creator leaves).
> - Risk: benign MLS leave errors (already removed, membership ended) are silently classified and swallowed; a hide failure after a successful leave throws `hideFailedAfterLeave` rather than the original MLS error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86e03b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->