### PR TITLE
Bump convos-releases pin (ShareExtension signing lanes)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783624733,
-        "narHash": "sha256-wkutNw0NUFMiQG9cP8RlfPw6BhzwNW+QAbKI/VT8OxE=",
+        "lastModified": 1783964180,
+        "narHash": "sha256-YSZOkFVYQzq5prx0hWFpB5Ch0MsF3OeQH6QFNF0ptqE=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "68805648516ae12de9f3d1eefedbbeb50fa81ec6",
+        "rev": "de23b401de869840f818de6ee2e73248e4510c9c",
         "type": "github"
       },
       "original": {

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
-  "enabledManagers": ["custom.regex"],
+  "enabledManagers": ["custom.regex", "nix"],
   "customManagers": [
     {
       "customType": "regex",
@@ -28,6 +28,21 @@
     }
   ],
   "packageRules": [
+    {
+      "matchManagers": ["nix"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["nix"],
+      "matchDepNames": ["convos-releases"],
+      "enabled": true,
+      "groupName": "convos-releases",
+      "branchTopic": "convos-releases",
+      "commitMessageTopic": "convos-releases flake input",
+      "prConcurrentLimit": 2,
+      "prCreation": "immediate",
+      "rebaseWhen": "behind-base-branch"
+    },
     {
       "matchPackageNames": ["https://github.com/xmtp/libxmtp"],
       "groupName": "libxmtp",


### PR DESCRIPTION
xmtplabs/convos-releases#3 changed lane code (`firebase.rb`, `ios.rb`, `release.rb`), which this repo pins via flake.lock — CI keeps using the old lanes until this bump. Brew-fastlane users already track main.

Pin: 68805648 → de23b401 (also carries the android play_internal lanes + warp runner defaults — not imported by the iOS stub, no effect here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHWYLAPmoBmF2XS9rrd8pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786556472&installation_id=128169237&pr_number=1167&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1167&signature=afd436d34e7308e15ccc7a984cb27bdc87396a483714f170e0203e45a81b42fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump convos-releases pin and configure Renovate to manage nix updates for ShareExtension signing lanes
> - Updates [flake.lock](https://github.com/xmtplabs/convos-ios/pull/1167/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to bump the `convos-releases` pin, which provides the ShareExtension signing lanes.
> - Configures [renovate.json](https://github.com/xmtplabs/convos-ios/pull/1167/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) to enable the nix manager but disable all nix updates globally, then re-enables updates specifically for the `convos-releases` dependency with immediate PR creation, a concurrency limit of 2, and rebase-when-behind-base-branch behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d07c90e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->