### PR TITLE
fix: restore per-conversation scoping for grant/timezone profile metadata

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -961,7 +961,9 @@ extension MessagingService {
                         name: update.hasName ? update.name : nil,
                         avatar: .addressed(update.hasEncryptedImage ? update.encryptedImage : nil),
                         memberKind: update.memberKind.dbMemberKind,
-                        metadata: metadata.isEmpty ? nil : metadata,
+                        // Authoritative whole map; empty propagates as a clear
+                        // (matches the stream path).
+                        metadata: metadata,
                         receivedAt: receivedAt
                     ),
                     selfInboxId: currentInboxId,

--- a/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileMessageHelpers.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileMessageHelpers.swift
@@ -83,6 +83,19 @@ public enum ProfileMetadataValue: Codable, Hashable, Sendable {
 
 public typealias ProfileMetadata = [String: ProfileMetadataValue]
 
+/// Metadata keys the sender manages per conversation (backed by the scoped
+/// self-metadata table). On the wire an omitted metadata map is
+/// indistinguishable from an empty one (proto3 map), so an empty map on a
+/// winning ProfileUpdate is read as "my scoped keys are now empty": the merge
+/// clears exactly these keys and leaves every other key (e.g. the agent
+/// attestation) untouched, so a metadata-less name-only update from a client
+/// that doesn't re-send its map cannot wipe unrelated state.
+public enum ConversationScopedMetadataKey {
+    public static let connections: String = "connections"
+    public static let timezone: String = "timezone"
+    public static let all: [String] = [connections, timezone]
+}
+
 extension MetadataValue {
     public init(_ value: ProfileMetadataValue) {
         self.init()

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfileInboundApplier.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfileInboundApplier.swift
@@ -26,6 +26,12 @@ enum ProfileInboundApplier {
 
     /// One inbound identity + avatar event for a member, before merge. Bundled so
     /// the seam's call sites (and `apply`) stay under the parameter-count limit.
+    ///
+    /// `metadata` semantics: non-nil is the sender's authoritative whole map -
+    /// a winning event replaces the stored one, and an empty map clears it
+    /// (ProfileUpdate paths pass the decoded map through untouched). Nil means
+    /// the event says nothing about metadata (snapshot/fill paths collapse an
+    /// empty map to nil so they can never clear).
     struct Incoming {
         let inboxId: String
         let source: ProfileSource

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfileMerge.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfileMerge.swift
@@ -9,10 +9,13 @@ import Foundation
 ///   assistant kind is never downgraded to generic `agent`, and the avatar is
 ///   tri-state (only `set`/`explicitClear` change a slot; `silent` leaves it).
 /// - Metadata: a non-nil incoming map is the sender's authoritative whole map -
-///   a winning event replaces the stored one, and an empty map clears it
-///   (revoked grants must propagate; every wire client re-sends its full map on
-///   each update, matching the legacy replace-wholesale receivers). Nil means
-///   the event says nothing about metadata and the stored map is kept.
+///   a winning event replaces the stored one. An empty map clears only the
+///   conversation-scoped keys (`ConversationScopedMetadataKey`) so a revoked
+///   grant propagates while a metadata-less name-only update cannot wipe
+///   unrelated keys, and the cleared state persists as an empty-map tombstone
+///   (distinct from nil/"never known") so a stale lower-source event cannot
+///   fill revoked keys back in. Nil means the event says nothing about
+///   metadata and the stored map is kept.
 enum ProfileMerge {
     /// Trimmed, non-empty name, or nil. A name that is nil/blank/whitespace is
     /// treated as "no name provided".
@@ -59,11 +62,12 @@ enum ProfileMerge {
         if winsOver(existingSource: existing.profileSource, existingUpdatedAt: existing.updatedAt, source: source, sentAt: sentAt) {
             result.name = nonBlank(incoming.name) ?? existing.name
             result.memberKind = preserveVerifiedKind(existing.memberKind, incoming.memberKind)
-            // A winning event's non-nil map replaces the stored one wholesale;
-            // empty clears it (a revoked grant must not survive as stale
-            // metadata). Nil says nothing and keeps the stored map.
+            // A winning event's non-nil non-empty map replaces the stored one
+            // wholesale; an empty map clears the conversation-scoped keys (a
+            // revoked grant must not survive as stale metadata). Nil says
+            // nothing and keeps the stored map.
             if let metadata = incoming.metadata {
-                result.metadata = metadata.isEmpty ? nil : metadata
+                result.metadata = metadata.isEmpty ? clearingScopedKeys(existing.metadata) : metadata
             }
             result.profileSource = source
             result.updatedAt = sentAt
@@ -81,6 +85,22 @@ enum ProfileMerge {
     /// clear) to a winning event; blank-fill and fresh rows treat it as absent.
     private static func nonEmpty(_ metadata: ProfileMetadata?) -> ProfileMetadata? {
         metadata.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /// A winning event's empty map clears only the conversation-scoped keys.
+    /// An omitted map decodes identically to an empty one, so a metadata-less
+    /// update from a client that does not re-send its map must not wipe
+    /// unrelated keys (e.g. the agent attestation) - and the scoped keys are
+    /// the only ones whose senders always publish their current full state.
+    /// The result may be an empty map: that is the tombstone that stops the
+    /// fill-blank path from resurrecting revoked keys out of a stale snapshot;
+    /// a nil (nothing was ever known) stays nil.
+    private static func clearingScopedKeys(_ existing: ProfileMetadata?) -> ProfileMetadata? {
+        guard var cleared = existing else { return nil }
+        for key in ConversationScopedMetadataKey.all {
+            cleared.removeValue(forKey: key)
+        }
+        return cleared
     }
 
     static func mergeAvatar(

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfileMerge.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfileMerge.swift
@@ -8,6 +8,11 @@ import Foundation
 /// - Guards: an empty/absent name never clears a populated one, a verified
 ///   assistant kind is never downgraded to generic `agent`, and the avatar is
 ///   tri-state (only `set`/`explicitClear` change a slot; `silent` leaves it).
+/// - Metadata: a non-nil incoming map is the sender's authoritative whole map -
+///   a winning event replaces the stored one, and an empty map clears it
+///   (revoked grants must propagate; every wire client re-sends its full map on
+///   each update, matching the legacy replace-wholesale receivers). Nil means
+///   the event says nothing about metadata and the stored map is kept.
 enum ProfileMerge {
     /// Trimmed, non-empty name, or nil. A name that is nil/blank/whitespace is
     /// treated as "no name provided".
@@ -44,7 +49,7 @@ enum ProfileMerge {
                 inboxId: inboxId,
                 name: nonBlank(incoming.name),
                 memberKind: incoming.memberKind,
-                metadata: incoming.metadata,
+                metadata: nonEmpty(incoming.metadata),
                 profileSource: source,
                 updatedAt: sentAt
             )
@@ -54,7 +59,12 @@ enum ProfileMerge {
         if winsOver(existingSource: existing.profileSource, existingUpdatedAt: existing.updatedAt, source: source, sentAt: sentAt) {
             result.name = nonBlank(incoming.name) ?? existing.name
             result.memberKind = preserveVerifiedKind(existing.memberKind, incoming.memberKind)
-            result.metadata = incoming.metadata ?? existing.metadata
+            // A winning event's non-nil map replaces the stored one wholesale;
+            // empty clears it (a revoked grant must not survive as stale
+            // metadata). Nil says nothing and keeps the stored map.
+            if let metadata = incoming.metadata {
+                result.metadata = metadata.isEmpty ? nil : metadata
+            }
             result.profileSource = source
             result.updatedAt = sentAt
         } else {
@@ -62,9 +72,15 @@ enum ProfileMerge {
             // never let a low-priority event change an existing kind.
             result.name = existing.name ?? nonBlank(incoming.name)
             result.memberKind = existing.memberKind ?? incoming.memberKind
-            result.metadata = existing.metadata ?? incoming.metadata
+            result.metadata = existing.metadata ?? nonEmpty(incoming.metadata)
         }
         return result
+    }
+
+    /// Non-empty map, or nil. An empty map only means something (an explicit
+    /// clear) to a winning event; blank-fill and fresh rows treat it as absent.
+    private static func nonEmpty(_ metadata: ProfileMetadata?) -> ProfileMetadata? {
+        metadata.flatMap { $0.isEmpty ? nil : $0 }
     }
 
     static func mergeAvatar(

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
@@ -215,7 +215,8 @@ actor ProfilePublisher {
         }
         let published = PublishedAvatar(url: url, salt: salt, nonce: nonce, key: key)
         let selfProfile = try await selfProfileStore.load()
-        try await session.sendProfileUpdate(name: selfProfile?.name, metadata: selfProfile?.metadata, avatar: published, conversationId: job.conversationId)
+        let metadata = try await outgoingMetadata(for: job.conversationId, selfProfile: selfProfile)
+        try await session.sendProfileUpdate(name: selfProfile?.name, metadata: metadata, avatar: published, conversationId: job.conversationId)
         let slot = DBProfileAvatar(
             inboxId: selfInboxId,
             conversationId: job.conversationId,
@@ -234,8 +235,57 @@ actor ProfilePublisher {
         let existing = try await profileStore.avatar(inboxId: selfInboxId, conversationId: job.conversationId)
         let published = publishedAvatar(from: existing)
         let selfProfile = try await selfProfileStore.load()
-        try await session.sendProfileUpdate(name: selfProfile?.name, metadata: selfProfile?.metadata, avatar: published, conversationId: job.conversationId)
+        let metadata = try await outgoingMetadata(for: job.conversationId, selfProfile: selfProfile)
+        try await session.sendProfileUpdate(name: selfProfile?.name, metadata: metadata, avatar: published, conversationId: job.conversationId)
         await stampPublished(selfProfile, conversationId: job.conversationId)
+    }
+
+    // MARK: - Scoped metadata
+
+    /// Publishes conversation-scoped metadata (cloud connection grants, agent
+    /// timezone) to one conversation immediately, merged over the global self
+    /// metadata, and persists the scoped map on success.
+    ///
+    /// Deliberately not routed through the durable queue: callers rely on a
+    /// send failure propagating so they can decline to persist their own state
+    /// (`CloudConnectionGrantWriter` declines the local grant change; the
+    /// timezone publisher declines its throttle stamp and retries on the next
+    /// foreground). The scoped map is persisted only after the send succeeds
+    /// for the same reason - a failed publish must leave no trace that later
+    /// lazy publishes would deliver.
+    func publishScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String) async throws {
+        guard let session else { throw ProfilePublishError.sessionUnavailable }
+        guard let selfInboxId = await resolveSelfInboxId() else {
+            throw ProfilePublishError.selfInboxUnavailable
+        }
+        let slot = try await profileStore.avatar(inboxId: selfInboxId, conversationId: conversationId)
+        let selfProfile = try await selfProfileStore.load()
+        let merged = Self.mergedMetadata(global: selfProfile?.metadata, scoped: metadata)
+        try await session.sendProfileUpdate(
+            name: selfProfile?.name,
+            metadata: merged,
+            avatar: publishedAvatar(from: slot),
+            conversationId: conversationId
+        )
+        try await selfProfileStore.saveScopedMetadata(metadata, conversationId: conversationId, updatedAt: now())
+    }
+
+    /// The metadata map for an outgoing ProfileUpdate to one conversation: the
+    /// global self metadata with that conversation's scoped keys merged over it
+    /// (scoped wins). Keeps every queue send carrying the conversation's grants
+    /// and timezone, so a later name or avatar publish can never wipe them at
+    /// the receiver.
+    private func outgoingMetadata(for conversationId: String, selfProfile: DBMyProfile?) async throws -> ProfileMetadata? {
+        let scoped = try await selfProfileStore.scopedMetadata(conversationId: conversationId)
+        return Self.mergedMetadata(global: selfProfile?.metadata, scoped: scoped)
+    }
+
+    static func mergedMetadata(global: ProfileMetadata?, scoped: ProfileMetadata?) -> ProfileMetadata? {
+        var merged = global ?? [:]
+        for (key, value) in scoped ?? [:] {
+            merged[key] = value
+        }
+        return merged.isEmpty ? nil : merged
     }
 
     /// Records that the self profile as of `selfProfile.updatedAt` has actually
@@ -283,4 +333,12 @@ actor ProfilePublisher {
         case staleSource
         case conversationGone
     }
+}
+
+/// Thrown by `publishScopedMetadata` when the immediate send cannot even be
+/// attempted. Surfaced to callers (unlike queue jobs, which reschedule) because
+/// scoped-metadata writers use the error to decline persisting their own state.
+enum ProfilePublishError: Error {
+    case sessionUnavailable
+    case selfInboxUnavailable
 }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
@@ -215,7 +215,7 @@ actor ProfilePublisher {
         }
         let published = PublishedAvatar(url: url, salt: salt, nonce: nonce, key: key)
         let selfProfile = try await selfProfileStore.load()
-        let metadata = try await outgoingMetadata(for: job.conversationId, selfProfile: selfProfile)
+        let metadata = try await outgoingMetadata(for: job.conversationId, selfInboxId: selfInboxId, selfProfile: selfProfile)
         try await session.sendProfileUpdate(name: selfProfile?.name, metadata: metadata, avatar: published, conversationId: job.conversationId)
         let slot = DBProfileAvatar(
             inboxId: selfInboxId,
@@ -235,7 +235,7 @@ actor ProfilePublisher {
         let existing = try await profileStore.avatar(inboxId: selfInboxId, conversationId: job.conversationId)
         let published = publishedAvatar(from: existing)
         let selfProfile = try await selfProfileStore.load()
-        let metadata = try await outgoingMetadata(for: job.conversationId, selfProfile: selfProfile)
+        let metadata = try await outgoingMetadata(for: job.conversationId, selfInboxId: selfInboxId, selfProfile: selfProfile)
         try await session.sendProfileUpdate(name: selfProfile?.name, metadata: metadata, avatar: published, conversationId: job.conversationId)
         await stampPublished(selfProfile, conversationId: job.conversationId)
     }
@@ -277,16 +277,18 @@ actor ProfilePublisher {
             avatar: publishedAvatar(from: slot),
             conversationId: conversationId
         )
-        try await selfProfileStore.saveScopedMetadata(metadata, conversationId: conversationId, updatedAt: now())
+        try await selfProfileStore.saveScopedMetadata(metadata, inboxId: selfInboxId, conversationId: conversationId, updatedAt: now())
     }
 
     /// The metadata map for an outgoing ProfileUpdate to one conversation: the
     /// global self metadata with that conversation's scoped keys merged over it
     /// (scoped wins). Keeps every queue send carrying the conversation's grants
     /// and timezone, so a later name or avatar publish can never wipe them at
-    /// the receiver.
-    private func outgoingMetadata(for conversationId: String, selfProfile: DBMyProfile?) async throws -> ProfileMetadata? {
-        let scoped = try await selfProfileStore.scopedMetadata(conversationId: conversationId)
+    /// the receiver. The caller's already-resolved inbox id is threaded through
+    /// so the store read cannot disagree with the publish about the active
+    /// account mid-flight.
+    private func outgoingMetadata(for conversationId: String, selfInboxId: String, selfProfile: DBMyProfile?) async throws -> ProfileMetadata? {
+        let scoped = try await selfProfileStore.scopedMetadata(inboxId: selfInboxId, conversationId: conversationId)
         return Self.mergedMetadata(global: selfProfile?.metadata, scoped: scoped)
     }
 

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
@@ -253,6 +253,16 @@ actor ProfilePublisher {
     /// foreground). The scoped map is persisted only after the send succeeds
     /// for the same reason - a failed publish must leave no trace that later
     /// lazy publishes would deliver.
+    ///
+    /// A persist failure after a successful send also throws, and that ordering
+    /// is deliberate. The remote transiently holds the new map, but the caller
+    /// declines its own state and the next queue publish (reading the old
+    /// stored map) reverts the remote, so everything converges on the pre-send
+    /// state. The alternatives are worse: persisting before the send turns a
+    /// failed send into a durable map that later lazy publishes deliver even
+    /// though the caller rolled back, and swallowing the persist failure lets
+    /// the caller commit state whose metadata the next queue publish silently
+    /// wipes from the remote.
     func publishScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String) async throws {
         guard let session else { throw ProfilePublishError.sessionUnavailable }
         guard let selfInboxId = await resolveSelfInboxId() else {

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
@@ -369,10 +369,24 @@ public actor ProfilesRepository {
         try await publisher.publishConversation(conversationId)
     }
 
-    /// Records new self metadata locally and bumps `updatedAt`. Propagation is
-    /// lazy per conversation, same as `publishMyProfile`.
+    /// Records new global self metadata locally and bumps `updatedAt`.
+    /// Propagation is lazy per conversation, same as `publishMyProfile`.
+    ///
+    /// Global identity metadata only. Conversation-scoped keys (cloud
+    /// connection grants, agent timezone) must go through
+    /// `publishMyProfileMetadata(_:toConversation:)` - putting them here would
+    /// broadcast one conversation's grants to every conversation.
     public func publishMyProfileMetadata(_ metadata: ProfileMetadata?) async throws {
         try await updateSelfProfile(SelfProfileEdit(metadata: .set(metadata)))
+    }
+
+    /// Publishes conversation-scoped metadata to one conversation immediately
+    /// (not via the lazy queue) and persists it for that conversation only, so
+    /// subsequent lazy publishes keep carrying it. Throws when the send cannot
+    /// be delivered; callers rely on that to decline persisting their own
+    /// dependent state (e.g. a cloud connection grant).
+    public func publishMyProfileMetadata(_ metadata: ProfileMetadata?, toConversation conversationId: String) async throws {
+        try await publisher.publishScopedMetadata(metadata, conversationId: conversationId)
     }
 
     /// Drops a conversation's avatar slots from every person's cache and the

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
@@ -14,12 +14,15 @@ protocol SelfProfileStoreProtocol: Sendable {
     /// The current user's conversation-scoped metadata map (cloud connection
     /// grants, agent timezone) for one conversation, or nil when none was ever
     /// published there. Scoped keys are merged over the global metadata at send
-    /// time; they never live in `DBMyProfile.metadata`.
-    func scopedMetadata(conversationId: String) async throws -> ProfileMetadata?
+    /// time; they never live in `DBMyProfile.metadata`. Takes the inbox id
+    /// explicitly (unlike `load`) so a publish that already resolved the self
+    /// inbox cannot silently read a different account's rows if the provider's
+    /// answer changes mid-flight.
+    func scopedMetadata(inboxId: String, conversationId: String) async throws -> ProfileMetadata?
 
     /// Persists the conversation-scoped metadata map for one conversation.
     /// A nil or empty map deletes the row.
-    func saveScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String, updatedAt: Date) async throws
+    func saveScopedMetadata(_ metadata: ProfileMetadata?, inboxId: String, conversationId: String, updatedAt: Date) async throws
 }
 
 final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
@@ -75,9 +78,8 @@ final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
         }
     }
 
-    func scopedMetadata(conversationId: String) async throws -> ProfileMetadata? {
-        guard let inboxId = await selfInboxIdProvider() else { return nil }
-        return try await databaseReader.read { db in
+    func scopedMetadata(inboxId: String, conversationId: String) async throws -> ProfileMetadata? {
+        try await databaseReader.read { db in
             try DBSelfConversationMetadata
                 .filter(DBSelfConversationMetadata.Columns.inboxId == inboxId)
                 .filter(DBSelfConversationMetadata.Columns.conversationId == conversationId)
@@ -85,8 +87,7 @@ final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
         }
     }
 
-    func saveScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String, updatedAt: Date) async throws {
-        guard let inboxId = await selfInboxIdProvider() else { return }
+    func saveScopedMetadata(_ metadata: ProfileMetadata?, inboxId: String, conversationId: String, updatedAt: Date) async throws {
         try await databaseWriter.write { db in
             guard let metadata, !metadata.isEmpty else {
                 _ = try DBSelfConversationMetadata
@@ -107,7 +108,7 @@ final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
 
 actor InMemorySelfProfileStore: SelfProfileStoreProtocol {
     private var current: DBMyProfile?
-    private var scopedByConversation: [String: ProfileMetadata] = [:]
+    private var scopedByInbox: [String: [String: ProfileMetadata]] = [:]
 
     func save(_ profile: DBMyProfile) {
         current = profile
@@ -119,18 +120,18 @@ actor InMemorySelfProfileStore: SelfProfileStoreProtocol {
 
     func clear() {
         current = nil
-        scopedByConversation = [:]
+        scopedByInbox = [:]
     }
 
-    func scopedMetadata(conversationId: String) -> ProfileMetadata? {
-        scopedByConversation[conversationId]
+    func scopedMetadata(inboxId: String, conversationId: String) -> ProfileMetadata? {
+        scopedByInbox[inboxId]?[conversationId]
     }
 
-    func saveScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String, updatedAt: Date) {
+    func saveScopedMetadata(_ metadata: ProfileMetadata?, inboxId: String, conversationId: String, updatedAt: Date) {
         guard let metadata, !metadata.isEmpty else {
-            scopedByConversation[conversationId] = nil
+            scopedByInbox[inboxId]?[conversationId] = nil
             return
         }
-        scopedByConversation[conversationId] = metadata
+        scopedByInbox[inboxId, default: [:]][conversationId] = metadata
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
@@ -10,6 +10,16 @@ protocol SelfProfileStoreProtocol: Sendable {
     func save(_ profile: DBMyProfile) async throws
     func load() async throws -> DBMyProfile?
     func clear() async throws
+
+    /// The current user's conversation-scoped metadata map (cloud connection
+    /// grants, agent timezone) for one conversation, or nil when none was ever
+    /// published there. Scoped keys are merged over the global metadata at send
+    /// time; they never live in `DBMyProfile.metadata`.
+    func scopedMetadata(conversationId: String) async throws -> ProfileMetadata?
+
+    /// Persists the conversation-scoped metadata map for one conversation.
+    /// A nil or empty map deletes the row.
+    func saveScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String, updatedAt: Date) async throws
 }
 
 final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
@@ -61,10 +71,40 @@ final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
             _ = try DBMyProfile.filter(DBMyProfile.Columns.inboxId == inboxId).deleteAll(db)
         }
     }
+
+    func scopedMetadata(conversationId: String) async throws -> ProfileMetadata? {
+        guard let inboxId = await selfInboxIdProvider() else { return nil }
+        return try await databaseReader.read { db in
+            try DBSelfConversationMetadata
+                .filter(DBSelfConversationMetadata.Columns.inboxId == inboxId)
+                .filter(DBSelfConversationMetadata.Columns.conversationId == conversationId)
+                .fetchOne(db)?.metadata
+        }
+    }
+
+    func saveScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String, updatedAt: Date) async throws {
+        guard let inboxId = await selfInboxIdProvider() else { return }
+        try await databaseWriter.write { db in
+            guard let metadata, !metadata.isEmpty else {
+                _ = try DBSelfConversationMetadata
+                    .filter(DBSelfConversationMetadata.Columns.inboxId == inboxId)
+                    .filter(DBSelfConversationMetadata.Columns.conversationId == conversationId)
+                    .deleteAll(db)
+                return
+            }
+            try DBSelfConversationMetadata(
+                inboxId: inboxId,
+                conversationId: conversationId,
+                metadata: metadata,
+                updatedAt: updatedAt
+            ).save(db)
+        }
+    }
 }
 
 actor InMemorySelfProfileStore: SelfProfileStoreProtocol {
     private var current: DBMyProfile?
+    private var scopedByConversation: [String: ProfileMetadata] = [:]
 
     func save(_ profile: DBMyProfile) {
         current = profile
@@ -76,5 +116,18 @@ actor InMemorySelfProfileStore: SelfProfileStoreProtocol {
 
     func clear() {
         current = nil
+        scopedByConversation = [:]
+    }
+
+    func scopedMetadata(conversationId: String) -> ProfileMetadata? {
+        scopedByConversation[conversationId]
+    }
+
+    func saveScopedMetadata(_ metadata: ProfileMetadata?, conversationId: String, updatedAt: Date) {
+        guard let metadata, !metadata.isEmpty else {
+            scopedByConversation[conversationId] = nil
+            return
+        }
+        scopedByConversation[conversationId] = metadata
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
@@ -69,6 +69,9 @@ final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
         guard let inboxId = await selfInboxIdProvider() else { return }
         try await databaseWriter.write { db in
             _ = try DBMyProfile.filter(DBMyProfile.Columns.inboxId == inboxId).deleteAll(db)
+            _ = try DBSelfConversationMetadata
+                .filter(DBSelfConversationMetadata.Columns.inboxId == inboxId)
+                .deleteAll(db)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -997,6 +997,7 @@ extension SessionManager {
         try DBProfileAvatar.deleteAll(db)
         try DBProfileAvatarSource.deleteAll(db)
         try DBProfilePublishJob.deleteAll(db)
+        try DBSelfConversationMetadata.deleteAll(db)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBSelfConversationMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBSelfConversationMetadata.swift
@@ -1,0 +1,30 @@
+import Foundation
+import GRDB
+
+/// The current user's conversation-scoped `ProfileUpdate` metadata, keyed by
+/// `(inboxId, conversationId)`. Some metadata keys are per-conversation on the
+/// wire - cloud connection grants carry the grants for one conversation only,
+/// and the agent timezone is published only to agent conversations - so they
+/// cannot live in the global `DBMyProfile.metadata` map: a global map makes
+/// one conversation's grants overwrite another's and broadcasts them to every
+/// conversation the user touches.
+///
+/// At send time the publisher merges this row's map over the global self
+/// metadata (scoped keys win), so every `ProfileUpdate` a conversation receives
+/// carries both the user's global identity metadata and that conversation's
+/// scoped keys.
+struct DBSelfConversationMetadata: Codable, FetchableRecord, PersistableRecord, Hashable, Sendable {
+    static let databaseTableName: String = "selfConversationMetadata"
+
+    enum Columns {
+        static let inboxId: Column = Column(CodingKeys.inboxId)
+        static let conversationId: Column = Column(CodingKeys.conversationId)
+        static let metadata: Column = Column(CodingKeys.metadata)
+        static let updatedAt: Column = Column(CodingKeys.updatedAt)
+    }
+
+    let inboxId: String
+    let conversationId: String
+    var metadata: ProfileMetadata
+    var updatedAt: Date
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -265,6 +265,7 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addProfileAvatarLastRenewed", migrate: Self.addProfileAvatarLastRenewed)
         migrator.registerMigration("makeProfileAvatarLatestViewDeterministic", migrate: Self.makeProfileAvatarLatestViewDeterministic)
         migrator.registerMigration("addConversationLocalStatePublishedProfileUpdatedAt", migrate: Self.addConversationLocalStatePublishedProfileUpdatedAt)
+        migrator.registerMigration("createSelfConversationMetadata", migrate: Self.createSelfConversationMetadata)
     }
 
     /// Additive, nullable column recording the `myProfile.updatedAt` of the self
@@ -279,6 +280,60 @@ extension SharedDatabaseMigrator {
         guard !hasColumn else { return }
         try db.alter(table: "conversationLocalState") { t in
             t.add(column: "publishedProfileUpdatedAt", .datetime)
+        }
+    }
+
+    /// Conversation-scoped self metadata (cloud connection grants, agent
+    /// timezone), keyed by `(inboxId, conversationId)`. These keys are
+    /// per-conversation on the wire, so they cannot live in the global
+    /// `myProfile.metadata` map: a global map makes one conversation's grants
+    /// overwrite another's and broadcasts them to every conversation. The FK
+    /// cascade purges a deleted conversation's rows, matching `profileAvatar`.
+    ///
+    /// Also strips the scoped keys out of any existing `myProfile.metadata`:
+    /// builds that ran the interim global routing wrote grants/timezone there,
+    /// and a value left behind would keep broadcasting to every conversation on
+    /// each publish. Decoded in Swift rather than `json_remove` so the stored
+    /// class (text vs blob) doesn't matter.
+    static func createSelfConversationMetadata(_ db: Database) throws {
+        try db.create(table: "selfConversationMetadata") { t in
+            t.column("inboxId", .text).notNull()
+            t.column("conversationId", .text).notNull()
+                .references("conversation", onDelete: .cascade)
+            t.column("metadata", .jsonText).notNull()
+            t.column("updatedAt", .datetime).notNull()
+            t.primaryKey(["inboxId", "conversationId"])
+        }
+
+        let scopedKeys = ["connections", "timezone"]
+        let rows = try Row.fetchAll(db, sql: "SELECT inboxId, metadata FROM myProfile WHERE metadata IS NOT NULL")
+        for row in rows {
+            let inboxId: String = row["inboxId"]
+            let raw: Data?
+            if let data = row["metadata"] as Data? {
+                raw = data
+            } else if let text = row["metadata"] as String? {
+                raw = text.data(using: .utf8)
+            } else {
+                raw = nil
+            }
+            guard let raw,
+                  var metadata = try? JSONDecoder().decode(ProfileMetadata.self, from: raw) else { continue }
+            guard scopedKeys.contains(where: { metadata[$0] != nil }) else { continue }
+            for key in scopedKeys {
+                metadata.removeValue(forKey: key)
+            }
+            let encoded: String?
+            if metadata.isEmpty {
+                encoded = nil
+            } else {
+                let data = try JSONEncoder().encode(metadata)
+                encoded = String(bytes: data, encoding: .utf8)
+            }
+            try db.execute(
+                sql: "UPDATE myProfile SET metadata = ? WHERE inboxId = ?",
+                arguments: [encoded, inboxId]
+            )
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -1204,7 +1204,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                             name: entry.update.hasName ? entry.update.name : nil,
                             avatar: .fillIfPresent(entry.update.hasEncryptedImage ? entry.update.encryptedImage : nil),
                             memberKind: entry.update.memberKind.dbMemberKind,
-                            metadata: metadata.isEmpty ? nil : metadata,
+                            // Authoritative whole map from the newest replayed
+                            // update; empty propagates as a clear. The recency
+                            // guard keeps an older replay from beating live data.
+                            metadata: metadata,
                             receivedAt: entry.sentAt
                         ),
                         selfInboxId: selfInboxId,

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ProfileMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ProfileMetadataWriter.swift
@@ -2,16 +2,18 @@ import Foundation
 import GRDB
 
 public protocol ProfileMetadataWriterProtocol: Sendable {
-    /// Reads the current user's self-profile metadata map, applies the caller's
-    /// mutation closure, and republishes the merged map through
-    /// `ProfilesRepository.publishMyProfileMetadata`, which fans it out to every
-    /// conversation. The whole read-modify-write runs as one serialized unit so
-    /// two callers (e.g. a connections write and a timezone write) can never
-    /// interleave and clobber each other's keys.
+    /// Reads the current user's conversation-scoped metadata map for
+    /// `conversationId`, applies the caller's mutation closure, and publishes
+    /// the merged map to that conversation immediately through
+    /// `ProfilesRepository.publishMyProfileMetadata(_:toConversation:)`. The
+    /// whole read-modify-write runs as one serialized unit so two callers
+    /// (e.g. a connections write and a timezone write) can never interleave
+    /// and clobber each other's keys.
     ///
-    /// `conversationId` and `inboxId` are retained on the signature for existing
-    /// callers; the metadata is now global (self-profile) rather than
-    /// per-conversation, so they no longer scope the read.
+    /// Scoped keys (cloud connection grants, agent timezone) are
+    /// per-conversation on the wire: the map published to one conversation is
+    /// independent of every other conversation's, and a send failure throws so
+    /// the caller can decline to persist its own dependent state.
     func updateMetadata(
         conversationId: String,
         inboxId: String,
@@ -19,21 +21,21 @@ public protocol ProfileMetadataWriterProtocol: Sendable {
     ) async throws
 }
 
-/// Shared serialization choke point for every per-sender
+/// Shared serialization choke point for every conversation-scoped
 /// `ProfileUpdate.metadata` write.
 ///
-/// The self-profile metadata map is rewritten wholesale on each publish (read
-/// existing -> merge key -> publish). Two async tasks in the same process can
-/// interleave on this non-atomic read-merge-write: a timezone publish and a
-/// `connections` publish both touch the same `selfProfile` row. If they overlap,
-/// the later write overwrites the earlier with a stale copy of the key the other
-/// task just set -- silent data loss.
+/// A conversation's scoped metadata map is rewritten wholesale on each publish
+/// (read existing -> merge key -> publish). Two async tasks in the same process
+/// can interleave on this non-atomic read-merge-write: a timezone publish and a
+/// `connections` publish both touch the same conversation's map. If they
+/// overlap, the later write overwrites the earlier with a stale copy of the key
+/// the other task just set -- silent data loss.
 ///
-/// To prevent that, all metadata map writes go through one shared instance of
-/// this class. `@MainActor` keeps the bookkeeping on a single actor, and an
-/// internal serial task chain makes each `updateMetadata` call run to completion
-/// (including its async hops) before the next one starts, so the read-merge-write
-/// is atomic across callers.
+/// To prevent that, all scoped metadata writes go through one shared instance
+/// of this class. `@MainActor` keeps the bookkeeping on a single actor, and an
+/// internal serial task chain makes each `updateMetadata` call run to
+/// completion (including its async hops) before the next one starts, so the
+/// read-merge-write is atomic across callers.
 @MainActor
 public final class ProfileMetadataWriter: ProfileMetadataWriterProtocol {
     private let profilesRepository: @Sendable () -> ProfilesRepository
@@ -65,11 +67,17 @@ public final class ProfileMetadataWriter: ProfileMetadataWriterProtocol {
             await previous.value
             do {
                 let existing = try await databaseReader.read { db in
-                    try DBMyProfile.filter(DBMyProfile.Columns.inboxId == inboxId).fetchOne(db)?.metadata
+                    try DBSelfConversationMetadata
+                        .filter(DBSelfConversationMetadata.Columns.inboxId == inboxId)
+                        .filter(DBSelfConversationMetadata.Columns.conversationId == conversationId)
+                        .fetchOne(db)?.metadata
                 }
                 var merged: ProfileMetadata = existing ?? [:]
                 update(&merged)
-                try await profilesRepository().publishMyProfileMetadata(merged.isEmpty ? nil : merged)
+                try await profilesRepository().publishMyProfileMetadata(
+                    merged.isEmpty ? nil : merged,
+                    toConversation: conversationId
+                )
                 return .success(())
             } catch {
                 return .failure(error)

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -499,7 +499,10 @@ actor StreamProcessor: StreamProcessorProtocol {
                         name: update.hasName ? update.name : nil,
                         avatar: .addressed(update.hasEncryptedImage ? update.encryptedImage : nil),
                         memberKind: update.memberKind.dbMemberKind,
-                        metadata: metadata.isEmpty ? nil : metadata,
+                        // A ProfileUpdate's map is authoritative; pass it through
+                        // even when empty so a cleared map (e.g. revoked grants)
+                        // propagates as a clear instead of reading as "no change".
+                        metadata: metadata,
                         receivedAt: receivedAt
                     ),
                     selfInboxId: currentInboxId,

--- a/ConvosCore/Tests/ConvosCoreTests/DeleteAllDataCleanSlateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DeleteAllDataCleanSlateTests.swift
@@ -61,6 +61,11 @@ struct DeleteAllDataCleanSlateTests {
                 nextAttemptAt: Date(timeIntervalSince1970: 1), createdAt: Date(timeIntervalSince1970: 1),
                 updatedAt: Date(timeIntervalSince1970: 1)
             ).save(db)
+            try DBSelfConversationMetadata(
+                inboxId: "me", conversationId: "c1",
+                metadata: ["connections": .string("grants")],
+                updatedAt: Date(timeIntervalSince1970: 1)
+            ).save(db)
         }
 
         try await dbManager.dbWriter.write { db in
@@ -73,7 +78,8 @@ struct DeleteAllDataCleanSlateTests {
                 profile: try DBProfile.fetchCount(db),
                 avatar: try DBProfileAvatar.fetchCount(db),
                 avatarSource: try DBProfileAvatarSource.fetchCount(db),
-                publishJob: try DBProfilePublishJob.fetchCount(db)
+                publishJob: try DBProfilePublishJob.fetchCount(db),
+                scopedMetadata: try DBSelfConversationMetadata.fetchCount(db)
             )
         }
         #expect(counts.myProfile == 0)
@@ -81,5 +87,6 @@ struct DeleteAllDataCleanSlateTests {
         #expect(counts.avatar == 0)
         #expect(counts.avatarSource == 0)
         #expect(counts.publishJob == 0)
+        #expect(counts.scopedMetadata == 0)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileInboundApplierTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileInboundApplierTests.swift
@@ -221,7 +221,32 @@ struct ProfileInboundApplierTests {
         try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: [:], sentAt: Date(timeIntervalSince1970: 2))
 
         let cleared = try profile(queue, inboxId: "alice")
-        #expect(cleared?.metadata == nil)
+        #expect(cleared?.metadata?["connections"] == nil)
+
+        // And a stale snapshot cannot resurrect the revoked grants: the clear
+        // left a tombstone, not a blank.
+        try apply(queue, inboxId: "alice", source: .profileSnapshot, name: "Alice", avatar: .fillIfPresent(nil), metadata: ["connections": .string("grants")], sentAt: Date(timeIntervalSince1970: 3))
+        let afterSnapshot = try profile(queue, inboxId: "alice")
+        #expect(afterSnapshot?.metadata?["connections"] == nil)
+    }
+
+    @Test("a metadata-less update clears scoped keys only, preserving e.g. an attestation")
+    func emptyMetadataPreservesUnscopedKeys() throws {
+        let queue = try makeQueue()
+        try apply(
+            queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil),
+            metadata: ["connections": .string("grants"), "custom": .string("kept")],
+            sentAt: Date(timeIntervalSince1970: 1)
+        )
+
+        // A name-only update from a client that does not re-send its map
+        // decodes as an empty map.
+        try apply(queue, inboxId: "alice", name: "Alice Renamed", avatar: .addressed(nil), metadata: [:], sentAt: Date(timeIntervalSince1970: 2))
+
+        let merged = try profile(queue, inboxId: "alice")
+        #expect(merged?.name == "Alice Renamed")
+        #expect(merged?.metadata?["connections"] == nil)
+        #expect(merged?.metadata?["custom"] == .string("kept"))
     }
 
     @Test("a newer update's non-empty metadata map replaces the stored one wholesale")

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileInboundApplierTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileInboundApplierTests.swift
@@ -66,6 +66,7 @@ struct ProfileInboundApplierTests {
         source: ProfileSource = .profileUpdate,
         name: String?,
         avatar: ProfileInboundApplier.AvatarDisposition,
+        metadata: ProfileMetadata? = nil,
         selfInboxId: String? = "me",
         fallbackKey: Data? = nil,
         sentAt: Date
@@ -80,7 +81,7 @@ struct ProfileInboundApplierTests {
                     name: name,
                     avatar: avatar,
                     memberKind: nil,
-                    metadata: nil,
+                    metadata: metadata,
                     receivedAt: sentAt
                 ),
                 selfInboxId: selfInboxId,
@@ -207,5 +208,45 @@ struct ProfileInboundApplierTests {
 
         let contact = try queue.read { db in try DBContact.fetchOne(db, key: "bob") }
         #expect(contact == nil)
+    }
+
+    @Test("a newer update's empty metadata map clears the stored metadata (revoked grants propagate)")
+    func updateEmptyMetadataClears() throws {
+        let queue = try makeQueue()
+        try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: ["connections": .string("grants")], sentAt: Date(timeIntervalSince1970: 1))
+        let seeded = try profile(queue, inboxId: "alice")
+        #expect(seeded?.metadata?["connections"] == .string("grants"))
+
+        // The sender revoked their last grant: the update's map is empty.
+        try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: [:], sentAt: Date(timeIntervalSince1970: 2))
+
+        let cleared = try profile(queue, inboxId: "alice")
+        #expect(cleared?.metadata == nil)
+    }
+
+    @Test("a newer update's non-empty metadata map replaces the stored one wholesale")
+    func updateMetadataReplacesWholesale() throws {
+        let queue = try makeQueue()
+        try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: ["connections": .string("grants")], sentAt: Date(timeIntervalSince1970: 1))
+        try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: ["timezone": .string("Europe/Paris")], sentAt: Date(timeIntervalSince1970: 2))
+
+        let replaced = try profile(queue, inboxId: "alice")
+        #expect(replaced?.metadata?["timezone"] == .string("Europe/Paris"))
+        #expect(replaced?.metadata?["connections"] == nil)
+    }
+
+    @Test("an older replayed update cannot clear newer metadata, and a snapshot never clears")
+    func staleAndSnapshotEventsCannotClearMetadata() throws {
+        let queue = try makeQueue()
+        try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: ["connections": .string("grants")], sentAt: Date(timeIntervalSince1970: 5))
+
+        // A replayed older update (empty map) loses on recency.
+        try apply(queue, inboxId: "alice", name: "Alice", avatar: .addressed(nil), metadata: [:], sentAt: Date(timeIntervalSince1970: 1))
+        // A snapshot path collapses empty to nil before the applier, so it says
+        // nothing about metadata even when newer.
+        try apply(queue, inboxId: "alice", source: .profileSnapshot, name: "Alice", avatar: .fillIfPresent(nil), metadata: nil, sentAt: Date(timeIntervalSince1970: 9))
+
+        let kept = try profile(queue, inboxId: "alice")
+        #expect(kept?.metadata?["connections"] == .string("grants"))
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileMergeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileMergeTests.swift
@@ -93,6 +93,62 @@ struct ProfileMergeIdentityTests {
         )
         #expect(upgrade.memberKind == .verifiedConvos)
     }
+
+    @Test("a winning event's metadata is authoritative: replaces wholesale, empty clears, nil keeps")
+    func metadataReplaceClearKeep() {
+        let existing = DBProfile(
+            inboxId: "i", name: "Alice", metadata: ["connections": .string("grants")],
+            profileSource: .profileUpdate, updatedAt: t1
+        )
+
+        let replaced = ProfileMerge.mergeIdentity(
+            existing: existing, inboxId: "i", incoming: IncomingIdentity(metadata: ["timezone": .string("Europe/Paris")]),
+            source: .profileUpdate, sentAt: t2
+        )
+        #expect(replaced.metadata?["timezone"] == .string("Europe/Paris"))
+        #expect(replaced.metadata?["connections"] == nil)
+
+        let cleared = ProfileMerge.mergeIdentity(
+            existing: existing, inboxId: "i", incoming: IncomingIdentity(metadata: [:]),
+            source: .profileUpdate, sentAt: t2
+        )
+        #expect(cleared.metadata == nil)
+
+        let kept = ProfileMerge.mergeIdentity(
+            existing: existing, inboxId: "i", incoming: IncomingIdentity(name: "Alice", metadata: nil),
+            source: .profileUpdate, sentAt: t2
+        )
+        #expect(kept.metadata?["connections"] == .string("grants"))
+    }
+
+    @Test("a losing event's empty metadata neither clears nor fills")
+    func losingEmptyMetadataIsInert() {
+        let existing = DBProfile(
+            inboxId: "i", name: "Alice", metadata: ["connections": .string("grants")],
+            profileSource: .profileUpdate, updatedAt: t2
+        )
+
+        // Older same-source event with an empty map: loses on recency, keeps.
+        let stale = ProfileMerge.mergeIdentity(
+            existing: existing, inboxId: "i", incoming: IncomingIdentity(metadata: [:]),
+            source: .profileUpdate, sentAt: t1
+        )
+        #expect(stale.metadata?["connections"] == .string("grants"))
+
+        // Lower-source event with an empty map: fill-only, and empty fills nothing.
+        let lower = ProfileMerge.mergeIdentity(
+            existing: existing, inboxId: "i", incoming: IncomingIdentity(metadata: [:]),
+            source: .profileSnapshot, sentAt: t2
+        )
+        #expect(lower.metadata?["connections"] == .string("grants"))
+
+        // A fresh row from an empty map stores nil, not an empty map.
+        let fresh = ProfileMerge.mergeIdentity(
+            existing: nil, inboxId: "i", incoming: IncomingIdentity(name: "Alice", metadata: [:]),
+            source: .profileUpdate, sentAt: t1
+        )
+        #expect(fresh.metadata == nil)
+    }
 }
 
 @Suite("Profile merge - avatar")

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileMergeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileMergeTests.swift
@@ -108,17 +108,59 @@ struct ProfileMergeIdentityTests {
         #expect(replaced.metadata?["timezone"] == .string("Europe/Paris"))
         #expect(replaced.metadata?["connections"] == nil)
 
+        // An empty map clears the scoped keys and leaves a tombstone.
         let cleared = ProfileMerge.mergeIdentity(
             existing: existing, inboxId: "i", incoming: IncomingIdentity(metadata: [:]),
             source: .profileUpdate, sentAt: t2
         )
-        #expect(cleared.metadata == nil)
+        #expect(cleared.metadata?["connections"] == nil)
+        #expect(cleared.metadata?.isEmpty == true)
 
         let kept = ProfileMerge.mergeIdentity(
             existing: existing, inboxId: "i", incoming: IncomingIdentity(name: "Alice", metadata: nil),
             source: .profileUpdate, sentAt: t2
         )
         #expect(kept.metadata?["connections"] == .string("grants"))
+    }
+
+    @Test("an empty map clears only the conversation-scoped keys, never e.g. an attestation")
+    func emptyMapClearsOnlyScopedKeys() {
+        let existing = DBProfile(
+            inboxId: "i", name: "Agent",
+            metadata: [
+                "connections": .string("grants"),
+                "timezone": .string("Europe/Paris"),
+                "attestation": .string("signed-attestation")
+            ],
+            profileSource: .profileUpdate, updatedAt: t1
+        )
+
+        // A metadata-less name-only update decodes as an empty map; it must
+        // not wipe keys outside the scoped set.
+        let merged = ProfileMerge.mergeIdentity(
+            existing: existing, inboxId: "i", incoming: IncomingIdentity(name: "Agent", metadata: [:]),
+            source: .profileUpdate, sentAt: t2
+        )
+        #expect(merged.metadata?["connections"] == nil)
+        #expect(merged.metadata?["timezone"] == nil)
+        #expect(merged.metadata?["attestation"] == .string("signed-attestation"))
+    }
+
+    @Test("the empty-map tombstone stops a stale snapshot from resurrecting revoked keys")
+    func tombstoneBlocksSnapshotResurrection() {
+        // Revoked: the winning clear left an empty-map tombstone.
+        let cleared = DBProfile(
+            inboxId: "i", name: "Alice", metadata: [:],
+            profileSource: .profileUpdate, updatedAt: t2
+        )
+
+        // A snapshot built from a stale view still carries the old grants;
+        // the fill-blank path must not treat the tombstone as "never known".
+        let afterSnapshot = ProfileMerge.mergeIdentity(
+            existing: cleared, inboxId: "i", incoming: IncomingIdentity(metadata: ["connections": .string("stale-grants")]),
+            source: .profileSnapshot, sentAt: t2
+        )
+        #expect(afterSnapshot.metadata?["connections"] == nil)
     }
 
     @Test("a losing event's empty metadata neither clears nor fills")

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileMetadataWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileMetadataWriterTests.swift
@@ -4,25 +4,72 @@ import GRDB
 import Testing
 
 /// Tests for ProfileMetadataWriter, the shared serialization choke point for
-/// self-profile metadata writes.
+/// conversation-scoped self-profile metadata writes (cloud connection grants,
+/// agent timezone).
 ///
-/// The writer reads the current user's `selfProfile` metadata, applies the
-/// caller's closure, and republishes the merged map through
-/// `ProfilesRepository.publishMyProfileMetadata` (which persists it back to the
-/// `selfProfile` row and, when a session is attached, fans it out).
+/// The writer reads the scoped map for one conversation, applies the caller's
+/// closure, and publishes the merged map to that conversation immediately
+/// through `ProfilesRepository.publishMyProfileMetadata(_:toConversation:)`.
 ///
 /// Covers:
-/// - read existing metadata -> apply closure -> persist merged map
-/// - empty merged map clears the metadata
-/// - concurrent writers to different keys both survive (no clobber)
+/// - read existing scoped metadata -> apply closure -> send + persist per conversation
+/// - two conversations' maps are independent (the global-map clobber regression)
+/// - scoped keys never land in the global `DBMyProfile.metadata`
+/// - an empty merged map deletes the scoped row
+/// - a send failure propagates and persists nothing
 @Suite("ProfileMetadataWriter Tests")
 struct ProfileMetadataWriterTests {
+    private final class RecordedSends: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [(metadata: ProfileMetadata?, conversationId: String)] = []
+
+        func append(metadata: ProfileMetadata?, conversationId: String) {
+            lock.lock()
+            storage.append((metadata, conversationId))
+            lock.unlock()
+        }
+
+        var all: [(metadata: ProfileMetadata?, conversationId: String)] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    /// Records sends; upload/encrypt are unreachable because the writer path
+    /// never publishes an avatar source.
+    private struct RecordingSession: ProfilePublishSession {
+        let inboxId: String
+        let sends: RecordedSends
+        var failSends: Bool = false
+
+        func imageKey(conversationId: String) async throws -> Data? { nil }
+
+        func encrypt(_ plaintext: Data, groupKey: Data) throws -> EncryptedAvatarPayload {
+            EncryptedAvatarPayload(ciphertext: plaintext, salt: Data(), nonce: Data())
+        }
+
+        func upload(_ ciphertext: Data, filename: String) async throws -> String { "" }
+
+        func sendProfileUpdate(name: String?, metadata: ProfileMetadata?, avatar: PublishedAvatar?, conversationId: String) async throws {
+            if failSends {
+                throw RecordingSessionError.send
+            }
+            sends.append(metadata: metadata, conversationId: conversationId)
+        }
+    }
+
+    private enum RecordingSessionError: Error {
+        case send
+    }
+
     private struct Fixture {
         let databaseManager: MockDatabaseManager
         let inboxId: String
         let writer: ProfileMetadataWriter
+        let sends: RecordedSends
 
-        init(inboxId: String = "self-inbox") {
+        init(inboxId: String = "self-inbox", failSends: Bool = false) async throws {
             let databaseManager = MockDatabaseManager.makeTestDatabase()
             self.databaseManager = databaseManager
             self.inboxId = inboxId
@@ -44,72 +91,165 @@ struct ProfileMetadataWriterTests {
                 conversationLocalStateWriter: ConversationLocalStateWriter(databaseWriter: databaseManager.dbWriter),
                 selfInboxIdProvider: { inboxId }
             )
+            let sends = RecordedSends()
+            self.sends = sends
+            await repository.bind(session: RecordingSession(inboxId: inboxId, sends: sends, failSends: failSends))
             self.writer = ProfileMetadataWriter(
                 profilesRepository: { repository },
                 databaseReader: databaseManager.dbReader
             )
         }
 
-        func seedSelfMetadata(_ metadata: ProfileMetadata?) throws {
+        /// The scoped-metadata FK requires real conversation rows.
+        func seedConversations(_ ids: [String]) throws {
+            try databaseManager.dbWriter.write { db in
+                try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+                for id in ids {
+                    try DBConversation(
+                        id: id,
+                        clientConversationId: id,
+                        inviteTag: "tag-\(id)",
+                        creatorId: inboxId,
+                        kind: .group,
+                        consent: .allowed,
+                        createdAt: Date(),
+                        name: nil,
+                        description: nil,
+                        imageURLString: nil,
+                        publicImageURLString: nil,
+                        includeInfoInPublicPreview: true,
+                        expiresAt: nil,
+                        debugInfo: .empty,
+                        isLocked: false,
+                        imageSalt: nil,
+                        imageNonce: nil,
+                        imageEncryptionKey: nil,
+                        conversationEmoji: nil,
+                        imageLastRenewed: nil,
+                        isUnused: false,
+                        hasHadVerifiedAgent: false
+                    ).insert(db)
+                }
+            }
+        }
+
+        func seedGlobalMetadata(_ metadata: ProfileMetadata?) throws {
             let profile = DBMyProfile(inboxId: inboxId, metadata: metadata, updatedAt: Date())
             try databaseManager.dbWriter.write { db in
                 try profile.save(db)
             }
         }
 
-        func loadSelfMetadata() throws -> ProfileMetadata? {
+        func loadGlobalMetadata() throws -> ProfileMetadata? {
             try databaseManager.dbReader.read { db in
                 try DBMyProfile.filter(DBMyProfile.Columns.inboxId == inboxId).fetchOne(db)?.metadata
             }
         }
+
+        func loadScopedMetadata(conversationId: String) throws -> ProfileMetadata? {
+            try databaseManager.dbReader.read { db in
+                try DBSelfConversationMetadata
+                    .filter(DBSelfConversationMetadata.Columns.inboxId == inboxId)
+                    .filter(DBSelfConversationMetadata.Columns.conversationId == conversationId)
+                    .fetchOne(db)?.metadata
+            }
+        }
     }
 
-    @Test("Applies the closure on top of existing metadata and persists the merge")
-    func mergesExistingMetadata() async throws {
-        let fixture = Fixture()
-        try fixture.seedSelfMetadata(["connections": .string("existing-grants")])
+    @Test("Applies the closure on top of the conversation's existing scoped metadata")
+    func mergesExistingScopedMetadata() async throws {
+        let fixture = try await Fixture()
+        try fixture.seedConversations(["convo-1"])
 
-        try await fixture.writer.updateMetadata(
-            conversationId: "convo-1",
-            inboxId: fixture.inboxId
-        ) { metadata in
+        try await fixture.writer.updateMetadata(conversationId: "convo-1", inboxId: fixture.inboxId) { metadata in
+            metadata["connections"] = .string("existing-grants")
+        }
+        try await fixture.writer.updateMetadata(conversationId: "convo-1", inboxId: fixture.inboxId) { metadata in
             metadata["timezone"] = .string("Europe/Paris")
         }
 
-        let metadata = try #require(try fixture.loadSelfMetadata())
+        let metadata = try #require(try fixture.loadScopedMetadata(conversationId: "convo-1"))
         #expect(metadata["connections"] == .string("existing-grants"))
         #expect(metadata["timezone"] == .string("Europe/Paris"))
+        // The published update carries the merged scoped map.
+        let lastSend = try #require(fixture.sends.all.last)
+        #expect(lastSend.conversationId == "convo-1")
+        #expect(lastSend.metadata?["connections"] == .string("existing-grants"))
+        #expect(lastSend.metadata?["timezone"] == .string("Europe/Paris"))
     }
 
-    @Test("An empty merged map clears the stored metadata")
-    func emptyMapClearsMetadata() async throws {
-        let fixture = Fixture()
+    @Test("Two conversations' scoped maps are independent - one grant write never clobbers another conversation's")
+    func conversationsDoNotClobberEachOther() async throws {
+        let fixture = try await Fixture()
+        try fixture.seedConversations(["convo-a", "convo-b"])
 
-        try await fixture.writer.updateMetadata(
-            conversationId: "convo-2",
-            inboxId: fixture.inboxId
-        ) { _ in }
+        try await fixture.writer.updateMetadata(conversationId: "convo-a", inboxId: fixture.inboxId) { metadata in
+            metadata["connections"] = .string("grants-a")
+        }
+        try await fixture.writer.updateMetadata(conversationId: "convo-b", inboxId: fixture.inboxId) { metadata in
+            metadata["connections"] = .string("grants-b")
+        }
+        // Clearing B's grants must not touch A's.
+        try await fixture.writer.updateMetadata(conversationId: "convo-b", inboxId: fixture.inboxId) { metadata in
+            metadata.removeValue(forKey: "connections")
+        }
 
-        let metadata = try fixture.loadSelfMetadata()
-        #expect(metadata == nil)
+        let storedA = try #require(try fixture.loadScopedMetadata(conversationId: "convo-a"))
+        #expect(storedA["connections"] == .string("grants-a"))
+        #expect(try fixture.loadScopedMetadata(conversationId: "convo-b") == nil)
+        // Each conversation's send carried only its own grants.
+        let sendsByConversation = Dictionary(grouping: fixture.sends.all, by: \.conversationId)
+        #expect(sendsByConversation["convo-a"]?.last?.metadata?["connections"] == .string("grants-a"))
+        #expect(sendsByConversation["convo-b"]?.last?.metadata?["connections"] == nil)
     }
 
-    @Test("Concurrent writes to different keys do not clobber each other")
-    func concurrentWritesPreserveBothKeys() async throws {
-        let fixture = Fixture()
+    @Test("Scoped keys never land in the global self metadata")
+    func scopedKeysStayOutOfGlobalMetadata() async throws {
+        let fixture = try await Fixture()
+        try fixture.seedConversations(["convo-1"])
+        try fixture.seedGlobalMetadata(["emoji": .string("global")])
 
-        // First write lands the connections key, persisting it to the self row
-        // so the second write reads it back and the merge preserves it.
-        // Serialized by the writer's internal task chain.
-        try await fixture.writer.updateMetadata(conversationId: "convo-3", inboxId: fixture.inboxId) { metadata in
+        try await fixture.writer.updateMetadata(conversationId: "convo-1", inboxId: fixture.inboxId) { metadata in
             metadata["connections"] = .string("grants")
         }
-        try await fixture.writer.updateMetadata(conversationId: "convo-3", inboxId: fixture.inboxId) { metadata in
+
+        let global = try #require(try fixture.loadGlobalMetadata())
+        #expect(global["connections"] == nil)
+        #expect(global["emoji"] == .string("global"))
+        // The outgoing update merges the global map under the scoped keys.
+        let lastSend = try #require(fixture.sends.all.last)
+        #expect(lastSend.metadata?["connections"] == .string("grants"))
+        #expect(lastSend.metadata?["emoji"] == .string("global"))
+    }
+
+    @Test("An empty merged map deletes the scoped row")
+    func emptyMapClearsScopedMetadata() async throws {
+        let fixture = try await Fixture()
+        try fixture.seedConversations(["convo-2"])
+
+        try await fixture.writer.updateMetadata(conversationId: "convo-2", inboxId: fixture.inboxId) { metadata in
             metadata["timezone"] = .string("America/New_York")
         }
+        try await fixture.writer.updateMetadata(conversationId: "convo-2", inboxId: fixture.inboxId) { metadata in
+            metadata.removeValue(forKey: "timezone")
+        }
 
-        let metadata = try #require(try fixture.loadSelfMetadata())
-        #expect(metadata["connections"] == .string("grants"))
-        #expect(metadata["timezone"] == .string("America/New_York"))
+        #expect(try fixture.loadScopedMetadata(conversationId: "convo-2") == nil)
+        let lastSend = try #require(fixture.sends.all.last)
+        #expect(lastSend.metadata == nil)
+    }
+
+    @Test("A send failure propagates and persists nothing")
+    func sendFailurePropagatesAndPersistsNothing() async throws {
+        let fixture = try await Fixture(failSends: true)
+        try fixture.seedConversations(["convo-3"])
+
+        await #expect(throws: (any Error).self) {
+            try await fixture.writer.updateMetadata(conversationId: "convo-3", inboxId: fixture.inboxId) { metadata in
+                metadata["connections"] = .string("grants")
+            }
+        }
+
+        #expect(try fixture.loadScopedMetadata(conversationId: "convo-3") == nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfilePublisherTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfilePublisherTests.swift
@@ -5,6 +5,7 @@ import Testing
 private struct RecordedSend: Sendable {
     let name: String?
     let avatarURL: String?
+    let metadata: ProfileMetadata?
     let conversationId: String
 }
 
@@ -52,7 +53,7 @@ private actor FakeProfilePublishSession: ProfilePublishSession {
             sendFailuresRemaining -= 1
             throw FakeSessionError.send
         }
-        sends.append(RecordedSend(name: name, avatarURL: avatar?.url, conversationId: conversationId))
+        sends.append(RecordedSend(name: name, avatarURL: avatar?.url, metadata: metadata, conversationId: conversationId))
     }
 }
 
@@ -299,5 +300,105 @@ struct ProfilePublisherTests {
         let unchanged = try await publishStore.source(inboxId: "me")
         #expect(unchanged?.version == 1)
         #expect(unchanged?.plaintext == Data([1, 2, 3]))
+    }
+
+    @Test("queue sends carry the conversation's scoped metadata merged over the global map")
+    func queueSendsMergeScopedMetadata() async throws {
+        let publishStore = InMemoryProfilePublishStore()
+        let selfProfileStore = InMemorySelfProfileStore()
+        let clock = TestClock(Date(timeIntervalSince1970: 1_000))
+        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: selfProfileStore, clock: clock)
+        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key, "c2": key])
+        await publisher.attach(session: session)
+
+        // Global identity metadata plus scoped keys for c1 only; the scoped
+        // "emoji" overrides the global value for c1 (scoped wins on conflict).
+        try await selfProfileStore.save(DBMyProfile(
+            inboxId: "me", name: "Me",
+            metadata: ["emoji": .string("global"), "kind": .string("person")],
+            updatedAt: clock.current
+        ))
+        try await selfProfileStore.saveScopedMetadata(
+            ["connections": .string("grants-c1"), "emoji": .string("scoped")],
+            conversationId: "c1",
+            updatedAt: clock.current
+        )
+
+        try await publisher.publishConversation("c1")
+        try await publisher.publishConversation("c2")
+
+        let sends = await session.sends
+        let sendC1 = try #require(sends.first { $0.conversationId == "c1" })
+        let sendC2 = try #require(sends.first { $0.conversationId == "c2" })
+        #expect(sendC1.metadata?["connections"] == .string("grants-c1"))
+        #expect(sendC1.metadata?["emoji"] == .string("scoped"))
+        #expect(sendC1.metadata?["kind"] == .string("person"))
+        // Another conversation never receives c1's scoped keys.
+        #expect(sendC2.metadata?["connections"] == nil)
+        #expect(sendC2.metadata?["emoji"] == .string("global"))
+    }
+
+    @Test("publishScopedMetadata sends immediately, persists on success, and scopes per conversation")
+    func scopedMetadataPublishesImmediately() async throws {
+        let publishStore = InMemoryProfilePublishStore()
+        let selfProfileStore = InMemorySelfProfileStore()
+        let clock = TestClock(Date(timeIntervalSince1970: 1_000))
+        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: selfProfileStore, clock: clock)
+        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: [:])
+        await publisher.attach(session: session)
+        try await selfProfileStore.save(DBMyProfile(inboxId: "me", name: "Me", updatedAt: clock.current))
+
+        try await publisher.publishScopedMetadata(["connections": .string("grants-a")], conversationId: "convo-a")
+        try await publisher.publishScopedMetadata(["connections": .string("grants-b")], conversationId: "convo-b")
+
+        // Both sends went out, each carrying only its own conversation's grants.
+        let sends = await session.sends
+        #expect(sends.count == 2)
+        let sendA = try #require(sends.first { $0.conversationId == "convo-a" })
+        let sendB = try #require(sends.first { $0.conversationId == "convo-b" })
+        #expect(sendA.metadata?["connections"] == .string("grants-a"))
+        #expect(sendB.metadata?["connections"] == .string("grants-b"))
+
+        // Writing conversation B never clobbered conversation A's stored map -
+        // the regression this table exists to prevent.
+        let storedA = try await selfProfileStore.scopedMetadata(conversationId: "convo-a")
+        let storedB = try await selfProfileStore.scopedMetadata(conversationId: "convo-b")
+        #expect(storedA?["connections"] == .string("grants-a"))
+        #expect(storedB?["connections"] == .string("grants-b"))
+        // Nothing leaked into the global map.
+        let global = try await selfProfileStore.load()
+        #expect(global?.metadata == nil)
+    }
+
+    @Test("a failed scoped send throws and persists nothing")
+    func scopedMetadataSendFailureLeavesNoTrace() async throws {
+        let publishStore = InMemoryProfilePublishStore()
+        let selfProfileStore = InMemorySelfProfileStore()
+        let clock = TestClock(Date(timeIntervalSince1970: 1_000))
+        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: selfProfileStore, clock: clock)
+        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: [:], sendFailures: 1)
+        await publisher.attach(session: session)
+
+        await #expect(throws: (any Error).self) {
+            try await publisher.publishScopedMetadata(["connections": .string("grants")], conversationId: "c1")
+        }
+        // The scoped map was not persisted, so no later lazy publish can
+        // deliver a grant the caller declined to keep.
+        let stored = try await selfProfileStore.scopedMetadata(conversationId: "c1")
+        #expect(stored == nil)
+    }
+
+    @Test("publishScopedMetadata without a bound session throws")
+    func scopedMetadataRequiresSession() async throws {
+        let publishStore = InMemoryProfilePublishStore()
+        let selfProfileStore = InMemorySelfProfileStore()
+        let clock = TestClock(Date(timeIntervalSince1970: 1_000))
+        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: selfProfileStore, clock: clock)
+
+        await #expect(throws: (any Error).self) {
+            try await publisher.publishScopedMetadata(["connections": .string("grants")], conversationId: "c1")
+        }
+        let stored = try await selfProfileStore.scopedMetadata(conversationId: "c1")
+        #expect(stored == nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfilePublisherTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfilePublisherTests.swift
@@ -320,6 +320,7 @@ struct ProfilePublisherTests {
         ))
         try await selfProfileStore.saveScopedMetadata(
             ["connections": .string("grants-c1"), "emoji": .string("scoped")],
+            inboxId: "me",
             conversationId: "c1",
             updatedAt: clock.current
         )
@@ -361,8 +362,8 @@ struct ProfilePublisherTests {
 
         // Writing conversation B never clobbered conversation A's stored map -
         // the regression this table exists to prevent.
-        let storedA = try await selfProfileStore.scopedMetadata(conversationId: "convo-a")
-        let storedB = try await selfProfileStore.scopedMetadata(conversationId: "convo-b")
+        let storedA = try await selfProfileStore.scopedMetadata(inboxId: "me", conversationId: "convo-a")
+        let storedB = try await selfProfileStore.scopedMetadata(inboxId: "me", conversationId: "convo-b")
         #expect(storedA?["connections"] == .string("grants-a"))
         #expect(storedB?["connections"] == .string("grants-b"))
         // Nothing leaked into the global map.
@@ -384,7 +385,7 @@ struct ProfilePublisherTests {
         }
         // The scoped map was not persisted, so no later lazy publish can
         // deliver a grant the caller declined to keep.
-        let stored = try await selfProfileStore.scopedMetadata(conversationId: "c1")
+        let stored = try await selfProfileStore.scopedMetadata(inboxId: "me", conversationId: "c1")
         #expect(stored == nil)
     }
 
@@ -398,7 +399,7 @@ struct ProfilePublisherTests {
         await #expect(throws: (any Error).self) {
             try await publisher.publishScopedMetadata(["connections": .string("grants")], conversationId: "c1")
         }
-        let stored = try await selfProfileStore.scopedMetadata(conversationId: "c1")
+        let stored = try await selfProfileStore.scopedMetadata(inboxId: "me", conversationId: "c1")
         #expect(stored == nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileStoreTestSupport.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileStoreTestSupport.swift
@@ -21,6 +21,7 @@ enum ProfileStoreTestSupport {
         }
         try SharedDatabaseMigrator.createProfileTables(db)
         try SharedDatabaseMigrator.createProfileAvatarLatestView(db)
+        try SharedDatabaseMigrator.createSelfConversationMetadata(db)
     }
 
     static func seedConversations(_ db: Database, ids: [String]) throws {

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileTablesMigrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileTablesMigrationTests.swift
@@ -206,4 +206,86 @@ struct ProfileTablesMigrationTests {
             #expect(job == nil)
         }
     }
+
+    /// The strip step reads `myProfile`, so the scoped-metadata migration tests
+    /// need that table in the minimal schema too.
+    private func makeSchemaWithMyProfile(_ db: Database) throws {
+        try makeSchema(db)
+        try db.create(table: "myProfile") { t in
+            t.column("inboxId", .text).notNull().primaryKey()
+            t.column("name", .text)
+            t.column("imageData", .blob)
+            t.column("imageAssetIdentifier", .text)
+            t.column("imageContentDigest", .text)
+            t.column("metadata", .jsonText)
+            t.column("updatedAt", .datetime).notNull()
+        }
+    }
+
+    @Test("createSelfConversationMetadata creates the table, round-trips, and cascades on conversation delete")
+    func createsSelfConversationMetadata() throws {
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try self.makeSchemaWithMyProfile(db)
+            try SharedDatabaseMigrator.createSelfConversationMetadata(db)
+            try self.insertConversation(db, id: "conv-1")
+            try DBSelfConversationMetadata(
+                inboxId: "me",
+                conversationId: "conv-1",
+                metadata: ["connections": .string("grants"), "timezone": .string("Europe/Paris")],
+                updatedAt: Date(timeIntervalSince1970: 1)
+            ).save(db)
+        }
+
+        try dbQueue.read { db in
+            #expect(try db.tableExists("selfConversationMetadata"))
+            let row = try DBSelfConversationMetadata.fetchOne(db)
+            #expect(row?.metadata["connections"] == .string("grants"))
+            #expect(row?.metadata["timezone"] == .string("Europe/Paris"))
+        }
+
+        try dbQueue.write { db in
+            try db.execute(sql: "DELETE FROM conversation WHERE id = ?", arguments: ["conv-1"])
+        }
+        try dbQueue.read { db in
+            let remaining = try DBSelfConversationMetadata.fetchCount(db)
+            #expect(remaining == 0)
+        }
+    }
+
+    @Test("createSelfConversationMetadata strips scoped keys from the global myProfile metadata")
+    func stripsScopedKeysFromGlobalMetadata() throws {
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try self.makeSchemaWithMyProfile(db)
+            // A build that ran the interim global routing: grants and timezone
+            // were written into the global map next to real global keys.
+            try DBMyProfile(
+                inboxId: "me",
+                name: "Me",
+                metadata: [
+                    "connections": .string("grants"),
+                    "timezone": .string("Europe/Paris"),
+                    "emoji": .string("kept")
+                ],
+                updatedAt: Date(timeIntervalSince1970: 1)
+            ).save(db)
+            try DBMyProfile(
+                inboxId: "only-scoped",
+                metadata: ["timezone": .string("America/New_York")],
+                updatedAt: Date(timeIntervalSince1970: 1)
+            ).save(db)
+            try SharedDatabaseMigrator.createSelfConversationMetadata(db)
+        }
+
+        try dbQueue.read { db in
+            let mixed = try DBMyProfile.filter(DBMyProfile.Columns.inboxId == "me").fetchOne(db)
+            #expect(mixed?.metadata?["connections"] == nil)
+            #expect(mixed?.metadata?["timezone"] == nil)
+            #expect(mixed?.metadata?["emoji"] == .string("kept"))
+            // A map that held only scoped keys collapses to nil.
+            let onlyScoped = try DBMyProfile.filter(DBMyProfile.Columns.inboxId == "only-scoped").fetchOne(db)
+            #expect(onlyScoped?.metadata == nil)
+        }
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/SelfProfileStoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SelfProfileStoreTests.swift
@@ -10,7 +10,7 @@ import Testing
 struct SelfProfileStoreTests {
     @Test("GRDB implementation satisfies the contract")
     func grdbContract() async throws {
-        let queue = try ProfileStoreTestSupport.makeQueue()
+        let queue = try ProfileStoreTestSupport.makeQueue(conversations: ["convo-a", "convo-b"])
         let store = GRDBSelfProfileStore(
             databaseWriter: queue,
             databaseReader: queue,
@@ -40,5 +40,33 @@ struct SelfProfileStoreTests {
         try await store.clear()
         let cleared = try await store.load()
         #expect(cleared == nil)
+
+        // Scoped metadata: per-conversation maps are independent of each other
+        // and of the global profile row.
+        let noScoped = try await store.scopedMetadata(conversationId: "convo-a")
+        #expect(noScoped == nil)
+
+        try await store.saveScopedMetadata(["connections": .string("grants-a")], conversationId: "convo-a", updatedAt: t)
+        try await store.saveScopedMetadata(["connections": .string("grants-b")], conversationId: "convo-b", updatedAt: t)
+        let scopedA = try await store.scopedMetadata(conversationId: "convo-a")
+        let scopedB = try await store.scopedMetadata(conversationId: "convo-b")
+        #expect(scopedA?["connections"] == .string("grants-a"))
+        #expect(scopedB?["connections"] == .string("grants-b"))
+
+        // Overwrite replaces the map for that conversation only.
+        try await store.saveScopedMetadata(["timezone": .string("Europe/Paris")], conversationId: "convo-a", updatedAt: t)
+        let replaced = try await store.scopedMetadata(conversationId: "convo-a")
+        #expect(replaced?["timezone"] == .string("Europe/Paris"))
+        #expect(replaced?["connections"] == nil)
+        let untouched = try await store.scopedMetadata(conversationId: "convo-b")
+        #expect(untouched?["connections"] == .string("grants-b"))
+
+        // Nil and empty maps delete the row.
+        try await store.saveScopedMetadata(nil, conversationId: "convo-a", updatedAt: t)
+        let deleted = try await store.scopedMetadata(conversationId: "convo-a")
+        #expect(deleted == nil)
+        try await store.saveScopedMetadata([:], conversationId: "convo-b", updatedAt: t)
+        let emptied = try await store.scopedMetadata(conversationId: "convo-b")
+        #expect(emptied == nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/SelfProfileStoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SelfProfileStoreTests.swift
@@ -68,5 +68,12 @@ struct SelfProfileStoreTests {
         try await store.saveScopedMetadata([:], conversationId: "convo-b", updatedAt: t)
         let emptied = try await store.scopedMetadata(conversationId: "convo-b")
         #expect(emptied == nil)
+
+        // clear() drops the scoped rows along with the profile, so a cleared
+        // self never resurfaces a previous account's grants or timezone.
+        try await store.saveScopedMetadata(["connections": .string("grants")], conversationId: "convo-a", updatedAt: t)
+        try await store.clear()
+        let scopedAfterClear = try await store.scopedMetadata(conversationId: "convo-a")
+        #expect(scopedAfterClear == nil)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/SelfProfileStoreTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SelfProfileStoreTests.swift
@@ -43,37 +43,37 @@ struct SelfProfileStoreTests {
 
         // Scoped metadata: per-conversation maps are independent of each other
         // and of the global profile row.
-        let noScoped = try await store.scopedMetadata(conversationId: "convo-a")
+        let noScoped = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-a")
         #expect(noScoped == nil)
 
-        try await store.saveScopedMetadata(["connections": .string("grants-a")], conversationId: "convo-a", updatedAt: t)
-        try await store.saveScopedMetadata(["connections": .string("grants-b")], conversationId: "convo-b", updatedAt: t)
-        let scopedA = try await store.scopedMetadata(conversationId: "convo-a")
-        let scopedB = try await store.scopedMetadata(conversationId: "convo-b")
+        try await store.saveScopedMetadata(["connections": .string("grants-a")], inboxId: "me", conversationId: "convo-a", updatedAt: t)
+        try await store.saveScopedMetadata(["connections": .string("grants-b")], inboxId: "me", conversationId: "convo-b", updatedAt: t)
+        let scopedA = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-a")
+        let scopedB = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-b")
         #expect(scopedA?["connections"] == .string("grants-a"))
         #expect(scopedB?["connections"] == .string("grants-b"))
 
         // Overwrite replaces the map for that conversation only.
-        try await store.saveScopedMetadata(["timezone": .string("Europe/Paris")], conversationId: "convo-a", updatedAt: t)
-        let replaced = try await store.scopedMetadata(conversationId: "convo-a")
+        try await store.saveScopedMetadata(["timezone": .string("Europe/Paris")], inboxId: "me", conversationId: "convo-a", updatedAt: t)
+        let replaced = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-a")
         #expect(replaced?["timezone"] == .string("Europe/Paris"))
         #expect(replaced?["connections"] == nil)
-        let untouched = try await store.scopedMetadata(conversationId: "convo-b")
+        let untouched = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-b")
         #expect(untouched?["connections"] == .string("grants-b"))
 
         // Nil and empty maps delete the row.
-        try await store.saveScopedMetadata(nil, conversationId: "convo-a", updatedAt: t)
-        let deleted = try await store.scopedMetadata(conversationId: "convo-a")
+        try await store.saveScopedMetadata(nil, inboxId: "me", conversationId: "convo-a", updatedAt: t)
+        let deleted = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-a")
         #expect(deleted == nil)
-        try await store.saveScopedMetadata([:], conversationId: "convo-b", updatedAt: t)
-        let emptied = try await store.scopedMetadata(conversationId: "convo-b")
+        try await store.saveScopedMetadata([:], inboxId: "me", conversationId: "convo-b", updatedAt: t)
+        let emptied = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-b")
         #expect(emptied == nil)
 
         // clear() drops the scoped rows along with the profile, so a cleared
         // self never resurfaces a previous account's grants or timezone.
-        try await store.saveScopedMetadata(["connections": .string("grants")], conversationId: "convo-a", updatedAt: t)
+        try await store.saveScopedMetadata(["connections": .string("grants")], inboxId: "me", conversationId: "convo-a", updatedAt: t)
         try await store.clear()
-        let scopedAfterClear = try await store.scopedMetadata(conversationId: "convo-a")
+        let scopedAfterClear = try await store.scopedMetadata(inboxId: "me", conversationId: "convo-a")
         #expect(scopedAfterClear == nil)
     }
 }


### PR DESCRIPTION
## Problem

The unified-profile cutover (#1126) rerouted `ProfileMetadataWriter` through the **global** `DBMyProfile.metadata` map. Conversation-scoped keys — cloud connection grants and agent timezone — were merged into one global map and broadcast to every conversation on each lazy publish. Three consequences:

1. **Cross-conversation grant clobber** — `CloudConnectionGrantWriter` builds its grants JSON filtered to one conversation, then writes it to the single global `connections` key. Granting a connection in conversation B overwrites conversation A's grants; A's agent effectively loses its grant. Clearing grants in one conversation wipes the key for all.
2. **Privacy leak** — composio entity/connection IDs, service list, and device timezone were published to every member of every conversation the user touches. `AgentTimezonePublisher`'s own doc says the timezone "must not leak into human-only conversations"; its agent-only gating had become decorative.
3. **Void delivery contract** — the grant writer's comment says "a send failure propagates to the caller, which then declines to persist the local grant change." The global path performs no network send and cannot fail on one, so grants persisted locally while delivery silently deferred to the user's next message in that conversation.

## Fix

New `selfConversationMetadata` table keyed by `(inboxId, conversationId)` holding the current user's scoped metadata per conversation:

- **`ProfileMetadataWriter`** is back to a scoped read-merge: it reads one conversation's map, applies the caller's mutation, and publishes it **immediately** through the new `ProfilesRepository.publishMyProfileMetadata(_:toConversation:)` → `ProfilePublisher.publishScopedMetadata`, which throws on failure — restoring the decline-to-persist contract for grants and the timezone throttle's retry-on-next-foreground behavior.
- **`ProfilePublisher`** merges each conversation's scoped keys over the global map at send time (scoped wins), so every queue send — name edits, avatar publishes — keeps carrying that conversation's grants/timezone and can never wipe them at the receiver.
- The scoped map is **persisted only after a successful send**, so a failed publish leaves no trace for later lazy publishes to deliver.
- The migration also **strips `connections`/`timezone` out of any existing `DBMyProfile.metadata`** written by the interim global routing, so polluted dev installs stop broadcasting them.
- Scoped rows cascade on conversation delete (FK, matching `profileAvatar`) and are cleared by `wipeAccountScopedRows`.

The global `publishMyProfileMetadata(_:)` (used by the profile editor) is unchanged; its doc now states scoped keys must not go through it.

## Tests

- `ProfileMetadataWriterTests` rewritten for scoped semantics, including the regression cases: two conversations' grants are independent (write/clear B never touches A), scoped keys never land in the global map, an empty merged map deletes the scoped row, and a failed send throws and persists nothing.
- `ProfilePublisherTests`: the fake session now records the **metadata** of every send (this was the coverage gap that let the regression through), plus new tests for queue-send merging (scoped wins over global; other conversations never receive another's scoped keys) and immediate scoped publish semantics.
- `ProfileTablesMigrationTests`: table creation/round-trip/cascade and the global-map strip (mixed map keeps other keys; scoped-only map collapses to nil).
- `SelfProfileStoreTests` contract extended to both store implementations; `DeleteAllDataCleanSlateTests` covers the new table.

Full ConvosCore suite (1,523 tests / 219 suites) passes against the local XMTP node; SwiftLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786063161&installation_id=128169237&pr_number=1144&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1144&signature=33e4a7651bea4c07457e010d4e94008be75b642cf7650c17adf4fa5240a31c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore per-conversation scoping for grant/timezone profile metadata
> - Introduces a `selfConversationMetadata` DB table (via a new migration) to store per-conversation self metadata keyed by `(inboxId, conversationId)`, replacing the previous global approach for scoped keys like `connections` and `timezone`.
> - Adds `scopedMetadata` and `saveScopedMetadata` methods to `SelfProfileStore` (both GRDB and in-memory), and a new `publishMyProfileMetadata(_:toConversation:)` API on `ProfilesRepository` for immediate per-conversation sends.
> - `ProfilePublisher` now merges scoped metadata over global metadata when sending profile updates, so each conversation gets only its own scoped keys.
> - Empty metadata maps now propagate as authoritative clears of scoped keys in `ProfileInboundApplier`, `StreamProcessor`, `ConversationWriter`, and push notification handling, instead of being silently dropped.
> - The migration strips `connections` and `timezone` keys from existing `myProfile.metadata` rows to prevent global broadcast of conversation-scoped values.
> - `SessionManager.wipeAccountScopedRows` is extended to delete all `DBSelfConversationMetadata` rows on reset.
> - Behavioral Change: previously, an empty inbound metadata map was a no-op; it now clears conversation-scoped keys from stored metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cc462d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->