### PR TITLE
fix: adds contact names to profile snapshot when direct adding

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -444,6 +444,27 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
                     invitedByInboxId: currentInboxId
                 )
                 try conversationMember.save(db)
+
+                // Seed a per-conversation profile name from the adder's contact
+                // record so the ProfileSnapshot sent below advertises the
+                // directly-added member's name to every other member (agents
+                // especially) instead of "Somebody", until the member
+                // self-attests via their own ProfileUpdate 
+                // Names only. Fill-only: never overwrite an existing profile,
+                // and skip contacts with no stored name. A later ProfileUpdate
+                // from the member wins via the normal inbound name-preservation.
+                let existingProfile = try DBMemberProfile.fetchOne(db, conversationId: conversationId, inboxId: memberInboxId)
+                if existingProfile?.name == nil,
+                   let contactName = try ContactsRepository.contactNameInTransaction(db: db, inboxId: memberInboxId) {
+                    let seededProfile = (existingProfile ?? DBMemberProfile(
+                        conversationId: conversationId,
+                        inboxId: memberInboxId,
+                        name: nil,
+                        avatar: nil
+                    )).with(name: contactName)
+                    try seededProfile.save(db)
+                }
+
                 Log.debug("Added local conversation member \(memberInboxId) to \(conversationId)")
             }
         }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785531942&installation_id=128169237&pr_number=1134&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1134&signature=46016e2f758da96f2b842b49b39d091bab64486b745846b11484339d2474478e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed contact name into member profile snapshot when directly adding members to a conversation
> When a member is added to a conversation, [ConversationMetadataWriter](https://github.com/xmtplabs/convos-ios/pull/1134/files#diff-ce17de6d3ad64e828d2531d31326211c4a7d54f39e9e4e299402b089d206eeaf) now looks up the local contact name and writes it to `DBMemberProfile` if no profile name already exists. This is a fill-only operation — existing profile names are never overwritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa33ec2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->