### PR TITLE
fix(onboarding): profile sheet header full-bleed under keyboard

### DIFF
--- a/Convos/Profile/ProfileSetupSheet.swift
+++ b/Convos/Profile/ProfileSetupSheet.swift
@@ -62,6 +62,11 @@ struct ProfileSetupSheet: View {
     @State private var contentHeight: CGFloat
 
     private static let privacyAndTermsURL: String = "https://hq.convos.org/privacy-and-terms"
+    /// How far the header band's background bleeds above the content's top
+    /// edge. Only the sheet-clipped gap left by keyboard avoidance is ever
+    /// visible, so the value just needs to comfortably exceed the largest
+    /// such gap on any device; the overdraw is otherwise clipped away.
+    private static let headerBleedHeight: CGFloat = 400.0
 
     init(mode: ProfileSetupSheetMode, onSaved: (() -> Void)? = nil) {
         self.mode = mode
@@ -180,7 +185,7 @@ struct ProfileSetupSheet: View {
         // the presentation background above the header. One paint layer, so
         // there is no seam at the band's own edge.
         .background {
-            Color.colorLava.padding(.top, -400.0)
+            Color.colorLava.padding(.top, -Self.headerBleedHeight)
         }
     }
 

--- a/Convos/Profile/ProfileSetupSheet.swift
+++ b/Convos/Profile/ProfileSetupSheet.swift
@@ -174,7 +174,14 @@ struct ProfileSetupSheet: View {
         // 132pt band per design: 40 above the text block, 28 below.
         .padding(.top, DesignConstants.Spacing.step10x)
         .padding(.bottom, 28.0)
-        .background(.colorLava)
+        // The negative padding bleeds the band upward, past the content's
+        // top edge; the sheet's shape clips it. Keyboard avoidance lays the
+        // content out below the sheet's top edge, which otherwise exposes
+        // the presentation background above the header. One paint layer, so
+        // there is no seam at the band's own edge.
+        .background {
+            Color.colorLava.padding(.top, -400.0)
+        }
     }
 
     private var nameRow: some View {


### PR DESCRIPTION
Follow-up to #1158. When the keyboard is up, keyboard avoidance lays the sheet content out below the sheet's top edge, which exposed the presentation background above the lava band (light cap, square band corners).

Fix: the header band's background now bleeds upward past the content's top edge — a single paint layer clipped by the sheet's shape — so any gap above the header reads as the band continuing into the rounded corners. No layout/metric changes; the band still renders 132pt with the 40/28 text placement when no gap exists.

Verified on the iPhone 17 sim: sheet over settings with the software keyboard up now shows the lava flush to the sheet's rounded top (screenshot in thread); no-keyboard state unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786306591&installation_id=128169237&pr_number=1162&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1162&signature=07b8016b0617fc4624328cce029d2042174f82e09d0b701e308a4f4da4a58521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix profile setup sheet header to bleed under keyboard in onboarding
> When keyboard avoidance shifts content upward, a gap could appear above the header band, exposing the presentation background. Adds a `headerBleedHeight` constant in [ProfileSetupSheet.swift](https://github.com/xmtplabs/convos-ios/pull/1162/files#diff-c33a881ce64e49858c5109b26bfa4ca9c278483c650338b9c92d38279c40cbf5) and applies negative top padding to the header's lava color background so it extends upward to fill that gap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebc17a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->