### PR TITLE
feat(invite): engagement-based keep rule for transient conversations

### DIFF
--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -448,10 +448,11 @@ struct ContactsView: View {
     }
 
     /// Runs the empty-invite teardown for a dismissed new-conversation sheet so
-    /// a "Show an invite code" convo the user closed without messaging or
-    /// adding anyone doesn't linger in the chats list. A no-op for convos that
-    /// gained messages / members, or for the picker-confirm path (those aren't
-    /// embedded-invite convos).
+    /// a "Show an invite code" convo the user closed without engaging doesn't
+    /// linger in the chats list. A no-op for engaged convos -- messages,
+    /// members now or ever, customized metadata, shared invite, scanned code
+    /// (see `EngagementLatches` / `ConversationEngagement`) -- and for the
+    /// picker-confirm path (those aren't embedded-invite convos).
     private func cleanUpDismissedNewConvo() {
         dismissedNewConvo?.cleanUpEmptyEmbeddedInviteIfNeeded()
         dismissedNewConvo = nil

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -25,6 +25,29 @@ struct IdentifiableError: Identifiable {
     }
 }
 
+/// Synchronous keep-signals for a minted conversation, latched by
+/// `NewConversationViewModel` at action time. Any set latch means the
+/// dismiss-time cleanup keeps the conversation.
+///
+/// - `sharedInvite`: the invite link was shared externally (native share
+///   sheet completed, or the in-convo "Share invite link" finished);
+///   deleting the conversation would break the recipient's join.
+/// - `scannedCode`: a recognized code was scanned through this VM; the
+///   scanned agent may not have joined yet (so the conversation can still
+///   read as empty) and a scanned invite join may still be in flight.
+/// - `customizedMetadata`: the user edited the name, description, or image;
+///   set before the async write so a rename-then-dismiss cannot race it.
+/// - `memberJoined`: the conversation had a member besides the local user
+///   at some point this session, even if they left again.
+struct EngagementLatches: OptionSet {
+    let rawValue: Int
+
+    static let sharedInvite: EngagementLatches = EngagementLatches(rawValue: 1 << 0)
+    static let scannedCode: EngagementLatches = EngagementLatches(rawValue: 1 << 1)
+    static let customizedMetadata: EngagementLatches = EngagementLatches(rawValue: 1 << 2)
+    static let memberJoined: EngagementLatches = EngagementLatches(rawValue: 1 << 3)
+}
+
 enum NewConversationMode {
     case newConversation
     case newAgent
@@ -85,6 +108,15 @@ class NewConversationViewModel: Identifiable, Hashable {
         didSet {
             conversationViewModel?.allowsContactCard = !suppressesContactCard
             conversationViewModel?.isInAgentBuilderFlow = isInAgentBuilderFlow
+            // Engagement latches survive the inbox-acquisition VM swap because
+            // they live here; re-wire the callbacks on every inner VM we vend
+            // (mirrors `allowsContactCard` above).
+            conversationViewModel?.onMetadataEdited = { [weak self] in
+                self?.engagement.insert(.customizedMetadata)
+            }
+            conversationViewModel?.onMemberJoined = { [weak self] in
+                self?.engagement.insert(.memberJoined)
+            }
             // Re-arm the optimistic agent overlay on every VM we vend so it
             // survives the placeholder -> real-conversation swap (mirrors
             // `suppressesContactCard` / `isInAgentBuilderFlow` above).
@@ -196,8 +228,8 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// Set when `commitConversationVisibility()` runs before the
     /// auto-created conversation reaches `.ready` (no id to flip yet).
     /// Flushed by `handleStateChange(.ready)`; cleared by
-    /// `deleteConversation()` so a dismissed builder can't promote a
-    /// conversation the user abandoned.
+    /// `tearDownAbandonedFlowTasks()` (both discard shapes) so a dismissed
+    /// builder can't promote a conversation the user abandoned.
     private var pendingVisibilityCommit: Bool = false
 
     /// The `.ready` hook's register(+queued commit) work. Awaited by
@@ -279,28 +311,21 @@ class NewConversationViewModel: Identifiable, Hashable {
     nonisolated(unsafe) private var _reachedJoiningState: Bool = false
     @ObservationIgnored
     private var _cleanedUp: Bool = false
-    /// Set once this conversation's invite link has actually been shared
-    /// externally (native share sheet completed, or the in-convo "Share invite
-    /// link" finished). The empty-conversation teardown keys off this so it
-    /// never deletes a conversation whose invite is already in someone else's
-    /// hands -- doing so would break their join.
+    /// Synchronous keep-signals accumulated over this VM's lifetime; once any
+    /// latch is set the dismiss-time cleanup keeps the conversation instead
+    /// of discarding it. Latches are set at action time -- before the async
+    /// database write lands -- so they cannot lose the race a state check at
+    /// dismiss could (e.g. a rename whose write is still in flight). The
+    /// database-derived gate (`ConversationEngagement` behind
+    /// `session.discardClaimedConversationIfUnengaged`) backstops any path
+    /// that misses a latch. See `EngagementLatches` for what each case means.
     @ObservationIgnored
-    private var didShareInvite: Bool = false
+    private var engagement: EngagementLatches = []
     /// Set when the pending state change was triggered by a scanned QR, so a
     /// successful join / agent-add navigates the user into the resulting
     /// conversation (and dismisses the scanner). Cleared once navigation fires.
     @ObservationIgnored
     private var pendingScanNavigation: Bool = false
-    /// Set the moment a recognized code is scanned, never cleared for this
-    /// VM's lifetime. A conversation that has processed a scan is no longer an
-    /// untouched embedded-invite draft -- a scanned agent may not have joined
-    /// yet (so it still reads as empty) and a scanned invite join may still be
-    /// in flight -- so the empty-convo teardown must keep it. Deliberately
-    /// independent of `onScanResolvedConversation`: surfaces that present this
-    /// VM without the navigation callback (the Contacts tab's embedded-invite
-    /// sheet) still get the protection.
-    @ObservationIgnored
-    private var didHandleScannedCode: Bool = false
     @ObservationIgnored
     private var inboxAcquisitionTask: Task<Void, Never>?
     @ObservationIgnored
@@ -473,12 +498,12 @@ class NewConversationViewModel: Identifiable, Hashable {
         guard !_reachedReadyState, !_reachedJoiningState, !_cleanedUp else { return }
         // Defensive: `.existingConversation` flows should already exit
         // via `_reachedReadyState` (useExisting emits .ready). If that
-        // ever drifts and `deleteConversation` stops being a no-op,
-        // this prevents destroying the real conversation behind the
-        // sheet on dismiss-before-ready.
+        // ever drifts and the discard stops being a no-op, this prevents
+        // destroying the real conversation behind the sheet on
+        // dismiss-before-ready.
         guard !isExistingConversation else { return }
         _cleanedUp = true
-        deleteConversation()
+        discardConversationIfUnengaged()
     }
 
     // MARK: - Inbox Acquisition
@@ -969,17 +994,19 @@ class NewConversationViewModel: Identifiable, Hashable {
 /// lived inline.
 extension NewConversationViewModel {
     /// Discards an embedded-invite conversation ("Show an invite code") that
-    /// the user dismissed without engaging -- nothing sent and nobody joined --
-    /// so the empty convo doesn't pile up in the chats list.
+    /// the user dismissed without engaging, so the empty convo doesn't pile
+    /// up in the chats list.
     ///
     /// The default `cleanUpIfNeeded` keeps any conversation that reached
     /// `.ready`, but an embedded-invite convo is warm-claimed with a pre-minted
     /// invite and reaches `.ready` immediately, so that guard would never fire.
-    /// This gates on real engagement instead -- no sent/received messages and
-    /// no other members -- and discards directly. A convo with messages, a
-    /// joined member,
-    /// or an already-shared invite is kept. Returns true when it handled (kept
-    /// or discarded) the convo so the caller skips the default path.
+    /// This gates on real engagement instead: any `EngagementLatches` latch
+    /// (invite shared, code scanned, metadata customized, member ever joined),
+    /// sent/received messages, or current other members keeps the convo;
+    /// otherwise it goes through the engagement-gated discard, whose
+    /// database-side check backstops any signal the latches missed. Returns
+    /// true when it handled (kept or discarded) the convo so the caller skips
+    /// the default path.
     ///
     /// Message count uses `countMessages`, which counts only real `.messages`
     /// groups -- the conversation's own self-join membership `.update` row is
@@ -987,16 +1014,13 @@ extension NewConversationViewModel {
     @discardableResult
     func cleanUpEmptyEmbeddedInviteIfNeeded() -> Bool {
         guard showsEmbeddedInvite, !_cleanedUp, !isExistingConversation else { return false }
-        // Keep the conversation when its invite was shared externally (deleting
-        // it would break the recipient's join) or when a scan was processed
-        // through it (a scanned agent may not have joined yet, so it can still
-        // read as empty here).
-        guard !didShareInvite, !didHandleScannedCode else { return true }
+        guard engagement.isEmpty else { return true }
         let hasMessages = (conversationViewModel?.messages.countMessages ?? 0) > 0
         let hasOtherMembers = (conversationViewModel?.conversation.membersWithoutCurrent.count ?? 0) > 0
-        guard !hasMessages, !hasOtherMembers else { return true }
+        let everHadOtherMembers = conversationViewModel?.everHadOtherMembers ?? false
+        guard !hasMessages, !hasOtherMembers, !everHadOtherMembers else { return true }
         _cleanedUp = true
-        deleteConversation()
+        discardConversationIfUnengaged()
         return true
     }
 
@@ -1004,7 +1028,7 @@ extension NewConversationViewModel {
     /// `cleanUpEmptyEmbeddedInviteIfNeeded` keeps the conversation instead of
     /// tearing it down and breaking the shared invite.
     func markInviteShared() {
-        didShareInvite = true
+        engagement.insert(.sharedInvite)
     }
 
     func onScanInviteCode() {
@@ -1023,14 +1047,14 @@ extension NewConversationViewModel {
         if let url = URL(string: code), let templateId = DeepLinkHandler.agentTemplateId(from: url) {
             // Marked at scan time, for recognized codes only, so the
             // empty-convo teardown keeps this conversation even when no
-            // navigation callback is wired (see `didHandleScannedCode`). An
+            // navigation callback is wired (see `EngagementLatches`). An
             // unrecognized payload never joins anything, so its convo stays
             // eligible for the normal empty-dismiss cleanup.
-            didHandleScannedCode = true
+            engagement.insert(.scannedCode)
             startAgentTemplateConversation(templateId: templateId)
         } else {
             if InviteURLDetector.detectInviteURL(in: code) != nil {
-                didHandleScannedCode = true
+                engagement.insert(.scannedCode)
             }
             joinConversation(inviteCode: code)
         }
@@ -1074,15 +1098,14 @@ extension NewConversationViewModel {
         try await conversationStateManager.send(text: text)
     }
 
+    /// Unconditional teardown for explicit deletes (the user's "Delete"
+    /// action) and the Agent Builder's deliberate cancel; a deliberate
+    /// delete must never be silently overridden by the engagement gate.
+    /// Implicit dismiss-cleanup routes through
+    /// `discardConversationIfUnengaged()` instead.
     func deleteConversation() {
         Log.info("Deleting conversation")
-        newConversationTask?.cancel()
-        joinConversationTask?.cancel()
-        joinTimeoutTask?.cancel()
-        // A queued visibility commit must not survive dismissal - the user
-        // abandoned the builder, so a late `.ready` shouldn't promote the
-        // conversation into the chats list.
-        pendingVisibilityCommit = false
+        tearDownAbandonedFlowTasks()
         // Drop the conversation row claimed via `prepareNewConversation()`
         // when the user backs out without engaging. Key off
         // `claimedConversationId` so existing-conversation flows
@@ -1097,6 +1120,34 @@ extension NewConversationViewModel {
                 await session.discardClaimedConversation(id: claimedId)
             }
         }
+    }
+
+    /// Implicit-dismiss counterpart of `deleteConversation()`: same task
+    /// teardown, but the claimed row goes through the session's
+    /// engagement-gated discard, which keeps (and commits visible) a
+    /// conversation whose database state shows engagement -- customized
+    /// metadata, chat messages, or a member now or ever -- and only
+    /// destroys a genuinely untouched one.
+    private func discardConversationIfUnengaged() {
+        Log.info("Discarding conversation if unengaged")
+        tearDownAbandonedFlowTasks()
+        if let claimedId = claimedConversationId {
+            Task { [session] in
+                await session.discardClaimedConversationIfUnengaged(id: claimedId)
+            }
+        }
+    }
+
+    /// Shared teardown for both discard shapes: the sheet is going away, so
+    /// in-flight create/join work is cancelled and a queued visibility
+    /// commit must not survive dismissal - the user abandoned the flow, so
+    /// a late `.ready` shouldn't promote the conversation into the chats
+    /// list.
+    private func tearDownAbandonedFlowTasks() {
+        newConversationTask?.cancel()
+        joinConversationTask?.cancel()
+        joinTimeoutTask?.cancel()
+        pendingVisibilityCommit = false
     }
 
     func setDismissAction(_ action: DismissAction) {
@@ -1185,7 +1236,7 @@ extension NewConversationViewModel {
     /// dismiss the scanner and navigate into it. No-op unless the pending state
     /// change came from a scan and the id is settled. The conversation survives
     /// the scanner-sheet dismissal regardless -- `handleScannedCode` already
-    /// marked it (`didHandleScannedCode`) at scan time.
+    /// marked it (`EngagementLatches.scannedCode`) at scan time.
     private func navigateToScannedConversationIfPending(_ conversationId: String) {
         guard pendingScanNavigation, !conversationId.isEmpty,
               let onScanResolvedConversation else { return }
@@ -1194,17 +1245,20 @@ extension NewConversationViewModel {
     }
 
     /// A scanned invite joins a different conversation, superseding the one this
-    /// embedded new-convo flow claimed up front. The state machine deletes the
-    /// superseded conversation's local rows during the join, but releasing the
+    /// embedded new-convo flow claimed up front. The state machine discards the
+    /// superseded conversation's local rows during the join (unless it is
+    /// engaged -- see `cleanUpPreviousConversationIfNeeded`), but releasing the
     /// claimed cache reservation and leaving its published MLS group are this
     /// VM's responsibility -- otherwise the group is stranded on the network and
-    /// the reservation leaks. Discard the claimed id (and clear it so the joined
-    /// conversation is kept normally on dismiss).
+    /// the reservation leaks. Discard the claimed id through the engagement
+    /// gate -- a customized conversation (e.g. renamed before the scan) is kept
+    /// rather than destroyed -- and clear it so the joined conversation is kept
+    /// normally on dismiss.
     private func discardSupersededClaimedConversationIfNeeded(_ result: ConversationReadyResult) {
         guard let supersededId = claimedConversationId, supersededId != result.conversationId else { return }
         claimedConversationId = nil
         Task { [session] in
-            await session.discardClaimedConversation(id: supersededId)
+            await session.discardClaimedConversationIfUnengaged(id: supersededId)
         }
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -412,6 +412,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     private(set) var conversation: Conversation {
         didSet {
             messagesListRepository.currentOtherMemberCount = conversation.membersWithoutCurrent.count
+            latchEverHadOtherMembersIfNeeded()
             syncVerifiedAgentToRepo()
             trackAssistantJoinedIfNeeded(oldValue: oldValue)
             presentingConversationForked = shouldPresentConversationForked
@@ -428,6 +429,33 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             if !isEditingConversationName { editingConversationName = conversation.name ?? "" }
             if !isEditingDescription { editingDescription = conversation.description ?? "" }
         }
+    }
+
+    /// Invoked synchronously the moment a metadata edit (name, description,
+    /// or image) is about to be written -- before the async writer task
+    /// spawns, and only when a change will actually be written. Wired by
+    /// `NewConversationViewModel` in its inner-VM forwarding block so the
+    /// engagement latch survives the inbox-acquisition VM swap; the latch
+    /// keeps a customized minted conversation from being discarded on
+    /// dismiss even when the write has not landed in the database yet.
+    @ObservationIgnored
+    var onMetadataEdited: (() -> Void)?
+    /// Invoked the first time the conversation gains a member besides the
+    /// local user. Wired like `onMetadataEdited`; feeds the engagement
+    /// latch so a joined-then-left member still keeps the conversation.
+    @ObservationIgnored
+    var onMemberJoined: (() -> Void)?
+    /// Latched true the first time `membersWithoutCurrent` becomes
+    /// non-empty; never reset for this VM's lifetime. The members table
+    /// only mirrors current membership, so this is the in-session record
+    /// that someone was here even if they left again.
+    @ObservationIgnored
+    private(set) var everHadOtherMembers: Bool = false
+
+    private func latchEverHadOtherMembersIfNeeded() {
+        guard !everHadOtherMembers, !conversation.membersWithoutCurrent.isEmpty else { return }
+        everHadOtherMembers = true
+        onMemberJoined?()
     }
 
     /// Set to `false` by the Agent Builder right before `Make` is tapped
@@ -523,10 +551,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let name = editingConversationName.trimmingCharacters(in: .whitespacesAndNewlines)
         let desc = editingDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         let toggle = _editingIncludeInfoInPublicPreview
+        let willWriteName = !name.isEmpty && name != (conversation.name ?? "")
+        let willWriteDesc = !desc.isEmpty && desc != (conversation.description ?? "")
+        if willWriteName || willWriteDesc {
+            onMetadataEdited?()
+        }
         Task { [weak self, metadataWriter, conversation] in
             guard let self else { return }
-            if !name.isEmpty, name != (conversation.name ?? "") { try? await metadataWriter.updateName(name, for: conversation.id) }
-            if !desc.isEmpty, desc != (conversation.description ?? "") { try? await metadataWriter.updateDescription(desc, for: conversation.id) }
+            if willWriteName { try? await metadataWriter.updateName(name, for: conversation.id) }
+            if willWriteDesc { try? await metadataWriter.updateDescription(desc, for: conversation.id) }
             if let toggle, toggle != conversation.includeInfoInPublicPreview { self.updateIncludeInfoInPublicPreview(toggle) }
         }
     }
@@ -2655,6 +2688,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         editingConversationName = trimmedConversationName
 
         if trimmedConversationName != (conversation.name ?? "") {
+            onMetadataEdited?()
             Task { [weak self] in
                 guard let self else { return }
                 do {
@@ -2669,6 +2703,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         }
 
         if isConversationImageDirty, let conversationImage = conversationImage {
+            onMetadataEdited?()
             // Key by the conversation id, not `imageCacheIdentifier`: before
             // the image upload persists, that identifier resolves to the other
             // member's inbox id and would cache this image as their avatar.
@@ -2692,6 +2727,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         editingDescription = trimmedConversationDescription
 
         if trimmedConversationDescription != (conversation.description ?? "") {
+            onMetadataEdited?()
             Task { [weak self] in
                 guard let self else { return }
                 do {
@@ -3759,14 +3795,19 @@ extension ConversationViewModel {
         isUpdatingPublicPreview = true
         let pendingName = editingConversationName.trimmingCharacters(in: .whitespacesAndNewlines)
         let pendingDesc = editingDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let willWriteName = !pendingName.isEmpty && pendingName != (conversation.name ?? "")
+        let willWriteDesc = !pendingDesc.isEmpty && pendingDesc != (conversation.description ?? "")
+        if willWriteName || willWriteDesc {
+            onMetadataEdited?()
+        }
         Task { [weak self, metadataWriter, conversation] in
             guard let self else { return }
             defer { self.isUpdatingPublicPreview = false }
             do {
-                if !pendingName.isEmpty, pendingName != (conversation.name ?? "") {
+                if willWriteName {
                     try await metadataWriter.updateName(pendingName, for: conversation.id)
                 }
-                if !pendingDesc.isEmpty, pendingDesc != (conversation.description ?? "") {
+                if willWriteDesc {
                     try await metadataWriter.updateDescription(pendingDesc, for: conversation.id)
                 }
                 try await metadataWriter.updateIncludeInfoInPublicPreview(enabled, for: conversation.id)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -981,10 +981,28 @@ extension ConversationStateMachine {
             return
         }
 
-        Log.debug("Cleaning up previous conversation: \(previousResult.conversationId)")
+        // An engaged previous conversation (customized metadata, chat
+        // messages, or a member now or ever) is user data, not a disposable
+        // pre-claimed draft: joining another conversation from inside it
+        // must not destroy it. The view-model layer's engagement-gated
+        // discard handles the cache-claim release for kept rows.
+        let previousConversationId = previousResult.conversationId
+        let isEngaged = (try? await databaseWriter.read { db in
+            try ConversationEngagement.isEngaged(
+                db,
+                conversationId: previousConversationId,
+                currentInboxId: DBInbox.currentInboxId(db)
+            )
+        }) ?? true
+        guard !isEngaged else {
+            Log.info("Keeping engaged previous conversation: \(previousConversationId)")
+            return
+        }
+
+        Log.debug("Cleaning up previous conversation: \(previousConversationId)")
         do {
             try await cleanUp(
-                conversationId: previousResult.conversationId,
+                conversationId: previousConversationId,
                 client: client,
                 apiClient: apiClient
             )

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -31,6 +31,9 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
     public func discardClaimedConversation(id conversationId: String) async {
     }
 
+    public func discardClaimedConversationIfUnengaged(id conversationId: String) async {
+    }
+
     public func deleteAllInboxes() async throws {
     }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/ConversationEngagement.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/ConversationEngagement.swift
@@ -5,11 +5,11 @@ import GRDB
 /// "engaged" - i.e. whether implicit dismiss-cleanup is allowed to discard
 /// it. A freshly pooled row is written with all-nil metadata
 /// (`UnusedConversationCache.writeUnusedConversationRow`), no messages, and
-/// the creator as its only member, so engagement is detectable as any
+/// the creator as its only member, so engagement is detectable as a
 /// deviation from that baseline:
 ///
-/// - any metadata customization: non-nil, non-empty `name`, `description`,
-///   or `conversationEmoji`, or a non-nil `imageURLString`;
+/// - metadata customization: non-nil, non-empty `name`, `description`, or
+///   `imageURLString`;
 /// - any chat message (the `.messages` grouping notion the messages list
 ///   counts - system rows like membership updates do not qualify);
 /// - another member right now, or ever
@@ -60,16 +60,24 @@ enum ConversationEngagement {
         return try hasChatMessages(db, conversationId: conversationId)
     }
 
-    /// Non-nil, non-empty on any of the four customizable columns. The pool
+    /// Non-nil, non-empty on any of the user-customizable columns. The pool
     /// writes them all nil; "New Convo" is a UI-only fallback that never
     /// reaches the database. Empty strings can appear when a user reverts a
     /// customization (e.g. clears the name), and count as not customized so
     /// a reverted conversation found on a later launch is discardable again.
+    ///
+    /// `conversationEmoji` is deliberately excluded: every minted
+    /// conversation gets an auto-assigned emoji at creation
+    /// (`ensureConversationEmoji` in the conversation state machine), so a
+    /// non-nil emoji says nothing about user intent. There is no in-app
+    /// emoji editor today; if one lands, it must latch engagement at the
+    /// view-model layer (`onMetadataEdited`) and this check can learn to
+    /// compare against the auto-assigned value.
     static func hasCustomizedMetadata(_ conversation: DBConversation) -> Bool {
-        if isNonEmpty(conversation.name) || isNonEmpty(conversation.description) || isNonEmpty(conversation.conversationEmoji) {
+        if isNonEmpty(conversation.name) || isNonEmpty(conversation.description) {
             return true
         }
-        return conversation.imageURLString != nil
+        return isNonEmpty(conversation.imageURLString)
     }
 
     private static func hasChatMessages(_ db: Database, conversationId: String) throws -> Bool {

--- a/ConvosCore/Sources/ConvosCore/Messaging/ConversationEngagement.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/ConversationEngagement.swift
@@ -1,0 +1,89 @@
+import Foundation
+import GRDB
+
+/// Single source of truth for whether a minted conversation counts as
+/// "engaged" - i.e. whether implicit dismiss-cleanup is allowed to discard
+/// it. A freshly pooled row is written with all-nil metadata
+/// (`UnusedConversationCache.writeUnusedConversationRow`), no messages, and
+/// the creator as its only member, so engagement is detectable as any
+/// deviation from that baseline:
+///
+/// - any metadata customization: non-nil, non-empty `name`, `description`,
+///   or `conversationEmoji`, or a non-nil `imageURLString`;
+/// - any chat message (the `.messages` grouping notion the messages list
+///   counts - system rows like membership updates do not qualify);
+/// - another member right now, or ever
+///   (`ConversationLocalState.hasHadOtherMembers` survives the member's
+///   row being deleted on departure sync).
+///
+/// Unsent composer drafts deliberately do not count: draft text is not
+/// persisted anywhere, so keeping the conversation for one would surface an
+/// empty row with the draft lost. If drafts ever gain persistence, add a
+/// draft check here.
+///
+/// Used by `SessionManager.discardClaimedConversationIfUnengaged` as the
+/// authoritative gate before a claimed conversation is destroyed. The view
+/// model layer keeps its own synchronous latches for in-flight writes that
+/// have not landed in the database yet.
+enum ConversationEngagement {
+    /// Content types that render inside `.messages` groups in the messages
+    /// list - the same set `[MessagesListItemType].countMessages` counts.
+    /// Membership/metadata updates and agent/connection system rows render
+    /// as their own list item types and are excluded.
+    static let chatMessageContentTypes: [MessageContentType] = [
+        .text, .emoji, .attachments, .invite, .agentShare, .linkPreview,
+    ]
+
+    static func isEngaged(_ db: Database, conversationId: String, currentInboxId: String?) throws -> Bool {
+        guard let conversation = try DBConversation.fetchOne(db, key: conversationId) else {
+            return false
+        }
+        if hasCustomizedMetadata(conversation) {
+            return true
+        }
+        // Minted rows are created by the local inbox, so the creator is a
+        // safe fallback identity for "self" when no inbox row exists yet.
+        let selfInboxId = currentInboxId ?? conversation.creatorId
+        let otherMemberCount = try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .filter(DBConversationMember.Columns.inboxId != selfInboxId)
+            .fetchCount(db)
+        if otherMemberCount > 0 {
+            return true
+        }
+        let localState = try ConversationLocalState
+            .filter(ConversationLocalState.Columns.conversationId == conversationId)
+            .fetchOne(db)
+        if localState?.hasHadOtherMembers == true {
+            return true
+        }
+        return try hasChatMessages(db, conversationId: conversationId)
+    }
+
+    /// Non-nil, non-empty on any of the four customizable columns. The pool
+    /// writes them all nil; "New Convo" is a UI-only fallback that never
+    /// reaches the database. Empty strings can appear when a user reverts a
+    /// customization (e.g. clears the name), and count as not customized so
+    /// a reverted conversation found on a later launch is discardable again.
+    static func hasCustomizedMetadata(_ conversation: DBConversation) -> Bool {
+        if isNonEmpty(conversation.name) || isNonEmpty(conversation.description) || isNonEmpty(conversation.conversationEmoji) {
+            return true
+        }
+        return conversation.imageURLString != nil
+    }
+
+    private static func hasChatMessages(_ db: Database, conversationId: String) throws -> Bool {
+        let chatTypes = chatMessageContentTypes.map(\.rawValue)
+        let count = try DBMessage
+            .filter(DBMessage.Columns.conversationId == conversationId)
+            .filter(DBMessage.Columns.messageType != DBMessageType.reaction.rawValue)
+            .filter(chatTypes.contains(DBMessage.Columns.contentType))
+            .fetchCount(db)
+        return count > 0
+    }
+
+    private static func isNonEmpty(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return !value.isEmpty
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -497,7 +497,8 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).save(db, onConflict: .ignore)
 
         return dbConversation

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -928,6 +928,44 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     }
 }
 
+// MARK: - Engagement-gated discard
+
+extension SessionManager {
+    public func discardClaimedConversationIfUnengaged(id conversationId: String) async {
+        guard !DBConversation.isDraft(id: conversationId) else {
+            await discardClaimedConversation(id: conversationId)
+            return
+        }
+        let isEngaged: Bool
+        do {
+            isEngaged = try await databaseReader.read { db in
+                try ConversationEngagement.isEngaged(
+                    db,
+                    conversationId: conversationId,
+                    currentInboxId: DBInbox.currentInboxId(db)
+                )
+            }
+        } catch {
+            // Destroying user data on a failed read is worse than leaving a
+            // row behind, so an engagement check that errors keeps the
+            // conversation.
+            Log.error("Engagement check failed for \(conversationId), keeping the conversation: \(error)")
+            isEngaged = true
+        }
+        guard isEngaged else {
+            await discardClaimedConversation(id: conversationId)
+            return
+        }
+        // The engaged path must never reach the consent-deny in
+        // `discardClaimedConversation`: the chats list filters on allowed
+        // consent, so deny-then-keep would hide the kept conversation anyway.
+        // Committing ensures visibility (idempotent if already committed) and
+        // releases the cache claim.
+        await commitClaimedConversation(id: conversationId)
+        Log.info("Kept engaged claimed conversation \(conversationId) instead of discarding it")
+    }
+}
+
 // MARK: - Stale-stranger GC
 
 extension SessionManager {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -76,17 +76,18 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     /// by the cache again.
     func registerClaimedConversation(id conversationId: String) async
 
-    /// Drops a conversation that was claimed via `prepareNewConversation()` but
-    /// never engaged with by the user — typically called from the new-
-    /// conversation / Agent Builder X-cancel path when no messages have
-    /// been sent. Deletes the local `DBConversation` row and its dependent
-    /// rows (members, profiles, local state) so the conversation disappears
-    /// from the conversations list, and releases the in-memory cache claim
-    /// so the next prewarm runs. The single-inbox refactor turned the
-    /// older `session.deleteInbox` cleanup into a no-op (it would destroy the
-    /// user's account); this is the replacement scoped to a single
-    /// conversation. Draft ids are a no-op — drafts don't have on-disk rows
-    /// the user can see.
+    /// Drops a conversation that was claimed via `prepareNewConversation()`,
+    /// unconditionally — the entry point for the explicit user Delete action
+    /// and the Agent Builder's deliberate cancel. Implicit dismiss-cleanup
+    /// should call `discardClaimedConversationIfUnengaged` instead so an
+    /// engaged conversation is kept. Deletes the local `DBConversation` row
+    /// and its dependent rows (members, profiles, local state) so the
+    /// conversation disappears from the conversations list, and releases the
+    /// in-memory cache claim so the next prewarm runs. The single-inbox
+    /// refactor turned the older `session.deleteInbox` cleanup into a no-op
+    /// (it would destroy the user's account); this is the replacement scoped
+    /// to a single conversation. Draft ids are a no-op — drafts don't have
+    /// on-disk rows the user can see.
     func discardClaimedConversation(id conversationId: String) async
 
     /// Engagement-gated variant of `discardClaimedConversation` for implicit

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -89,6 +89,16 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     /// the user can see.
     func discardClaimedConversation(id conversationId: String) async
 
+    /// Engagement-gated variant of `discardClaimedConversation` for implicit
+    /// cleanup paths (sheet dismiss, flow teardown, superseded claims). Reads
+    /// `ConversationEngagement.isEngaged` first: an engaged conversation
+    /// (customized metadata, chat messages, another member now or ever) is
+    /// committed visible and kept instead of destroyed; an untouched one goes
+    /// through the full discard. Explicit user deletes should keep calling
+    /// the unconditional `discardClaimedConversation` - a deliberate delete
+    /// must never be silently overridden by the gate.
+    func discardClaimedConversationIfUnengaged(id conversationId: String) async
+
     func deleteAllInboxes() async throws
     func deleteAllInboxesWithProgress() -> AsyncThrowingStream<InboxDeletionProgress, Error>
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/ConversationLocalState.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/ConversationLocalState.swift
@@ -16,6 +16,7 @@ struct ConversationLocalState: Codable, FetchableRecord, PersistableRecord, Hash
         static let hidesInviteCard: Column = Column(CodingKeys.hidesInviteCard)
         static let leftHostedInviteSession: Column = Column(CodingKeys.leftHostedInviteSession)
         static let wasRemoved: Column = Column(CodingKeys.wasRemoved)
+        static let hasHadOtherMembers: Column = Column(CodingKeys.hasHadOtherMembers)
     }
 
     let conversationId: String
@@ -27,6 +28,13 @@ struct ConversationLocalState: Codable, FetchableRecord, PersistableRecord, Hash
     let hidesInviteCard: Bool
     let leftHostedInviteSession: Bool
     let wasRemoved: Bool
+    /// Set-once high-water mark: true once the conversation has ever had a
+    /// member besides the local inbox. Current membership rows are deleted
+    /// when a member leaves, so this is the only queryable record of a
+    /// joined-then-departed member. Local-only, so network sync can never
+    /// clobber it; deleted with the conversation. Read by
+    /// `ConversationEngagement.isEngaged`.
+    let hasHadOtherMembers: Bool
 
     static let conversationForeignKey: ForeignKey = ForeignKey([Columns.conversationId], to: [DBConversation.Columns.id])
 
@@ -47,7 +55,8 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
     func with(isPinned: Bool) -> Self {
@@ -60,7 +69,8 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
     func with(isMuted: Bool) -> Self {
@@ -73,7 +83,8 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
     func with(pinnedOrder: Int?) -> Self {
@@ -86,7 +97,8 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
     func with(hidesInviteCard: Bool) -> Self {
@@ -99,7 +111,8 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
     func with(leftHostedInviteSession: Bool) -> Self {
@@ -112,7 +125,8 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
     func with(wasRemoved: Bool) -> Self {
@@ -125,7 +139,22 @@ extension ConversationLocalState {
             pinnedOrder: pinnedOrder,
             hidesInviteCard: hidesInviteCard,
             leftHostedInviteSession: leftHostedInviteSession,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
+        )
+    }
+    func with(hasHadOtherMembers: Bool) -> Self {
+        .init(
+            conversationId: conversationId,
+            isPinned: isPinned,
+            isUnread: isUnread,
+            isUnreadUpdatedAt: isUnreadUpdatedAt,
+            isMuted: isMuted,
+            pinnedOrder: pinnedOrder,
+            hidesInviteCard: hidesInviteCard,
+            leftHostedInviteSession: leftHostedInviteSession,
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: hasHadOtherMembers
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -209,6 +209,34 @@ extension SharedDatabaseMigrator {
         return migrator
     }
 
+    /// Set-once high-water mark: true once a conversation has ever had a
+    /// member besides the local inbox. Member rows are deleted on departure
+    /// sync, so without this flag a joined-then-left conversation is
+    /// indistinguishable from an untouched draft - and the engagement gate
+    /// (`ConversationEngagement`) would let implicit cleanup discard it.
+    ///
+    /// The column defaults to false; the backfill flags conversations that
+    /// currently hold a member row for an inbox other than the local one.
+    /// Departed-member history cannot be reconstructed on upgrade, so
+    /// pre-migration joined-then-left conversations start false - they are
+    /// still protected by their messages or metadata in practice. Extracted
+    /// as an internal static helper so the migration test can exercise the
+    /// real upgrade path without tripping the DEBUG
+    /// `eraseDatabaseOnSchemaChange`.
+    static func addConversationLocalStateHasHadOtherMembers(_ db: Database) throws {
+        try db.alter(table: "conversationLocalState") { t in
+            t.add(column: "hasHadOtherMembers", .boolean).notNull().defaults(to: false)
+        }
+        try db.execute(sql: """
+            UPDATE conversationLocalState
+            SET hasHadOtherMembers = 1
+            WHERE conversationId IN (
+                SELECT conversationId FROM conversation_members
+                WHERE inboxId NOT IN (SELECT inboxId FROM inbox)
+            )
+            """)
+    }
+
     private static func registerConnectionGrantMigrations(on migrator: inout DatabaseMigrator) {
         migrator.registerMigration("addConnectionGrantBackendGrantId", migrate: Self.addConnectionGrantBackendGrantId)
         migrator.registerMigration("addConnectionGrantBundleScope", migrate: Self.addConnectionGrantBundleScope)
@@ -219,6 +247,10 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration(
             "addConversationLocalStateLeftHostedInviteSession",
             migrate: Self.addConversationLocalStateLeftHostedInviteSession
+        )
+        migrator.registerMigration(
+            "addConversationLocalStateHasHadOtherMembers",
+            migrate: Self.addConversationLocalStateHasHadOtherMembers
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLocalStateWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationLocalStateWriter.swift
@@ -55,7 +55,8 @@ final class ConversationLocalStateWriter: ConversationLocalStateWriterProtocol, 
                     pinnedOrder: nil,
                     hidesInviteCard: false,
                     leftHostedInviteSession: false,
-                    wasRemoved: false
+                    wasRemoved: false,
+                    hasHadOtherMembers: false
                 )
 
             let pinnedOrder: Int? = if isPinned {
@@ -117,7 +118,8 @@ final class ConversationLocalStateWriter: ConversationLocalStateWriterProtocol, 
                     pinnedOrder: nil,
                     hidesInviteCard: false,
                     leftHostedInviteSession: false,
-                    wasRemoved: false
+                    wasRemoved: false,
+                    hasHadOtherMembers: false
                 )
             let updated = update(current)
             try updated.save(db)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -446,6 +446,11 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
                 try conversationMember.save(db)
                 Log.debug("Added local conversation member \(memberInboxId) to \(conversationId)")
             }
+            try ConversationWriter.markHasHadOtherMembersIfNeeded(
+                conversationId: conversationId,
+                currentMemberInboxIds: Set(memberInboxIds),
+                in: db
+            )
         }
 
         Log.info("Added members to conversation \(conversationId): \(memberInboxIds)")

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -216,7 +216,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 pinnedOrder: nil,
                 hidesInviteCard: false,
                 leftHostedInviteSession: false,
-                wasRemoved: false
+                wasRemoved: false,
+                hasHadOtherMembers: false
             )
             try localState.save(db)
 
@@ -346,7 +347,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         )
         try localState.insert(db, onConflict: .ignore)
 
@@ -360,6 +362,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         }
 
         try Self.clearRemovedMarkerIfMember(
+            conversationId: prepared.dbConversation.id,
+            currentMemberInboxIds: currentMemberInboxIds,
+            in: db
+        )
+
+        try Self.markHasHadOtherMembersIfNeeded(
             conversationId: prepared.dbConversation.id,
             currentMemberInboxIds: currentMemberInboxIds,
             in: db
@@ -416,6 +424,30 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             .filter(ConversationLocalState.Columns.conversationId == conversationId)
             .filter(ConversationLocalState.Columns.wasRemoved == true)
             .updateAll(db, ConversationLocalState.Columns.wasRemoved.set(to: false))
+    }
+
+    /// Latches the set-once `hasHadOtherMembers` high-water mark when the
+    /// synced member list contains an inbox besides the local one. Member
+    /// rows are deleted when a member leaves, so this persisted flag is the
+    /// only durable record that the conversation ever had a second member -
+    /// the engagement gate reads it to keep such conversations from being
+    /// discarded as untouched drafts. Only ever writes true; the flag is
+    /// never reset. Static for unit-testability, mirroring
+    /// `clearRemovedMarkerIfMember`.
+    static func markHasHadOtherMembersIfNeeded(
+        conversationId: String,
+        currentMemberInboxIds: Set<String>,
+        in db: Database
+    ) throws {
+        guard let localInboxId = try DBInbox.currentInboxId(db) else {
+            Log.warning("markHasHadOtherMembersIfNeeded: no current inbox, skipping for \(conversationId)")
+            return
+        }
+        guard currentMemberInboxIds.contains(where: { $0 != localInboxId }) else { return }
+        try ConversationLocalState
+            .filter(ConversationLocalState.Columns.conversationId == conversationId)
+            .filter(ConversationLocalState.Columns.hasHadOtherMembers == false)
+            .updateAll(db, ConversationLocalState.Columns.hasHadOtherMembers.set(to: true))
     }
 
     /// Post-persist side effects the stream path runs after each individual

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/IncomingMessageWriter.swift
@@ -213,7 +213,8 @@ class IncomingMessageWriter: IncomingMessageWriterProtocol, @unchecked Sendable 
                 pinnedOrder: nil,
                 hidesInviteCard: false,
                 leftHostedInviteSession: false,
-                wasRemoved: false
+                wasRemoved: false,
+                hasHadOtherMembers: false
             )
         guard !current.wasRemoved else { return }
         // Unpinning here frees the pin slot a hidden conversation would

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
@@ -598,7 +598,8 @@ private struct HydrationHarness {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).insert(db)
 
         for (index, inboxId) in ([currentInboxId] + otherInboxIds).enumerated() {

--- a/ConvosCore/Tests/ConvosCoreTests/ChronologicalSortIdTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ChronologicalSortIdTests.swift
@@ -430,7 +430,8 @@ struct ChronologicalSortIdTests {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).insert(db)
 
         try DBConversationMember(

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationEngagementTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationEngagementTests.swift
@@ -153,20 +153,29 @@ struct ConversationEngagementTests {
         let results: [Bool] = try dbManager.dbWriter.write { db in
             try Self.seedPoolConversation(db: db, id: "named", name: "Keep Me")
             try Self.seedPoolConversation(db: db, id: "described", description: "About us")
-            try Self.seedPoolConversation(db: db, id: "emojied", emoji: "🎉")
             try Self.seedPoolConversation(db: db, id: "pictured", imageURLString: "https://example.com/pic.jpg")
-            return try ["named", "described", "emojied", "pictured"].map { (id: String) -> Bool in
+            return try ["named", "described", "pictured"].map { (id: String) -> Bool in
                 try Self.isEngaged(db, id: id)
             }
         }
-        #expect(results == [true, true, true, true])
+        #expect(results == [true, true, true])
+    }
+
+    @Test("The auto-assigned conversation emoji does not count as customization")
+    func autoAssignedEmojiNotEngaged() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo", emoji: "🎉")
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == false)
     }
 
     @Test("Empty-string metadata does not count as customization")
     func emptyStringMetadataNotEngaged() throws {
         let dbManager = MockDatabaseManager.makeTestDatabase()
         let engaged = try dbManager.dbWriter.write { db in
-            try Self.seedPoolConversation(db: db, id: "convo", name: "", description: "", emoji: "")
+            try Self.seedPoolConversation(db: db, id: "convo", name: "", description: "", imageURLString: "")
             return try Self.isEngaged(db, id: "convo")
         }
         #expect(engaged == false)

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationEngagementTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationEngagementTests.swift
@@ -1,0 +1,358 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the engagement keep rule: `ConversationEngagement.isEngaged`
+/// (the predicate the guarded discard reads), the `hasHadOtherMembers`
+/// high-water mark set points, the migration backfill, and
+/// `SessionManager.discardClaimedConversationIfUnengaged`'s keep path.
+@Suite("Conversation engagement keep rule", .serialized)
+struct ConversationEngagementTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let otherInboxId: String = "inbox-other"
+
+    // MARK: - Seeding
+
+    private static func seedInbox(db: Database) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+    }
+
+    /// Seeds a conversation shaped like a fresh pool row: all-nil metadata,
+    /// the local inbox as sole member, no messages. Parameters deviate from
+    /// that baseline per test.
+    private static func seedPoolConversation(
+        db: Database,
+        id: String,
+        name: String? = nil,
+        description: String? = nil,
+        emoji: String? = nil,
+        imageURLString: String? = nil,
+        isUnused: Bool = true,
+        hasHadOtherMembers: Bool = false,
+        includeOtherMember: Bool = false
+    ) throws {
+        try seedInbox(db: db)
+
+        try DBConversation(
+            id: id,
+            clientConversationId: id,
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: name,
+            description: description,
+            imageURLString: imageURLString,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: true,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: emoji,
+            imageLastRenewed: nil,
+            isUnused: isUnused,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: Date.distantPast,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            leftHostedInviteSession: false,
+            wasRemoved: false,
+            hasHadOtherMembers: hasHadOtherMembers
+        ).insert(db)
+
+        var memberInboxIds: [String] = [currentInboxId]
+        if includeOtherMember {
+            memberInboxIds.append(otherInboxId)
+        }
+        for inboxId in memberInboxIds {
+            try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: inboxId == currentInboxId ? .superAdmin : .member,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            ).insert(db)
+        }
+    }
+
+    private static func seedMessage(
+        db: Database,
+        id: String,
+        conversationId: String,
+        contentType: MessageContentType,
+        messageType: DBMessageType = .original
+    ) throws {
+        try DBMessage(
+            id: id,
+            clientMessageId: id,
+            conversationId: conversationId,
+            senderId: currentInboxId,
+            dateNs: 1,
+            date: Date(),
+            sortId: nil,
+            status: .published,
+            messageType: messageType,
+            contentType: contentType,
+            text: contentType == .text ? "hello" : nil,
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            attachmentUrls: [],
+            update: nil
+        ).insert(db)
+    }
+
+    private static func isEngaged(_ db: Database, id: String) throws -> Bool {
+        try ConversationEngagement.isEngaged(db, conversationId: id, currentInboxId: currentInboxId)
+    }
+
+    // MARK: - isEngaged truth table
+
+    @Test("Fresh pool row is not engaged")
+    func freshPoolRowNotEngaged() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo")
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == false)
+    }
+
+    @Test("Missing conversation is not engaged")
+    func missingConversationNotEngaged() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.isEngaged(db, id: "missing")
+        }
+        #expect(engaged == false)
+    }
+
+    @Test("Each customized metadata field marks the conversation engaged")
+    func metadataCustomizationEngages() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let results: [Bool] = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "named", name: "Keep Me")
+            try Self.seedPoolConversation(db: db, id: "described", description: "About us")
+            try Self.seedPoolConversation(db: db, id: "emojied", emoji: "🎉")
+            try Self.seedPoolConversation(db: db, id: "pictured", imageURLString: "https://example.com/pic.jpg")
+            return try ["named", "described", "emojied", "pictured"].map { (id: String) -> Bool in
+                try Self.isEngaged(db, id: id)
+            }
+        }
+        #expect(results == [true, true, true, true])
+    }
+
+    @Test("Empty-string metadata does not count as customization")
+    func emptyStringMetadataNotEngaged() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo", name: "", description: "", emoji: "")
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == false)
+    }
+
+    @Test("A chat message marks the conversation engaged")
+    func chatMessageEngages() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo")
+            try Self.seedMessage(db: db, id: "m1", conversationId: "convo", contentType: .text)
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == true)
+    }
+
+    @Test("Membership-update rows alone do not engage")
+    func updateOnlyRowsNotEngaged() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo")
+            try Self.seedMessage(db: db, id: "u1", conversationId: "convo", contentType: .update)
+            try Self.seedMessage(db: db, id: "u2", conversationId: "convo", contentType: .connectionEvent)
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == false)
+    }
+
+    @Test("A current other member marks the conversation engaged")
+    func otherMemberEngages() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo", includeOtherMember: true)
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == true)
+    }
+
+    @Test("hasHadOtherMembers keeps a joined-then-left conversation engaged")
+    func hasHadOtherMembersEngages() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let engaged = try dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "convo", hasHadOtherMembers: true)
+            return try Self.isEngaged(db, id: "convo")
+        }
+        #expect(engaged == true)
+    }
+
+    // MARK: - markHasHadOtherMembersIfNeeded
+
+    @Test("Synced member list with another inbox latches the flag")
+    func syncedOtherMemberLatchesFlag() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let state = try dbManager.dbWriter.write { db -> ConversationLocalState? in
+            try Self.seedPoolConversation(db: db, id: "convo")
+            try ConversationWriter.markHasHadOtherMembersIfNeeded(
+                conversationId: "convo",
+                currentMemberInboxIds: [Self.currentInboxId, Self.otherInboxId],
+                in: db
+            )
+            return try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == "convo")
+                .fetchOne(db)
+        }
+        #expect(state?.hasHadOtherMembers == true)
+    }
+
+    @Test("Solo member list leaves the flag unset")
+    func soloMemberListLeavesFlagUnset() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let state = try dbManager.dbWriter.write { db -> ConversationLocalState? in
+            try Self.seedPoolConversation(db: db, id: "convo")
+            try ConversationWriter.markHasHadOtherMembersIfNeeded(
+                conversationId: "convo",
+                currentMemberInboxIds: [Self.currentInboxId],
+                in: db
+            )
+            return try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == "convo")
+                .fetchOne(db)
+        }
+        #expect(state?.hasHadOtherMembers == false)
+    }
+
+    @Test("Flag survives the member leaving (solo sync after a two-member sync)")
+    func flagSurvivesMemberDeparture() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let result = try dbManager.dbWriter.write { db -> (flag: Bool?, engaged: Bool) in
+            try Self.seedPoolConversation(db: db, id: "convo", includeOtherMember: true)
+            try ConversationWriter.markHasHadOtherMembersIfNeeded(
+                conversationId: "convo",
+                currentMemberInboxIds: [Self.currentInboxId, Self.otherInboxId],
+                in: db
+            )
+            // Departure sync: the member row is deleted and the next synced
+            // member list is solo again.
+            try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == "convo")
+                .filter(DBConversationMember.Columns.inboxId == Self.otherInboxId)
+                .deleteAll(db)
+            try ConversationWriter.markHasHadOtherMembersIfNeeded(
+                conversationId: "convo",
+                currentMemberInboxIds: [Self.currentInboxId],
+                in: db
+            )
+            let state = try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == "convo")
+                .fetchOne(db)
+            return (state?.hasHadOtherMembers, try Self.isEngaged(db, id: "convo"))
+        }
+        #expect(result.flag == true)
+        #expect(result.engaged == true)
+    }
+
+    // MARK: - Migration backfill
+
+    @Test("Backfill flags conversations that currently hold a non-local member row")
+    func migrationBackfill() throws {
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            // Minimal prior schema: only the tables the migration touches.
+            try db.create(table: "inbox") { t in
+                t.column("inboxId", .text).notNull().primaryKey()
+            }
+            try db.create(table: "conversationLocalState") { t in
+                t.column("conversationId", .text).notNull().primaryKey()
+            }
+            try db.create(table: "conversation_members") { t in
+                t.column("conversationId", .text).notNull()
+                t.column("inboxId", .text).notNull()
+            }
+            try db.execute(sql: "INSERT INTO inbox (inboxId) VALUES ('inbox-current')")
+            // Solo minted conversation: only the local inbox as a member.
+            try db.execute(sql: "INSERT INTO conversationLocalState (conversationId) VALUES ('solo')")
+            try db.execute(sql: "INSERT INTO conversation_members VALUES ('solo', 'inbox-current')")
+            // Conversation with a second member.
+            try db.execute(sql: "INSERT INTO conversationLocalState (conversationId) VALUES ('shared')")
+            try db.execute(sql: "INSERT INTO conversation_members VALUES ('shared', 'inbox-current')")
+            try db.execute(sql: "INSERT INTO conversation_members VALUES ('shared', 'inbox-other')")
+
+            try SharedDatabaseMigrator.addConversationLocalStateHasHadOtherMembers(db)
+        }
+
+        try dbQueue.read { db in
+            let solo = try Bool.fetchOne(
+                db,
+                sql: "SELECT hasHadOtherMembers FROM conversationLocalState WHERE conversationId = 'solo'"
+            )
+            let shared = try Bool.fetchOne(
+                db,
+                sql: "SELECT hasHadOtherMembers FROM conversationLocalState WHERE conversationId = 'shared'"
+            )
+            #expect(solo == false)
+            #expect(shared == true)
+        }
+    }
+
+    // MARK: - Guarded discard
+
+    @Test("Guarded discard keeps an engaged conversation, commits it visible, and never denies consent")
+    func guardedDiscardKeepsEngagedConversation() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let session = SessionManager(
+            databaseWriter: dbManager.dbWriter,
+            databaseReader: dbManager.dbReader,
+            environment: .tests,
+            identityStore: MockKeychainIdentityStore(),
+            platformProviders: .mock
+        )
+        try await dbManager.dbWriter.write { db in
+            try Self.seedPoolConversation(db: db, id: "renamed", name: "Keep Me", isUnused: true)
+        }
+
+        await session.discardClaimedConversationIfUnengaged(id: "renamed")
+
+        let conversation = try await dbManager.dbReader.read { db in
+            try DBConversation.fetchOne(db, key: "renamed")
+        }
+        let localStateCount = try await dbManager.dbReader.read { db in
+            try ConversationLocalState
+                .filter(ConversationLocalState.Columns.conversationId == "renamed")
+                .fetchCount(db)
+        }
+        #expect(conversation != nil)
+        #expect(conversation?.isUnused == false)
+        #expect(conversation?.consent == .allowed)
+        #expect(localStateCount == 1)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLocalStateWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLocalStateWriterTests.swift
@@ -90,7 +90,8 @@ struct ConversationLocalStateWriterTests {
                 pinnedOrder: 3,
                 hidesInviteCard: false,
                 leftHostedInviteSession: false,
-                wasRemoved: false
+                wasRemoved: false,
+                hasHadOtherMembers: false
             ).insert(db)
         }
 
@@ -169,7 +170,8 @@ struct ConversationLocalStateWriterTests {
                 pinnedOrder: 3,
                 hidesInviteCard: true,
                 leftHostedInviteSession: false,
-                wasRemoved: false
+                wasRemoved: false,
+                hasHadOtherMembers: false
             ).insert(db)
         }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationRemovedStateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationRemovedStateTests.swift
@@ -69,7 +69,8 @@ struct ConversationRemovedStateTests {
             pinnedOrder: isPinned ? 1 : nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: false
         ).insert(db)
 
         for inboxId in [currentInboxId, otherInboxId] {

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsRepositoryFindOneToOneTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsRepositoryFindOneToOneTests.swift
@@ -63,7 +63,8 @@ struct ConversationsRepositoryFindOneToOneTests {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).insert(db)
 
         try addMember(db: db, conversationId: id, inboxId: currentInboxId, role: .superAdmin)
@@ -303,7 +304,8 @@ struct ConversationsRepositoryFindOneToOneTests {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).insert(db)
         try addMember(db: db, conversationId: id, inboxId: currentInboxId, role: .member)
         try addMember(db: db, conversationId: id, inboxId: otherInboxId, role: .superAdmin)

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryBenchmarkTests.swift
@@ -77,7 +77,8 @@ struct MessagesRepositoryBenchmarkTests {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).insert(db)
 
         for (i, inboxId) in memberInboxIds.enumerated() {

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesRepositoryTests.swift
@@ -496,7 +496,8 @@ struct MessagesRepositoryTests {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: false
+            wasRemoved: false,
+            hasHadOtherMembers: false
         ).insert(db)
 
         try DBConversationMember(

--- a/ConvosCore/Tests/ConvosCoreTests/NSEGroupNotificationDropGuardTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/NSEGroupNotificationDropGuardTests.swift
@@ -62,7 +62,8 @@ struct NSEGroupNotificationDropGuardTests {
             pinnedOrder: nil,
             hidesInviteCard: false,
             leftHostedInviteSession: false,
-            wasRemoved: wasRemoved
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: false
         ).insert(db)
 
         var memberInboxIds: [String] = [otherInboxId]

--- a/docs/plans/transient-conversation-engagement.md
+++ b/docs/plans/transient-conversation-engagement.md
@@ -18,7 +18,7 @@ Keep a minted conversation if any of the following hold; otherwise it is a trans
 
 - it ever had two members, even if the second member later left;
 - the user put content in it (a sent message);
-- the user customized any metadata: name, description, image, or emoji (all four exist as `DBConversation` columns; there is no per-conversation color in the schema);
+- the user customized any metadata: name, description, or image (there is no per-conversation color in the schema, and the conversation emoji is auto-assigned -- see below);
 - existing keeps: the invite was shared externally, or a scanned code was handled.
 
 Explicit user deletes stay unconditional. Only implicit dismiss-cleanup goes through the engagement gate.
@@ -27,7 +27,8 @@ Unsent composer drafts do not count. Draft text lives only in memory (`Conversat
 
 ## What the database gives us
 
-- Fresh mint defaults: a pooled row is written with `name`, `description`, `imageURLString`, and `conversationEmoji` all nil (`UnusedConversationCache.writeUnusedConversationRow`). "New Convo" is a UI-only fallback, never materialized in the database. "Customized" is therefore cleanly detectable as non-nil, non-empty on any of the four columns. All customization paths funnel through `ConversationMetadataWriter` and always persist to `DBConversation`.
+- Fresh mint defaults: a pooled row is written with `name`, `description`, `imageURLString`, and `conversationEmoji` all nil (`UnusedConversationCache.writeUnusedConversationRow`). "New Convo" is a UI-only fallback, never materialized in the database. "Customized" is therefore detectable as non-nil, non-empty on the name, description, and image columns. All customization paths funnel through `ConversationMetadataWriter` and always persist to `DBConversation`.
+- One exception, found during validation: `conversationEmoji` is auto-assigned to every minted conversation at creation (`ensureConversationEmoji` in the conversation state machine, seeded from the conversation id), so a non-nil emoji says nothing about user intent and is excluded from the predicate. There is no in-app emoji editor today; if one lands, it must latch engagement at the view-model layer, and the predicate can learn to compare against the auto-assigned value.
 - Messages: real messages persist as `DBMessage` rows; membership changes persist as `contentType == .update` rows. The view-model-side message count only counts chat content (the `.messages` grouping in `MessagesListItemType`), so a database-side count must mirror that exclusion.
 - Members: the members table mirrors current membership only. Departed members' rows are deleted on network sync (`ConversationWriter`) and on explicit removal (`ConversationMetadataWriter.removeMembers`). There is no "ever had two members" record in queryable columns, so a high-water mark is needed.
 
@@ -40,7 +41,7 @@ Two candidate shapes, each with a blind spot the other covers:
 
 Chosen: hybrid. The database-derived predicate is the authoritative gate inside the terminal discard, and a thin synchronous latch on the view model covers the in-flight-write race.
 
-1. `ConversationEngagement.isEngaged(db:conversationId:currentInboxId:)` in ConvosCore -- the single predicate: any of `name`/`description`/`conversationEmoji` non-nil and non-empty, `imageURLString` non-nil, real-message count greater than zero (excluding `.update` and other non-chat content types, mirroring the `.messages` grouping filter), non-self member count greater than zero, or `hasHadOtherMembers` true.
+1. `ConversationEngagement.isEngaged(db:conversationId:currentInboxId:)` in ConvosCore -- the single predicate: any of `name`/`description`/`imageURLString` non-nil and non-empty, real-message count greater than zero (excluding `.update` and other non-chat content types, mirroring the `.messages` grouping filter), non-self member count greater than zero, or `hasHadOtherMembers` true.
 2. `SessionManager.discardClaimedConversationIfUnengaged(id:)` -- a new protocol method next to `discardClaimedConversation`. It checks the predicate before `updateConsentState(.denied)`: a kept conversation must never get consent-denied, or it vanishes from the list anyway. Engaged -> commit the claimed conversation (ensures visibility; safe if already committed) and return without deleting. Unengaged -> the existing discard body. The unconditional `discardClaimedConversation` stays for explicit user deletes and the Agent Builder's deliberate cancel.
 3. On the view model, the flag pile (`didShareInvite`, `didHandleScannedCode`) consolidates into a single `EngagementLatches` OptionSet (`.sharedInvite`, `.scannedCode`, `.customizedMetadata`, `.memberJoined`), with the existing mark methods kept as facades so call sites do not churn. The `cleanUpEmptyEmbeddedInviteIfNeeded` keep-guard becomes: any latch set, or messages present, or other members present.
 4. `.customizedMetadata` wiring: `ConversationViewModel` gains an `onMetadataEdited` callback, invoked synchronously (before spawning the write task, and only when a change will actually be written) from the name-edit branches and the pending public-preview name/description writes. `NewConversationViewModel` wires it in its inner view-model forwarding block so it survives inner-VM swaps, following the `onInviteShared` precedent.

--- a/docs/plans/transient-conversation-engagement.md
+++ b/docs/plans/transient-conversation-engagement.md
@@ -1,0 +1,94 @@
+# Transient conversation engagement: one keep/discard predicate
+
+Goal: stop the implicit dismiss-cleanup from deleting minted conversations the user has actually engaged with (renamed, customized, populated), while preserving the transient behavior for genuinely untouched drafts. iOS only.
+
+## The bug
+
+Repro: Home -> "+" -> "Show an invite code" -> rename the convo -> back/dismiss -> the renamed convo is deleted from home.
+
+The Show-code flow mints a `NewConversationViewModel` with an embedded invite and commits a warm pool row visible immediately. Renaming goes through `ConversationMetadataWriter.updateName` (XMTP `group.updateName`, then the `DBConversation.name` save), but nothing informs the wrapping `NewConversationViewModel` and no flag is set. On dismiss, `cleanUpEmptyEmbeddedInviteIfNeeded` checks exactly four things: invite shared, code scanned, loaded message count, current other-member count. A rename (or photo/description/emoji change) touches none of them, so the fall-through calls `deleteConversation()` -> `SessionManager.discardClaimedConversation`, which denies consent, leaves the group, and deletes every database row. The rename is durable on the network before the local row is destroyed; there is no recovery path.
+
+Root cause in one line: the dismiss-cleanup predicate has no metadata-customization signal, and the terminal discard has no engagement awareness at all.
+
+The wider pattern: each keep-signal accumulated so far (`didShareInvite`, `didHandleScannedCode`, ready/joining state guards, the Agent Builder's `hasCommitted`) was added to fix one bug. Metadata customization is the next bug in the same series, which motivates a shared predicate rather than one more flag.
+
+## Product rule
+
+Keep a minted conversation if any of the following hold; otherwise it is a transient and is discarded on dismiss:
+
+- it ever had two members, even if the second member later left;
+- the user put content in it (a sent message);
+- the user customized any metadata: name, description, image, or emoji (all four exist as `DBConversation` columns; there is no per-conversation color in the schema);
+- existing keeps: the invite was shared externally, or a scanned code was handled.
+
+Explicit user deletes stay unconditional. Only implicit dismiss-cleanup goes through the engagement gate.
+
+Unsent composer drafts do not count. Draft text lives only in memory (`ConversationViewModel.messageText`); there is no draft persistence. Counting a non-empty draft as engagement would keep the conversation but lose the draft, leaving an empty ghost row -- precisely the class of leftovers the lazy-mint work eliminated. If composer drafts ever gain persistence, a `.typedDraft` latch is a one-line addition.
+
+## What the database gives us
+
+- Fresh mint defaults: a pooled row is written with `name`, `description`, `imageURLString`, and `conversationEmoji` all nil (`UnusedConversationCache.writeUnusedConversationRow`). "New Convo" is a UI-only fallback, never materialized in the database. "Customized" is therefore cleanly detectable as non-nil, non-empty on any of the four columns. All customization paths funnel through `ConversationMetadataWriter` and always persist to `DBConversation`.
+- Messages: real messages persist as `DBMessage` rows; membership changes persist as `contentType == .update` rows. The view-model-side message count only counts chat content (the `.messages` grouping in `MessagesListItemType`), so a database-side count must mirror that exclusion.
+- Members: the members table mirrors current membership only. Departed members' rows are deleted on network sync (`ConversationWriter`) and on explicit removal (`ConversationMetadataWriter.removeMembers`). There is no "ever had two members" record in queryable columns, so a high-water mark is needed.
+
+## Design: hybrid gate + latch
+
+Two candidate shapes, each with a blind spot the other covers:
+
+- Event flags on the view model (the existing pattern, extended): synchronous, fits the existing call shape, and latches at edit-commit time -- before the async write -- so it cannot lose the race where a rename's network commit precedes its database write. But it is exactly the mechanism that produced the bug series: every new customization surface must remember to wire a flag, and flags die with the view model.
+- State derived from the database at cleanup time: one implementation protects every current and future path automatically, robust to view-model lifecycle and app kill. But the UI call sites branch synchronously, and a state check alone can race an in-flight rename write.
+
+Chosen: hybrid. The database-derived predicate is the authoritative gate inside the terminal discard, and a thin synchronous latch on the view model covers the in-flight-write race.
+
+1. `ConversationEngagement.isEngaged(db:conversationId:currentInboxId:)` in ConvosCore -- the single predicate: any of `name`/`description`/`conversationEmoji` non-nil and non-empty, `imageURLString` non-nil, real-message count greater than zero (excluding `.update` and other non-chat content types, mirroring the `.messages` grouping filter), non-self member count greater than zero, or `hasHadOtherMembers` true.
+2. `SessionManager.discardClaimedConversationIfUnengaged(id:)` -- a new protocol method next to `discardClaimedConversation`. It checks the predicate before `updateConsentState(.denied)`: a kept conversation must never get consent-denied, or it vanishes from the list anyway. Engaged -> commit the claimed conversation (ensures visibility; safe if already committed) and return without deleting. Unengaged -> the existing discard body. The unconditional `discardClaimedConversation` stays for explicit user deletes and the Agent Builder's deliberate cancel.
+3. On the view model, the flag pile (`didShareInvite`, `didHandleScannedCode`) consolidates into a single `EngagementLatches` OptionSet (`.sharedInvite`, `.scannedCode`, `.customizedMetadata`, `.memberJoined`), with the existing mark methods kept as facades so call sites do not churn. The `cleanUpEmptyEmbeddedInviteIfNeeded` keep-guard becomes: any latch set, or messages present, or other members present.
+4. `.customizedMetadata` wiring: `ConversationViewModel` gains an `onMetadataEdited` callback, invoked synchronously (before spawning the write task, and only when a change will actually be written) from the name-edit branches and the pending public-preview name/description writes. `NewConversationViewModel` wires it in its inner view-model forwarding block so it survives inner-VM swaps, following the `onInviteShared` precedent.
+5. `.memberJoined` wiring: latched in `ConversationViewModel`'s conversation-update observer when the non-self member set becomes non-empty. This covers joined-then-left within a session; the persisted flag below covers it across sessions.
+6. All implicit discard call sites route through the guarded path: the embedded-invite cleanup fall-through, the generic `cleanUpIfNeeded` fall-through, and the superseded-claim discard (scanning a code that resolves into a different conversation must not destroy a renamed original). `deleteConversation()` keeps the unconditional discard as the explicit-delete entry.
+
+With this, the rename bug is fixed twice over: the latch keeps the conversation at the UI predicate with no race, and even if a future surface forgets the latch, the session-level gate refuses to destroy a row whose database state shows engagement.
+
+## "Ever two members" needs new state
+
+Because departed members' rows are deleted on sync, there is no queryable high-water mark. Deriving one from persisted `.update` messages (added-member ids survive the member leaving) would avoid a migration, but requires decoding update JSON per row at discard time and depends on the stream echo having landed; a joiner added and departed during a brief network gap could be missed.
+
+Chosen instead: an explicit set-once flag `hasHadOtherMembers` on `ConversationLocalState`. Local-only state can never be clobbered by network sync (avoiding the merge-preservation dance that synced fields need), and the discard path already deletes the row with the conversation. Direct precedent for a has-had flag: `hasHadVerifiedAgent`.
+
+- Set points: `ConversationWriter`'s member-store path when the stored member set contains a non-self inbox, and `ConversationMetadataWriter.addMembers`.
+- Migration: add the column defaulting false, backfilled true where a non-self `DBConversationMember` row exists.
+
+The in-session latch makes the flag's timeliness non-critical; the flag exists for cross-session correctness (app killed after a member joined and left; discard decided on a later launch or by a different surface).
+
+## Edge cases
+
+- Rename to empty, or to empty then back: the name editor writes only when the trimmed value differs, so typing nothing over a nil name latches nothing (correct: not engagement). "Foo" then cleared back to empty ends with `name == ""` in the database, so the predicate must use non-nil and non-empty -- a reverted conversation found on a later launch is discardable again, while the session latch keeps it for this session (conservative keep; the user did act).
+- Customize, then open share, then cancel: `onInviteShared` never fires, but `.customizedMetadata` keeps it. The Send-invite cancel paths are unchanged: the user never enters that hidden conversation, so customization is impossible there; cancel still discards, now with the gate as a backstop.
+- Member joined then left: the in-session latch plus the persisted flag keep it, even though the current-member count reads zero at dismiss.
+- A user literally typing "New Convo" produces a non-empty database name and is kept (they did act; fine).
+- App kill mid-flow: no cleanup runs. Show-code rows were committed visible at claim, so the conversation (with any landed rename) persists. Deferred-visibility claims stay unused and are recycled by the pool next launch. Lost latches are harmless because latch-consulting cleanup never runs after a kill.
+- Consent-deny ordering: the engagement check must precede `updateConsentState(.denied)`; deny-then-keep would hide the kept conversation from the list, which filters on allowed consent.
+- Agent Builder cancel stays on the unconditional discard path: deliberate cancel semantics, and the builder writes no conversation metadata pre-commit anyway.
+- The in-conversation join sheet uses `.joinInvite`-mode view models with no embedded invite; the embedded predicate no-ops and the joining-state guard governs, unchanged.
+
+## Risks
+
+- Consent-deny ordering (above) is the sharpest edge; covered by a unit test asserting a kept conversation's consent is not denied.
+- `ConversationLocalState` migration breadth: several memberwise init sites plus hydration; mechanical, and the compiler catches misses, but `insert(onConflict: .ignore)` writes must not silently reset an existing true.
+- Message-count semantics drift: the database count must match the view model's chat-only notion or the two layers of the predicate disagree; extract the filter, do not duplicate it.
+- A rename write landing after an unengaged-verdict delete throws `conversationNotFound` inside `updateName` (logged, harmless, pre-existing shape); the latch makes this reachable only by paths with no UI.
+
+## Validation
+
+Unit coverage: the engagement truth table (fresh pool row not engaged; each metadata field set -> engaged; empty-string name -> not; one real message -> engaged; update-only rows -> not; `hasHadOtherMembers` -> engaged); the guarded discard (engaged -> row survives, stays visible, consent not denied; unengaged -> full deletion parity); the writer set points and the migration backfill.
+
+Simulator checklist, the original repro first:
+
+1. "+" -> Show an invite code -> rename -> dismiss: the renamed row stays in home, and survives relaunch.
+2. Same with a photo or description instead of a rename -> kept.
+3. "+" -> Show-code -> no interaction -> dismiss: no row remains (transient discard regression guard).
+4. "+" -> Send an invite -> cancel the share -> no row; complete the share -> kept.
+5. A second device joins via the invite then leaves; dismiss -> kept (ever-two-members).
+6. Show-code -> rename -> scan a code that joins another conversation (supersede path) -> the renamed conversation is still in the list.
+7. Kill the app after a rename -> relaunch -> conversation present.
+8. Explicit delete still deletes an engaged conversation.


### PR DESCRIPTION
Stacked on #1124. Fixes "customize a new convo -> go back -> it's deleted" by replacing the accumulated per-site keep-flags with one engagement rule, enforced where the discard actually happens.

## The rule
A conversation is kept if any of:
- it ever had another member (`hasHadOtherMembers`, new persisted flag -- departed rows are deleted on sync, so a high-water mark is required),
- it has chat content (messages/attachments; reactions and system rows don't count),
- any metadata was customized (name, description, or photo; emoji is excluded because every minted conversation gets one auto-assigned),
- an invite was shared or a code was scanned into it.
Otherwise it stays transient and is discarded on dismiss. Unsent composer drafts don't count (they aren't persisted, so keeping the convo would lose the draft anyway). Explicit user deletes stay unconditional.

## How
- `ConversationEngagement.isEngaged` -- state-derived predicate, evaluated inside the new `SessionManager.discardClaimedConversationIfUnengaged` before the consent-deny; engaged conversations are committed-visible instead of discarded. Every implicit discard path routes through it (embedded-invite cleanup, compose cleanup, scan-supersede in both the view model and the conversation state machine).
- `EngagementLatches` OptionSet consolidates the previous flag pile (`didShareInvite`, `didHandleScannedCode`, + new metadata/member latches) for the synchronous window before DB writes land.
- Migration backfills `hasHadOtherMembers` from existing member rows.

## Verification
- 1376 tests / 192 suites green (14 new engagement tests), SwiftLint --strict clean.
- Sim QA: the rename repro (+ relaunch persistence), photo customization, untouched Show-code still discards, Send-invite cancel discards / share keeps, member joined-then-left keeps, kill-mid-flow persists, supersede keeps a renamed convo, explicit delete still deletes.

Plan: `docs/plans/transient-conversation-engagement.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785603633&installation_id=128169237&pr_number=1135&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1135&signature=2907d6fe1627a15a5b4d090575db7e51e24e88f7497950f5564ff2bc149986fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add engagement-based keep rule to prevent deletion of transient conversations with user activity
> - Introduces `ConversationEngagement.isEngaged` to determine if a transient conversation should be kept, checking for customized metadata, chat messages, current members, or the new `hasHadOtherMembers` latch.
> - Adds `hasHadOtherMembers` column to `ConversationLocalState` via a new database migration with SQL backfill based on current membership state.
> - Replaces unconditional `deleteConversation` calls in `NewConversationViewModel` with engagement-gated `discardConversationIfUnengaged`, which commits rather than deletes engaged conversations.
> - Adds `SessionManager.discardClaimedConversationIfUnengaged(id:)` that reads engagement state and commits the conversation if engaged (or if the engagement check errors), only discarding when unengaged.
> - `ConversationStateMachine.cleanUpPreviousConversationIfNeeded` now skips cleanup when the previous conversation is engaged.
> - `ConversationViewModel` gains `onMetadataEdited` and `onMemberJoined` callbacks and an `everHadOtherMembers` latch wired into `NewConversationViewModel`'s `EngagementLatches` set.
> - Risk: on engagement-check errors, conversations are treated as engaged and kept rather than discarded, which may leave uncleaned conversations in edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f87881b. 16 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->