### PR TITLE
fix(scan): route scan navigation through the chats tab from every entry point

### DIFF
--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -267,6 +267,26 @@ final class ConversationsViewModel {
     /// Resolved to a selection once the row appears.
     @ObservationIgnored
     private var pendingScanNavigationConversationId: String?
+    /// Mirrors whether the Chats tab is frontmost in the tab shell (kept
+    /// current by `MainTabView`). Scan navigation must not select a
+    /// conversation while another tab is visible: selecting hides the tab bar
+    /// and lifts the conversation indicator on every tab, while the pushed
+    /// conversation mounts in the background Chats stack -- stranding the
+    /// user on a hybrid screen with no way back. Defaults to true for hosts
+    /// without a tab shell (previews, tests).
+    @ObservationIgnored
+    var isChatsTabActive: Bool = true {
+        didSet {
+            guard isChatsTabActive, !oldValue else { return }
+            resolvePendingScanNavigationIfPossible()
+        }
+    }
+    /// Asks the tab shell to bring the Chats tab frontmost. Invoked when a
+    /// scan resolves so the user is directed to Chats no matter which tab the
+    /// scan started from; the parked navigation is consumed only after the
+    /// switch has committed (see `isChatsTabActive`).
+    @ObservationIgnored
+    var bringChatsTabToFront: (() -> Void)?
 
     private var horizontalSizeClass: UserInterfaceSizeClass?
 
@@ -1245,26 +1265,38 @@ extension ConversationsViewModel {
     /// handler unwinds (nil-ing the sheet there would tear down a VM mid-call).
     /// The just-joined row may not be in `conversations` yet, so it's parked and
     /// resolved by the conversations publisher once the row lands.
-    /// Also the landing point for the Contacts-tab scan handoff: the shell
-    /// switches to the Chats tab and routes the joined conversation id here
-    /// (see `MainTabView.contactsTabContent`).
+    /// The landing point for every scan entry (home scanner, Contacts-tab
+    /// sheets, the shared toolbar scan on any tab): it asks the shell to bring
+    /// the Chats tab frontmost, and the parked id is consumed only once that
+    /// switch has committed.
     func navigateToScannedConversation(_ conversationId: String) {
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.pendingScanNavigationConversationId = conversationId
             self.newConversationViewModel = nil
+            self.bringChatsTabToFront?()
             self.resolvePendingScanNavigationIfPossible()
         }
     }
 
     /// Selects the parked scan-navigation target once its row exists in the list.
-    /// Called after the sheet dismiss and whenever the conversations list
-    /// updates. Selecting drives the same `navigationDestination` push a list tap
-    /// does; the metrics navigator fires via the `selectedConversationId`
-    /// onChange.
+    /// Called after the sheet dismiss, whenever the conversations list updates,
+    /// and when the Chats tab becomes frontmost. Selecting drives the same
+    /// `navigationDestination` push a list tap does; the metrics navigator fires
+    /// via the `selectedConversationId` onChange.
+    /// Consuming is gated on the Chats tab being frontmost: selecting from any
+    /// other tab would hide the tab bar and float the conversation indicator
+    /// over that tab while the push mounts in the background Chats stack, an
+    /// unrecoverable hybrid screen. When gated, the id stays parked and the
+    /// shell is asked to switch; the `isChatsTabActive` observer re-runs this
+    /// once the switch lands.
     func resolvePendingScanNavigationIfPossible() {
         guard let pendingId = pendingScanNavigationConversationId,
               conversations.contains(where: { $0.id == pendingId }) else { return }
+        guard isChatsTabActive else {
+            bringChatsTabToFront?()
+            return
+        }
         pendingScanNavigationConversationId = nil
         selectedConversationId = pendingId
     }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -278,6 +278,8 @@ struct MainTabView: View {
                 ensureNavigators()
                 tabRootNavState.markScreenAppeared()
                 navStateForTab(activeTab).markScreenAppeared()
+                conversationsViewModel.bringChatsTabToFront = { activeTab = .chats }
+                conversationsViewModel.isChatsTabActive = activeTab == .chats
             }
             .modifier(metricsObserversModifier)
     }
@@ -329,8 +331,12 @@ struct MainTabView: View {
             }
         }
         .tint(Color.colorTextPrimary)
-        .onChange(of: activeTab) { _, _ in
+        .onChange(of: activeTab) { _, newTab in
             updateBuilderBarReveal(forOffset: activeTabScrollOffset)
+            // Fires after SwiftUI has applied the tab switch, so a parked
+            // scan navigation gated on the Chats tab consumes only once the
+            // switch has actually committed.
+            conversationsViewModel.isChatsTabActive = newTab == .chats
         }
     }
 
@@ -356,11 +362,11 @@ struct MainTabView: View {
     }
 
     /// A scan started from the Contacts tab joined a conversation. The joined
-    /// convo lives under the Chats tab, so switch there first, then route the
-    /// id through the same parked-selection navigation the home scan uses
-    /// (the row may not be in the list yet; it resolves once it lands).
+    /// convo lives under the Chats tab; `navigateToScannedConversation` asks
+    /// the shell to switch there (via `bringChatsTabToFront`) and selects the
+    /// conversation only once the switch has committed and the row is in the
+    /// list, so the push can never land while Contacts is frontmost.
     private func handleContactsScanJoinedConversation(_ conversationId: String) {
-        activeTab = .chats
         conversationsViewModel.navigateToScannedConversation(conversationId)
     }
 


### PR DESCRIPTION
Fixes the irrecoverable hybrid state when scanning an invite from the Contacts tab: contacts list still frontmost, the joined conversation's header pill floating over the search bar, tab bar gone, no way out.

## Root cause (deterministic, not a race)
The shared navigation-bar viewfinder button exists on every tab. From Contacts, its scan-success closure navigated directly with no tab switch: the conversation push mounts in the background Chats stack (the only `navigationDestination` for it), while the shell -- which keys the conversation header pill and tab-bar hiding on the selected conversation, tab-agnostically -- dresses the still-frontmost Contacts view with conversation chrome. Nothing on Contacts can pop the selection, so the state is irrecoverable. The earlier fix only wired ContactsView's own sheet entry points, not the shared toolbar path (the Things tab had the same gap).

## Fix
All scan navigation now goes through a single choke point: the parked conversation id is only consumed when the Chats tab is actually frontmost; otherwise the shell is asked to switch and the id stays parked until the switch commits. A wrong-context push can no longer mount, from any entry point or ordering -- the hybrid state is unconstructible.

## Verification
- Deterministic repro of the field bug before the fix (video), zero hybrid frames after (10fps sweep of the dismiss -> switch -> push window).
- Contacts toolbar scan (the broken path), Contacts sheet scan, home scan, and Things-tab toolbar scan all land inside the joined conversation on the Chats tab.
- SwiftLint --strict clean; Dev build clean (warnings-as-errors).

Follow-up to #1154.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786216776&installation_id=128169237&pr_number=1156&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1156&signature=1dc576b6df2cafbaef5dab37fb472f90d58815ef45617ef286354aba6e1a7df4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route scan navigation through the Chats tab from every entry point
> - `ConversationsViewModel` gains a `bringChatsTabToFront` closure and an `isChatsTabActive` flag to coordinate tab switching with the shell ([ConversationsViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/1156/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce)).
> - `resolvePendingScanNavigationIfPossible` now defers selecting a scanned conversation until the Chats tab is active; if not, it requests the tab switch and waits.
> - `MainTabView` wires up the `bringChatsTabToFront` callback and keeps `isChatsTabActive` in sync on tab changes, removing the direct `activeTab = .chats` assignment from `handleContactsScanJoinedConversation` ([MainTabView.swift](https://github.com/xmtplabs/convos-ios/pull/1156/files#diff-2b02f95e9fabdce514b1dd6d74d930ca17fcc2380c7504789454c035484e9d67)).
> - Behavioral Change: tab switching responsibility moves from `MainTabView` to `ConversationsViewModel`; scans initiated from non-Chats tabs now trigger an async tab switch before conversation selection resolves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a306f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->