### PR TITLE
fix(invite): follow-up fixes

### DIFF
--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -53,6 +53,12 @@ struct ContactsView: View {
     /// presented from under this tab's stack, so the shell injects a closure
     /// that calls `ConversationsViewModel.onStartAgent()`. Nil hides the row.
     private let onMakeAgent: (() -> Void)?
+    /// A code scanned inside a presented new-convo sheet resolved to a joined
+    /// conversation. That conversation lives under the Chats tab, which this
+    /// tab can't reach on its own, so the shell injects a closure that
+    /// switches tabs and selects it (mirroring the home-scan navigation).
+    /// Nil leaves the user on this tab after the join.
+    private let onScanJoinedConversation: ((String) -> Void)?
     /// True while a contact detail is pushed on the host's stack (the shell
     /// lifts the stack path and mirrors it here). `onDisappear` fires for a
     /// child push too, not just a real leave, so the claimed invite
@@ -71,6 +77,7 @@ struct ContactsView: View {
         suggestedAgentsService: (any SuggestedAgentsServiceProtocol)? = nil,
         scrollTarget: Binding<String?>? = nil,
         onMakeAgent: (() -> Void)? = nil,
+        onScanJoinedConversation: ((String) -> Void)? = nil,
         hasPushedContactDetail: Bool = false
     ) {
         _viewModel = State(initialValue: ContactsViewModel(
@@ -85,6 +92,7 @@ struct ContactsView: View {
         self.showsComposeButton = showsComposeButton
         self.scrollTarget = scrollTarget
         self.onMakeAgent = onMakeAgent
+        self.onScanJoinedConversation = onScanJoinedConversation
         self.hasPushedContactDetail = hasPushedContactDetail
     }
 
@@ -443,8 +451,24 @@ struct ContactsView: View {
         // it, promote it into the chats list. If they dismiss without
         // engaging, `cleanUpDismissedNewConvo` discards it.
         Task { await enteredViewModel.commitConversationVisibility() }
+        enteredViewModel.onScanResolvedConversation = handleScanResolvedConversation
         dismissedNewConvo = enteredViewModel
         presentingNewConvo = enteredViewModel
+    }
+
+    /// A scan inside the presented sheet finished joining a conversation.
+    /// Dismiss the sheet first, then hand the id to the shell so it can
+    /// switch to the Chats tab and select the joined conversation. Deferred
+    /// one hop so the presenting VM's `.ready` handler unwinds before the
+    /// sheet state changes (mirrors the home-scan sequencing in
+    /// `ConversationsViewModel.navigateToScannedConversation`). The joined
+    /// convo survives the dismissal cleanup -- the scanned-code engagement
+    /// latch keeps it (see `cleanUpDismissedNewConvo`).
+    private func handleScanResolvedConversation(_ conversationId: String) {
+        Task { @MainActor in
+            presentingNewConvo = nil
+            onScanJoinedConversation?(conversationId)
+        }
     }
 
     /// Runs the empty-invite teardown for a dismissed new-conversation sheet so
@@ -534,6 +558,7 @@ struct ContactsView: View {
             ),
             coreActions: coreActions
         )
+        viewModel.onScanResolvedConversation = handleScanResolvedConversation
         dismissedNewConvo = viewModel
         presentingNewConvo = viewModel
     }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -1245,7 +1245,10 @@ extension ConversationsViewModel {
     /// handler unwinds (nil-ing the sheet there would tear down a VM mid-call).
     /// The just-joined row may not be in `conversations` yet, so it's parked and
     /// resolved by the conversations publisher once the row lands.
-    private func navigateToScannedConversation(_ conversationId: String) {
+    /// Also the landing point for the Contacts-tab scan handoff: the shell
+    /// switches to the Chats tab and routes the joined conversation id here
+    /// (see `MainTabView.contactsTabContent`).
+    func navigateToScannedConversation(_ conversationId: String) {
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.pendingScanNavigationConversationId = conversationId

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -350,8 +350,18 @@ struct MainTabView: View {
             suggestedAgentsService: SuggestedAgentsService.live(),
             scrollTarget: $contactsScrollTarget,
             onMakeAgent: { conversationsViewModel.onStartAgent() },
+            onScanJoinedConversation: handleContactsScanJoinedConversation,
             hasPushedContactDetail: !contactsPath.isEmpty
         )
+    }
+
+    /// A scan started from the Contacts tab joined a conversation. The joined
+    /// convo lives under the Chats tab, so switch there first, then route the
+    /// id through the same parked-selection navigation the home scan uses
+    /// (the row may not be in the list yet; it resolves once it lands).
+    private func handleContactsScanJoinedConversation(_ conversationId: String) {
+        activeTab = .chats
+        conversationsViewModel.navigateToScannedConversation(conversationId)
     }
 
     /// Wraps each tab's content in its own `NavigationStack` carrying the

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/DraftConversationRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/DraftConversationRepository.swift
@@ -35,12 +35,21 @@ class DraftConversationRepository: DraftConversationRepositoryProtocol {
         )
     }
 
+    // `map` + `switchToLatest` (not `flatMap`, which merges) so that when a
+    // join flips the conversation id, the previous id's observation is
+    // cancelled. Merged, the stale observation kept re-emitting the old draft
+    // row on every overlapping database write during the join, interleaving
+    // with the joined conversation's emissions and flickering the chat header
+    // and embedded invite card between the two conversations.
+    // `removeDuplicates` on the output drops the redundant re-emissions a
+    // region-based observation produces for writes that don't change the
+    // composed value.
     lazy var conversationPublisher: AnyPublisher<Conversation?, Never> = {
         let dbReader = dbReader
         Log.debug("Creating conversationPublisher for conversationId: \(conversationId)")
         return conversationIdPublisher
             .removeDuplicates()
-            .flatMap { conversationId -> AnyPublisher<Conversation?, Never> in
+            .map { conversationId -> AnyPublisher<Conversation?, Never> in
                 Log.debug("Conversation ID changed to: \(conversationId)")
                 return ValueObservation
                     .tracking { db in
@@ -64,6 +73,8 @@ class DraftConversationRepository: DraftConversationRepositoryProtocol {
                     .replaceError(with: nil)
                     .eraseToAnyPublisher()
             }
+            .switchToLatest()
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }()
 


### PR DESCRIPTION
Two fixes landed on the feature branch after #1124's squash merge was cut and never shipped. This branch cherry-picks them onto `dev` unchanged.

- **fix(scan): stop the draft conversation publisher from merging stale id observations** — the draft repository's `conversationPublisher` used `flatMap` over the conversation-id stream, so a scanned join left the superseded conversation's database observation live and its emissions interleaved with the joined conversation's. Fixes the field report of the chat header, invite card, and Verifying pill flickering between two conversations while a scanned join verified. Now `map` + `switchToLatest` + `removeDuplicates`.
- **fix(contacts): land in the joined conversation after a Contacts-tab scan** — the Contacts tab's new-convo sheet never wired `onScanResolvedConversation`, so scanning an invite from there joined the conversation but left the user parked on the Contacts tab (field report: scan-from-Contacts appears stuck). The shell now dismisses the sheet, switches to the Chats tab, and routes the joined conversation through the same parked-selection navigation the home scanner uses.

Four other post-merge-looking commits on that branch (member-list engagement latch, include-info toggle engagement, `hasSharedInvite` persistence + migration, scanned-code keep-latch release) were verified already shipped inside the #1124 squash and are not repeated here.

Verified on this base: `Convos (Dev)` builds clean, SwiftLint `--strict` clean, full ConvosCore suite passes (1543 tests, 221 suites), and the app boots over an existing install with the migration chain applying cleanly.

Follow-ups from #1124.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786199354&installation_id=128169237&pr_number=1154&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1154&signature=30dd5327b2488f2cc67b2fa3e04a467cf7371b3dff1865c5d8eb92e15b5451fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix post-merge invite feature issues with cross-tab scan navigation and conversation observation
> - `ContactsView` gains an `onScanJoinedConversation` closure so scan-joined conversations from its new-conversation sheet are handed off to the shell; a new `handleScanResolvedConversation` method dismisses the sheet and triggers the handoff.
> - `MainTabView` wires up the closure to switch to the Chats tab and call `ConversationsViewModel.navigateToScannedConversation`, enabling cross-tab navigation after a scan from the Contacts tab.
> - `DraftConversationRepository.conversationPublisher` replaces `flatMap` with `map` + `switchToLatest` so changing the observed conversation id cancels the prior observation; `removeDuplicates` filters redundant emissions from region-based observations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64a4a4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->