### PR TITLE
Keep the emoji avatar for the empty-state CTA carousel

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -75,9 +75,12 @@ public extension Conversation {
     /// Mock conversation backing the chats-tab empty-state CTA carousel.
     /// Built as a group with two other members so `avatarType` resolves to
     /// the supplied emoji rather than a single member's profile, and the
-    /// rendered title is the supplied name. `lastMessageText` is attached
-    /// whenever present; the pinned-item preview bubble only shows it once
-    /// `isUnread` flips true.
+    /// rendered title is the supplied name. The other members' profiles carry
+    /// no avatar because member avatars outrank the conversation emoji in
+    /// `avatarType`; a mock avatar would render the CTA as a cluster of
+    /// never-loading initials instead of the emoji. `lastMessageText` is
+    /// attached whenever present; the pinned-item preview bubble only shows it
+    /// once `isUnread` flips true.
     static func emptyStateMock(
         id: String,
         name: String,
@@ -85,10 +88,22 @@ public extension Conversation {
         isUnread: Bool = false,
         lastMessageText: String? = nil
     ) -> Conversation {
+        let avatarlessMember: (String) -> ConversationMember = { inboxId in
+            ConversationMember(
+                profile: Profile(
+                    inboxId: inboxId,
+                    conversationId: "client-\(id)",
+                    name: "John Doe",
+                    avatar: nil
+                ),
+                role: .member,
+                isCurrentUser: false
+            )
+        }
         let members: [ConversationMember] = [
             .mock(isCurrentUser: true),
-            .mock(isCurrentUser: false),
-            .mock(isCurrentUser: false),
+            avatarlessMember("empty-state-member-1"),
+            avatarlessMember("empty-state-member-2"),
         ]
         let creator: ConversationMember = members.first(where: { $0.isCurrentUser }) ?? .mock(isCurrentUser: true)
         var lastMessage: MessagePreview?

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -609,6 +609,20 @@ struct DefaultConversationDisplayTests {
         }
     }
 
+    @Test("emptyStateMock avatarType resolves to the supplied emoji")
+    func emptyStateMockAvatarTypeIsSuppliedEmoji() {
+        // The empty-state CTA carousel mock must render its emoji, not a
+        // cluster of never-loading mock avatars, even though member avatars
+        // outrank the conversation emoji for real groups.
+        let conversation = Conversation.emptyStateMock(id: "cta", name: "Book Club", emoji: "📚")
+
+        if case .emoji(let emoji) = conversation.avatarType {
+            #expect(emoji == "📚")
+        } else {
+            #expect(Bool(false), "Expected emoji avatar type - the empty-state mock members must not form a cluster")
+        }
+    }
+
     // MARK: - Member Name Limiting Tests
 
     @Test("Four named profiles shows three and 1 other")


### PR DESCRIPTION
## Summary

After #1140 gave the member-photo cluster priority over the seeded conversation emoji, the Convos-tab empty-state CTA carousel ("Book Club" / "Tahoe Trip" / "Dunes Soccer Club") started rendering a cluster of gray "JD" monogram bubbles instead of each mock convo's emoji. The mock members come from `Profile.mock`, which hardcodes a fake `https://example.com/avatar.jpg` avatar URL — so the mock group counts as "has member avatars" and takes the cluster path, but the URL never loads and the cluster degrades to initials.

## Fix

Scope the fix to the mock: `Conversation.emptyStateMock` now builds its two other members with avatar-less profiles, so `avatarType` falls through to `.emoji(defaultEmoji)`, which returns the supplied `conversationEmoji`. Real groups keep the #1140 behavior (cluster outranks emoji).

## Testing

- New regression test `emptyStateMockAvatarTypeIsSuppliedEmoji` pins the empty-state mock to `.emoji`.
- Full ConvosCore suite: 1543 tests in 221 suites passed.
- SwiftLint (strict) and SwiftFormat clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786143501&installation_id=128169237&pr_number=1149&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1149&signature=03402711b917ec96b5a4244d0df1ff047fa907fa556173ccfec46e29b7d62643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep emoji avatar for empty-state CTA carousel by clearing member avatars in `Conversation.emptyStateMock`
> Member avatars take precedence over conversation emoji when resolving `avatarType`. The two non-current mock members in `emptyStateMock` previously used generic mocks that included profile avatars, causing the emoji to be ignored.
>
> - Sets `Profile.avatar` to `nil` for both non-current members in [`Conversation.emptyStateMock`](https://github.com/xmtplabs/convos-ios/pull/1149/files#diff-772603937c1e0966b591b930c6c6a6d0f7a57fa42b96c828c5c471babc57c5cb) so the supplied emoji is used instead of a clustered avatar.
> - Adds a test in [`DefaultConversationDisplayTests`](https://github.com/xmtplabs/convos-ios/pull/1149/files#diff-6c3a35457df9f60046f38ed010b5e3c17e576c733fb9acb743380367dcd9207d) asserting that `emptyStateMock` resolves `avatarType` to `.emoji` with the expected string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65eaefa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->