### PR TITLE
Remove photo and camera icons from the inline agent builder bar

### DIFF
--- a/Convos/Conversations List/AgentBuilderBar.swift
+++ b/Convos/Conversations List/AgentBuilderBar.swift
@@ -4,10 +4,10 @@ import SwiftUI
 /// stable glass capsule whose width + tint animate between two states:
 ///
 /// - **Expanded**: a capsule -- agent avatar leading, a "Make an agent"
-///   placeholder label, and three trailing icon buttons for photo / camera
-///   / voice-memo entry points. Capped at the width it would occupy on the
-///   largest iPhone in portrait so it doesn't stretch the full width of a
-///   wide iPad, and centered within the available width.
+///   placeholder label, and a trailing icon button for the voice-memo entry
+///   point. Capped at the width it would occupy on the largest iPhone in
+///   portrait so it doesn't stretch the full width of a wide iPad, and
+///   centered within the available width.
 /// - **Collapsed**: a 52pt circle at the trailing edge (the capsule shrunk
 ///   to its height with a black tint so it reads as a solid agent avatar).
 ///
@@ -28,8 +28,6 @@ import SwiftUI
 struct AgentBuilderBar: View {
     let isExpanded: Bool
     let onTap: () -> Void
-    let onTapPhotos: () -> Void
-    let onTapCamera: () -> Void
     let onTapVoiceMemo: () -> Void
     /// Optional matched-transition source applied to the glass shape. When
     /// set, sheets presented after tapping the bar zoom out of it.
@@ -93,7 +91,7 @@ struct AgentBuilderBar: View {
                 .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            attachmentButtonGroup
+            voiceMemoButton
         }
         .padding(DesignConstants.Spacing.step2x)
         .frame(maxWidth: .infinity)
@@ -109,13 +107,18 @@ struct AgentBuilderBar: View {
             .frame(width: Constant.collapsedSize, height: Constant.collapsedSize)
     }
 
-    private var attachmentButtonGroup: some View {
-        HStack(spacing: Constant.attachmentIconSpacing) {
-            attachmentButton(systemImage: "photo.fill", label: "Add photo", action: onTapPhotos)
-            attachmentButton(systemImage: "camera.fill", label: "Take photo", action: onTapCamera)
-            attachmentButton(systemImage: "waveform", label: "Record voice memo", action: onTapVoiceMemo)
+    private var voiceMemoButton: some View {
+        Button(action: onTapVoiceMemo) {
+            Image(systemName: "waveform")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(Color.colorTextSecondary)
+                .frame(width: Constant.trailingIconWidth, height: Constant.trailingIconHeight)
+                .contentShape(.rect)
         }
-        .padding(.horizontal, Constant.attachmentGroupHorizontalPadding)
+        .buttonStyle(.plain)
+        .hoverEffect(.lift)
+        .accessibilityLabel("Record voice memo")
+        .padding(.horizontal, Constant.trailingIconHorizontalPadding)
     }
 
     private var agentAvatar: some View {
@@ -132,19 +135,6 @@ struct AgentBuilderBar: View {
             .accessibilityLabel("Make an agent")
     }
 
-    private func attachmentButton(systemImage: String, label: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(Color.colorTextSecondary)
-                .frame(width: Constant.attachmentIconWidth, height: Constant.attachmentIconHeight)
-                .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        .hoverEffect(.lift)
-        .accessibilityLabel(label)
-    }
-
     private enum Constant {
         /// Height of both visual states: the expanded content's natural height
         /// (36pt glyph footprint + step2x*2 padding = 52pt). The collapsed
@@ -159,14 +149,13 @@ struct AgentBuilderBar: View {
         /// the available width is always <= this, so the cap never binds.
         static let maxExpandedWidth: CGFloat = 408.0
         /// The leading glyph sits in a 36x36 footprint, inset per the design so
-        /// the visible mark (~16.7x18) reads in line with the trailing icons.
+        /// the visible mark (~16.7x18) reads in line with the trailing icon.
         /// The asset has no internal padding, so the inset is applied here.
         static let expandedIconFrameSize: CGFloat = 36.0
         static let expandedIconInsets: EdgeInsets = EdgeInsets(top: 8, leading: 10.67, bottom: 10, trailing: 8.67)
-        static let attachmentIconWidth: CGFloat = 20.0
-        static let attachmentIconHeight: CGFloat = 18.0
-        static let attachmentIconSpacing: CGFloat = 24.0
-        static let attachmentGroupHorizontalPadding: CGFloat = 8.0
+        static let trailingIconWidth: CGFloat = 20.0
+        static let trailingIconHeight: CGFloat = 18.0
+        static let trailingIconHorizontalPadding: CGFloat = 8.0
     }
 }
 
@@ -186,13 +175,13 @@ private struct MatchedTransitionSourceModifier: ViewModifier {
 }
 
 #Preview("Expanded") {
-    AgentBuilderBar(isExpanded: true, onTap: {}, onTapPhotos: {}, onTapCamera: {}, onTapVoiceMemo: {})
+    AgentBuilderBar(isExpanded: true, onTap: {}, onTapVoiceMemo: {})
         .padding()
         .background(Color.colorBackgroundSurfaceless)
 }
 
 #Preview("Collapsed") {
-    AgentBuilderBar(isExpanded: false, onTap: {}, onTapPhotos: {}, onTapCamera: {}, onTapVoiceMemo: {})
+    AgentBuilderBar(isExpanded: false, onTap: {}, onTapVoiceMemo: {})
         .padding()
         .background(Color.colorBackgroundSurfaceless)
 }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -1,6 +1,5 @@
 import ConvosCore
 import ConvosMetrics
-import PhotosUI
 import SwiftUI
 
 /// Root tab shell for the app. Hosts the existing `ConversationsView` under
@@ -71,15 +70,6 @@ struct MainTabView: View {
     /// because SwiftUI's safe-area inset chain doesn't reliably propagate
     /// to the UIKit collection view.
     @State private var builderBarHeight: CGFloat = 0
-    /// Photo / camera / voice-memo entry points for the
-    /// `AgentBuilderBar`. Tapping the photo or camera icon presents
-    /// the matching picker first; only once the user has actually picked
-    /// (or captured) media do we open the builder sheet, so abandoning
-    /// the picker leaves the user where they were. Voice memo skips the
-    /// picker and opens the builder directly in recording mode.
-    @State private var isPhotoPickerPresented: Bool = false
-    @State private var isCameraPresented: Bool = false
-    @State private var selectedPhotos: [PhotosPickerItem] = []
     /// Drives the app-settings sheet that the `AppIndicatorPill` (in
     /// every tab that renders one) presents on tap. Lives at this shell
     /// level so both the Chats and Things tabs share a single sheet
@@ -677,8 +667,6 @@ struct MainTabView: View {
         AgentBuilderBar(
             isExpanded: expanded,
             onTap: openBuilder,
-            onTapPhotos: { isPhotoPickerPresented = true },
-            onTapCamera: { isCameraPresented = true },
             onTapVoiceMemo: openBuilderInVoiceMemoMode,
             transitionSourceNamespace: namespace,
             transitionSourceId: Constant.builderTransitionId
@@ -713,49 +701,6 @@ struct MainTabView: View {
     /// to wait for the inner conversation VM's recorder to materialize.
     private func openBuilderInVoiceMemoMode() {
         conversationsViewModel.onStartAgent(entryMode: .voiceMemo)
-    }
-
-    /// Camera capture (still image): open the builder and load the image
-    /// into the inner conversation VM's attachment list. The fullScreenCover
-    /// is dismissed by flipping `isCameraPresented` before opening the
-    /// builder so the sheet sits on top of the (now-dismissing) camera
-    /// cover with no visible flash.
-    private func handleCameraImageCaptured(_ image: UIImage) {
-        isCameraPresented = false
-        conversationsViewModel.onStartAgent()
-        guard let builderViewModel = conversationsViewModel.agentBuilderViewModel else { return }
-        builderViewModel.addPhotoAttachment(image)
-    }
-
-    private func handleCameraVideoCaptured(_ url: URL) {
-        isCameraPresented = false
-        conversationsViewModel.onStartAgent()
-        guard let builderViewModel = conversationsViewModel.agentBuilderViewModel else { return }
-        builderViewModel.addVideoAttachment(url: url)
-    }
-
-    /// Photo / video library selection: load each picked item asynchronously
-    /// (videos transferred as `VideoFile`, stills as `Data` -> `UIImage`)
-    /// and add them to the freshly-created builder VM. The picker is
-    /// dismissed and `selectedPhotos` is cleared synchronously so a
-    /// subsequent tap on the photo icon opens the picker fresh.
-    private func handleSelectedPhotosChanged(to newValue: [PhotosPickerItem]) {
-        guard !newValue.isEmpty else { return }
-        let items = newValue
-        selectedPhotos = []
-        isPhotoPickerPresented = false
-        conversationsViewModel.onStartAgent()
-        guard let builderViewModel = conversationsViewModel.agentBuilderViewModel else { return }
-        Task {
-            for item in items {
-                if let videoFile = try? await item.loadTransferable(type: VideoFile.self) {
-                    await MainActor.run { builderViewModel.addVideoAttachment(url: videoFile.url) }
-                } else if let data = try? await item.loadTransferable(type: Data.self),
-                          let image = UIImage(data: data) {
-                    await MainActor.run { builderViewModel.addPhotoAttachment(image) }
-                }
-            }
-        }
     }
 
     private enum Constant {
@@ -913,23 +858,17 @@ private struct BuilderBarHeightKey: PreferenceKey {
     }
 }
 
-/// All the sheets / covers / pickers that the `MainTabView` shell hosts,
-/// extracted into a `ViewModifier` so the host's `body` stays within the
+/// All the sheets / covers that the `MainTabView` shell hosts, extracted
+/// into a `ViewModifier` so the host's `body` stays within the
 /// `warn-long-expression-type-checking` budget.
 struct MainTabSheetsModifier: ViewModifier {
     @Bindable var conversationsViewModel: ConversationsViewModel
     let profileSettingsViewModel: ProfileSettingsViewModel
     let coreActions: any CoreActions
     @Binding var presentingAppSettings: Bool
-    @Binding var isPhotoPickerPresented: Bool
-    @Binding var isCameraPresented: Bool
-    @Binding var selectedPhotos: [PhotosPickerItem]
     @Binding var thingsAgentContactMember: ConversationMember?
     let thingsPushedConvoVM: ConversationViewModel?
     let namespace: Namespace.ID
-    let onPhotosChanged: ([PhotosPickerItem]) -> Void
-    let onCameraImageCaptured: (UIImage) -> Void
-    let onCameraVideoCaptured: (URL) -> Void
 
     func body(content: Content) -> some View {
         content
@@ -943,22 +882,6 @@ struct MainTabSheetsModifier: ViewModifier {
                 .navigationTransition(
                     .zoom(sourceID: "agent-builder-transition-source", in: namespace)
                 )
-            }
-            .photosPicker(
-                isPresented: $isPhotoPickerPresented,
-                selection: $selectedPhotos,
-                maxSelectionCount: maxPendingMediaAttachments,
-                matching: .any(of: [.images, .videos])
-            )
-            .onChange(of: selectedPhotos) { _, newValue in
-                onPhotosChanged(newValue)
-            }
-            .fullScreenCover(isPresented: $isCameraPresented) {
-                CameraPickerView(
-                    onImageCaptured: onCameraImageCaptured,
-                    onVideoCaptured: onCameraVideoCaptured
-                )
-                .ignoresSafeArea()
             }
             .sheet(isPresented: $presentingAppSettings) {
                 AppSettingsView(
@@ -1071,15 +994,9 @@ extension MainTabView {
             profileSettingsViewModel: profileSettingsViewModel,
             coreActions: coreActions,
             presentingAppSettings: $presentingAppSettings,
-            isPhotoPickerPresented: $isPhotoPickerPresented,
-            isCameraPresented: $isCameraPresented,
-            selectedPhotos: $selectedPhotos,
             thingsAgentContactMember: $thingsAgentContactMember,
             thingsPushedConvoVM: thingsPushedConvoVM,
-            namespace: namespace,
-            onPhotosChanged: handleSelectedPhotosChanged(to:),
-            onCameraImageCaptured: handleCameraImageCaptured,
-            onCameraVideoCaptured: handleCameraVideoCaptured
+            namespace: namespace
         )
     }
 }


### PR DESCRIPTION
## Summary

Removes the photo and camera icon buttons from the agent builder bar that shows inline in the tab views (Chats and Things; Contacts never showed the bar). The bar keeps the voice-memo entry point, and the full agent builder sheet's composer is untouched.

- `AgentBuilderBar`: drop the `onTapPhotos` / `onTapCamera` callbacks and the photo/camera buttons; the attachment button group collapses to a single voice-memo button.
- `MainTabView`: remove the now-dead plumbing — photo picker / camera presentation state, the `.photosPicker` and camera `.fullScreenCover` modifiers on `MainTabSheetsModifier`, and the capture handlers (`handleCameraImageCaptured`, `handleCameraVideoCaptured`, `handleSelectedPhotosChanged`), plus the unused `PhotosUI` import.

## Testing

- `Convos (Dev)` simulator build succeeds with no type-check warnings (arm64; the x86_64 sim slice of `NotificationService` fails to link against the current libxmtp nightly on `dev` independently of this change).
- ConvosCore test suite: 1477 tests in 212 suites passed.
- SwiftLint / SwiftFormat clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786036545&installation_id=128169237&pr_number=1142&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1142&signature=5c1ba409a3557468b3ad8959cb1e9698a66d168a2070bfbe9c63626ba8830acd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove photo and camera buttons from the inline agent builder bar
> - Removes photo library and camera capture entry points from `AgentBuilderBar`, leaving only the voice memo button in the expanded state.
> - Deletes related state properties, callbacks, and sheet modifiers from [MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/1142/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67), including `PhotosPicker` and `CameraPickerView` presentation logic.
> - Cleans up `AgentBuilderBar.Constant` by replacing attachment-group sizing constants with a single set of trailing icon constants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36a13bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->