### PR TITLE
Schedule TestFlight prod builds (3x/day, skip-if-stale)

### DIFF
--- a/.github/workflows/testflight-prod.yml
+++ b/.github/workflows/testflight-prod.yml
@@ -1,6 +1,15 @@
 # Prod TestFlight Release — thin caller. The job lives in convos-releases:
 # https://github.com/xmtplabs/convos-releases/blob/main/.github/workflows/ios-testflight-prod.yml
 #
+# Scheduled (not per-merge): Apple limits TestFlight uploads per version —
+# a train closes entirely once that version ships to the App Store
+# ("Invalid Pre-Release Train ... closed for new build submissions"; bump
+# MARKETING_VERSION to reopen), and long trains cap at ~100 builds. Three
+# slots a day bounds a 30-day train at ≤90 builds and stops per-merge
+# uploads from burning quota on busy days; the check job skips a slot when
+# dev hasn't changed since the last successful upload. Manual
+# workflow_dispatch always builds.
+#
 # Required repository secrets (passed via `secrets: inherit`):
 #   CONVOS_CERTIFICATES_TOKEN, MATCH_PASSWORD, APP_STORE_CONNECT_API_KEY_ID,
 #   APP_STORE_CONNECT_ISSUER_ID, APP_STORE_CONNECT_API_PRIVATE_KEY,
@@ -9,18 +18,50 @@
 name: Prod TestFlight Release
 
 on:
-  push:
-    branches: [dev]
+  schedule:
+    # 13:00 / 17:00 / 21:00 UTC — schedule events run on the default
+    # branch (dev), so each slot builds the dev tip.
+    - cron: "0 13,17,21 * * *"
   workflow_dispatch:
 
-# Single-slot queue: a new commit on dev cancels the in-flight build so
-# only the latest commit's build reaches TestFlight.
+# Single-slot queue: only one TestFlight build runs at a time.
 concurrency:
   group: testflight-prod
   cancel-in-progress: true
 
 jobs:
+  # Skip a scheduled slot when dev is unchanged since the last successful
+  # build — an identical rebuild would still consume a build number.
+  check_fresh:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      fresh: ${{ steps.check.outputs.fresh }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch — building regardless of staleness."
+            exit 0
+          fi
+          last=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/testflight-prod.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // empty')
+          if [ "$last" = "${{ github.sha }}" ]; then
+            echo "fresh=false" >> "$GITHUB_OUTPUT"
+            echo "dev unchanged since last successful build ($last) — skipping."
+          else
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+            echo "New commits since $last — building."
+          fi
+
   testflight_prod:
+    needs: check_fresh
+    if: needs.check_fresh.outputs.fresh == 'true'
     # Callers must grant what the reusable workflow's job declares — a called
     # workflow can't elevate beyond the caller's grant.
     permissions:

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -51,14 +51,6 @@ fastlane ios verify_api_key
 
 Sanity check API Key
 
-### ios latest_build
-
-```sh
-fastlane ios latest_build
-```
-
-
-
 ### ios bootstrap
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783541743,
-        "narHash": "sha256-wxkwFTSpNVm3V8PX4vcS6iIZxEEqrPAY3muUEJ1CRE0=",
+        "lastModified": 1783624733,
+        "narHash": "sha256-wkutNw0NUFMiQG9cP8RlfPw6BhzwNW+QAbKI/VT8OxE=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "989466b1cfc61908809009f382e5046f71fa7449",
+        "rev": "68805648516ae12de9f3d1eefedbbeb50fa81ec6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Replaces per-merge TestFlight uploads with a schedule to stop burning Apple's per-version upload budget:

- **Why**: today's post-merge run failed with `Invalid Pre-Release Train. The train version '2.0.4' is closed for new build submissions` — a train closes when its version ships to the App Store, and long trains also cap at ~100 builds. Per-merge uploads (19 on Jun 12 alone) burn that quota fast.
- **What**: cron 13:00/17:00/21:00 UTC (schedule runs on the default branch, dev) + a `check_fresh` job that skips a slot when dev is unchanged since the last successful upload. `workflow_dispatch` always builds. 3/day bounds a 30-day train at ≤90 builds.
- Also: bumps the convos-releases flake pin to `68805648` (final-review item — aligns with convos-client's pin) and removes the ghost `latest_build` lane from fastlane/README.
- **Note**: 2.0.4 needs the usual marketing-version bump to reopen uploads; that's orthogonal to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHWYLAPmoBmF2XS9rrd8pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786218175&installation_id=128169237&pr_number=1157&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1157&signature=70bccfa0f198eddf0d8f3b899894564bef85d12ac5609ff5f1aa6ff49915cdbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Schedule TestFlight prod builds 3x/day and skip builds when no new commits exist
> - Replaces the `push` trigger on `dev` with a cron schedule (13:00, 17:00, 21:00 UTC) in [testflight-prod.yml](.github/workflows/testflight-prod.yml); `workflow_dispatch` is retained.
> - Adds a `check_fresh` job that compares the current commit SHA to the last successful run's SHA via the GitHub API, setting a `fresh` output to skip redundant builds.
> - The `testflight_prod` job now depends on `check_fresh` and only runs when `fresh == 'true'`; manual dispatches always set `fresh=true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fafdee9. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->