### PR TITLE
fix(scan): stop the invite card double-render during a scan join

### DIFF
--- a/Convos/Conversation Detail/ConversationView+MetricsObservers.swift
+++ b/Convos/Conversation Detail/ConversationView+MetricsObservers.swift
@@ -104,28 +104,4 @@ extension ConversationView {
             if completed { onInviteShared?() }
         }
     }
-
-    /// Minimal pinned fallback for the `showsEmbeddedInvite` new-convo flows
-    /// during their pre-creation draft window. The inline `.invite` cell is
-    /// gated on a non-draft conversation, so a brand-new draft convo has no
-    /// transcript to host the card yet; this inset covers that narrow window
-    /// only, and the inline cell takes over once the convo is created.
-    /// Collapsed while the keyboard is up so the tall panel never squeezes the
-    /// composer.
-    @ViewBuilder
-    var draftEmbeddedInviteInset: some View {
-        if showsEmbeddedInvite, viewModel.conversation.isDraft, !isKeyboardVisible {
-            InviteCodeBody(
-                conversation: viewModel.conversation,
-                encodedURLString: viewModel.invite.inviteURLString,
-                mode: inviteScanMode,
-                initialSegment: embeddedInviteInitialSegment,
-                isInviteReady: !viewModel.invite.isEmpty,
-                onScannedCode: inviteScanScannedHandler,
-                onShareCompleted: onInviteShareCompletedHandler
-            )
-            .padding(.vertical, DesignConstants.Spacing.step4x)
-            .frame(maxWidth: .infinity)
-        }
-    }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -51,11 +51,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var showingFullInfo: Bool = false
     @State private var showingAgentsInfo: Bool = false
     @State private var pagerSelectedPage: ConversationPagerPage = .messages
-    /// Tracks keyboard visibility so the pager dots hide, the pager-dots inset
-    /// collapses, and the draft-window invite inset collapses while the
-    /// keyboard is up. Internal so `draftEmbeddedInviteInset` in the
-    /// metrics-observers extension can read it.
-    @State var isKeyboardVisible: Bool = false
+    /// Tracks keyboard visibility so the pager dots hide and the pager-dots
+    /// inset collapses while the keyboard is up.
+    @State private var isKeyboardVisible: Bool = false
     /// Lifted out of `MessagesView` so this view can gate the pager
     /// against horizontal swipes while the long-press context menu is
     /// presented.
@@ -533,7 +531,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
             messagesPage: { messagesView },
             thingsPage: { thingsPage }
         )
-        .safeAreaInset(edge: .top) { draftEmbeddedInviteInset }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
             isKeyboardVisible = true
         }

--- a/Convos/Conversation Detail/InviteCodeBody.swift
+++ b/Convos/Conversation Detail/InviteCodeBody.swift
@@ -9,9 +9,9 @@ import UIKit
 // toggle plus its two tabs (Invite = legacy QR card + "Share invite link";
 // Scan = live viewfinder + "Or scan from camera roll"), without any full-screen nav
 // chrome. `InviteCodeOverlay` composes this under its floating liquid-glass
-// nav for the full-screen flow; `ConversationView` embeds it via a top
-// `safeAreaInset` when a "Show an invite code" convo owns the QR inline. Both
-// share this single implementation so the toggle + tabs don't fork.
+// nav for the full-screen flow; the transcript's index-0 `.invite` cell hosts
+// it inline when a convo owns the QR (`showsInviteScanCard`). Both share this
+// single implementation so the toggle + tabs don't fork.
 
 /// The toggle + Invite/Scan tabs, sized to a fixed column. Owns the segment
 /// selection, QR generation, the live scanner, and the screenshot-picker

--- a/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/Convos/Conversation Detail/Messages/Messages View Controller/View Controller/MessagesViewController.swift
@@ -962,11 +962,17 @@ extension MessagesViewController {
         // The `.invite` cell is the top-of-convo invite surface: it renders the
         // full inline Invite/Scan card during an active hosted session
         // (`showsInviteScanCard`) and the regular inviter QR + menu once the
-        // session ends. There is no longer a pinned overlay to dedupe against.
-        if hasLoadedAllMessages, !conversation.isDraft, summaryAllowsInvite, headerMode != .suppressed {
-            if conversation.creator.isCurrentUser && !conversation.isLocked && !conversation.isFull {
+        // session ends. While the card is active it is the single host for the
+        // whole embedded flow, including the pre-creation draft and the
+        // scan-join placeholder/claimed windows: the conversation swaps of a
+        // scan join reconfigure the one cell in place instead of deleting and
+        // re-inserting it, which would cross-fade two stacked cards and reset
+        // the camera mid-flow.
+        if hasLoadedAllMessages, summaryAllowsInvite, headerMode != .suppressed {
+            let hostsInviteHeader = !conversation.isDraft && conversation.creator.isCurrentUser && !conversation.isLocked && !conversation.isFull
+            if showsInviteScanCard || hostsInviteHeader {
                 cells.insert(.invite(invite), at: 0)
-            } else if headerMode == .standard, !hasVerifiedConvosAgent {
+            } else if !conversation.isDraft, headerMode == .standard, !hasVerifiedConvosAgent {
                 cells.insert(.conversationInfo(conversation), at: 0)
             }
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
@@ -65,8 +65,15 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             return "date-\(dateGroup.hashValue)"
         case .messages(let group):
             return "messages-group-\(group.id)"
-        case .invite(let invite):
-            return "invite-\(invite.id)"
+        case .invite:
+            // The transcript hosts at most one invite card (index 0), so its
+            // identity is the slot, not the invite payload. Keying on the
+            // payload made every invite change (hydration, the embedded
+            // new-convo flow's created->claimed swap) an animated
+            // delete+insert that cross-faded two full cards and restarted
+            // the Scan tab camera; a stable id turns those into in-place
+            // reconfigurations of the single card.
+            return "invite"
         case .conversationInfo(let conversation):
             return "conversation-info-\(conversation.id)"
         case .agentOutOfCredits(let member, _):


### PR DESCRIPTION
Fixes the stacked double-render ("over-impression") of the in-convo Scan/Invite card during a scan join -- doubled captions, ghosted toggle, camera restart, and a colored rim were two full card instances cross-fading.

## Root cause (proven via runtime changeset logging)
- The `.invite` cell's diff identity included the invite slug, so the invite swap/hydration after a scan produced an animated delete+insert pair: the collection view fades the old card out while the new one fades in (~300ms of two stacked cards, camera torn down/restarted, view state reset).
- Separately, the pre-creation pinned inset could overlap the transcript cell for a moment when the scan's placeholder draft arrived.

## Fix
- The `.invite` cell's identity is now the slot itself (constant): payload changes reconfigure the single cell in place -- no delete/insert, no cross-fade, camera preview and tab selection survive the conversation swap.
- The cell hosts the card for the whole embedded flow, keyed on a per-surface constant, and the pinned draft inset is removed -- exactly one card instance can exist at any moment.
- Post-fix changeset logs show only in-place updates across the created -> draft -> claimed -> joined window.

Also resolves two known polish anomalies as a side effect: the Invite-segment spinner reset during Verifying, and the camera restart at the id flip.

## Verification
- Before/after screen recordings + frame montages (zero doubled frames after the fix).
- Regression: Contacts-tab scan still lands in the joined conversation; home-scan steady with segment preserved.
- ConvosCore suite green (1543 tests), SwiftLint --strict clean, Dev build clean.

Follow-up to #1154.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786213246&installation_id=128169237&pr_number=1155&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1155&signature=ea4b3f2150216014faa55de3031a34f716f867211e6d266160c39456e67a185c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double-render of invite card during scan join by consolidating to a single host
> - Removes the `draftEmbeddedInviteInset` top safe-area inset from `ConversationView`, so the invite/scan card is only rendered at index 0 of the messages list, never as a separate overlay.
> - Updates `MessagesViewController.processUpdates` to insert the `.invite` cell at index 0 whenever `showsInviteScanCard` is active (including during draft and scan-join windows), regardless of draft state.
> - Gives the `.invite` list item a stable constant id (`"invite"` instead of `"invite-<id>"`), so payload changes trigger in-place reconfiguration rather than an animated delete/insert cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42bc545.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->