### PR TITLE
add agent variant picker to profiles

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -80,6 +80,7 @@ struct ContactDetailView: View {
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
+    @State private var presentingAgentVariantPicker: Bool = false
     /// Existing conversation pushed onto the host navigation stack when the
     /// user taps a row in the "Convos with you" sections.
     @State private var pushedConversation: NewConversationViewModel?
@@ -97,6 +98,10 @@ struct ContactDetailView: View {
     /// The agent template's description, resolved on appear for template-backed
     /// agents (it isn't stored on the contact). Rendered under the name.
     @State private var agentDescription: String?
+    @State private var agentVariants: [ConvosAPI.AgentVariant] = []
+    @State private var selectedAgentVariantId: String?
+    @State private var isUpdatingAgentVariant: Bool = false
+    @State private var agentVariantErrorMessage: String?
     @State private var navState: ContactCardNavigatorImpl = .init()
     @State private var navigator: ContactCardCollector?
 
@@ -149,6 +154,7 @@ struct ContactDetailView: View {
             .task(id: contact.inboxId) { await syncBlockedState() }
             .task(id: contact.agentTemplateId) { await observeAgentTemplateConversations() }
             .task(id: contact.agentTemplateId) { await loadAgentDescription() }
+            .task(id: contact.agentInstanceId) { await loadAgentVariants() }
             .onAppear {
                 ensureNavigator()
                 navState.markScreenAppeared()
@@ -183,6 +189,23 @@ struct ContactDetailView: View {
                     profileSettingsViewModel: profileSettingsViewModel
                 )
                 .background(.colorBackgroundSurfaceless)
+            }
+            .sheet(isPresented: $presentingAgentVariantPicker) {
+                AgentVariantPickerSheet(
+                    variants: agentVariants,
+                    selectedVariantId: selectedAgentVariantId,
+                    isUpdating: isUpdatingAgentVariant,
+                    onSelect: updateAgentVariant(variantId:),
+                    onClear: { updateAgentVariant(variantId: nil) }
+                )
+                .presentationDetents([.medium, .large])
+            }
+            .alert("Variant update failed", isPresented: agentVariantErrorBinding) {
+                Button("OK", role: .cancel) {
+                    agentVariantErrorMessage = nil
+                }
+            } message: {
+                Text(agentVariantErrorMessage ?? "")
             }
             .navigationDestination(item: $pushedConversation) { vm in
                 pushedConversationView(vm)
@@ -236,6 +259,21 @@ struct ContactDetailView: View {
         guard agentDescription == nil, let session, let templateId = contact.agentTemplateId else { return }
         let info = await session.agentShareResolver().resolve(identifier: templateId)
         agentDescription = info?.descriptionText
+    }
+
+    private func loadAgentVariants() async {
+        guard ConfigManager.shared.currentEnvironment.isInternalBuild,
+              contact.agentInstanceId != nil,
+              let session else {
+            agentVariants = []
+            return
+        }
+        do {
+            agentVariants = try await session.listAgentVariants()
+        } catch {
+            Log.warning("Failed to load agent variants: \(error.localizedDescription)")
+            agentVariants = []
+        }
     }
 
     /// Agent "code card" share flow: a QR encoding the template's published
@@ -356,12 +394,16 @@ struct ContactDetailView: View {
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
                     agentInstanceId: contact.agentInstanceId,
+                    showVariantPicker: showsAgentVariantPicker,
+                    selectedVariantLabel: selectedAgentVariantLabel,
+                    isUpdatingVariant: isUpdatingAgentVariant,
                     showsInstanceIdRow: showsInstanceIdRow,
                     agentAttestation: contact.agentAttestation,
                     agentVerification: contact.agentVerification,
                     agentTemplateConversations: agentTemplateConversations,
                     onSelectConversation: handleSelectAgentTemplateConversation,
                     onSendMessage: isAgentTemplate ? handleChatWithAgentTemplate : handleSendMessage,
+                    onPickVariant: { presentingAgentVariantPicker = true },
                     onShare: { presentingAgentShareSheet = true },
                     onRemove: handleRemoveTap,
                     onToggleBlock: handleBlockTap
@@ -411,6 +453,31 @@ struct ContactDetailView: View {
     /// row only - the id itself is always plumbed through.
     private var showsInstanceIdRow: Bool {
         ConfigManager.shared.currentEnvironment.isInternalBuild
+    }
+
+    private var showsAgentVariantPicker: Bool {
+        ConfigManager.shared.currentEnvironment.isInternalBuild
+            && contact.agentInstanceId != nil
+            && !agentVariants.isEmpty
+    }
+
+    private var selectedAgentVariantLabel: String {
+        guard let selectedAgentVariantId,
+              let variant = agentVariants.first(where: { $0.slug == selectedAgentVariantId }) else {
+            return "Default variant"
+        }
+        return variant.label
+    }
+
+    private var agentVariantErrorBinding: Binding<Bool> {
+        Binding(
+            get: { agentVariantErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    agentVariantErrorMessage = nil
+                }
+            }
+        )
     }
 
     /// Pill rendered below the subtitle. "You" for the current user's
@@ -569,6 +636,27 @@ struct ContactDetailView: View {
 
     private func handleRemoveTap() {
         onRemove?()
+    }
+
+    private func updateAgentVariant(variantId: String?) {
+        guard let session,
+              let instanceId = contact.agentInstanceId,
+              !isUpdatingAgentVariant else { return }
+        Task { @MainActor in
+            isUpdatingAgentVariant = true
+            defer { isUpdatingAgentVariant = false }
+            do {
+                let response = try await session.updateAgentVariant(
+                    instanceId: instanceId,
+                    variantId: variantId
+                )
+                selectedAgentVariantId = response.variantId
+                presentingAgentVariantPicker = false
+            } catch {
+                Log.error("Failed to update agent variant \(instanceId): \(error.localizedDescription)")
+                agentVariantErrorMessage = "We couldn't update this agent's variant. Please try again."
+            }
+        }
     }
 
     private func applyBlockChange(block: Bool) {
@@ -767,6 +855,74 @@ private struct ContactDetailSubtitle: View {
 
 // MARK: - Action stack
 
+private struct AgentVariantPickerSheet: View {
+    let variants: [ConvosAPI.AgentVariant]
+    let selectedVariantId: String?
+    let isUpdating: Bool
+    let onSelect: (String) -> Void
+    let onClear: () -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Button(action: onClear) {
+                    variantRow(
+                        title: "Default variant",
+                        subtitle: "Use the standard agent profile",
+                        isSelected: selectedVariantId == nil
+                    )
+                }
+                .disabled(isUpdating)
+
+                ForEach(variants) { variant in
+                    Button(action: { onSelect(variant.slug) }) {
+                        variantRow(
+                            title: variant.label,
+                            subtitle: variant.whatToTest,
+                            isSelected: selectedVariantId == variant.slug
+                        )
+                    }
+                    .disabled(isUpdating)
+                }
+            }
+            .navigationTitle("Variant")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private func variantRow(title: String, subtitle: String, isSelected: Bool) -> some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step1x) {
+                Text(title)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(.colorTextPrimary)
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: DesignConstants.Spacing.step2x)
+            if isUpdating && isSelected {
+                ProgressView()
+            } else if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.colorTextPrimary)
+            }
+        }
+        .contentShape(Rectangle())
+    }
+}
+
 /// Renders the "Convos with you" sections (template-backed agents only),
 /// then the chat CTA ("New chat" for agents, "Chat" for human members),
 /// Share, Remove, and Block - in that order. The chat CTA is the
@@ -793,6 +949,9 @@ private struct ContactDetailActions: View {
     /// Always plumbed through when the contact has one. Display gate
     /// is `showsInstanceIdRow`, not nullability of this field.
     let agentInstanceId: String?
+    let showVariantPicker: Bool
+    let selectedVariantLabel: String
+    let isUpdatingVariant: Bool
     /// True on Dev/Local builds. Hides the row on production.
     let showsInstanceIdRow: Bool
     /// Agent's published attestation signature (`nil` when it joined without
@@ -808,6 +967,7 @@ private struct ContactDetailActions: View {
     /// Called with the conversation when a "Convos with you" row is tapped.
     let onSelectConversation: (Conversation) -> Void
     let onSendMessage: () -> Void
+    let onPickVariant: () -> Void
     let onShare: () -> Void
     let onRemove: () -> Void
     let onToggleBlock: () -> Void
@@ -822,6 +982,9 @@ private struct ContactDetailActions: View {
             }
             if showChat {
                 chatButton
+            }
+            if showVariantPicker {
+                variantRow
             }
             if showShare {
                 shareRow
@@ -884,6 +1047,18 @@ private struct ContactDetailActions: View {
             accessibilityLabel: "Share \(contactDisplayName)",
             accessibilityIdentifier: "contact-detail-share-agent-row",
             action: onShare
+        )
+    }
+
+    private var variantRow: some View {
+        ContactDetailActionRow(
+            label: "Variant",
+            footer: selectedVariantLabel,
+            color: .colorTextPrimary,
+            isDisabled: isUpdatingVariant,
+            accessibilityLabel: "Change agent variant",
+            accessibilityIdentifier: "contact-detail-agent-variant",
+            action: onPickVariant
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -228,6 +228,41 @@ public enum ConvosAPI {
         public static let agentBuilder: AgentJoinOptions = AgentJoinOptions(onboarding: "agent-builder")
     }
 
+    public struct AgentVariantUpdateRequest: Encodable, Sendable {
+        public let variantId: String?
+
+        public init(variantId: String?) {
+            self.variantId = variantId
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            if let variantId {
+                try container.encode(variantId, forKey: .variantId)
+            } else {
+                try container.encodeNil(forKey: .variantId)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case variantId
+        }
+    }
+
+    public struct AgentVariantUpdateResponse: Codable, Sendable {
+        public let success: Bool
+        public let instanceId: String
+        public let variantId: String?
+        public let applied: String
+
+        public init(success: Bool, instanceId: String, variantId: String?, applied: String) {
+            self.success = success
+            self.instanceId = instanceId
+            self.variantId = variantId
+            self.applied = applied
+        }
+    }
+
     public struct AgentJoinResponse: Codable {
         public let success: Bool
         public let joined: Bool

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -107,6 +107,8 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// the poll hit the default worker, which has no record of the instance.
     func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse
 
+    func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse
+
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
     /// template id (UUID) or hashed url slug (e.g. `gandalf.felpl`). Backs the
@@ -941,6 +943,14 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // request. Kept well under the loop's overall deadline so a stuck
         // request fails fast and the next iteration's deadline check fires.
         request.timeoutInterval = 10
+        return try await performRequest(request)
+    }
+
+    func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse {
+        let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
+        var request = try authenticatedRequest(for: "v2/agents/\(encoded)/variant", method: "PATCH")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(ConvosAPI.AgentVariantUpdateRequest(variantId: variantId))
         return try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -119,6 +119,15 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         )
     }
 
+    func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse {
+        .init(
+            success: true,
+            instanceId: instanceId,
+            variantId: variantId,
+            applied: "profile_metadata"
+        )
+    }
+
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         .init(
             id: UUID().uuidString,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1473,6 +1473,16 @@ extension SessionManager {
 // MARK: - Agent-template repository factory
 
 extension SessionManager {
+    public func listAgentVariants() async throws -> [ConvosAPI.AgentVariant] {
+        try await apiClient.getAgentVariants()
+    }
+
+    public func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse {
+        try await apiClient.updateAgentVariant(instanceId: instanceId, variantId: variantId)
+    }
+}
+
+extension SessionManager {
     public func agentTemplateRepository() -> any AgentTemplateRepositoryProtocol {
         agentTemplateRepositoryInstance
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -138,6 +138,9 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    func listAgentVariants() async throws -> [ConvosAPI.AgentVariant]
+    func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse
+
     /// Opportunistic foreground republish of the user's timezone across every
     /// agent conversation (agent-timezone Channel B refresh). Throttled so a
     /// conversation is only republished when the device timezone changed since
@@ -306,5 +309,18 @@ extension SessionManagerProtocol {
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         try await addAgentToConversation(conversationId: conversationId, templateId: templateId, options: nil, forceErrorCode: nil)
+    }
+
+    public func listAgentVariants() async throws -> [ConvosAPI.AgentVariant] {
+        []
+    }
+
+    public func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse {
+        ConvosAPI.AgentVariantUpdateResponse(
+            success: true,
+            instanceId: instanceId,
+            variantId: variantId,
+            applied: "profile_metadata"
+        )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -72,6 +72,15 @@ extension ConvosAPIClientProtocol {
         []
     }
 
+    func updateAgentVariant(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentVariantUpdateResponse {
+        ConvosAPI.AgentVariantUpdateResponse(
+            success: true,
+            instanceId: instanceId,
+            variantId: variantId,
+            applied: "profile_metadata"
+        )
+    }
+
     /// Default for the public agent-template detail fetch used by the
     /// agent-share card/chip resolver. Tests that exercise it specifically
     /// should override on their fixture.


### PR DESCRIPTION
Summary
- add API/session support for updating an existing agent variant
- add a Variant row and picker sheet to the agent profile/settings page
- reuse the existing dev variant registry picker data and support clearing back to the default variant

Why
- internal builds need to switch existing agents to a different registered variant from the same profile surface used for agent settings.

Validation
- xcodebuild -project Convos.xcodeproj -scheme ConvosCore -destination "generic/platform=iOS Simulator" build
- full Convos (Dev) app build still fails locally at link time because LibXMTPSwiftFFI.xcframework is missing the x86_64 simulator slice for the NotificationService target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786193720&installation_id=128169237&pr_number=1153&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1153&signature=661dbe922b06b53da2a67308f1afade40bf2ffe9ce7dd81982eb86816b523638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent variant picker to contact profiles
> - Adds a 'Variant' row to `ContactDetailActions` that opens a new `AgentVariantPickerSheet`, allowing users to select or clear an agent variant for an agent instance.
> - `ContactDetailView` loads available variants on appear via `SessionManager.listAgentVariants()` and applies changes via a new PATCH endpoint `v2/agents/{instanceId}/variant`. Errors surface as an alert.
> - The variant picker and row are gated to internal builds and only shown when the contact has an `agentInstanceId` and at least one variant is available.
> - Adds `updateAgentVariant` to `ConvosAPIClient`, `SessionManager`, and their protocols/mocks to support the new endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 204cf7e. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->