### PR TITLE
fix(onboarding): re-offer profile sheet while profile unset; gate swipe dismissal

### DIFF
--- a/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationOnboardingCoordinator.swift
@@ -151,26 +151,14 @@ final class ConversationOnboardingCoordinator {
     private static let legacyHasSetQuicknamePrefix: String = "hasSetQuicknameForConversation_"
     private static let hasSeenAddAsProfileKey: String = "hasSeenAddAsProfile"
     private static let hasShownNUXPaywallKey: String = "hasShownNUXPaywall"
+    /// Legacy shown-once latch for the launch profile sheet. The sheet now
+    /// gates purely on the global profile being unset (see
+    /// `ConversationsViewModel.presentFirstLaunchProfileSetupIfNeeded`);
+    /// the key is only kept so resets clear installs that wrote it.
     private static let hasShownFirstLaunchProfileSheetKey: String = "hasShownFirstLaunchProfileSheet"
 
     static func markProfileEditorShown() {
         UserDefaults.standard.set(true, forKey: hasShownProfileEditorKey)
-    }
-
-    /// Whether the first-launch "Hello / My name is" profile sheet is still
-    /// owed: it hasn't been shown yet and the user has never been through a
-    /// profile editor (set up in Settings, completed the in-conversation
-    /// flow, or adopted a paired identity).
-    static var shouldOfferFirstLaunchProfileSheet: Bool {
-        !UserDefaults.standard.bool(forKey: hasShownFirstLaunchProfileSheetKey)
-            && !UserDefaults.standard.bool(forKey: hasShownProfileEditorKey)
-    }
-
-    /// Latches the first-launch profile sheet: set when the sheet is
-    /// presented (or found unnecessary because a profile already exists),
-    /// so it never shows twice.
-    static func markFirstLaunchProfileSheetShown() {
-        UserDefaults.standard.set(true, forKey: hasShownFirstLaunchProfileSheetKey)
     }
 
     /// Marks the global onboarding flags as completed so the in-conversation

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -962,23 +962,23 @@ extension ConversationsViewModel {
         }
     }
 
-    /// First-launch profile setup: shows the "Hello / My name is" sheet
-    /// once, instead of the in-conversation "Add your name and pic"
-    /// prompt. Only reached when `checkForPairableDeviceIfNeeded` found no
-    /// other identity in the iCloud-synced keychain backup, so it can
-    /// never race the found-device pairing prompt; the explicit pairing
-    /// guards below cover deep-link and incoming pairing flows. The
-    /// in-conversation onboarding flow stays as a fallback for users who
-    /// dismiss this sheet without saving.
+    /// Launch profile setup: shows the "Hello / My name is" sheet whenever
+    /// the user has no name or profile photo set — including users who went
+    /// through onboarding before this sheet existed — instead of the
+    /// in-conversation "Add your name and pic" prompt. Once per launch (the
+    /// caller's check latch). Only reached when
+    /// `checkForPairableDeviceIfNeeded` found no other identity in the
+    /// iCloud-synced keychain backup, so it can never race the found-device
+    /// pairing prompt; the explicit pairing guards below cover deep-link
+    /// and incoming pairing flows.
     private func presentFirstLaunchProfileSetupIfNeeded() async {
-        guard ConversationOnboardingCoordinator.shouldOfferFirstLaunchProfileSheet else { return }
         guard pendingJoinerPairing == nil,
               foundDevicePairingPrompt == nil,
               incomingPairingRequest == nil else { return }
         // Don't decide on an unloaded snapshot: at cold launch the shared
         // profile view model holds default values even for a fully
-        // onboarded user. On timeout skip without latching so the next
-        // launch retries (mirrors ConversationOnboardingCoordinator).
+        // onboarded user. On timeout skip so the next launch retries
+        // (mirrors ConversationOnboardingCoordinator).
         let profileLoaded = await ProfileSettingsViewModel.shared.waitForProfileLoad(
             timeout: Constant.firstLaunchProfileLoadTimeout
         )
@@ -986,17 +986,13 @@ extension ConversationsViewModel {
             QAEvent.emit(.onboarding, "first_launch_profile_sheet_load_timeout")
             return
         }
-        guard ProfileSettingsViewModel.shared.profileSettings.isDefault else {
-            // A profile already exists (e.g. restored data): never show.
-            ConversationOnboardingCoordinator.markFirstLaunchProfileSheetShown()
-            return
-        }
+        // A profile already exists (name or photo): never show.
+        guard ProfileSettingsViewModel.shared.profileSettings.isDefault else { return }
         // Re-check the pairing guards: a deep-link pairing flow may have
         // started while we awaited the profile load.
         guard pendingJoinerPairing == nil,
               foundDevicePairingPrompt == nil,
               incomingPairingRequest == nil else { return }
-        ConversationOnboardingCoordinator.markFirstLaunchProfileSheetShown()
         presentingFirstLaunchProfileSetup = true
         QAEvent.emit(.onboarding, "first_launch_profile_sheet_shown")
     }

--- a/Convos/Profile/ProfileSetupSheet.swift
+++ b/Convos/Profile/ProfileSetupSheet.swift
@@ -138,6 +138,9 @@ struct ProfileSetupSheet: View {
         }
         .presentationDetents([.height(contentHeight)])
         .presentationDragIndicator(.hidden)
+        // Until the save gate is satisfied (name entered, terms accepted on
+        // first launch) the sheet can only be completed, not swiped away.
+        .interactiveDismissDisabled(!canSave)
         .presentationBackground(.colorBackgroundRaisedSecondary)
         .accessibilityIdentifier("profile-setup-sheet")
         .sheet(isPresented: $isImagePickerPresented) {

--- a/qa/tests/01-onboarding.md
+++ b/qa/tests/01-onboarding.md
@@ -13,7 +13,7 @@ Verify that a first-time user is offered the first-launch "Hello / My name is" p
 ### Launch into first-launch profile setup
 
 1. Launch the app. It lands on the home shell (Chats tab, compose button visible).
-2. The "Hello / My name is" profile setup sheet self-presents over the Chats tab. Poll for `profile-setup-name-field` with `sim_wait_for_element` (timeout: 20s — the sheet waits for the inbox and global profile load on a cold fresh install).
+2. The "Hello / My name is" profile setup sheet self-presents over the Chats tab. Poll for `profile-setup-name-field` with `sim_wait_for_element` (timeout: 20s — the sheet waits for the inbox and global profile load on a cold fresh install). It presents on every launch while the user has no name or photo set — including users who completed onboarding before this sheet existed — and cannot be swiped away while "Come in" is disabled.
 3. Verify the sheet's empty state:
    - A name field (`profile-setup-name-field`) with placeholder "Name", an avatar on the left (`profile-setup-avatar`) showing the `person.crop.circle.fill` icon, and photo/camera buttons on the right (`profile-setup-photo-button`, `profile-setup-camera-button`).
    - The "I agree to Convos Privacy & Terms" row with a toggle (`profile-setup-terms-toggle`), ON by default.
@@ -45,13 +45,14 @@ Verify that a first-time user is offered the first-launch "Hello / My name is" p
 13. Navigate back to the conversations list.
 14. Verify the conversation you created appears in the list.
 
-## Fallback flow (01b): sheet dismissed without saving
+## Dismissal gating (01b)
 
-The in-conversation onboarding flow still exists as a fallback. To exercise it:
+The sheet cannot be swiped away while "Come in" is disabled, and it re-presents on every launch until a profile is set:
 
-1. On a fresh install, swipe the first-launch sheet down without saving.
-2. Create a conversation. The legacy `setup-profile-button` prompt appears in the conversation's bottom bar, and the flow continues as before (quick-edit name field → "Profile saved" pill → notification prompt).
-3. The first-launch sheet does not re-appear on later launches (it shows once).
+1. On a fresh install with the name field empty, try to swipe the sheet down — it must bounce back (interactive dismissal is disabled while the save gate is unsatisfied).
+2. Type a name (terms toggle already on) so "Come in" enables, then swipe the sheet down without saving. Dismissal now succeeds.
+3. Create a conversation. The legacy `setup-profile-button` prompt appears in the conversation's bottom bar as the fallback (quick-edit name field → "Profile saved" pill → notification prompt).
+4. Relaunch the app without ever saving a profile — the sheet self-presents again (it gates on the profile being unset, not on having been shown before). Once a name or photo is saved, it stops appearing.
 
 ## Pass/Fail Criteria
 

--- a/qa/tests/structured/01-onboarding.yaml
+++ b/qa/tests/structured/01-onboarding.yaml
@@ -51,11 +51,14 @@ steps:
     note: >
       The "Hello / My name is" sheet self-presents over the Chats tab once the
       inbox is ready (it waits for the global profile load, so allow up to
-      20s on a cold fresh install). It only shows when no other device's
-      identity exists in the iCloud-synced keychain backup — an erased
-      simulator satisfies that. If the found-device pairing sheet appears
-      instead, the simulator was not fully erased. The CTA reads "Come in"
-      and is disabled until a name is entered (the terms toggle defaults on).
+      20s on a cold fresh install). It presents on every launch while the
+      user has no name or photo set — the shown-once latch was removed — and
+      it only shows when no other device's identity exists in the
+      iCloud-synced keychain backup; an erased simulator satisfies that. If
+      the found-device pairing sheet appears instead, the simulator was not
+      fully erased. The CTA reads "Come in" and is disabled until a name is
+      entered (the terms toggle defaults on). While the CTA is disabled the
+      sheet cannot be swiped away (interactive dismissal is blocked).
 
   - id: first_launch_profile_setup
     name: "Set name via the first-launch sheet"
@@ -100,8 +103,9 @@ steps:
     note: >
       The profile was set on the first-launch sheet, so the legacy
       in-conversation "Add your name and pic" prompt must not appear. (That
-      flow still exists as a fallback for users who dismiss the first-launch
-      sheet without saving — see 01b in the markdown doc.)
+      flow still exists as a fallback for users who enable the CTA but swipe
+      the sheet away without saving; the sheet re-presents on the next
+      launch while the profile stays unset — see 01b in the markdown doc.)
 
   - id: notification_permission
     name: "Notification permission step shown"


### PR DESCRIPTION
Follow-ups to #1158/#1162:

1. **Expanded gate**: the "Hello / My name is" sheet now presents on launch whenever the global profile has **no name or photo set** — including users who went through the older onboarding flows — rather than only once ever. The `hasShownFirstLaunchProfileSheet` latch is removed from the gate (key still cleared by `resetUserDefaults()` for installs that wrote it). All other guards unchanged: only when no iCloud key backups exist, no pairing UI is up, and the profile load has resolved; once per launch.
2. **Dismissal gating**: `interactiveDismissDisabled(!canSave)` — while "Come in"/"Save" is disabled (no name, terms toggled off, or a save in flight) the sheet can't be swiped away.

Verified on an erased iPhone 17 sim, full cycle: fresh install → sheet presents → swipe with empty name **bounces back** → relaunch → sheet **re-presents** (`first_launch_profile_sheet_shown` fired each launch) → typed a name → swipe now dismisses → relaunch → sheet returns (still unsaved) → saved a name → relaunch → **no sheet**.

QA test 01 (md + structured yaml) updated to the new semantics, including a dismissal-gating section (01b) replacing the old shows-once fallback flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555349&installation_id=128169237&pr_number=1166&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1166&signature=8f7e16fe7347d23699d965d8fdf0d2739d8f8edcdfdf6b54cdfef3d64fa01dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-present profile setup sheet on every launch while profile is unset and block swipe dismissal
> - Removes the shown-once latch (`shouldOfferFirstLaunchProfileSheet`) from [`ConversationOnboardingCoordinator`](https://github.com/xmtplabs/convos-ios/pull/1166/files#diff-cfdcd58edc9cdb689c4014d4562251b351c87c7f4a586d344060839e97af7f6f) so the profile setup sheet is shown on every launch until the user saves a name or photo.
> - [`presentFirstLaunchProfileSetupIfNeeded`](https://github.com/xmtplabs/convos-ios/pull/1166/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce) now checks `profileSettings.isDefault` at launch instead of a stored flag, presenting the sheet whenever the profile has no name or photo.
> - Adds `.interactiveDismissDisabled(!canSave)` to [`ProfileSetupSheet`](https://github.com/xmtplabs/convos-ios/pull/1166/files#diff-c33a881ce64e49858c5109b26bfa4ca9c278483c650338b9c92d38279c40cbf5) so the sheet cannot be swiped down until the save action is enabled.
> - Behavioral Change: users who previously dismissed the profile sheet without saving will see it again on next launch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13cebf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->