### PR TITLE
Pairing prompt: first-launch fix, newer-backup suppression, real device names

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -24,16 +24,22 @@ extension PairableDeviceBackup {
     /// itself into the backup slot, so the current identity is usually
     /// present too), newest backup first. Static and pure so it can be
     /// unit tested without a keychain.
+    ///
+    /// A nil `currentInboxId` means the primary slot is empty - a true
+    /// first launch checking before silent identity registration has
+    /// completed - so there is nothing to exclude and every backup is
+    /// pairable. This cannot leak the install's own backup as a
+    /// self-pair: a backup mirror is only ever written after its primary,
+    /// and callers read the backups before the primary slot, so an own
+    /// mirror in `backups` implies the primary read that follows sees a
+    /// non-nil identity. Callers whose primary read fails (throws, as
+    /// opposed to returning nil) must not call this with nil - they
+    /// can't tell whether an own backup is present and should hide the
+    /// prompt until a later check succeeds.
     static func pairableBackups(
         from backups: [KeychainIdentityBackup],
         excludingInboxId currentInboxId: String?
     ) -> [PairableDeviceBackup] {
-        // A nil current identity means the keychain read failed, not that
-        // there is nothing to exclude - without the exclusion this
-        // install's own backup would surface in the "Pair <device>?"
-        // prompt and offer a self-pair. Hide the prompt until the
-        // identity read succeeds (the check re-runs on next activation).
-        guard let currentInboxId else { return [] }
         return backups
             .filter { $0.inboxId != currentInboxId }
             .map { (backup: KeychainIdentityBackup) -> PairableDeviceBackup in

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1126,10 +1126,16 @@ public extension SessionManager {
     /// `loadSync()` that follows. Reading in the other order races silent
     /// identity registration and could report this install's own
     /// just-created placeholder as pairable.
+    ///
+    /// A nil primary identity is expected on a true first launch (the
+    /// check runs from the chats list's onAppear, which can beat silent
+    /// registration) and means nothing needs excluding. Only a throwing
+    /// primary read hides the backups, since then an own mirror can't be
+    /// told apart from another device's.
     func pairableDeviceBackups() async -> [PairableDeviceBackup] {
         do {
             let backups = try await identityStore.loadSyncedBackups()
-            let currentInboxId = (try? identityStore.loadSync())?.inboxId
+            let currentInboxId = try identityStore.loadSync()?.inboxId
             return PairableDeviceBackup.pairableBackups(from: backups, excludingInboxId: currentInboxId)
         } catch {
             Log.warning("SessionManager.pairableDeviceBackups failed: \(error)")

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -43,20 +43,22 @@ struct PairableDeviceBackupTests {
         #expect(pairable.first?.deviceName == "Other iPhone")
     }
 
-    @Test("Returns nothing when the current identity is unknown")
-    func hidesAllBackupsWithoutCurrentIdentity() throws {
-        // A nil current inbox means the keychain read failed, not that
-        // there is nothing to exclude; surfacing anything risks offering
-        // this install's own backup as a self-pair.
-        let first = try makeBackup(inboxId: "inbox-a", backedUpAt: Date())
-        let second = try makeBackup(inboxId: "inbox-b", backedUpAt: Date())
+    @Test("Returns every backup when no identity exists yet")
+    func returnsAllBackupsWithoutCurrentIdentity() throws {
+        // A nil current inbox means the primary slot is empty - a true
+        // first launch checking before silent identity registration
+        // completes. That launch is the whole point of the found-device
+        // prompt, so nothing may be hidden; there is no self-pair risk
+        // because an own backup mirror is only written after its primary.
+        let older = try makeBackup(inboxId: "inbox-a", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let newer = try makeBackup(inboxId: "inbox-b", backedUpAt: Date(timeIntervalSince1970: 2_000))
 
         let pairable = PairableDeviceBackup.pairableBackups(
-            from: [first, second],
+            from: [older, newer],
             excludingInboxId: nil
         )
 
-        #expect(pairable.isEmpty)
+        #expect(pairable.map(\.inboxId) == ["inbox-b", "inbox-a"])
     }
 
     @Test("Sorts newest backup first, undated backups last")

--- a/qa/tests/structured/44-icloud-pairing-prompt.yaml
+++ b/qa/tests/structured/44-icloud-pairing-prompt.yaml
@@ -94,8 +94,13 @@ steps:
     save:
       found_device_name: "deviceName= param of pairing.found_device_prompt_shown (underscores stand in for spaces)"
     note: >
-      The prompt waits on placeholder registration plus the chats list
-      appearing, hence the generous timeout. Title reads "Pair <name>?"
+      The prompt must appear on this first launch, before silent
+      placeholder registration completes - a check that runs with no
+      primary identity yet treats every backup as pairable. If it only
+      appears after a relaunch, that is the first-launch suppression bug
+      (nil identity used to hide all backups), not a pass. The generous
+      timeout covers app startup plus the chats list appearing. Title
+      reads "Pair <name>?"
       where <name> is the device name stamped on A's backup (for a sim
       clone this is A's simulator name); subtitle: "Your <name> was found
       in iCloud, if you have it nearby, you can pair it now". The only


### PR DESCRIPTION
Three fixes to the found-device pairing prompt (#983), each found in QA or Jarod's on-device testing.

## 1. Prompt missing on true first launch

`PairableDeviceBackup.pairableBackups` treated a nil current inbox id as "keychain read failed" and hid every backup. On a true first launch the identity is legitimately nil (the chats-list `onAppear` check beats silent placeholder registration), so the prompt never showed on the one launch the feature exists for. Nil identity now means "nothing to exclude"; genuinely throwing keychain reads still hide the prompt (`try?` -> `try` in `SessionManager`).

**Verified:** full QA test 44 re-run (run `b78dfc142d6c`): prompt appeared on the wiped first launch itself (`pairableCount=1`, sheet interactive in ~5s), all criteria pass, no relaunch. A genuinely fresh install still reports `pairableCount=0` (no false prompt / self-pair).

## 2. Second device's newer key offered to the first device

Installing on Device B wrote a newer backup into the shared iCloud slot, and Device A would then prompt to pair with it - offering to demote itself to an identity created after its own. The filter now uses this install's own backup mirror as the reference clock and drops any foreign backup stamped after it. When ordering can't be proven (true first launch, missing own mirror, legacy undated blob) the backup stays pairable.

Adds a `CONVOS_QA_RESTAMP_FOREIGN_BACKUPS=<seconds>` QA launch hook (non-production only) that shifts foreign backups' `backedUpAt` so both sides of the rule are testable on one simulator.

**Verified on-sim:** wipe launch -> older backup prompts (control); restamp `+3600` -> `pairableCount=0`, no prompt; restamp `-86400` -> prompt returns.

## 3. Devices all named "iPhone"

`UIDevice.current.name` returns the generic model string on physical devices since iOS 16 without the `com.apple.developer.device-information.user-assigned-device-name` entitlement (simulators return the sim name, which is why QA never saw it). New `DeviceModelName` helper falls back to the marketing model name ("iPhone 16 Pro") from the hardware identifier whenever the generic string comes back; unknown future identifiers degrade to the generic name. Wired into both name providers (`IOSDeviceInfo` and the app-target `DeviceInfo`).

**Follow-up (process):** request the user-assigned-device-name entitlement from Apple to get "Jarod's iPhone" back; this fallback covers until then.

## Tests

- New unit tests: nil identity returns all backups; newer-than-own excluded both directions; missing ordering info keeps backups.
- Full ConvosCore suite: 1517 tests in 219 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)