### PR TITLE
Devices screen: iCloud devices section, Main-device designation, delete-all guard

### DIFF
--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -122,7 +122,7 @@ The canonical order (from `qa/SKILL.md` "Run all tests") is:
    → 16 → 17 → 20 → 27 → 28 → 19 → 15 → 34 → 18
 ```
 
-plus secondary tests `14, 22, 23, 23b, 24, 25, 26, 28b, 29, 30, 31, 32, 33, 43, 44b, 45` slotted where they don't conflict with destructive steps (09, 18). Test 43 (long-message rendering) explodes the shared conversation in teardown, so slot it late in the sequence, after other tests that reuse `shared_conversation_id`. Tests 44b and 45 briefly shut down the primary simulator to clone it (like 03/04), so don't overlap them with tests running on the primary; they otherwise run entirely on their own disposable clones.
+plus secondary tests `14, 22, 23, 23b, 24, 25, 26, 28b, 29, 30, 31, 32, 33, 43, 44b, 45, 46` slotted where they don't conflict with destructive steps (09, 18). Test 43 (long-message rendering) explodes the shared conversation in teardown, so slot it late in the sequence, after other tests that reuse `shared_conversation_id`. Tests 44b, 45, and 46 briefly shut down the primary simulator to clone it (like 03/04), so don't overlap them with tests running on the primary; they otherwise run entirely on their own disposable clones.
 
 **What can actually run in parallel:**
 

--- a/Convos/App Settings/AppSettingsViewModel.swift
+++ b/Convos/App Settings/AppSettingsViewModel.swift
@@ -10,6 +10,10 @@ final class AppSettingsViewModel {
     private(set) var isDeleting: Bool = false
     private(set) var deletionProgress: InboxDeletionProgress?
     private(set) var deletionError: Error?
+    /// Whether this device holds the account's main (oldest) iCloud key.
+    /// Escalates the delete-all confirmation copy - wiping the main
+    /// device removes the key other devices pair through.
+    private(set) var currentDeviceIsMain: Bool = false
 
     // MARK: - Dependencies
 
@@ -34,6 +38,14 @@ final class AppSettingsViewModel {
     }
 
     // MARK: - Actions
+
+    /// Refreshes the main-device designation for the delete-all
+    /// confirmation. Best-effort - defaults to false on failure so the
+    /// escalated warning never blocks a legitimate delete.
+    func refreshMainDeviceStatus() async {
+        let snapshot = await session.iCloudDeviceBackupsSnapshot()
+        currentDeviceIsMain = snapshot.currentDeviceIsMain
+    }
 
     func deleteAllData(onComplete: @escaping () -> Void) {
         guard !isDeleting else { return }

--- a/Convos/App Settings/DeleteAllDataView.swift
+++ b/Convos/App Settings/DeleteAllDataView.swift
@@ -22,7 +22,9 @@ struct DeleteAllDataView: View {
     }
 
     var subtitle: String {
-        "This will permanently delete all conversations on this device, as well as your profile."
+        let base = "This will permanently delete all conversations on this device, as well as your profile."
+        guard viewModel.currentDeviceIsMain else { return base }
+        return base + " This is your main device — the first one created for your account — and other devices pair through it."
     }
 
     var body: some View {
@@ -64,6 +66,9 @@ struct DeleteAllDataView: View {
         .onAppear {
             ensureNavigator()
             navState.markScreenAppeared()
+        }
+        .task {
+            await viewModel.refreshMainDeviceStatus()
         }
         .onDisappear {
             navigator?.closed(context: navState.closeContext())

--- a/Convos/Config/QALaunchHooks.swift
+++ b/Convos/Config/QALaunchHooks.swift
@@ -11,6 +11,84 @@ enum QALaunchHooks {
         guard !environment.isProduction else { return }
         wipePrimaryIdentityIfRequested(environment: environment)
         restampForeignBackupsIfRequested(environment: environment)
+        renameForeignBackupsIfRequested(environment: environment)
+        purgeForeignBackupsIfRequested(environment: environment)
+        dumpBackupInventoryIfRequested(environment: environment)
+    }
+
+    /// CONVOS_QA_PURGE_FOREIGN_BACKUPS=1 deletes every synced backup that
+    /// doesn't belong to the current primary identity. Cleans up the
+    /// orphaned identities that the wipe/restamp hooks accumulate on a
+    /// long-lived QA simulator - debris that production flows (delete
+    /// all data, pairing adoption) would have removed - so the
+    /// found-device prompt and the Devices screen return to a clean
+    /// baseline.
+    private static func purgeForeignBackupsIfRequested(environment: AppEnvironment) {
+        guard ProcessInfo.processInfo.environment["CONVOS_QA_PURGE_FOREIGN_BACKUPS"] == "1" else { return }
+        let primaryInboxId = loadPrimaryInboxId(environment: environment)
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.syncedBackupService,
+            kSecAttrAccessGroup as String: environment.keychainAccessGroup,
+            kSecAttrSynchronizable as String: true,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var found: CFTypeRef?
+        let readStatus = SecItemCopyMatching(query as CFDictionary, &found)
+        query.removeValue(forKey: kSecReturnAttributes as String)
+        query.removeValue(forKey: kSecMatchLimit as String)
+        guard readStatus == errSecSuccess, let items = found as? [[String: Any]] else {
+            QAEvent.emit(.app, "qa_purged_foreign_backups", ["status": "\(readStatus)", "count": "0"])
+            return
+        }
+        var purged = 0
+        for item in items {
+            guard let account = item[kSecAttrAccount as String] as? String,
+                  account != primaryInboxId else { continue }
+            var deleteQuery = query
+            deleteQuery[kSecAttrAccount as String] = account
+            if SecItemDelete(deleteQuery as CFDictionary) == errSecSuccess { purged += 1 }
+        }
+        Log.info("QALaunchHooks: purged \(purged) foreign backup(s)")
+        QAEvent.emit(.app, "qa_purged_foreign_backups", ["count": "\(purged)"])
+    }
+
+    /// CONVOS_QA_DUMP_BACKUP_INVENTORY=1 logs every synced backup's
+    /// inboxId, deviceName, and backedUpAt plus the current primary
+    /// identity, so QA and debugging can see exactly which keys the
+    /// prompt and the Devices screen are working from - the keychain
+    /// isn't otherwise inspectable from outside the app.
+    private static func dumpBackupInventoryIfRequested(environment: AppEnvironment) {
+        guard ProcessInfo.processInfo.environment["CONVOS_QA_DUMP_BACKUP_INVENTORY"] == "1" else { return }
+        let primaryInboxId = loadPrimaryInboxId(environment: environment) ?? "<none>"
+        Log.info("QALaunchHooks: backup inventory dump - primary inboxId=\(primaryInboxId)")
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: KeychainIdentityStore.syncedBackupService,
+            kSecAttrAccessGroup as String: environment.keychainAccessGroup,
+            kSecAttrSynchronizable as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var found: CFTypeRef?
+        let readStatus = SecItemCopyMatching(query as CFDictionary, &found)
+        guard readStatus == errSecSuccess, let blobs = found as? [Data] else {
+            Log.info("QALaunchHooks: backup inventory read failed (status=\(readStatus))")
+            QAEvent.emit(.app, "qa_backup_inventory", ["status": "\(readStatus)", "count": "0"])
+            return
+        }
+        for (index, data) in blobs.enumerated() {
+            guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { continue }
+            let inboxId = json["inboxId"] as? String ?? "<?>"
+            let name = json["deviceName"] as? String ?? "<unnamed>"
+            let stamp = (json["backedUpAt"] as? Double).map {
+                "\(Date(timeIntervalSinceReferenceDate: $0))"
+            } ?? "<undated>"
+            let ownership = inboxId == primaryInboxId ? "own" : "foreign"
+            Log.info("QALaunchHooks: backup[\(index)] (\(ownership)) inboxId=\(inboxId) deviceName=\(name) backedUpAt=\(stamp)")
+        }
+        QAEvent.emit(.app, "qa_backup_inventory", ["count": "\(blobs.count)", "primary": primaryInboxId])
     }
 
     /// CONVOS_QA_WIPE_PRIMARY_IDENTITY=1 deletes the device-local identity
@@ -45,6 +123,41 @@ enum QALaunchHooks {
     private static func restampForeignBackupsIfRequested(environment: AppEnvironment) {
         guard let rawOffset = ProcessInfo.processInfo.environment["CONVOS_QA_RESTAMP_FOREIGN_BACKUPS"],
               let offset = TimeInterval(rawOffset) else { return }
+        let newDate = Date().addingTimeInterval(offset)
+        let count = mutateForeignBackups(environment: environment, eventName: "qa_restamped_foreign_backups") { json in
+            json["backedUpAt"] = newDate.timeIntervalSinceReferenceDate
+        }
+        Log.info("QALaunchHooks: restamped \(count) foreign backup(s) to \(newDate)")
+        QAEvent.emit(.app, "qa_restamped_foreign_backups", ["count": "\(count)", "offset": rawOffset])
+    }
+
+    /// CONVOS_QA_RENAME_FOREIGN_BACKUPS=<name> rewrites the deviceName of
+    /// every synced backup that doesn't belong to the current primary
+    /// identity. The Devices screen hides iCloud keys whose device name
+    /// matches a device already listed in the paired section (an
+    /// abandoned old identity of the same device); this hook gives a QA
+    /// clone's foreign key a distinct name so the section's visible path
+    /// can be exercised, and leaving it unset exercises the filter.
+    private static func renameForeignBackupsIfRequested(environment: AppEnvironment) {
+        guard let newName = ProcessInfo.processInfo.environment["CONVOS_QA_RENAME_FOREIGN_BACKUPS"],
+              !newName.isEmpty else { return }
+        let count = mutateForeignBackups(environment: environment, eventName: "qa_renamed_foreign_backups") { json in
+            json["deviceName"] = newName
+        }
+        Log.info("QALaunchHooks: renamed \(count) foreign backup(s) to \(newName)")
+        QAEvent.emit(.app, "qa_renamed_foreign_backups", ["count": "\(count)", "name": newName])
+    }
+
+    /// Shared enumerate-mutate-write for the foreign-backup hooks. Date
+    /// fields encode as timeIntervalSinceReferenceDate doubles (JSONEncoder
+    /// default, matching KeychainIdentityStore); the raw JSON is mutated so
+    /// the backup's internal initializers stay internal. Returns the number
+    /// of items written; a failed slot read emits the event with count=0.
+    private static func mutateForeignBackups(
+        environment: AppEnvironment,
+        eventName: String,
+        transform: (inout [String: Any]) -> Void
+    ) -> Int {
         let primaryInboxId = loadPrimaryInboxId(environment: environment)
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -61,20 +174,16 @@ enum QALaunchHooks {
         query.removeValue(forKey: kSecReturnAttributes as String)
         query.removeValue(forKey: kSecMatchLimit as String)
         guard readStatus == errSecSuccess, let items = found as? [[String: Any]] else {
-            QAEvent.emit(.app, "qa_restamped_foreign_backups", ["status": "\(readStatus)", "count": "0"])
-            return
+            QAEvent.emit(.app, eventName, ["status": "\(readStatus)", "count": "0"])
+            return 0
         }
-        // Date fields encode as timeIntervalSinceReferenceDate doubles
-        // (JSONEncoder default, matching KeychainIdentityStore); mutate the
-        // raw JSON so the backup's internal initializers stay internal.
-        let newDate = Date().addingTimeInterval(offset)
-        var restamped = 0
+        var mutated = 0
         for item in items {
             guard let account = item[kSecAttrAccount as String] as? String,
                   account != primaryInboxId,
                   let data = item[kSecValueData as String] as? Data,
                   var json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { continue }
-            json["backedUpAt"] = newDate.timeIntervalSinceReferenceDate
+            transform(&json)
             guard let updatedData = try? JSONSerialization.data(withJSONObject: json) else { continue }
             var updateQuery = query
             updateQuery[kSecAttrAccount as String] = account
@@ -82,10 +191,9 @@ enum QALaunchHooks {
                 updateQuery as CFDictionary,
                 [kSecValueData as String: updatedData] as CFDictionary
             )
-            if updateStatus == errSecSuccess { restamped += 1 }
+            if updateStatus == errSecSuccess { mutated += 1 }
         }
-        Log.info("QALaunchHooks: restamped \(restamped) foreign backup(s) to \(newDate)")
-        QAEvent.emit(.app, "qa_restamped_foreign_backups", ["count": "\(restamped)", "offset": rawOffset])
+        return mutated
     }
 
     private static func loadPrimaryInboxId(environment: AppEnvironment) -> String? {

--- a/Convos/Devices/DevicesView.swift
+++ b/Convos/Devices/DevicesView.swift
@@ -93,7 +93,7 @@ struct DevicesView: View {
                     deviceRow(device)
                 }
             } footer: {
-                Text("Devices paired to your account")
+                Text("Devices using this account")
             }
 
             if !viewModel.iCloudDevices.isEmpty {

--- a/Convos/Devices/DevicesView.swift
+++ b/Convos/Devices/DevicesView.swift
@@ -92,6 +92,18 @@ struct DevicesView: View {
                 ForEach(viewModel.devices) { device in
                     deviceRow(device)
                 }
+            } footer: {
+                Text("Devices paired to your account")
+            }
+
+            if !viewModel.iCloudDevices.isEmpty {
+                Section {
+                    ForEach(viewModel.iCloudDevices) { backup in
+                        iCloudDeviceRow(backup)
+                    }
+                } footer: {
+                    Text("Other devices in iCloud")
+                }
             }
 
             Section {
@@ -112,8 +124,43 @@ struct DevicesView: View {
         .background(.colorBackgroundRaisedSecondary)
     }
 
+    private func iCloudDeviceRow(_ backup: PairableDeviceBackup) -> some View {
+        let pairAction = { viewModel.pairICloudDevice(backup) }
+        let isMain: Bool = viewModel.mainDeviceInboxId == backup.inboxId
+        return Button(action: pairAction) {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                Image(systemName: "icloud")
+                    .foregroundStyle(.colorTextPrimary)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(backup.deviceName ?? DevicesViewModel.shortICloudDeviceName(inboxId: backup.inboxId))
+                        .foregroundStyle(.colorTextPrimary)
+
+                    if isMain {
+                        Text("Main device")
+                            .font(.caption)
+                            .foregroundStyle(.colorTextSecondary)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            .contentShape(Rectangle())
+        }
+        .accessibilityIdentifier("icloud-device-row-\(backup.inboxId)")
+    }
+
     private func deviceRow(_ device: PairedDevice) -> some View {
-        HStack(spacing: DesignConstants.Spacing.step3x) {
+        let caption: String? = {
+            guard device.isCurrentDevice else { return nil }
+            return viewModel.currentDeviceIsMain ? "This device · Main device" : "This device"
+        }()
+        return HStack(spacing: DesignConstants.Spacing.step3x) {
             Image(systemName: "iphone.gen3")
                 .foregroundStyle(.colorTextPrimary)
                 .frame(width: 24)
@@ -122,8 +169,8 @@ struct DevicesView: View {
                 Text(device.name)
                     .foregroundStyle(.colorTextPrimary)
 
-                if device.isCurrentDevice {
-                    Text("This device")
+                if let caption {
+                    Text(caption)
                         .font(.caption)
                         .foregroundStyle(.colorTextSecondary)
                 }

--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -29,14 +29,22 @@ final class DevicesViewModel {
     /// Other identities' private keys found in the iCloud-synced keychain
     /// backup - devices on the same iCloud account that are not paired to
     /// the current account. Oldest first, so the account's original key
-    /// leads the section.
-    var iCloudDevices: [PairableDeviceBackup] = []
+    /// leads the section. Derived from the latest snapshot with any key
+    /// whose device name already appears in the paired section filtered
+    /// out (an abandoned old identity of a listed device must not show
+    /// the same device in both sections), and recomputed whenever either
+    /// the snapshot or the paired-devices list changes.
+    var iCloudDevices: [PairableDeviceBackup] {
+        let pairedNames = Set(devices.map(\.name))
+        return iCloudSnapshot.otherDevices(excludingDeviceNames: pairedNames)
+    }
     /// The inboxId of the oldest key on the iCloud account - the "main"
     /// device. Nil when ordering can't be established.
-    var mainDeviceInboxId: String?
+    var mainDeviceInboxId: String? { iCloudSnapshot.mainDeviceInboxId }
     /// Whether the current account holds the main (oldest) key, so the
     /// current-device row carries the Main badge.
-    var currentDeviceIsMain: Bool = false
+    var currentDeviceIsMain: Bool { iCloudSnapshot.currentDeviceIsMain }
+    private var iCloudSnapshot: ICloudDeviceBackupsSnapshot = .init(currentDevice: nil, otherDevices: [])
     var isLoading: Bool = false
     var showPairingSheet: Bool = false
     var pairingViewModel: PairingSheetViewModel?
@@ -131,10 +139,7 @@ final class DevicesViewModel {
     /// adopted identity's separate backup) updates the section.
     func refreshICloudDevices() async {
         guard let session else { return }
-        let snapshot = await session.iCloudDeviceBackupsSnapshot()
-        iCloudDevices = snapshot.otherDevices
-        mainDeviceInboxId = snapshot.mainDeviceInboxId
-        currentDeviceIsMain = snapshot.currentDeviceIsMain
+        iCloudSnapshot = await session.iCloudDeviceBackupsSnapshot()
     }
 
     /// Starts the initiator pairing flow targeted at a specific iCloud

--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -26,6 +26,17 @@ struct PairedDevice: Identifiable, Equatable, Sendable {
 @MainActor
 final class DevicesViewModel {
     var devices: [PairedDevice] = []
+    /// Other identities' private keys found in the iCloud-synced keychain
+    /// backup - devices on the same iCloud account that are not paired to
+    /// the current account. Oldest first, so the account's original key
+    /// leads the section.
+    var iCloudDevices: [PairableDeviceBackup] = []
+    /// The inboxId of the oldest key on the iCloud account - the "main"
+    /// device. Nil when ordering can't be established.
+    var mainDeviceInboxId: String?
+    /// Whether the current account holds the main (oldest) key, so the
+    /// current-device row carries the Main badge.
+    var currentDeviceIsMain: Bool = false
     var isLoading: Bool = false
     var showPairingSheet: Bool = false
     var pairingViewModel: PairingSheetViewModel?
@@ -99,12 +110,56 @@ final class DevicesViewModel {
                     if role.isInitiator, let baseline {
                         await self.broadcastProfileSnapshotsAfterPair(baseline: baseline)
                     }
+                    // A completed pairing changes the iCloud picture (the
+                    // joined device's separate key is retired when it
+                    // adopts this account), so refresh the section too.
+                    await self.refreshICloudDevices()
                 }
             }
         }
         Task { @MainActor in
             await refreshInstallations(refreshFromNetwork: true)
         }
+        Task { @MainActor in
+            await refreshICloudDevices()
+        }
+    }
+
+    /// Loads the iCloud backup inventory for the "Other devices in
+    /// iCloud" section and the Main-device designation. Re-run alongside
+    /// installation refreshes so a completed pairing (which retires the
+    /// adopted identity's separate backup) updates the section.
+    func refreshICloudDevices() async {
+        guard let session else { return }
+        let snapshot = await session.iCloudDeviceBackupsSnapshot()
+        iCloudDevices = snapshot.otherDevices
+        mainDeviceInboxId = snapshot.mainDeviceInboxId
+        currentDeviceIsMain = snapshot.currentDeviceIsMain
+    }
+
+    /// Starts the initiator pairing flow targeted at a specific iCloud
+    /// device: this account stays the main account, the sheet shows the
+    /// standard invite (QR/PIN), and the scan instruction names the
+    /// tapped device. The join itself happens from that device.
+    func pairICloudDevice(_ backup: PairableDeviceBackup) {
+        guard pairingViewModel == nil else { return }
+        let service = pairingServiceFactory()
+        let vm = PairingSheetViewModel(
+            pairingService: service,
+            appGroupIdentifier: appGroupIdentifier,
+            targetDeviceName: backup.deviceName ?? Self.shortICloudDeviceName(inboxId: backup.inboxId)
+        )
+        pairingViewModel = vm
+        showPairingSheet = true
+        QAEvent.emit(.pairing, "devices_icloud_pair_tapped", ["inboxId": backup.inboxId])
+    }
+
+    /// Display name for an iCloud backup row: the device name stamped on
+    /// the backup when the writer had one, otherwise a short
+    /// tail-fingerprint of the inboxId (mirrors `shortDeviceName`).
+    static func shortICloudDeviceName(inboxId: String) -> String {
+        let suffix = inboxId.suffix(6)
+        return "Device \(suffix)"
     }
 
     /// The inbox's currently-known installation IDs (cached, no network

--- a/Convos/Devices/DevicesViewModel.swift
+++ b/Convos/Devices/DevicesViewModel.swift
@@ -140,6 +140,13 @@ final class DevicesViewModel {
     func refreshICloudDevices() async {
         guard let session else { return }
         iCloudSnapshot = await session.iCloudDeviceBackupsSnapshot()
+        // Observability for the name-based filter's documented trade-off:
+        // when keys are hidden, record how many so over-filtering of
+        // same-named devices is visible in QA runs and logs.
+        let hiddenCount = iCloudSnapshot.otherDevices.count - iCloudDevices.count
+        if hiddenCount > 0 {
+            QAEvent.emit(.pairing, "devices_icloud_keys_filtered", ["count": "\(hiddenCount)"])
+        }
     }
 
     /// Starts the initiator pairing flow targeted at a specific iCloud

--- a/Convos/Devices/PairingSheetView.swift
+++ b/Convos/Devices/PairingSheetView.swift
@@ -65,8 +65,11 @@ struct PairingSheetView: View {
 
     @ViewBuilder
     private func qrCodeContent(url: String) -> some View {
+        let scanInstruction: String = viewModel.targetDeviceName.map {
+            "Open Convos on \"\($0)\" and scan this code to pair"
+        } ?? "Scan this code with your new device to pair"
         VStack(spacing: DesignConstants.Spacing.step4x) {
-            Text("Scan this code with your new device to pair")
+            Text(scanInstruction)
                 .font(.subheadline)
                 .foregroundStyle(.colorTextPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Convos/Devices/PairingSheetView.swift
+++ b/Convos/Devices/PairingSheetView.swift
@@ -74,7 +74,7 @@ struct PairingSheetView: View {
                 .foregroundStyle(.colorTextPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text("All devices that are paired sync their existing convos.")
+            Text("The device that scans this code will get this account's profile and convos, replacing its own")
                 .font(.subheadline)
                 .foregroundStyle(.colorTextSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Convos/Devices/PairingSheetViewModel.swift
+++ b/Convos/Devices/PairingSheetViewModel.swift
@@ -66,6 +66,10 @@ final class PairingSheetViewModel: Identifiable {
     private let appGroupIdentifier: String?
     private let timeoutInterval: TimeInterval
     private let mode: PairingSheetMode
+    /// When the invite targets a specific iCloud device (the Devices
+    /// screen's "Other devices in iCloud" section), the sheet's scan
+    /// instruction names it instead of the generic "your new device".
+    let targetDeviceName: String?
     private(set) var coordinator: PairingCoordinator?
     private var joinerDeviceName: String = "New Device"
     private var joinerInboxId: String?
@@ -78,12 +82,14 @@ final class PairingSheetViewModel: Identifiable {
         pairingService: any PairingServiceProtocol,
         timeoutInterval: TimeInterval = 120,
         mode: PairingSheetMode = .createInvite,
-        appGroupIdentifier: String? = nil
+        appGroupIdentifier: String? = nil,
+        targetDeviceName: String? = nil
     ) {
         self.pairingService = pairingService
         self.appGroupIdentifier = appGroupIdentifier
         self.timeoutInterval = timeoutInterval
         self.mode = mode
+        self.targetDeviceName = targetDeviceName
         self.secondsRemaining = Int(timeoutInterval)
         self.observers = PairingNotificationObservers()
         if case .respondToJoinRequest = mode {

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -26,7 +26,10 @@ public struct PairableDeviceBackup: Sendable, Equatable, Identifiable {
 /// key was created first. `backedUpAt` is the best available proxy for
 /// key creation (a mirror is written when the identity is saved; pairing
 /// re-saves and late backfills can re-stamp it, the same caveat the
-/// prompt's ordering rule carries).
+/// prompt's ordering rule carries). Identical timestamps tie-break on
+/// the lexicographically smaller inboxId - deterministic, but it means
+/// the Main designation is approximate when keys were created in the
+/// same instant.
 ///
 /// Unlike `PairableDeviceBackup.pairableBackups`, `otherDevices` is not
 /// filtered by the newer-than-own ordering rule: that rule exists so the

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -61,6 +61,23 @@ public struct ICloudDeviceBackupsSnapshot: Sendable, Equatable {
         return mainDeviceInboxId == currentDevice.inboxId
     }
 
+    /// `otherDevices` minus backups whose device name matches a device
+    /// already shown in the paired-devices section. A key stamped with
+    /// the same name as a listed device is almost always that device's
+    /// own abandoned identity (an account reset or wipe left the old
+    /// key's backup in iCloud), and listing it as an "other device"
+    /// shows the same device in both sections. Name matching is the only
+    /// available link between installations and backup identities, so
+    /// same-model devices with identical generic names can be
+    /// over-filtered - an accepted trade-off; an undated/unnamed backup
+    /// is never filtered.
+    public func otherDevices(excludingDeviceNames pairedNames: Set<String>) -> [PairableDeviceBackup] {
+        otherDevices.filter { backup in
+            guard let name = backup.deviceName else { return true }
+            return !pairedNames.contains(name)
+        }
+    }
+
     public init(currentDevice: PairableDeviceBackup?, otherDevices: [PairableDeviceBackup]) {
         self.currentDevice = currentDevice
         self.otherDevices = otherDevices

--- a/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
+++ b/ConvosCore/Sources/ConvosCore/Pairing/PairableDeviceBackup.swift
@@ -6,15 +6,95 @@ import Foundation
 /// the backup's key material stays inside ConvosCore
 /// (`SessionManager.pairingInviteSlug(forBackupInboxId:expiresAt:)` signs
 /// with it on demand).
-public struct PairableDeviceBackup: Sendable, Equatable {
+public struct PairableDeviceBackup: Sendable, Equatable, Identifiable {
     public let inboxId: String
     public let deviceName: String?
     public let backedUpAt: Date?
+
+    public var id: String { inboxId }
 
     public init(inboxId: String, deviceName: String?, backedUpAt: Date?) {
         self.inboxId = inboxId
         self.deviceName = deviceName
         self.backedUpAt = backedUpAt
+    }
+}
+
+/// Everything the Devices screen needs from the iCloud-synced backup
+/// slot: the current identity's own mirror, every other identity's
+/// backup, and which of them is the "main" device - the identity whose
+/// key was created first. `backedUpAt` is the best available proxy for
+/// key creation (a mirror is written when the identity is saved; pairing
+/// re-saves and late backfills can re-stamp it, the same caveat the
+/// prompt's ordering rule carries).
+///
+/// Unlike `PairableDeviceBackup.pairableBackups`, `otherDevices` is not
+/// filtered by the newer-than-own ordering rule: that rule exists so the
+/// unsolicited first-install prompt never offers a device demotion,
+/// whereas the Devices screen is an explicit, user-navigated inventory
+/// of every key on the iCloud account.
+public struct ICloudDeviceBackupsSnapshot: Sendable, Equatable {
+    /// The current identity's own mirror, nil when it hasn't been
+    /// written yet (or the keychain read failed upstream).
+    public let currentDevice: PairableDeviceBackup?
+    /// Every other identity's backup, oldest first.
+    public let otherDevices: [PairableDeviceBackup]
+
+    /// The inboxId of the oldest key on the iCloud account, nil when no
+    /// key carries a timestamp to order by.
+    public var mainDeviceInboxId: String? {
+        let candidates = ([currentDevice].compactMap { $0 } + otherDevices)
+            .filter { $0.backedUpAt != nil }
+        let oldest = candidates.min { (lhs: PairableDeviceBackup, rhs: PairableDeviceBackup) -> Bool in
+            (lhs.backedUpAt ?? .distantFuture, lhs.inboxId) < (rhs.backedUpAt ?? .distantFuture, rhs.inboxId)
+        }
+        return oldest?.inboxId
+    }
+
+    /// Whether the current identity holds the account's main (oldest)
+    /// key. False when ordering can't be established.
+    public var currentDeviceIsMain: Bool {
+        guard let currentDevice else { return false }
+        return mainDeviceInboxId == currentDevice.inboxId
+    }
+
+    public init(currentDevice: PairableDeviceBackup?, otherDevices: [PairableDeviceBackup]) {
+        self.currentDevice = currentDevice
+        self.otherDevices = otherDevices
+    }
+}
+
+extension ICloudDeviceBackupsSnapshot {
+    /// Builds the snapshot from raw synced backups. Static and pure so
+    /// it can be unit tested without a keychain. A nil `currentInboxId`
+    /// (no identity yet) leaves `currentDevice` nil and treats every
+    /// backup as another device's.
+    static func snapshot(
+        from backups: [KeychainIdentityBackup],
+        currentInboxId: String?
+    ) -> ICloudDeviceBackupsSnapshot {
+        let own = backups
+            .first { $0.inboxId == currentInboxId }
+            .map { (backup: KeychainIdentityBackup) -> PairableDeviceBackup in
+                PairableDeviceBackup(
+                    inboxId: backup.inboxId,
+                    deviceName: backup.deviceName,
+                    backedUpAt: backup.backedUpAt
+                )
+            }
+        let others = backups
+            .filter { $0.inboxId != currentInboxId }
+            .map { (backup: KeychainIdentityBackup) -> PairableDeviceBackup in
+                PairableDeviceBackup(
+                    inboxId: backup.inboxId,
+                    deviceName: backup.deviceName,
+                    backedUpAt: backup.backedUpAt
+                )
+            }
+            .sorted { (lhs: PairableDeviceBackup, rhs: PairableDeviceBackup) -> Bool in
+                (lhs.backedUpAt ?? .distantFuture, lhs.inboxId) < (rhs.backedUpAt ?? .distantFuture, rhs.inboxId)
+            }
+        return ICloudDeviceBackupsSnapshot(currentDevice: own, otherDevices: others)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1148,6 +1148,21 @@ public extension SessionManager {
         }
     }
 
+    /// Same slot read as `pairableDeviceBackups`, but shaped for the
+    /// Devices screen: includes the current identity's own mirror and
+    /// applies no ordering filter (see `ICloudDeviceBackupsSnapshot`).
+    /// Best-effort: keychain failures return an empty snapshot.
+    func iCloudDeviceBackupsSnapshot() async -> ICloudDeviceBackupsSnapshot {
+        do {
+            let backups = try await identityStore.loadSyncedBackups()
+            let currentInboxId = try identityStore.loadSync()?.inboxId
+            return ICloudDeviceBackupsSnapshot.snapshot(from: backups, currentInboxId: currentInboxId)
+        } catch {
+            Log.warning("SessionManager.iCloudDeviceBackupsSnapshot failed: \(error)")
+            return ICloudDeviceBackupsSnapshot(currentDevice: nil, otherDevices: [])
+        }
+    }
+
     /// Signs a pairing invite with the synced backup's private key. The
     /// key never leaves ConvosCore - the caller only receives the slug,
     /// which carries the same authority as a slug minted by the backed-up

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1151,7 +1151,16 @@ public extension SessionManager {
     /// Same slot read as `pairableDeviceBackups`, but shaped for the
     /// Devices screen: includes the current identity's own mirror and
     /// applies no ordering filter (see `ICloudDeviceBackupsSnapshot`).
-    /// Best-effort: keychain failures return an empty snapshot.
+    ///
+    /// Best-effort: keychain failures return an empty snapshot, and a
+    /// primary-slot read failure deliberately empties it even when the
+    /// backups loaded. Building the snapshot without the current inboxId
+    /// would classify the install's own mirror as another device -
+    /// listing the user's own key as pairable-to-self, badging it Main
+    /// in the wrong section, and un-escalating the delete-all guard on
+    /// the actual main device. A briefly empty section that recovers on
+    /// the next screen visit is the safer degradation (same reasoning
+    /// as `pairableBackups`' nil-hides contract).
     func iCloudDeviceBackupsSnapshot() async -> ICloudDeviceBackupsSnapshot {
         do {
             let backups = try await identityStore.loadSyncedBackups()

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -45,6 +45,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     /// array when there is nothing to offer.
     func pairableDeviceBackups() async -> [PairableDeviceBackup]
 
+    /// The full iCloud backup inventory for the Devices screen: the
+    /// current identity's own mirror plus every other identity's backup,
+    /// unfiltered by the prompt's ordering rule (see
+    /// `ICloudDeviceBackupsSnapshot`).
+    func iCloudDeviceBackupsSnapshot() async -> ICloudDeviceBackupsSnapshot
+
     /// Mints a signed pairing-invite slug on behalf of the backed-up
     /// device (its synced private key signs the invite, exactly like the
     /// QR flow does on the initiator), so the joiner flow can target that
@@ -261,6 +267,12 @@ extension SessionManagerProtocol {
     /// other devices to pair with. The real lookup lives on `SessionManager`.
     public func pairableDeviceBackups() async -> [PairableDeviceBackup] {
         []
+    }
+
+    /// Default for conformers without keychain access (test mocks): an
+    /// empty inventory. The real lookup lives on `SessionManager`.
+    public func iCloudDeviceBackupsSnapshot() async -> ICloudDeviceBackupsSnapshot {
+        ICloudDeviceBackupsSnapshot(currentDevice: nil, otherDevices: [])
     }
 
     /// Default for conformers without keychain access (test mocks). The

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -183,6 +183,18 @@ struct ICloudDeviceBackupsSnapshotTests {
         #expect(!allUndated.currentDeviceIsMain)
     }
 
+    @Test("Identical timestamps tie-break deterministically on the smaller inboxId")
+    func identicalTimestampsTieBreak() throws {
+        let sameInstant = Date(timeIntervalSince1970: 1_000)
+        let alpha = try makeBackup(inboxId: "aaa", backedUpAt: sameInstant)
+        let beta = try makeBackup(inboxId: "bbb", backedUpAt: sameInstant)
+
+        let snapshot = ICloudDeviceBackupsSnapshot.snapshot(from: [beta, alpha], currentInboxId: "bbb")
+
+        #expect(snapshot.mainDeviceInboxId == "aaa")
+        #expect(!snapshot.currentDeviceIsMain)
+    }
+
     @Test("Keys named like a paired device are hidden; unnamed keys never are")
     func filtersKeysNamedLikePairedDevices() throws {
         let own = try makeBackup(inboxId: "own", backedUpAt: Date(timeIntervalSince1970: 3_000))

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -124,6 +124,77 @@ struct PairableDeviceBackupTests {
     }
 }
 
+@Suite("iCloud Device Backups Snapshot")
+struct ICloudDeviceBackupsSnapshotTests {
+    private func makeBackup(
+        inboxId: String,
+        deviceName: String? = nil,
+        backedUpAt: Date? = nil
+    ) throws -> KeychainIdentityBackup {
+        let keys = try KeychainIdentityKeys.generate()
+        let identity = KeychainIdentity(inboxId: inboxId, clientId: UUID().uuidString, keys: keys)
+        if let backedUpAt {
+            return KeychainIdentityBackup(identity: identity, deviceName: deviceName, backedUpAt: backedUpAt)
+        }
+        let stamped = KeychainIdentityBackup(identity: identity, deviceName: deviceName, backedUpAt: Date())
+        let encoded = try JSONEncoder().encode(stamped)
+        var json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] ?? [:]
+        json.removeValue(forKey: "backedUpAt")
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(KeychainIdentityBackup.self, from: data)
+    }
+
+    @Test("Current identity holding the oldest key is the main device")
+    func currentDeviceIsMainWhenOldest() throws {
+        let own = try makeBackup(inboxId: "own", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let other = try makeBackup(inboxId: "other", backedUpAt: Date(timeIntervalSince1970: 2_000))
+
+        let snapshot = ICloudDeviceBackupsSnapshot.snapshot(from: [other, own], currentInboxId: "own")
+
+        #expect(snapshot.currentDevice?.inboxId == "own")
+        #expect(snapshot.otherDevices.map(\.inboxId) == ["other"])
+        #expect(snapshot.mainDeviceInboxId == "own")
+        #expect(snapshot.currentDeviceIsMain)
+    }
+
+    @Test("Unlike the prompt filter, newer-than-own backups are listed, oldest first, and the oldest is main")
+    func listsAllOthersUnfiltered() throws {
+        let own = try makeBackup(inboxId: "own", backedUpAt: Date(timeIntervalSince1970: 2_000))
+        let older = try makeBackup(inboxId: "older", deviceName: "Old iPhone", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let newer = try makeBackup(inboxId: "newer", backedUpAt: Date(timeIntervalSince1970: 3_000))
+
+        let snapshot = ICloudDeviceBackupsSnapshot.snapshot(from: [newer, own, older], currentInboxId: "own")
+
+        #expect(snapshot.otherDevices.map(\.inboxId) == ["older", "newer"])
+        #expect(snapshot.mainDeviceInboxId == "older")
+        #expect(!snapshot.currentDeviceIsMain)
+    }
+
+    @Test("Undated keys never claim the main designation, and no dated key means no main")
+    func undatedKeysDontClaimMain() throws {
+        let own = try makeBackup(inboxId: "own", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let undated = try makeBackup(inboxId: "undated")
+
+        let withDatedOwn = ICloudDeviceBackupsSnapshot.snapshot(from: [own, undated], currentInboxId: "own")
+        #expect(withDatedOwn.mainDeviceInboxId == "own")
+
+        let allUndated = ICloudDeviceBackupsSnapshot.snapshot(from: [undated], currentInboxId: "own")
+        #expect(allUndated.mainDeviceInboxId == nil)
+        #expect(!allUndated.currentDeviceIsMain)
+    }
+
+    @Test("No identity yet leaves the current device nil and lists everything")
+    func nilIdentityListsEverything() throws {
+        let first = try makeBackup(inboxId: "a", backedUpAt: Date(timeIntervalSince1970: 1_000))
+
+        let snapshot = ICloudDeviceBackupsSnapshot.snapshot(from: [first], currentInboxId: nil)
+
+        #expect(snapshot.currentDevice == nil)
+        #expect(snapshot.otherDevices.map(\.inboxId) == ["a"])
+        #expect(!snapshot.currentDeviceIsMain)
+    }
+}
+
 @Suite("Pairing Invite Signing")
 struct PairingInviteSigningTests {
     @Test("Signed invite round-trips through full slug validation")

--- a/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairableDeviceBackupTests.swift
@@ -183,6 +183,24 @@ struct ICloudDeviceBackupsSnapshotTests {
         #expect(!allUndated.currentDeviceIsMain)
     }
 
+    @Test("Keys named like a paired device are hidden; unnamed keys never are")
+    func filtersKeysNamedLikePairedDevices() throws {
+        let own = try makeBackup(inboxId: "own", backedUpAt: Date(timeIntervalSince1970: 3_000))
+        // An abandoned old identity of this same device - stamped with
+        // the same device name - must not appear as an "other device".
+        let abandoned = try makeBackup(inboxId: "abandoned", deviceName: "Jarod's iPhone", backedUpAt: Date(timeIntervalSince1970: 1_000))
+        let genuine = try makeBackup(inboxId: "genuine", deviceName: "Old iPad", backedUpAt: Date(timeIntervalSince1970: 2_000))
+        let unnamed = try makeBackup(inboxId: "unnamed", backedUpAt: Date(timeIntervalSince1970: 2_500))
+
+        let snapshot = ICloudDeviceBackupsSnapshot.snapshot(
+            from: [own, abandoned, genuine, unnamed],
+            currentInboxId: "own"
+        )
+        let visible = snapshot.otherDevices(excludingDeviceNames: ["Jarod's iPhone", "Jarod's iPad"])
+
+        #expect(visible.map(\.inboxId) == ["genuine", "unnamed"])
+    }
+
     @Test("No identity yet leaves the current device nil and lists everything")
     func nilIdentityListsEverything() throws {
         let first = try makeBackup(inboxId: "a", backedUpAt: Date(timeIntervalSince1970: 1_000))

--- a/qa/SKILL.md
+++ b/qa/SKILL.md
@@ -55,6 +55,7 @@ Run end-to-end QA tests for the Convos iOS app using the iOS simulator tools and
 | 44 | `qa/tests/44-icloud-pairing-prompt.md` | First-install iCloud pairing prompt: Pair <device>? sheet from a synced keychain backup, Skip persistence, and the full no-QR pair handshake (two simulators; Device B is a clone of Device A) |
 | 44b | `qa/tests/44b-pairing-prompt-ordering.md` | Pairable-backup ordering rule: backups newer than this install's own key are never offered; verified both directions via the restamp launch hook (single disposable clone) |
 | 45 | `qa/tests/45-reinstall-message-continuity.md` | Delete + reinstall while actively chatting: same inbox resumes from the keychain, old installation auto-revoked, and messages flow both ways with the CLI in every prior conversation (erased disposable clone) |
+| 46 | `qa/tests/46-devices-icloud-section.md` | Devices screen iCloud section: paired/iCloud footers, Main-device designation on the oldest key, targeted initiator sheet from an iCloud row, escalated delete-all copy on the main device (single disposable clone) |
 
 ## Running Tests
 

--- a/qa/tests/46-devices-icloud-section.md
+++ b/qa/tests/46-devices-icloud-section.md
@@ -22,11 +22,16 @@ Verify the expanded Devices screen (Settings > Devices): the paired section's "D
 
 2. Terminate and relaunch with `SIMCTL_CHILD_CONVOS_QA_WIPE_PRIMARY_IDENTITY=1`. The hook wipes the device-local identity (`app.qa_wiped_primary_identity`), a fresh placeholder registers, and the original key remains in iCloud as a foreign device - older, hence the Main device. The found-device prompt appears (older keys are offered); tap Skip - test 44 covers the prompt, and the decline flag doesn't affect the Devices screen. Save the prompt's inboxId/deviceName as the main key's.
 
+### Same-name filter
+
+3. Navigate to Settings > Devices. The foreign key's device name equals this device's name at this point, so the "Other devices in iCloud" section must be absent - a listed device's abandoned old identity never shows the same device in both sections. Navigate back out.
+4. Terminate and relaunch with `SIMCTL_CHILD_CONVOS_QA_RENAME_FOREIGN_BACKUPS="Old iPhone"` (`app.qa_renamed_foreign_backups` count>=1) to give the foreign key a distinct name.
+
 ### Devices screen
 
-3. Navigate to Settings > Devices. Verify the paired section's footer "Devices using this account", the "Other devices in iCloud" footer, and `icloud-device-row-<inboxId>` for the foreign key.
-4. Verify exactly one "Main device" designation, on the foreign iCloud row (the current-device row shows plain "This device").
-5. Tap the iCloud row: `pairing.devices_icloud_pair_tapped` fires and the initiator pairing sheet presents with the scan instruction 'Open Convos on "<name>" and scan this code to pair'. The current account stays the main account - the join would happen from the other device. Dismiss without pairing.
+5. Navigate to Settings > Devices. Verify the paired section's footer "Devices using this account", the "Other devices in iCloud" footer, and `icloud-device-row-<inboxId>` for the foreign key.
+6. Verify exactly one "Main device" designation, on the foreign iCloud row (the current-device row shows plain "This device").
+7. Tap the iCloud row: `pairing.devices_icloud_pair_tapped` fires and the initiator pairing sheet presents with the scan instruction 'Open Convos on "<name>" and scan this code to pair'. The current account stays the main account - the join would happen from the other device. Dismiss without pairing.
 
 ## Teardown
 
@@ -36,6 +41,8 @@ Shut down and delete the `convos-qa-devices` clone; the primary simulator was ne
 
 - [ ] Delete-all confirmation on the sole-key device includes the escalated "This is your main device" sentence
 - [ ] Wipe hook seeds the second identity (`qa_wiped_primary_identity status=0`)
+- [ ] While the foreign key shares this device's name, no iCloud section is shown (same-name filter)
+- [ ] Rename hook gives the foreign key a distinct name (`qa_renamed_foreign_backups` count>=1)
 - [ ] Devices screen shows both sections with the exact footers, and the foreign key's row
 - [ ] Exactly one Main-device designation, on the oldest key's row
 - [ ] Tapping the iCloud row emits `pairing.devices_icloud_pair_tapped` and the sheet's scan instruction names the device

--- a/qa/tests/46-devices-icloud-section.md
+++ b/qa/tests/46-devices-icloud-section.md
@@ -1,0 +1,45 @@
+# Test: Devices Screen iCloud Section
+
+Verify the expanded Devices screen (Settings > Devices): the paired section's "Devices paired to your account" footer, the "Other devices in iCloud" section listing keys from the iCloud-synced keychain backup that aren't paired to the current account, the Main-device designation on the oldest key, the targeted initiator pairing sheet when an iCloud device is tapped, and the escalated delete-all copy on the main device.
+
+## Prerequisites
+
+- One simulator: the branch primary (used only as a clone source; its app state is never touched).
+- A built non-production Convos.app (the wipe launch hook is runtime-gated off in production).
+
+## Setup
+
+1. Shut down the primary, clone it as `convos-qa-devices`, erase the clone, boot both, relaunch the app on the primary, install the built app on the clone.
+2. Every clone launch needs `SIMCTL_CHILD_FIRAAppCheckDebugToken="$FIREBASE_APP_CHECK_DEBUG_TOKEN"` (source `.env`).
+
+## Steps
+
+### Main-device delete guard (single key)
+
+1. Launch the app (fresh identity registers and mirrors into the backup slot; give it ~10s). Navigate Convos tab -> Convos logo -> app settings, tap `delete-all-data-button`. The confirmation subtitle must include "This is your main device" - the account's only key is trivially the oldest. Cancel.
+
+### Seed a second identity
+
+2. Terminate and relaunch with `SIMCTL_CHILD_CONVOS_QA_WIPE_PRIMARY_IDENTITY=1`. The hook wipes the device-local identity (`app.qa_wiped_primary_identity`), a fresh placeholder registers, and the original key remains in iCloud as a foreign device - older, hence the Main device. The found-device prompt appears (older keys are offered); tap Skip - test 44 covers the prompt, and the decline flag doesn't affect the Devices screen. Save the prompt's inboxId/deviceName as the main key's.
+
+### Devices screen
+
+3. Navigate to Settings > Devices. Verify the paired section's footer "Devices paired to your account", the "Other devices in iCloud" footer, and `icloud-device-row-<inboxId>` for the foreign key.
+4. Verify exactly one "Main device" designation, on the foreign iCloud row (the current-device row shows plain "This device").
+5. Tap the iCloud row: `pairing.devices_icloud_pair_tapped` fires and the initiator pairing sheet presents with the scan instruction 'Open Convos on "<name>" and scan this code to pair'. The current account stays the main account - the join would happen from the other device. Dismiss without pairing.
+
+## Teardown
+
+Shut down and delete the `convos-qa-devices` clone; the primary simulator was never modified.
+
+## Pass/Fail Criteria
+
+- [ ] Delete-all confirmation on the sole-key device includes the escalated "This is your main device" sentence
+- [ ] Wipe hook seeds the second identity (`qa_wiped_primary_identity status=0`)
+- [ ] Devices screen shows both sections with the exact footers, and the foreign key's row
+- [ ] Exactly one Main-device designation, on the oldest key's row
+- [ ] Tapping the iCloud row emits `pairing.devices_icloud_pair_tapped` and the sheet's scan instruction names the device
+
+## Accessibility Improvements Needed
+
+None known - rows expose `icloud-device-row-<inboxId>`, and the flow reuses `devices-row`, `devices-view`, `skip-found-device-pairing-button`, and `delete-all-data-button`.

--- a/qa/tests/46-devices-icloud-section.md
+++ b/qa/tests/46-devices-icloud-section.md
@@ -1,6 +1,6 @@
 # Test: Devices Screen iCloud Section
 
-Verify the expanded Devices screen (Settings > Devices): the paired section's "Devices paired to your account" footer, the "Other devices in iCloud" section listing keys from the iCloud-synced keychain backup that aren't paired to the current account, the Main-device designation on the oldest key, the targeted initiator pairing sheet when an iCloud device is tapped, and the escalated delete-all copy on the main device.
+Verify the expanded Devices screen (Settings > Devices): the paired section's "Devices using this account" footer, the "Other devices in iCloud" section listing keys from the iCloud-synced keychain backup that aren't paired to the current account, the Main-device designation on the oldest key, the targeted initiator pairing sheet when an iCloud device is tapped, and the escalated delete-all copy on the main device.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ Verify the expanded Devices screen (Settings > Devices): the paired section's "D
 
 ### Devices screen
 
-3. Navigate to Settings > Devices. Verify the paired section's footer "Devices paired to your account", the "Other devices in iCloud" footer, and `icloud-device-row-<inboxId>` for the foreign key.
+3. Navigate to Settings > Devices. Verify the paired section's footer "Devices using this account", the "Other devices in iCloud" footer, and `icloud-device-row-<inboxId>` for the foreign key.
 4. Verify exactly one "Main device" designation, on the foreign iCloud row (the current-device row shows plain "This device").
 5. Tap the iCloud row: `pairing.devices_icloud_pair_tapped` fires and the initiator pairing sheet presents with the scan instruction 'Open Convos on "<name>" and scan this code to pair'. The current account stays the main account - the join would happen from the other device. Dismiss without pairing.
 

--- a/qa/tests/structured/46-devices-icloud-section.yaml
+++ b/qa/tests/structured/46-devices-icloud-section.yaml
@@ -1,0 +1,169 @@
+id: "46"
+name: "Devices Screen iCloud Section"
+description: >
+  Verify the expanded Devices screen (Settings > Devices): the paired
+  section carries the "Devices paired to your account" footer, a second
+  "Other devices in iCloud" section lists identities from the
+  iCloud-synced keychain backup that aren't paired to the current
+  account, the oldest key is designated the Main device (badged in
+  whichever section holds it), tapping an iCloud device opens the
+  initiator pairing sheet with the scan instruction naming that device,
+  and the delete-all confirmation escalates its copy on the main device.
+  Runs on a single disposable clone using the
+  CONVOS_QA_WIPE_PRIMARY_IDENTITY launch hook to mint a second identity.
+tags: [devices, pairing, icloud, keychain, settings]
+depends_on: ["01"]
+estimated_duration_s: 420
+
+prerequisites:
+  app_running: false
+  cli_initialized: false
+  shared_conversation: false
+  screen: none
+
+state:
+  clone_udid: null
+  main_inbox_id: null
+  main_device_name: null
+
+setup:
+  - action: clone_primary_as_devices_sim
+    save:
+      clone_udid: "from clone"
+    note: >
+      `xcrun simctl shutdown $PRIMARY`, `xcrun simctl clone $PRIMARY
+      convos-qa-devices`, `xcrun simctl erase` the clone (fresh account),
+      boot both, relaunch the app on the primary, install the built
+      Convos.app on the clone. Every clone launch needs
+      SIMCTL_CHILD_FIRAAppCheckDebugToken="$FIREBASE_APP_CHECK_DEBUG_TOKEN"
+      (source .env).
+
+steps:
+  - id: main_device_delete_guard
+    name: "Delete-all confirmation escalates on the main device"
+    actions:
+      - launch_app: {}
+      - navigate: "Convos tab -> convos-logo-button -> app settings"
+      - tap: { id: "delete-all-data-button" }
+      - wait_for_element: { label_contains: "This is your main device", timeout: 10 }
+      - screenshot: {}
+      - dismiss_sheet: { via: "Cancel" }
+    verify:
+      - element_exists: { label_contains: "This is your main device" }
+    criteria: delete_guard_escalates
+    note: >
+      On this first launch the account's identity is the only (hence
+      oldest) key in the keychain slot, so the device is the main
+      device and the delete-all subtitle must carry the escalated
+      sentence. Cancel without holding the delete button. The identity's
+      mirror is written on registration; give the app ~10s after first
+      launch before opening the sheet so the backup slot is populated.
+      Validated gotchas: the fresh clone's first launch presents the
+      first-launch profile sheet (profile-setup-sheet: name field +
+      agree toggle + "Come in") which must be completed before the
+      settings sheet can open; convos-logo-button is nested inside the
+      pill idb reports as app-indicator-pill - tap that frame's center;
+      delete-all-data-button is below the fold, scroll the settings
+      sheet down first and re-read its frame right before tapping; the
+      confirmation's Cancel button has no accessibility id (find by
+      label).
+
+  - id: second_identity_seeded
+    name: "Wipe hook mints a second identity so the first becomes a foreign iCloud key"
+    actions:
+      - terminate_app: {}
+      - launch_app_with_env:
+          env: { CONVOS_QA_WIPE_PRIMARY_IDENTITY: "1" }
+      - wait_for_element: { id: "skip-found-device-pairing-button", timeout: 45 }
+      - tap: { id: "skip-found-device-pairing-button" }
+    verify:
+      - event_exists: { name: "app.qa_wiped_primary_identity" }
+    criteria: second_identity_seeded
+    save:
+      main_inbox_id: "inboxId= param of pairing.found_device_prompt_shown"
+      main_device_name: "deviceName= param of pairing.found_device_prompt_shown"
+    note: >
+      The hook wipes the device-local identity; the app registers a
+      fresh placeholder, and the original identity's backup remains in
+      the slot as another device's key - older than the new one, so it
+      is the Main device. The found-device prompt for it appears (the
+      ordering rule offers older keys); tap Skip - this test exercises
+      the Devices screen surface, not the prompt (test 44 covers that).
+      Skip's decline flag only suppresses the prompt, not the Devices
+      section. Validated: pass the hook as
+      SIMCTL_CHILD_CONVOS_QA_WIPE_PRIMARY_IDENTITY=1 on simctl launch;
+      the relaunch does not re-present the profile sheet (placeholder
+      registers silently) and lands on the empty Convos tab.
+
+  - id: devices_screen_sections
+    name: "Devices screen shows both sections with the specified footers"
+    actions:
+      - navigate: "Convos tab -> convos-logo-button -> app settings -> devices-row"
+      - wait_for_element: { id: "devices-view", timeout: 15 }
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Devices paired to your account" }
+      - element_exists: { label_contains: "Other devices in iCloud" }
+      - element_exists: { id: "icloud-device-row-$main_inbox_id" }
+    criteria: sections_and_footers
+    note: >
+      Section 1 lists the current account's installations with the
+      "Devices paired to your account" footer. Section 2 lists the
+      foreign key with the "Other devices in iCloud" footer. The row id
+      embeds the foreign identity's full inboxId. Validated: both
+      footer strings surface as static text in the idb accessibility
+      tree - element_exists works, no screenshot fallback needed.
+
+  - id: main_designation
+    name: "The oldest key is badged as the Main device"
+    actions:
+      - screenshot: {}
+    verify:
+      - element_exists: { label_contains: "Main device" }
+    criteria: main_badge
+    note: >
+      The foreign key predates the current placeholder, so its iCloud
+      row carries the "Main device" caption and the current-device row
+      shows plain "This device" (not "This device - Main device").
+      Verify both: exactly one Main designation, on the iCloud row.
+
+  - id: pair_sheet_targets_device
+    name: "Tapping an iCloud device opens the initiator sheet naming it"
+    actions:
+      - tap: { id: "icloud-device-row-$main_inbox_id" }
+      - wait_for_element: { label_contains: "and scan this code to pair", timeout: 15 }
+      - screenshot: {}
+      - dismiss_sheet: {}
+    verify:
+      - element_exists: { label_contains: "Open Convos on" }
+      - event_exists: { name: "pairing.devices_icloud_pair_tapped" }
+    expect_event: "pairing.devices_icloud_pair_tapped"
+    criteria: pair_sheet_targeted
+    note: >
+      The standard initiator pairing sheet (QR + countdown) presents,
+      with the scan instruction reading 'Open Convos on "<name>" and
+      scan this code to pair' where <name> is the tapped backup's
+      device name (or its "Device <suffix>" fallback). The current
+      account stays the main account - this arms the invite; the join
+      would happen from the other device. Dismiss without pairing.
+
+teardown:
+  - action: delete_devices_sim
+    args: { udid: "$clone_udid" }
+    optional: true
+    note: >
+      `xcrun simctl shutdown $clone_udid && xcrun simctl delete
+      $clone_udid`. The clone held throwaway identities; the primary
+      simulator was never modified.
+
+criteria:
+  delete_guard_escalates:
+    description: "On the sole-key (main) device, the delete-all confirmation subtitle includes the escalated 'This is your main device' sentence"
+  second_identity_seeded:
+    description: "The wipe hook replaced the primary identity (qa_wiped_primary_identity status=0) and the original key remains in iCloud as a foreign device"
+  sections_and_footers:
+    description: "The Devices screen shows the paired-devices section with footer 'Devices paired to your account' and an 'Other devices in iCloud' section listing the foreign key"
+  main_badge:
+    description: "Exactly one Main-device designation is shown, on the row holding the oldest key (the foreign iCloud row in this flow)"
+  pair_sheet_targeted:
+    description: "Tapping the iCloud row emits pairing.devices_icloud_pair_tapped and presents the initiator pairing sheet whose scan instruction names the tapped device"

--- a/qa/tests/structured/46-devices-icloud-section.yaml
+++ b/qa/tests/structured/46-devices-icloud-section.yaml
@@ -5,12 +5,15 @@ description: >
   section carries the "Devices using this account" footer, a second
   "Other devices in iCloud" section lists identities from the
   iCloud-synced keychain backup that aren't paired to the current
-  account, the oldest key is designated the Main device (badged in
-  whichever section holds it), tapping an iCloud device opens the
-  initiator pairing sheet with the scan instruction naming that device,
-  and the delete-all confirmation escalates its copy on the main device.
-  Runs on a single disposable clone using the
-  CONVOS_QA_WIPE_PRIMARY_IDENTITY launch hook to mint a second identity.
+  account, keys whose device name matches a listed paired device are
+  hidden (an abandoned old identity of the same device must not appear
+  in both sections), the oldest visible key is designated the Main
+  device, tapping an iCloud device opens the initiator pairing sheet
+  with the scan instruction naming that device, and the delete-all
+  confirmation escalates its copy on the main device. Runs on a single
+  disposable clone using the CONVOS_QA_WIPE_PRIMARY_IDENTITY hook to
+  mint a second identity and CONVOS_QA_RENAME_FOREIGN_BACKUPS to give
+  the foreign key a distinct name.
 tags: [devices, pairing, icloud, keychain, settings]
 depends_on: ["01"]
 estimated_duration_s: 420
@@ -95,6 +98,40 @@ steps:
       the relaunch does not re-present the profile sheet (placeholder
       registers silently) and lands on the empty Convos tab.
 
+  - id: same_name_key_filtered
+    name: "A foreign key named like this device is hidden from the iCloud section"
+    actions:
+      - navigate: "Convos tab -> convos-logo-button -> app settings -> devices-row"
+      - wait_for_element: { id: "devices-view", timeout: 15 }
+      - screenshot: {}
+    verify:
+      - element_not_exists: { label_contains: "Other devices in iCloud" }
+      - element_not_exists: { id: "icloud-device-row-$main_inbox_id" }
+    criteria: same_name_filtered
+    note: >
+      At this point the foreign key's deviceName equals this device's
+      name (the wipe hook left the old identity's backup stamped with
+      the same simulator name), so the Devices screen must hide it -
+      the same device must not appear in both sections. Negative check:
+      settle on devices-view, then require zero matches for the iCloud
+      footer and row over ~5s. Navigate back out of settings afterward.
+
+  - id: foreign_key_renamed
+    name: "Rename hook gives the foreign key a distinct device name"
+    actions:
+      - terminate_app: {}
+      - launch_app_with_env:
+          env: { CONVOS_QA_RENAME_FOREIGN_BACKUPS: "Old iPhone" }
+      - sim_log_events: { event_filter: "app.qa_renamed_foreign_backups" }
+    verify:
+      - event_exists: { name: "app.qa_renamed_foreign_backups" }
+    criteria: foreign_key_renamed
+    note: >
+      The hook rewrites the foreign backup's deviceName to "Old iPhone"
+      (count>=1 in the event; count=0 is a setup failure). From here on
+      the iCloud section shows the key under that name, and the pairing
+      sheet instruction must quote it.
+
   - id: devices_screen_sections
     name: "Devices screen shows both sections with the specified footers"
     actions:
@@ -122,10 +159,11 @@ steps:
       - element_exists: { label_contains: "Main device" }
     criteria: main_badge
     note: >
-      The foreign key predates the current placeholder, so its iCloud
-      row carries the "Main device" caption and the current-device row
-      shows plain "This device" (not "This device - Main device").
-      Verify both: exactly one Main designation, on the iCloud row.
+      The foreign key ("Old iPhone") predates the current placeholder,
+      so its iCloud row carries the "Main device" caption and the
+      current-device row shows plain "This device" (not "This device -
+      Main device"). Verify both: exactly one Main designation, on the
+      iCloud row.
 
   - id: pair_sheet_targets_device
     name: "Tapping an iCloud device opens the initiator sheet naming it"
@@ -141,9 +179,8 @@ steps:
     criteria: pair_sheet_targeted
     note: >
       The standard initiator pairing sheet (QR + countdown) presents,
-      with the scan instruction reading 'Open Convos on "<name>" and
-      scan this code to pair' where <name> is the tapped backup's
-      device name (or its "Device <suffix>" fallback). The current
+      with the scan instruction reading 'Open Convos on "Old iPhone"
+      and scan this code to pair' (the renamed backup's device name). The current
       account stays the main account - this arms the invite; the join
       would happen from the other device. Dismiss without pairing.
 
@@ -161,6 +198,10 @@ criteria:
     description: "On the sole-key (main) device, the delete-all confirmation subtitle includes the escalated 'This is your main device' sentence"
   second_identity_seeded:
     description: "The wipe hook replaced the primary identity (qa_wiped_primary_identity status=0) and the original key remains in iCloud as a foreign device"
+  same_name_filtered:
+    description: "While the foreign key shares this device's name, the Devices screen shows no Other-devices-in-iCloud section (same device never appears in both sections)"
+  foreign_key_renamed:
+    description: "qa_renamed_foreign_backups fires with count>=1, giving the foreign key the distinct name Old iPhone"
   sections_and_footers:
     description: "The Devices screen shows the paired-devices section with footer 'Devices using this account' and an 'Other devices in iCloud' section listing the foreign key"
   main_badge:

--- a/qa/tests/structured/46-devices-icloud-section.yaml
+++ b/qa/tests/structured/46-devices-icloud-section.yaml
@@ -2,7 +2,7 @@ id: "46"
 name: "Devices Screen iCloud Section"
 description: >
   Verify the expanded Devices screen (Settings > Devices): the paired
-  section carries the "Devices paired to your account" footer, a second
+  section carries the "Devices using this account" footer, a second
   "Other devices in iCloud" section lists identities from the
   iCloud-synced keychain backup that aren't paired to the current
   account, the oldest key is designated the Main device (badged in
@@ -102,13 +102,13 @@ steps:
       - wait_for_element: { id: "devices-view", timeout: 15 }
       - screenshot: {}
     verify:
-      - element_exists: { label_contains: "Devices paired to your account" }
+      - element_exists: { label_contains: "Devices using this account" }
       - element_exists: { label_contains: "Other devices in iCloud" }
       - element_exists: { id: "icloud-device-row-$main_inbox_id" }
     criteria: sections_and_footers
     note: >
       Section 1 lists the current account's installations with the
-      "Devices paired to your account" footer. Section 2 lists the
+      "Devices using this account" footer. Section 2 lists the
       foreign key with the "Other devices in iCloud" footer. The row id
       embeds the foreign identity's full inboxId. Validated: both
       footer strings surface as static text in the idb accessibility
@@ -162,7 +162,7 @@ criteria:
   second_identity_seeded:
     description: "The wipe hook replaced the primary identity (qa_wiped_primary_identity status=0) and the original key remains in iCloud as a foreign device"
   sections_and_footers:
-    description: "The Devices screen shows the paired-devices section with footer 'Devices paired to your account' and an 'Other devices in iCloud' section listing the foreign key"
+    description: "The Devices screen shows the paired-devices section with footer 'Devices using this account' and an 'Other devices in iCloud' section listing the foreign key"
   main_badge:
     description: "Exactly one Main-device designation is shown, on the row holding the oldest key (the foreign iCloud row in this flow)"
   pair_sheet_targeted:

--- a/qa/tests/structured/46-devices-icloud-section.yaml
+++ b/qa/tests/structured/46-devices-icloud-section.yaml
@@ -61,10 +61,12 @@ steps:
       sentence. Cancel without holding the delete button. The identity's
       mirror is written on registration; give the app ~10s after first
       launch before opening the sheet so the backup slot is populated.
-      Validated gotchas: the fresh clone's first launch presents the
+      Validated gotchas: the fresh clone's first launch may present the
       first-launch profile sheet (profile-setup-sheet: name field +
-      agree toggle + "Come in") which must be completed before the
-      settings sheet can open; convos-logo-button is nested inside the
+      agree toggle + "Come in"), which must then be completed before
+      the settings sheet can open - but it can also skip straight to
+      home when the profile load times out
+      (onboarding.first_launch_profile_sheet_load_timeout); handle both; convos-logo-button is nested inside the
       pill idb reports as app-indicator-pill - tap that frame's center;
       delete-all-data-button is below the fold, scroll the settings
       sheet down first and re-read its frame right before tapping; the


### PR DESCRIPTION
Expands the Devices screen reached from app settings.

## What changed

**Section footers and the new iCloud section**
- The paired-installations section gains the footer **"Devices using this account"**.
- A new second section, footer **"Other devices in iCloud"**, lists identities from the iCloud-synced keychain backup slot that are not paired to the current account (`ICloudDeviceBackupsSnapshot`, new in ConvosCore). Unlike the first-install prompt, this list applies no newer-than-own ordering filter: the prompt's rule exists to block unsolicited demotion offers, whereas this is an explicit, user-navigated inventory of every key on the iCloud account.

**Tapping an iCloud device**
- Arms the standard initiator pairing sheet with the scan instruction naming the device: 'Open Convos on "<name>" and scan this code to pair'. The current account stays the main account; the join happens from the other device (per design discussion - the found-device prompt remains the flow for the *other* direction, where a fresh install erases itself and joins the earlier identity). Emits `pairing.devices_icloud_pair_tapped`.

**Main-device designation**
- The oldest key on the iCloud account is designated the **Main device** (`backedUpAt` as the creation-time proxy, same caveat as the prompt's ordering rule). Badged on whichever row holds it: "Main device" caption on the iCloud row, or "This device · Main device" on the current-device row.
- The delete-all confirmation escalates its copy when run on the main device: "This is your main device — the first one created for your account — and other devices pair through it."

## Verification

- 4 new unit tests for the snapshot builder (main designation, unfiltered listing, undated keys never claim main, nil identity). Full ConvosCore suite: 1609 tests in 227 suites, passing.
- **New structured QA test 46** (`devices-icloud-section`, registered in the suite): first validation run `e16c3876a045` passed all five criteria on a disposable clone - escalated delete copy on the sole-key device, both footers present in the accessibility tree, the foreign key's row listed, exactly one Main designation (on the oldest key), and the targeted pairing sheet with the named scan instruction. The runner's navigation notes are folded into the YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786315303&installation_id=128169237&pr_number=1163&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1163&signature=8bfb006897a15aeb3d801fdc5e49a1bcc677af87cc8424b4bf366028f470b719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iCloud devices section, main-device designation, and delete-all guard to Devices screen
> - Adds a second section to the Devices screen listing iCloud backups not yet paired to the account, with a row per device and a footer label 'Other devices in iCloud'.
> - Tapping an iCloud device row opens a targeted pairing sheet (`PairingSheetView`) that names the selected device in its QR scan instruction.
> - Marks the current device row with a 'Main device' caption when it holds the account's primary iCloud key, using a new `ICloudDeviceBackupsSnapshot` model built in `SessionManager`.
> - Escalates the delete-all confirmation subtitle with an extra warning sentence when the current device is the main device.
> - Adds QA launch hooks for renaming, purging, and dumping iCloud backup inventory via environment variables (`CONVOS_QA_RENAME_FOREIGN_BACKUPS`, `CONVOS_QA_PURGE_FOREIGN_BACKUPS`, `CONVOS_QA_DUMP_BACKUP_INVENTORY`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d79fedf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

