### PR TITLE
feat(agent-builder): raise prompt-hint clamp to 350

### DIFF
--- a/Convos/Agent Builder/PromptHintsModel.swift
+++ b/Convos/Agent Builder/PromptHintsModel.swift
@@ -104,7 +104,7 @@ final class PromptHintsModel {
         }
     }
 
-    /// Trim, drop empties, and clamp each hint to the backend's 240-char
+    /// Trim, drop empties, and clamp each hint to the backend's 350-char
     /// contract so a malformed row can't blow out the composer.
     private static func sanitize(_ raw: [String]) -> [String] {
         raw
@@ -117,6 +117,6 @@ final class PromptHintsModel {
 
     private enum Constant {
         static let maxAttempts: Int = 5
-        static let maxHintLength: Int = 240
+        static let maxHintLength: Int = 350
     }
 }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -333,7 +333,7 @@ public enum ConvosAPI {
     }
 
     /// Response envelope for `GET /v2/agent-prompt-hints` -- a flat list of
-    /// curated prompt strings (each <= 240 chars) the agent builder's dice
+    /// curated prompt strings (each <= 350 chars) the agent builder's dice
     /// control drops into the "What needs done?" composer. Public and
     /// unauthenticated; decoding is tolerant of extra keys via default Codable
     /// behavior.

--- a/ConvosTests/PromptHintsModelTests.swift
+++ b/ConvosTests/PromptHintsModelTests.swift
@@ -65,13 +65,13 @@ final class PromptHintsModelTests: XCTestCase {
     }
 
     func testSanitizeTrimsDropsEmptyAndClamps() async {
-        let long = String(repeating: "x", count: 300)
+        let long = String(repeating: "x", count: 400)
         let disk = DiskSpy(stored: [])
         let model = makeModel(service: MockPromptHintsService(hints: ["  spaced  ", "", long]), disk: disk)
         await model.loadOnLaunch()
         XCTAssertEqual(model.hints.count, 2, "Empty / whitespace-only hints are dropped")
         XCTAssertEqual(model.hints.first, "spaced", "Hints are trimmed")
-        XCTAssertEqual(model.hints.last?.count, 240, "Hints are clamped to the 240-char contract")
+        XCTAssertEqual(model.hints.last?.count, 350, "Hints are clamped to the 350-char contract")
     }
 
     func testLoadOnLaunchRunsOnlyOnce() async {


### PR DESCRIPTION
Raise the client-side prompt-hint clamp from 240 to 350 (`PromptHintsModel.Constant.maxHintLength`) so served hints up to the new backend cap aren't truncated in the composer. Doc comments updated; the clamp test now feeds a 400-char hint and asserts a 350-char result.

Part of a coordinated 4-repo change raising the curated dice prompt-hint cap 240→350. The backend PR is the gate and should merge first. Note: already-shipped app builds keep clamping to 240, so hints of 241–350 chars truncate there until users update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2NeQiZiBavQCgyPZVZKd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785946588&installation_id=128169237&pr_number=1139&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1139&signature=f12107b026afbd82dfdfc22b9d6b8941d11821a714de3d32d52fd205a1013801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `PromptHintsModel` hint clamp limit from 240 to 350 characters
> Updates `PromptHintsModel.Constant.maxHintLength` from 240 to 350 to match the updated backend contract. Documentation in [ConvosAPIClient+Models.swift](https://github.com/xmtplabs/convos-ios/pull/1139/files#diff-869f0fb39659b9175c5a2597ca99467c503f8bdf5805e619872b7c8e07f73ce3) is updated to reflect the new limit, and tests in [PromptHintsModelTests.swift](https://github.com/xmtplabs/convos-ios/pull/1139/files#diff-a82cb9546cf3427419cf2ea2944c3fee981cad981e2fe6a9741cead69d54f7fa) are adjusted accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f72197f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->