### PR TITLE
Fix invite-actions spacing on Contacts tab while suggested agents load

### DIFF
--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -182,11 +182,16 @@ struct ContactsView: View {
     /// a user with no contacts still sees the invite actions -- the exact moment
     /// they need them. The contacts list renders the same actions via its
     /// `leadingContent`; this covers the branches that don't reach the list.
+    /// The explicit padding mirrors the list's default row insets so the
+    /// actions don't shift when the list takes over (e.g. once the
+    /// suggested-agents page lands).
     @ViewBuilder
     private func emptyStateWithInviteActions<Body: View>(@ViewBuilder body: () -> Body) -> some View {
         if let actions = inviteActionsContent {
             VStack(spacing: 0) {
                 actions
+                    .padding(.top, DesignConstants.Spacing.step4x)
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
                 body()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)


### PR DESCRIPTION
## Problem

On the Contacts tab, before the suggested agents have loaded, the "Invite a new contact" section renders with no leading inset and sits tight under the search bar — the rows hug the screen edge, then jump into place once the agents arrive.

| Loading (before) | Loaded |
|---|---|
| Rows flush to the left edge, header tight under search bar | Rows properly inset |

## Cause

The top-three invite actions render through two paths in `ContactsView`:

- Once sections exist, `ContactsPickerActionsSection` is `leadingContent` inside the contacts `List`, which supplies its default row insets (~16pt leading/trailing plus vertical row padding).
- While the suggested-agents first page is in flight (or the list is empty), `emptyStateWithInviteActions` places the same view in a bare `VStack(spacing: 0)` with no padding at all.

## Fix

Apply explicit padding (`DesignConstants.Spacing.step4x` top and horizontal) to the actions on the VStack path, mirroring the List's default row insets so the section doesn't shift when the list takes over.

## Verification

- `xcodebuild build` of Convos (Dev) for iOS Simulator passes with no type-check warnings
- SwiftLint clean on the changed file
- ConvosCore test suite: 1542 tests in 221 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786144279&installation_id=128169237&pr_number=1150&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1150&signature=2da155af6c3bba661e5d888e58b1c5d9cbcd8ac0c6c576572f7586765c6832c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spacing of invite actions in `ContactsView.emptyStateWithInviteActions` while suggested agents load
> Adds explicit top and horizontal padding (`DesignConstants.Spacing.step4x`) to the invite actions view in [ContactsView.swift](https://github.com/xmtplabs/convos-ios/pull/1150/files#diff-100cced20d6f49dfda46f616cdaf24be3b4023cf85a615bebc4bf2b69fe133cc) when rendered inside the empty-state container. The doc comment explains the padding is applied explicitly due to layout behavior during the suggested agents loading state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07442fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->