### PR TITLE
Pairing prompt: suppress newer backups + real device model names

### DIFF
--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -122,7 +122,7 @@ The canonical order (from `qa/SKILL.md` "Run all tests") is:
    → 16 → 17 → 20 → 27 → 28 → 19 → 15 → 34 → 18
 ```
 
-plus secondary tests `14, 22, 23, 23b, 24, 25, 26, 28b, 29, 30, 31, 32, 33, 43` slotted where they don't conflict with destructive steps (09, 18). Test 43 (long-message rendering) explodes the shared conversation in teardown, so slot it late in the sequence, after other tests that reuse `shared_conversation_id`.
+plus secondary tests `14, 22, 23, 23b, 24, 25, 26, 28b, 29, 30, 31, 32, 33, 43, 44b` slotted where they don't conflict with destructive steps (09, 18). Test 43 (long-message rendering) explodes the shared conversation in teardown, so slot it late in the sequence, after other tests that reuse `shared_conversation_id`. Test 44b briefly shuts down the primary simulator to clone it (like 03/04), so don't overlap it with tests running on the primary; it otherwise runs entirely on its own disposable clone.
 
 **What can actually run in parallel:**
 

--- a/Convos/Config/QALaunchHooks.swift
+++ b/Convos/Config/QALaunchHooks.swift
@@ -10,6 +10,7 @@ enum QALaunchHooks {
     static func run(environment: AppEnvironment) {
         guard !environment.isProduction else { return }
         wipePrimaryIdentityIfRequested(environment: environment)
+        restampForeignBackupsIfRequested(environment: environment)
     }
 
     /// CONVOS_QA_WIPE_PRIMARY_IDENTITY=1 deletes the device-local identity
@@ -33,5 +34,75 @@ enum QALaunchHooks {
         let status = SecItemDelete(query as CFDictionary)
         Log.info("QALaunchHooks: wiped primary identity slot (status=\(status))")
         QAEvent.emit(.app, "qa_wiped_primary_identity", ["status": "\(status)"])
+    }
+
+    /// CONVOS_QA_RESTAMP_FOREIGN_BACKUPS=<seconds> rewrites the
+    /// `backedUpAt` of every synced backup that doesn't belong to the
+    /// current primary identity to now+<seconds>. Lets QA place a foreign
+    /// backup before or after this install's own key to exercise the
+    /// pairable-backup ordering rule (backups newer than the device's own
+    /// key are never offered) without waiting out real clock time.
+    private static func restampForeignBackupsIfRequested(environment: AppEnvironment) {
+        guard let rawOffset = ProcessInfo.processInfo.environment["CONVOS_QA_RESTAMP_FOREIGN_BACKUPS"],
+              let offset = TimeInterval(rawOffset) else { return }
+        let primaryInboxId = loadPrimaryInboxId(environment: environment)
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.syncedBackupService,
+            kSecAttrAccessGroup as String: environment.keychainAccessGroup,
+            kSecAttrSynchronizable as String: true,
+            kSecReturnData as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var found: CFTypeRef?
+        let readStatus = SecItemCopyMatching(query as CFDictionary, &found)
+        query.removeValue(forKey: kSecReturnData as String)
+        query.removeValue(forKey: kSecReturnAttributes as String)
+        query.removeValue(forKey: kSecMatchLimit as String)
+        guard readStatus == errSecSuccess, let items = found as? [[String: Any]] else {
+            QAEvent.emit(.app, "qa_restamped_foreign_backups", ["status": "\(readStatus)", "count": "0"])
+            return
+        }
+        // Date fields encode as timeIntervalSinceReferenceDate doubles
+        // (JSONEncoder default, matching KeychainIdentityStore); mutate the
+        // raw JSON so the backup's internal initializers stay internal.
+        let newDate = Date().addingTimeInterval(offset)
+        var restamped = 0
+        for item in items {
+            guard let account = item[kSecAttrAccount as String] as? String,
+                  account != primaryInboxId,
+                  let data = item[kSecValueData as String] as? Data,
+                  var json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { continue }
+            json["backedUpAt"] = newDate.timeIntervalSinceReferenceDate
+            guard let updatedData = try? JSONSerialization.data(withJSONObject: json) else { continue }
+            var updateQuery = query
+            updateQuery[kSecAttrAccount as String] = account
+            let updateStatus = SecItemUpdate(
+                updateQuery as CFDictionary,
+                [kSecValueData as String: updatedData] as CFDictionary
+            )
+            if updateStatus == errSecSuccess { restamped += 1 }
+        }
+        Log.info("QALaunchHooks: restamped \(restamped) foreign backup(s) to \(newDate)")
+        QAEvent.emit(.app, "qa_restamped_foreign_backups", ["count": "\(restamped)", "offset": rawOffset])
+    }
+
+    private static func loadPrimaryInboxId(environment: AppEnvironment) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.defaultService,
+            kSecAttrAccount as String: KeychainIdentityStore.identityAccount,
+            kSecAttrAccessGroup as String: environment.keychainAccessGroup,
+            kSecAttrSynchronizable as String: false,
+            kSecReturnData as String: true
+        ]
+        var found: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &found) == errSecSuccess,
+              let data = found as? Data,
+              let identity = try? JSONDecoder().decode(KeychainIdentity.self, from: data) else {
+            return nil
+        }
+        return identity.inboxId
     }
 }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -895,7 +895,10 @@ extension ConversationsViewModel {
     /// and the conversations count includes the hidden prewarmed convo),
     /// which would permanently suppress the prompt from the second launch
     /// on. The prompt therefore shows whenever another identity's backup
-    /// exists and the user hasn't declined; data on an established
+    /// predating this install's own key exists and the user hasn't
+    /// declined (newer backups are never offered - installing on a second
+    /// device must not make the first offer to demote itself; see
+    /// `PairableDeviceBackup.pairableBackups`). Data on an established
     /// install stays safe because the joiner flow runs its own
     /// hold-to-erase guard before anything destructive.
     func checkForPairableDeviceIfNeeded() {

--- a/Convos/Utilities & Extensions/DeviceInfo.swift
+++ b/Convos/Utilities & Extensions/DeviceInfo.swift
@@ -1,3 +1,4 @@
+import ConvosCoreiOS
 import Foundation
 import UIKit
 
@@ -30,11 +31,12 @@ struct DeviceInfo {
         return identifierForVendor ?? fallbackIdentifier
     }
 
-    /// Returns the user-facing device name (e.g. "Jarod's iPhone").
-    /// Used by the pairing flow to show "X is requesting to pair" copy
-    /// on the joining device.
+    /// Returns the user-facing device name (e.g. "Jarod's iPhone" when the
+    /// user-assigned-device-name entitlement allows it, "iPhone 16 Pro"
+    /// otherwise - see `DeviceModelName`). Used by the pairing flow to show
+    /// "X is requesting to pair" copy on the joining device.
     static var deviceName: String {
-        UIDevice.current.name
+        DeviceModelName.userFacingDeviceName()
     }
 
     /// Returns the current OS string

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -36,12 +36,29 @@ extension PairableDeviceBackup {
     /// opposed to returning nil) must not call this with nil - they
     /// can't tell whether an own backup is present and should hide the
     /// prompt until a later check succeeds.
+    ///
+    /// Backups written after this install's own key are also excluded:
+    /// the "Pair <device>?" prompt exists to recover an identity that
+    /// predates this install, and a newer backup means the other device
+    /// was set up after this one (installing on a second device must not
+    /// make the first device offer to demote itself to that newer
+    /// identity). The install's own mirror in `backups` is the reference
+    /// clock - it was stamped when this install's identity was saved.
+    /// When ordering can't be established (no own mirror yet, or either
+    /// side missing a timestamp) the backup stays pairable.
     static func pairableBackups(
         from backups: [KeychainIdentityBackup],
         excludingInboxId currentInboxId: String?
     ) -> [PairableDeviceBackup] {
+        let ownBackedUpAt: Date? = backups
+            .first { $0.inboxId == currentInboxId }?
+            .backedUpAt
         return backups
             .filter { $0.inboxId != currentInboxId }
+            .filter { (backup: KeychainIdentityBackup) -> Bool in
+                guard let ownBackedUpAt, let backedUpAt = backup.backedUpAt else { return true }
+                return backedUpAt <= ownBackedUpAt
+            }
             .map { (backup: KeychainIdentityBackup) -> PairableDeviceBackup in
                 PairableDeviceBackup(
                     inboxId: backup.inboxId,

--- a/ConvosCore/Sources/ConvosCoreiOS/DeviceModelName.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/DeviceModelName.swift
@@ -1,0 +1,98 @@
+#if canImport(UIKit)
+import Foundation
+import UIKit
+
+/// Resolves the best available user-facing name for this device.
+///
+/// Since iOS 16, `UIDevice.current.name` returns the generic model string
+/// ("iPhone") instead of the user-assigned name ("Jarod's iPhone") unless
+/// the app carries the `com.apple.developer.device-information.
+/// user-assigned-device-name` entitlement, which requires Apple approval.
+/// Until that entitlement is granted, pairing surfaces would label every
+/// physical device "iPhone". This helper falls back to the marketing model
+/// name ("iPhone 16 Pro") derived from the hardware identifier so the
+/// pairing prompt and device list can at least distinguish models.
+/// Simulators return their simulator name from `UIDevice.current.name`
+/// and never hit the fallback.
+public enum DeviceModelName {
+    /// The user-assigned device name when available, otherwise the
+    /// marketing model name, otherwise whatever `UIDevice.current.name`
+    /// returned.
+    @MainActor
+    public static func userFacingDeviceName() -> String {
+        let name = UIDevice.current.name
+        guard isGenericModelString(name, model: UIDevice.current.model) else {
+            return name
+        }
+        return marketingName(forMachineIdentifier: currentMachineIdentifier()) ?? name
+    }
+
+    /// Whether `name` is the privacy-redacted generic model string rather
+    /// than a user-assigned name. Redacted names equal `UIDevice.model`
+    /// ("iPhone", "iPad"); any other value came from the user or the
+    /// simulator.
+    static func isGenericModelString(_ name: String, model: String) -> Bool {
+        name == model || Constant.genericModelStrings.contains(name)
+    }
+
+    /// Hardware identifier like "iPhone17,1". On simulators the uname
+    /// machine field is the host architecture, so the simulator's model
+    /// identifier env var takes precedence.
+    static func currentMachineIdentifier() -> String {
+        if let simulatorModel = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] {
+            return simulatorModel
+        }
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineBytes: [UInt8] = withUnsafeBytes(of: &systemInfo.machine) { (buffer: UnsafeRawBufferPointer) -> [UInt8] in
+            Array(buffer.prefix(while: { $0 != 0 }))
+        }
+        return String(bytes: machineBytes, encoding: .utf8) ?? ""
+    }
+
+    /// Marketing name for a hardware identifier, nil when unknown (new
+    /// models ship faster than this table updates; callers degrade to the
+    /// generic name).
+    static func marketingName(forMachineIdentifier identifier: String) -> String? {
+        Constant.marketingNames[identifier]
+    }
+
+    private enum Constant {
+        static let genericModelStrings: Set<String> = ["iPhone", "iPad", "iPod touch"]
+
+        /// Devices new enough to run the app's minimum OS.
+        static let marketingNames: [String: String] = [
+            "iPhone12,1": "iPhone 11",
+            "iPhone12,3": "iPhone 11 Pro",
+            "iPhone12,5": "iPhone 11 Pro Max",
+            "iPhone12,8": "iPhone SE (2nd generation)",
+            "iPhone13,1": "iPhone 12 mini",
+            "iPhone13,2": "iPhone 12",
+            "iPhone13,3": "iPhone 12 Pro",
+            "iPhone13,4": "iPhone 12 Pro Max",
+            "iPhone14,2": "iPhone 13 Pro",
+            "iPhone14,3": "iPhone 13 Pro Max",
+            "iPhone14,4": "iPhone 13 mini",
+            "iPhone14,5": "iPhone 13",
+            "iPhone14,6": "iPhone SE (3rd generation)",
+            "iPhone14,7": "iPhone 14",
+            "iPhone14,8": "iPhone 14 Plus",
+            "iPhone15,2": "iPhone 14 Pro",
+            "iPhone15,3": "iPhone 14 Pro Max",
+            "iPhone15,4": "iPhone 15",
+            "iPhone15,5": "iPhone 15 Plus",
+            "iPhone16,1": "iPhone 15 Pro",
+            "iPhone16,2": "iPhone 15 Pro Max",
+            "iPhone17,1": "iPhone 16 Pro",
+            "iPhone17,2": "iPhone 16 Pro Max",
+            "iPhone17,3": "iPhone 16",
+            "iPhone17,4": "iPhone 16 Plus",
+            "iPhone17,5": "iPhone 16e",
+            "iPhone18,1": "iPhone 17 Pro",
+            "iPhone18,2": "iPhone 17 Pro Max",
+            "iPhone18,3": "iPhone 17",
+            "iPhone18,4": "iPhone Air",
+        ]
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosCoreiOS/DeviceModelName.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/DeviceModelName.swift
@@ -92,6 +92,7 @@ public enum DeviceModelName {
             "iPhone18,2": "iPhone 17 Pro Max",
             "iPhone18,3": "iPhone 17",
             "iPhone18,4": "iPhone Air",
+            "iPhone18,5": "iPhone 17e",
         ]
     }
 }

--- a/ConvosCore/Sources/ConvosCoreiOS/IOSDeviceInfo.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/IOSDeviceInfo.swift
@@ -14,7 +14,7 @@ public final class IOSDeviceInfo: DeviceInfoProviding, @unchecked Sendable {
 
     public init() {
         _identifierForVendor = UIDevice.current.identifierForVendor?.uuidString
-        _deviceName = UIDevice.current.name
+        _deviceName = DeviceModelName.userFacingDeviceName()
     }
 
     /// Returns the device's identifier for vendor (IDFV).
@@ -53,8 +53,9 @@ public final class IOSDeviceInfo: DeviceInfoProviding, @unchecked Sendable {
         #endif
     }
 
-    /// User-visible device name from `UIDevice.current.name`. Captured at
-    /// init time (main-actor) and exposed nonisolated.
+    /// User-visible device name (user-assigned when the entitlement allows
+    /// it, marketing model name otherwise - see `DeviceModelName`).
+    /// Captured at init time (main-actor) and exposed nonisolated.
     public nonisolated var deviceName: String {
         _deviceName
     }

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -32,7 +32,11 @@ struct PairableDeviceBackupTests {
     @Test("Excludes the current install's own identity")
     func excludesCurrentIdentity() throws {
         let own = try makeBackup(inboxId: "own-inbox", backedUpAt: Date())
-        let other = try makeBackup(inboxId: "other-inbox", deviceName: "Other iPhone", backedUpAt: Date())
+        let other = try makeBackup(
+            inboxId: "other-inbox",
+            deviceName: "Other iPhone",
+            backedUpAt: Date(timeIntervalSinceNow: -60)
+        )
 
         let pairable = PairableDeviceBackup.pairableBackups(
             from: [own, other],
@@ -59,6 +63,49 @@ struct PairableDeviceBackupTests {
         )
 
         #expect(pairable.map(\.inboxId) == ["inbox-b", "inbox-a"])
+    }
+
+    @Test("Excludes backups written after this install's own key")
+    func excludesBackupsNewerThanOwnIdentity() throws {
+        // Device A installed first (t=1000), Device B second (t=2000).
+        // Opening A must not offer to pair with B's newer identity;
+        // opening B still offers A's older one.
+        let deviceA = try makeBackup(inboxId: "inbox-a", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let deviceB = try makeBackup(inboxId: "inbox-b", backedUpAt: Date(timeIntervalSince1970: 2_000))
+
+        let pairableOnA = PairableDeviceBackup.pairableBackups(
+            from: [deviceA, deviceB],
+            excludingInboxId: "inbox-a"
+        )
+        let pairableOnB = PairableDeviceBackup.pairableBackups(
+            from: [deviceA, deviceB],
+            excludingInboxId: "inbox-b"
+        )
+
+        #expect(pairableOnA.isEmpty)
+        #expect(pairableOnB.map(\.inboxId) == ["inbox-a"])
+    }
+
+    @Test("Keeps backups when ordering can't be established")
+    func keepsBackupsWithoutOrderingInformation() throws {
+        // An undated foreign backup (legacy blob) stays pairable, and a
+        // missing own mirror leaves even newer backups pairable - only a
+        // provable newer-than-own ordering suppresses.
+        let own = try makeBackup(inboxId: "own-inbox", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let undated = try makeBackup(inboxId: "undated-inbox")
+        let newer = try makeBackup(inboxId: "newer-inbox", backedUpAt: Date(timeIntervalSince1970: 2_000))
+
+        let withOwnMirror = PairableDeviceBackup.pairableBackups(
+            from: [own, undated],
+            excludingInboxId: "own-inbox"
+        )
+        let withoutOwnMirror = PairableDeviceBackup.pairableBackups(
+            from: [newer],
+            excludingInboxId: "own-inbox"
+        )
+
+        #expect(withOwnMirror.map(\.inboxId) == ["undated-inbox"])
+        #expect(withoutOwnMirror.map(\.inboxId) == ["newer-inbox"])
     }
 
     @Test("Sorts newest backup first, undated backups last")

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -54,7 +54,6 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 43 | `qa/tests/43-long-message-rendering.md` | Long-message UX: short renders unchanged, long shows Read More + inline expand, pathological pushes MessageDetailView (Back/Copy/Reply), no-hang guard |
 | 44 | `qa/tests/44-icloud-pairing-prompt.md` | First-install iCloud pairing prompt: Pair <device>? sheet from a synced keychain backup, Skip persistence, and the full no-QR pair handshake (two simulators; Device B is a clone of Device A) |
 | 44b | `qa/tests/44b-pairing-prompt-ordering.md` | Pairable-backup ordering rule: backups newer than this install's own key are never offered; verified both directions via the restamp launch hook (single disposable clone) |
-| 44b | `qa/tests/44b-pairing-prompt-ordering.md` | Pairable-backup ordering rule: backups newer than this install's own key are never offered; verified both directions via the restamp launch hook (single disposable clone) |
 
 ## Running Tests
 

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -53,6 +53,8 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 42 | `qa/tests/42-agent-builder-attachment-summary.md` | Agent builder: create agent with prompt + photo attachment, verify summary card renders the photo thumbnail (pre- and post-rehydration) |
 | 43 | `qa/tests/43-long-message-rendering.md` | Long-message UX: short renders unchanged, long shows Read More + inline expand, pathological pushes MessageDetailView (Back/Copy/Reply), no-hang guard |
 | 44 | `qa/tests/44-icloud-pairing-prompt.md` | First-install iCloud pairing prompt: Pair <device>? sheet from a synced keychain backup, Skip persistence, and the full no-QR pair handshake (two simulators; Device B is a clone of Device A) |
+| 44b | `qa/tests/44b-pairing-prompt-ordering.md` | Pairable-backup ordering rule: backups newer than this install's own key are never offered; verified both directions via the restamp launch hook (single disposable clone) |
+| 44b | `qa/tests/44b-pairing-prompt-ordering.md` | Pairable-backup ordering rule: backups newer than this install's own key are never offered; verified both directions via the restamp launch hook (single disposable clone) |
 
 ## Running Tests
 

--- a/qa/TOOLS-CLAUDE.md
+++ b/qa/TOOLS-CLAUDE.md
@@ -153,7 +153,7 @@ tail -c +$((LOG_MARKER_BYTES + 1)) "$APP_GROUP" | grep -F '[EVENT]'
 tail -c +$((LOG_MARKER_BYTES + 1)) "$APP_GROUP" | grep -F '[EVENT] message.sent'
 ```
 
-If the app is relaunched mid-test, the log file is truncated and rewritten — re-read `APP_GROUP` and reset `LOG_MARKER_BYTES` to 0. You can detect this cheaply before any read:
+A relaunch mid-test may truncate and rewrite the log file, or may simply append (observed both ways; clones also inherit the source simulator's full log history). Don't assume either — keep byte-offset markers and run this cheap shrink check before any read:
 
 ```bash
 CURRENT_SIZE=$(wc -c < "$APP_GROUP")

--- a/qa/tests/44b-pairing-prompt-ordering.md
+++ b/qa/tests/44b-pairing-prompt-ordering.md
@@ -1,0 +1,44 @@
+# Test: Pairing Prompt Ordering (Newer Backups Suppressed)
+
+Verify the pairable-backup ordering rule: the first-install "Pair <device>?" prompt only offers iCloud-synced backups created *before* this install's own key. A backup written after this install's key (i.e. a second device set up later) must never be offered - the first device must not offer to demote itself to the newer identity.
+
+## Prerequisites
+
+- One simulator: the branch primary, fully onboarded (its app mirrors its identity into the synced-backup keychain slot automatically on registration).
+- A non-production build - both QA launch hooks used here are runtime-gated off in production.
+
+## Setup
+
+All steps run on a disposable clone so the primary simulator's account state is never touched:
+
+1. Shut down the primary (`simctl clone` requires it), clone it as `convos-qa-ordering`, boot both, relaunch the app on the primary. The clone's keychain contains the primary identity item and its synced-backup mirror.
+2. Every app launch on the clone needs the App Check debug token for placeholder registration: `source .env` and pass `SIMCTL_CHILD_FIRAAppCheckDebugToken="$FIREBASE_APP_CHECK_DEBUG_TOKEN"` on each `simctl launch`.
+
+## Steps
+
+### Establish a newer own key with an older foreign backup
+
+1. Launch the app on the clone with `SIMCTL_CHILD_CONVOS_QA_WIPE_PRIMARY_IDENTITY=1`. The hook deletes the device-local identity (`app.qa_wiped_primary_identity` with `status=0`) and the app registers a fresh placeholder whose backup mirror is stamped now; the prior identity's older backup is discovered and the "Pair <name>?" sheet appears (`pairing.found_device_prompt_shown`). Do not tap Skip - it sets the `hasDeclinedFoundDevicePairing` flag and would suppress the prompt for the rest of the test. Terminate the app to move on.
+
+### Newer foreign backup is suppressed
+
+2. Relaunch with `SIMCTL_CHILD_CONVOS_QA_RESTAMP_FOREIGN_BACKUPS=3600`. The hook rewrites every non-own backup's `backedUpAt` to now+3600s (`app.qa_restamped_foreign_backups` with `count=<n>`; `count=0` means no foreign backup was present and the setup failed - do not treat it as a pass).
+3. The launch's `pairing.found_device_check` must report `pairableCount=0` and the prompt must not appear. This is a negative check: after the check event fires, poll for `pair-found-device-button` over ~8 seconds and require zero matches.
+
+### Older foreign backup is offered again
+
+4. Relaunch with `SIMCTL_CHILD_CONVOS_QA_RESTAMP_FOREIGN_BACKUPS=-86400`. The same backup is restamped a day into the past; `pairing.found_device_check` reports `pairableCount>=1` and the "Pair <name>?" sheet appears again (`pairing.found_device_prompt_shown`). This proves step 3's suppression was the ordering rule and not a decline flag, keychain miss, or hook side effect - the only thing that changed between the launches is the timestamp.
+
+## Teardown
+
+Shut down and delete the `convos-qa-ordering` clone. It holds only a throwaway placeholder identity; the primary simulator was never modified.
+
+## Pass/Fail Criteria
+
+- [ ] On the wiped launch, `app.qa_wiped_primary_identity` fires with `status=0` and the Pair prompt appears for the prior identity's backup
+- [ ] With the foreign backup restamped to now+3600s, `pairing.found_device_check` reports `pairableCount=0` and the prompt does not appear (`qa_restamped_foreign_backups count >= 1`)
+- [ ] With the foreign backup restamped to now-86400s, `pairing.found_device_check` reports `pairableCount>=1` and the prompt appears again
+
+## Accessibility Improvements Needed
+
+None known - the test reuses test 44's identifiers (`pair-found-device-button`) and log events end-to-end.

--- a/qa/tests/structured/44b-pairing-prompt-ordering.yaml
+++ b/qa/tests/structured/44b-pairing-prompt-ordering.yaml
@@ -1,0 +1,125 @@
+id: "44b"
+name: "Pairing Prompt Ordering (Newer Backups Suppressed)"
+description: >
+  Verify the pairable-backup ordering rule: the "Pair <device>?" prompt
+  only offers iCloud-synced backups created before this install's own
+  key. A backup restamped to the future (standing in for "a second
+  device was set up after this one") must not be offered; restamped to
+  the past it must be offered again. Runs on a single disposable clone
+  of the primary simulator using the CONVOS_QA_WIPE_PRIMARY_IDENTITY
+  and CONVOS_QA_RESTAMP_FOREIGN_BACKUPS launch hooks - no second
+  onboarded device needed.
+tags: [pairing, multi-device, devices, icloud, keychain]
+depends_on: ["01"]
+estimated_duration_s: 300
+
+prerequisites:
+  app_running: true
+  cli_initialized: false
+  shared_conversation: false
+  # The primary simulator's app must be onboarded so its identity has
+  # been mirrored into the synced-backup keychain slot; the clone
+  # inherits that backup.
+  screen: conversations_list
+
+state:
+  clone_udid: null
+  found_device_name: null
+
+setup:
+  - action: clone_primary_as_ordering_sim
+    save:
+      clone_udid: "from clone"
+    note: >
+      `xcrun simctl shutdown $PRIMARY`, `xcrun simctl clone $PRIMARY
+      convos-qa-ordering`, boot both, relaunch the app on the primary.
+      All test steps run on the clone; the primary's account state is
+      never touched. simctl clone requires the source to be shut down -
+      expect a brief primary outage here. Launches of the app on the
+      clone need the App Check debug token for placeholder registration:
+      source .env and pass
+      SIMCTL_CHILD_FIRAAppCheckDebugToken="$FIREBASE_APP_CHECK_DEBUG_TOKEN"
+      on every simctl launch below.
+
+steps:
+  - id: wipe_creates_newer_own_key
+    name: "Wipe hook replaces the primary identity and the old backup prompts"
+    actions:
+      - launch_app_with_env:
+          env: { CONVOS_QA_WIPE_PRIMARY_IDENTITY: "1" }
+      - wait_for_element: { id: "pair-found-device-button", timeout: 45 }
+      - screenshot: {}
+    verify:
+      - event_exists: { name: "app.qa_wiped_primary_identity" }
+      - element_exists: { id: "pair-found-device-button" }
+    expect_event: "pairing.found_device_prompt_shown"
+    criteria: older_backup_prompts
+    save:
+      found_device_name: "deviceName= param of pairing.found_device_prompt_shown"
+    note: >
+      This mirrors test 44's single-sim shortcut: the wipe hook deletes
+      the device-local identity, the app registers a fresh placeholder
+      (whose backup mirror is stamped now), and the prior identity's
+      older backup is offered. Do not tap Skip - it sets the
+      hasDeclinedFoundDevicePairing flag and would suppress the prompt
+      for the rest of the test. Terminate the app instead to move on.
+
+  - id: newer_backup_suppressed
+    name: "Foreign backup restamped to the future is not offered"
+    actions:
+      - terminate_app: {}
+      - launch_app_with_env:
+          env: { CONVOS_QA_RESTAMP_FOREIGN_BACKUPS: "3600" }
+      - sim_log_events: { event_filter: "pairing.found_device_check" }
+      - screenshot: {}
+    verify:
+      - event_exists: { name: "app.qa_restamped_foreign_backups" }
+      - element_not_exists: { id: "pair-found-device-button" }
+    expect_event: "pairing.found_device_check"
+    criteria: newer_backup_suppressed
+    note: >
+      The restamp hook shifts every non-own backup's backedUpAt to
+      now+3600s, making the prior identity's backup strictly newer than
+      this install's own key. found_device_check must report
+      pairableCount=0 and the prompt must stay absent - hold a negative
+      poll on pair-found-device-button for ~8s after the check event
+      fires. qa_restamped_foreign_backups carries count=<n>; expect
+      count >= 1, and treat count=0 as a setup failure (no foreign
+      backup present), not a pass.
+
+  - id: older_backup_reprompts
+    name: "Foreign backup restamped to the past is offered again"
+    actions:
+      - terminate_app: {}
+      - launch_app_with_env:
+          env: { CONVOS_QA_RESTAMP_FOREIGN_BACKUPS: "-86400" }
+      - wait_for_element: { id: "pair-found-device-button", timeout: 30 }
+      - screenshot: {}
+    verify:
+      - event_exists: { name: "app.qa_restamped_foreign_backups" }
+      - element_exists: { id: "pair-found-device-button" }
+    expect_event: "pairing.found_device_prompt_shown"
+    criteria: older_backup_reprompts
+    note: >
+      Restamping the same backup a day into the past proves the
+      suppression in the previous step was the ordering rule and not a
+      decline flag, keychain miss, or hook side effect: the only thing
+      that changed between the two launches is the timestamp.
+
+teardown:
+  - action: delete_ordering_sim
+    args: { udid: "$clone_udid" }
+    optional: true
+    note: >
+      `xcrun simctl shutdown $clone_udid && xcrun simctl delete
+      $clone_udid`. The clone holds a throwaway placeholder identity and
+      exists only for this test; deleting it is the whole teardown. The
+      primary simulator was never modified.
+
+criteria:
+  older_backup_prompts:
+    description: "On the wiped launch, the prior identity's (older) backup drives the Pair prompt: qa_wiped_primary_identity fires with status=0 and pair-found-device-button appears"
+  newer_backup_suppressed:
+    description: "With the foreign backup restamped to now+3600s, found_device_check reports pairableCount=0 and the Pair prompt does not appear (qa_restamped_foreign_backups count >= 1)"
+  older_backup_reprompts:
+    description: "With the same backup restamped to now-86400s, found_device_check reports pairableCount>=1 and the Pair prompt appears again"

--- a/qa/tests/structured/44b-pairing-prompt-ordering.yaml
+++ b/qa/tests/structured/44b-pairing-prompt-ordering.yaml
@@ -60,7 +60,9 @@ steps:
       This mirrors test 44's single-sim shortcut: the wipe hook deletes
       the device-local identity, the app registers a fresh placeholder
       (whose backup mirror is stamped now), and the prior identity's
-      older backup is offered. Do not tap Skip - it sets the
+      older backup is offered. pairableCount may exceed 1 if the primary
+      carried backups from earlier wipe cycles - the criteria use >=1
+      and =0 semantics on purpose. Do not tap Skip - it sets the
       hasDeclinedFoundDevicePairing flag and would suppress the prompt
       for the rest of the test. Terminate the app instead to move on.
 


### PR DESCRIPTION
Follow-ups to #1143 from Jarod's on-device testing of the pairing flow.

## 1. Second device's newer key was offered to the first device

Installing on Device B wrote a newer backup into the shared iCloud slot, and Device A would then prompt to pair with it - offering to demote itself to an identity created after its own. The pairable filter now uses this install's own backup mirror as the reference clock and drops any foreign backup stamped after it. When ordering can't be proven (true first launch, missing own mirror, legacy undated blob) the backup stays pairable, so #1143's first-launch recovery flow is untouched.

Adds a `CONVOS_QA_RESTAMP_FOREIGN_BACKUPS=<seconds>` QA launch hook (non-production only) that shifts foreign backups' `backedUpAt` so both directions of the rule are testable on one simulator, and **new structured QA test 44b** covering it (validated green on run `00aae63e2037`).

**Verified on-sim:** wipe launch -> older backup prompts (control); restamp `+3600` -> `pairableCount=0`, no prompt; restamp `-86400` -> prompt returns.

## 2. Devices all named "iPhone"

`UIDevice.current.name` returns the generic model string on physical devices since iOS 16 without the `com.apple.developer.device-information.user-assigned-device-name` entitlement (simulators return the sim name, which is why QA never saw it). New `DeviceModelName` helper falls back to the marketing model name ("iPhone 16 Pro") from the hardware identifier whenever the generic string comes back; unknown future identifiers degrade to the generic name. Wired into both name providers (`IOSDeviceInfo` and the app-target `DeviceInfo`). Identifier table verified against the canonical list, covering iPhone 11 through the iPhone 17 generation including 17e.

**Follow-up (process):** request the user-assigned-device-name entitlement from Apple to restore "Jarod's iPhone"; zero code changes needed when it lands (`DeviceModelName` passes any non-generic name through).

## Tests

- New unit tests: newer-than-own excluded in both directions; missing ordering info (no own mirror, undated blob) keeps backups pairable.
- Full ConvosCore suite on this head: 1523 tests in 220 suites, all passing.
- QA test 44b first run: all 3 criteria pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786130265&installation_id=128169237&pr_number=1146&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1146&signature=906ef8a363152bf11901a3dc244f32e06db1a5548fa6614fbf15a3dc063eecdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress newer backups from pairing prompt and show real device model names
> - `PairableDeviceBackup.pairableBackups` now excludes foreign backups whose `backedUpAt` is strictly newer than the current install's own backup timestamp; undated or incomparable backups remain pairable.
> - `DeviceModelName.userFacingDeviceName()` is added in [DeviceModelName.swift](https://github.com/xmtplabs/convos-ios/pull/1146/files#diff-934c67245f1faf5454c0da8302cd2f1200c5917c018551fbce14da1860bf8bc6) and used by both `DeviceInfo.deviceName` and `IOSDeviceInfo.deviceName` to return the user-assigned name when available, or a marketing model name (e.g. "iPhone 16 Pro") as fallback.
> - A new QA launch hook `CONVOS_QA_RESTAMP_FOREIGN_BACKUPS` rewrites `backedUpAt` on foreign iCloud Keychain backups at launch, enabling test 44b to verify the ordering rule.
> - Behavioral Change: backups from devices with a more recent backup than the current device are no longer shown in the pairing prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54af5bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->