### PR TITLE
Show verified template-less agents in contacts

### DIFF
--- a/Convos/Contacts/Contact+BrowseVisibility.swift
+++ b/Convos/Contacts/Contact+BrowseVisibility.swift
@@ -4,23 +4,21 @@ import Foundation
 extension Contact {
     /// Whether this contact renders in the Contacts browse list - and thus
     /// counts toward the App Settings "Contacts" badge, which must agree
-    /// with the list. Shown: humans with a display name, and verified,
-    /// template-backed agents (tagged with the Agent pill). Hidden:
-    /// unverified agents, verified agents whose template hasn't mirrored yet,
-    /// and unnamed humans (they'd render as "Somebody" with nothing to
-    /// distinguish them). All agents stay in `DBContact` so chat-side
-    /// surfaces can still resolve them.
+    /// with the list. Shown: humans with a display name, verified
+    /// template-backed agents, and verified agents that do not have a mirrored
+    /// template yet. Hidden: unverified agents and unnamed humans (they'd
+    /// render as "Somebody" with nothing to distinguish them). All agents stay
+    /// in `DBContact` so chat-side surfaces can still resolve them.
     ///
-    /// An agent must be BOTH verified and template-backed to appear:
-    /// - `isVerifiedAgent` (unforgeable attestation) - so a stale or spoofed
-    ///   `templateId` on a non-verified contact never surfaces it, and only
-    ///   real agents show.
-    /// - `agentTemplateId != nil` - the contact list collapses agent
-    ///   instances to one canonical row per template (`dedupingAgentsByTemplate`),
-    ///   so an agent with no template has no canonical key and can't be shown.
+    /// Agents must be verified to appear; a template id is optional. Template-
+    /// backed agents still collapse to one canonical row per template
+    /// (`dedupingAgentsByTemplate`). Template-less verified agents are keyed by
+    /// inbox id and behave like direct contacts: selecting them adds that
+    /// already-running agent inbox rather than spawning a fresh template
+    /// instance.
     var isVisibleInContactsList: Bool {
         if isAgent {
-            return isVerifiedAgent && agentTemplateId != nil
+            return isVerifiedAgent
         }
         guard let displayName, !displayName.isEmpty else { return false }
         return true

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -273,8 +273,10 @@ struct ContactsPickerView: View {
     }
 
     private func performConfirm() {
-        // Split the selection: agents are spawned by template, not added
-        // as members, so they're excluded from the member ids.
+        // Split the selection: template-backed agents are spawned by template,
+        // not added as members, so they're excluded from the member ids.
+        // Verified template-less agents have no template to spawn from, so
+        // they remain in `memberIds` and join by their existing inbox id.
         let agentTemplateIds = viewModel.selectedAgentTemplateIds
         let memberIds = viewModel.selectedInboxIds.subtracting(viewModel.selectedAgentInboxIds)
         onConfirm(memberIds, agentTemplateIds)

--- a/Convos/Contacts/ContactsPickerViewModel.swift
+++ b/Convos/Contacts/ContactsPickerViewModel.swift
@@ -235,25 +235,29 @@ final class ContactsPickerViewModel {
         selectedInboxIds.contains(inboxId)
     }
 
-    /// `inboxId`s of the currently selected agents.
+    /// `inboxId`s of selected template-backed agents. Those are excluded from
+    /// member ids at confirmation because they are spawned by template id.
+    /// Verified template-less agents intentionally stay in `selectedInboxIds`
+    /// only, so confirming adds their existing inbox directly.
     var selectedAgentInboxIds: Set<String> {
         Set(selectedContacts.filter { $0.agentTemplateId != nil }.map(\.inboxId))
     }
 
     /// `agentTemplateId`s of the currently selected agents, threaded into
-    /// conversation creation so a fresh instance of each template is
-    /// spawned into the new (or existing) conversation.
+    /// conversation creation so a fresh instance of each template-backed agent
+    /// is spawned into the new (or existing) conversation.
     var selectedAgentTemplateIds: [String] {
         selectedContacts.compactMap(\.agentTemplateId)
     }
 
     /// Single source of truth for "is this contact a valid picker row".
     /// A contact is pickable when it shows in the Contacts browse list
-    /// (`isVisibleInContactsList`: template-backed agents and named humans)
+    /// (`isVisibleInContactsList`: verified agents and named humans)
     /// and the user hasn't blocked it. Blocked contacts stay in the browse
     /// list so they can be unblocked, but they are never a valid picker
     /// target. Template-backed agents are selectable in every mode, since
-    /// starting (or adding to) a conversation spawns a fresh instance.
+    /// starting (or adding to) a conversation spawns a fresh instance;
+    /// template-less verified agents are selected by inbox id.
     static func isPickable(_ contact: Contact) -> Bool {
         !contact.isBlocked && contact.isVisibleInContactsList
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Contact+CanonicalTemplate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Contact+CanonicalTemplate.swift
@@ -60,9 +60,11 @@ extension Array where Element == Contact {
     /// Collapses template-backed agents to a single representative per
     /// `agentTemplateId` (the first encountered), overlaying the cached
     /// canonical template identity when available; humans and template-less
-    /// contacts pass through untouched. Order is preserved. When the cache
-    /// is still cold for a template, its representative shows instance data
-    /// until the canonical identity arrives.
+    /// contacts pass through untouched. Template-less verified agents therefore
+    /// keep their inbox identity and can be selected as already-running direct
+    /// contacts. Order is preserved. When the cache is still cold for a
+    /// template, its representative shows instance data until the canonical
+    /// identity arrives.
     func dedupingAgentsByTemplate(using templates: [String: AgentTemplateInfo]) -> [Contact] {
         // A block on ANY instance of a template blocks the canonical row, so
         // collapsing instances can never hide a block the user made.

--- a/ConvosTests/ContactsPickerViewModelTests.swift
+++ b/ConvosTests/ContactsPickerViewModelTests.swift
@@ -32,11 +32,11 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, carl.inboxId].sorted())
     }
 
-    /// New-conversation mode surfaces humans and template-backed agents
-    /// (you can spawn a fresh instance into the new convo). Template-less
-    /// agents - legacy verified assistants and unverified agents - stay
-    /// hidden.
-    func testNewConversationShowsTemplateBackedAgentsOnly() {
+    /// New-conversation mode surfaces humans, template-backed agents, and
+    /// verified template-less agents. Template-backed selections can spawn a
+    /// fresh instance; template-less verified agents are added by inbox id.
+    /// Unverified agents stay hidden.
+    func testNewConversationShowsVerifiedAgentsIncludingTemplateLessAgents() {
         let alice = Contact.mock(displayName: "Alice")
         let coffeeAgent = Contact.mock(
             displayName: "Americano",
@@ -56,22 +56,24 @@ final class ContactsPickerViewModelTests: XCTestCase {
         let viewModel = ContactsPickerViewModel(mode: .newConversation, contactsRepository: repo)
 
         let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
-        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, coffeeAgent.inboxId].sorted())
+        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, coffeeAgent.inboxId, legacyAssistant.inboxId].sorted())
     }
 
-    /// Add-to-conversation mode is human-only - agents aren't spawned into
-    /// an existing conversation from the picker.
-    func testAddToConversationShowsAgents() {
-        // Template-backed agents are selectable in add-to-conversation mode
-        // too: confirming spawns a fresh instance of the template into the
-        // existing conversation.
+    /// Add-to-conversation mode surfaces humans and verified agents.
+    func testAddToConversationShowsVerifiedAgents() {
+        // Template-backed agents spawn a fresh instance into the existing
+        // conversation; verified template-less agents are added by inbox id.
         let alice = Contact.mock(displayName: "Alice")
         let coffeeAgent = Contact.mock(
             displayName: "Americano",
             agentVerification: .verified(.convos),
             agentTemplateId: "tmpl-coffee"
         )
-        let repo = MockContactsRepository(contacts: [alice, coffeeAgent])
+        let legacyAssistant = Contact.mock(
+            displayName: "Legacy Assistant",
+            agentVerification: .verified(.convos)
+        )
+        let repo = MockContactsRepository(contacts: [alice, coffeeAgent, legacyAssistant])
 
         let viewModel = ContactsPickerViewModel(
             mode: .addToConversation(conversationId: "convo-1", conversationTitle: nil),
@@ -79,7 +81,7 @@ final class ContactsPickerViewModelTests: XCTestCase {
         )
 
         let allRowIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.id) }
-        XCTAssertEqual(allRowIds, [alice.inboxId, coffeeAgent.inboxId])
+        XCTAssertEqual(allRowIds.sorted(), [alice.inboxId, coffeeAgent.inboxId, legacyAssistant.inboxId].sorted())
     }
 
     /// Multiple agents can be selected alongside humans; each selected
@@ -115,6 +117,21 @@ final class ContactsPickerViewModelTests: XCTestCase {
         // Deselecting one agent leaves the other selected.
         viewModel.toggleSelection(for: coffee.inboxId)
         XCTAssertEqual(viewModel.selectedAgentTemplateIds, ["tmpl-tea"])
+    }
+
+    func testVerifiedTemplateLessAgentSelectionStaysInMemberInboxIds() {
+        let assistant = Contact.mock(
+            displayName: "Legacy Assistant",
+            agentVerification: .verified(.convos)
+        )
+        let repo = MockContactsRepository(contacts: [assistant])
+        let viewModel = ContactsPickerViewModel(mode: .newConversation, contactsRepository: repo)
+
+        viewModel.toggleSelection(for: assistant.inboxId)
+
+        XCTAssertEqual(viewModel.selectedInboxIds, [assistant.inboxId])
+        XCTAssertTrue(viewModel.selectedAgentInboxIds.isEmpty)
+        XCTAssertTrue(viewModel.selectedAgentTemplateIds.isEmpty)
     }
 
     func testHashBucketSortsLastForNonAlphaNames() {
@@ -305,7 +322,7 @@ final class ContactsPickerViewModelTests: XCTestCase {
 
     /// `pickableContacts` is the shared filter the Compose flow uses to decide
     /// whether the picker is worth showing. It must agree with what the picker
-    /// renders -- named humans only, not blocked, not verified agents.
+    /// renders -- named humans and verified agents, not blocked or hidden rows.
     func testPickableContactsKeepsNamedHumans() {
         let alice = Contact.mock(displayName: "Alice")
         let bob = Contact.mock(displayName: "Bob")
@@ -320,12 +337,15 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(result.map(\.inboxId), [alice.inboxId])
     }
 
-    func testPickableContactsExcludesVerifiedAgents() {
+    func testPickableContactsKeepsVerifiedAgents() {
         let alice = Contact.mock(displayName: "Alice")
         let convosAgent = Contact.mock(displayName: "Convos Assistant", agentVerification: .verified(.convos))
         let oauthAgent = Contact.mock(displayName: "OAuth Bot", agentVerification: .verified(.userOAuth))
         let result = ContactsPickerViewModel.pickableContacts([alice, convosAgent, oauthAgent])
-        XCTAssertEqual(result.map(\.inboxId), [alice.inboxId])
+        XCTAssertEqual(
+            result.map(\.inboxId).sorted(),
+            [alice.inboxId, convosAgent.inboxId, oauthAgent.inboxId].sorted()
+        )
     }
 
     func testPickableContactsExcludesUnnamed() {
@@ -336,14 +356,14 @@ final class ContactsPickerViewModelTests: XCTestCase {
         XCTAssertEqual(result.map(\.inboxId), [named.inboxId])
     }
 
-    /// All agents / blocked / unnamed collapses to empty -- which is exactly
+    /// Hidden / blocked / unnamed contacts collapse to empty -- which is exactly
     /// what makes Compose skip the picker and open the new-conversation view
     /// directly (the bug behind the "13 contacts but empty picker" report).
     func testPickableContactsEmptyWhenNonePickable() {
-        let agent = Contact.mock(displayName: "Agent", agentVerification: .verified(.convos))
+        let unverifiedAgent = Contact.mock(displayName: "Agent", agentVerification: .unverified)
         let blocked = Contact.mock(displayName: "Blocked", isBlocked: true)
         let unnamed = Contact.mock(displayName: nil)
-        XCTAssertTrue(ContactsPickerViewModel.pickableContacts([agent, blocked, unnamed]).isEmpty)
+        XCTAssertTrue(ContactsPickerViewModel.pickableContacts([unverifiedAgent, blocked, unnamed]).isEmpty)
     }
 
     // MARK: - Suggested agents

--- a/ConvosTests/ContactsViewModelTests.swift
+++ b/ConvosTests/ContactsViewModelTests.swift
@@ -10,11 +10,10 @@ import XCTest
 final class ContactsViewModelTests: XCTestCase {
     // MARK: - Agents in the browse list
 
-    /// Only template-backed agents appear in the browse list (tagged with
-    /// the trailing Agent pill). Humans always show; agents without a
-    /// template id - legacy verified assistants and unverified agents -
-    /// stay in `DBContact` for chat-side resolution but are hidden here.
-    func testSectionsShowOnlyTemplateBackedAgents() {
+    /// Verified agents appear in the browse list even before a template id has
+    /// mirrored. Humans always show; unverified agents stay in `DBContact` for
+    /// chat-side resolution but are hidden here.
+    func testSectionsShowVerifiedAgentsIncludingTemplateLessAgents() {
         let alice = Contact.mock(displayName: "Alice")
         let coffeeAgent = Contact.mock(
             displayName: "Americano",
@@ -34,14 +33,14 @@ final class ContactsViewModelTests: XCTestCase {
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
         let allIds: [String] = viewModel.sections.flatMap { $0.rows.map(\.contact.inboxId) }
-        // Human + template-backed agent show; template-less agents hidden.
-        XCTAssertEqual(allIds.sorted(), [alice.inboxId, coffeeAgent.inboxId].sorted())
+        // Human + verified agents show; only unverified agents are hidden.
+        XCTAssertEqual(allIds.sorted(), [alice.inboxId, coffeeAgent.inboxId, legacyAssistant.inboxId].sorted())
     }
 
     /// `contactCount` drives the empty-state vs list-state branch in the
     /// `ContactsView` body and the compose button's enabled flag. It counts
-    /// only browsable rows - humans and template-backed agents - so a
-    /// template-less agent does not inflate the total.
+    /// only browsable rows - humans and verified agents, including verified
+    /// template-less agents.
     func testContactCountCountsBrowsableRowsOnly() {
         let alice = Contact.mock(displayName: "Alice")
         let coffeeAgent = Contact.mock(
@@ -57,8 +56,8 @@ final class ContactsViewModelTests: XCTestCase {
 
         let viewModel = ContactsViewModel(contactsRepository: repo)
 
-        XCTAssertEqual(viewModel.contactCount, 2)
-        XCTAssertEqual(viewModel.sections.flatMap { $0.rows }.count, 2)
+        XCTAssertEqual(viewModel.contactCount, 3)
+        XCTAssertEqual(viewModel.sections.flatMap { $0.rows }.count, 3)
     }
 
     // MARK: - Search

--- a/qa/tests/36-agents-as-contacts.md
+++ b/qa/tests/36-agents-as-contacts.md
@@ -29,12 +29,12 @@ conversation. (Screenshots captured during the run.)
   (`agent-composer-text-field`) and tap `agent-make-button`; the builder names the
   agent and provisions it. This avoids the invite deep-link path (which opened Safari
   / created non-joining drafts on this build) entirely.
-- **Backend provisioning is required.** The built agent only becomes a *visible*
-  contact once the backend assigns a templateId. If the account isn't provisioned
+- **Local stack caveat:** the browse list now intentionally shows verified agents
+  even before the backend mirrors a templateId. If the account isn't provisioned
   (`GET /accounts/me/credits` 403 / generator `ownerAccountId does not exist`), the
-  agent shows "lost power" and stays template-less -> hidden from contacts. Then
-  `isVisibleInContactsList` is false. (This was the local-stack gap; once the stack
-  provisions the account, the agent is a visible contact.)
+  agent may show "lost power" / missing publish/share affordances, but it remains
+  selectable as an existing inbox. Once the stack provisions the account and assigns
+  a templateId, starting or adding it can spawn a fresh template instance.
 - **Publish/share is a known-issue on local.** Even with a visible contact, Share can
   404 (`agent-templates` registry has no published row for the templateId). The app
   surfaces a readable DisplayError now (not "error 6").

--- a/qa/tests/structured/36-agents-as-contacts.yaml
+++ b/qa/tests/structured/36-agents-as-contacts.yaml
@@ -76,10 +76,11 @@ steps:
     criteria: agent_template_provisioned
     note: >
       Until the templateId is assigned, the agent is verified but template-less
-      (agentTemplateId == nil) and isVisibleInContactsList returns false, so it will
-      NOT appear in the browse list. A "lost power" / "Upgrade" badge here means the
-      local backend credit/generator provisioning failed - see prerequisites.
-
+      (agentTemplateId == nil). It should still appear in the browse list and picker
+      as an existing inbox, but starting/adding it will not spawn a fresh template
+      instance. A "lost power" / "Upgrade" badge here means the local backend
+      account/provisioning path failed; fix the local account seed before treating
+      template-backed spawning/publish-share behavior as an app regression.
   - id: agent_appears_in_contacts
     name: "The built template-backed agent appears in the Contacts list"
     actions:

--- a/qa/tests/structured/37-agent-contact-visibility-edges.yaml
+++ b/qa/tests/structured/37-agent-contact-visibility-edges.yaml
@@ -8,10 +8,10 @@ description: >
   conversation is inline-disabled, and adding a second agent to a conversation that
   already has one is blocked by the !hasAgent guard. Guards
   ContactsPickerViewModel.isPickable / already-in-chat handling and
-  AddFromContactsPickerModifier.handleConfirm. Two visibility invariants that can't
+  AddFromContactsPickerModifier.handleConfirm. Visibility invariants that can't
   be reproduced cleanly through the builder UI (a verified agent with no templateId
-  staying hidden; a metadata-less name-only update keeping the sticky templateId)
-  are covered by the ConvosCore unit suite and noted below.
+  surfacing as an existing inbox; a metadata-less name-only update keeping the sticky
+  templateId) are covered by the ConvosCore unit suite and noted below.
 tags: [agents, contacts, picker, edge-cases, local-stack, agent-builder]
 depends_on: ["36"]
 estimated_duration_s: 420


### PR DESCRIPTION
## Summary
- show verified agents in contacts/pickers even when agentTemplateId is missing
- keep template-backed agents spawning by templateId, while template-less verified agents are added by inboxId
- update picker/contact tests and QA docs for the new expected behavior

## Local verification
- Swift syntax sanity check: balanced braces/parens on edited Swift files
- YAML structured QA files parsed by patch linter

## Note
This Linux host does not have Xcode or Swift, so I opened this PR to run the macOS GitHub Actions checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786143463&installation_id=128169237&pr_number=1148&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1148&signature=5b31ed1477fe63691854aed4480a5e1bd5d9e4a189fbf81904573de9ace35740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show verified template-less agents in the Contacts browse list
> - Changes `Contact.isVisibleInContactsList` in [Contact+BrowseVisibility.swift](https://github.com/xmtplabs/convos-ios/pull/1148/files#diff-d093d0e41bd58c6de496cfc9aa22a0f327d78ebf04e251b03c0ccb983d7575c8) to require only verification for agent visibility, dropping the previous requirement for a non-nil `agentTemplateId`.
> - Template-less verified agents are now keyed by inbox id in the contacts list; template-backed agents still deduplicate by template id.
> - Updates tests in [ContactsPickerViewModelTests.swift](https://github.com/xmtplabs/convos-ios/pull/1148/files#diff-cad7c9f752829474974050dc138fce165eeafeb5146d6cd0c0f3ee12d510e897) and [ContactsViewModelTests.swift](https://github.com/xmtplabs/convos-ios/pull/1148/files#diff-e92c6ea1bc84cfe3214a35811b8af67cc4dd987ed99d870aefe1185e257cbf26) to assert template-less verified agents appear in browse lists and contact counts.
> - `selectedAgentInboxIds` continues to capture only template-backed agents (`agentTemplateId != nil`), so template-less agents join conversations via their existing inbox id.
> - Behavioral Change: verified agents without a `templateId` now appear in contact counts and the contacts picker where they were previously hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized befd5e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->