### PR TITLE
Fix main-thread hangs reported by Sentry app-hang monitoring

### DIFF
--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -72,6 +72,9 @@ final class ContactsViewModel {
     /// contact set changes; `rebuildSections()` reads only this cache so
     /// keystroke/filter changes never touch the database mid-render.
     private var sourceConversationsCache: [String: ContactSourceConversation] = [:]
+    /// Monotonic token for in-flight source-conversation refreshes, so a
+    /// slow older fetch can't overwrite the result of a newer one.
+    private var sourceConversationsGeneration: Int = 0
 
     /// Shared suggested-agents fetch/pagination state. A nil service yields no
     /// section (e.g. previews that don't wire one).
@@ -129,10 +132,14 @@ final class ContactsViewModel {
     /// so subtitles fill in as soon as the fetch lands.
     private func refreshSourceConversations() {
         let ids = Set(allContacts.compactMap { $0.addedViaConversationId })
+        sourceConversationsGeneration += 1
+        let generation = sourceConversationsGeneration
         Task.detached(priority: .userInitiated) { [weak self, contactsRepository = self.contactsRepository] in
             guard let sources = try? contactsRepository.sourceConversations(forIds: ids) else { return }
             await MainActor.run { [weak self] in
-                guard let self, self.sourceConversationsCache != sources else { return }
+                guard let self,
+                      generation == self.sourceConversationsGeneration,
+                      self.sourceConversationsCache != sources else { return }
                 self.sourceConversationsCache = sources
                 self.rebuildSections()
             }

--- a/Convos/Contacts/ContactsViewModel.swift
+++ b/Convos/Contacts/ContactsViewModel.swift
@@ -64,6 +64,14 @@ final class ContactsViewModel {
     private let contactsRepository: any ContactsRepositoryProtocol
     private var cancellable: AnyCancellable?
     private var allContacts: [Contact] = []
+    /// True once the repository publisher has delivered a value; gates the
+    /// best-effort initial fetch so it can't overwrite fresher data.
+    private var hasReceivedContacts: Bool = false
+    /// Source-conversation metadata for the "you met them in X" subtitles,
+    /// keyed by conversation id. Refreshed off the main thread when the
+    /// contact set changes; `rebuildSections()` reads only this cache so
+    /// keystroke/filter changes never touch the database mid-render.
+    private var sourceConversationsCache: [String: ContactSourceConversation] = [:]
 
     /// Shared suggested-agents fetch/pagination state. A nil service yields no
     /// section (e.g. previews that don't wire one).
@@ -86,13 +94,21 @@ final class ContactsViewModel {
         cancellable = contactsRepository.contactsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] contacts in
+                self?.hasReceivedContacts = true
                 self?.applyContacts(contacts)
             }
 
         // Best-effort initial fetch for the first paint while the publisher
-        // wires up its observation.
-        if let initial = try? contactsRepository.fetchAll() {
-            applyContacts(initial)
+        // wires up its observation. Runs detached: this init happens during
+        // SwiftUI body evaluation, and a synchronous read can stall for
+        // seconds waiting on the database reader pool (app-hang
+        // CONVOS-IOS-3T).
+        Task.detached(priority: .userInitiated) { [weak self, contactsRepository] in
+            guard let initial = try? contactsRepository.fetchAll() else { return }
+            await MainActor.run { [weak self] in
+                guard let self, !self.hasReceivedContacts else { return }
+                self.applyContacts(initial)
+            }
         }
     }
 
@@ -105,6 +121,22 @@ final class ContactsViewModel {
         contactCount = visibleContacts().count
         rebuildSections()
         isLoading = false
+        refreshSourceConversations()
+    }
+
+    /// Refreshes `sourceConversationsCache` for the current contact set, off
+    /// the main thread. Rebuilds sections when the metadata actually changed
+    /// so subtitles fill in as soon as the fetch lands.
+    private func refreshSourceConversations() {
+        let ids = Set(allContacts.compactMap { $0.addedViaConversationId })
+        Task.detached(priority: .userInitiated) { [weak self, contactsRepository = self.contactsRepository] in
+            guard let sources = try? contactsRepository.sourceConversations(forIds: ids) else { return }
+            await MainActor.run { [weak self] in
+                guard let self, self.sourceConversationsCache != sources else { return }
+                self.sourceConversationsCache = sources
+                self.rebuildSections()
+            }
+        }
     }
 
     /// Contacts actually rendered in the browser list. Shared with other
@@ -143,8 +175,7 @@ final class ContactsViewModel {
             default: return lhs < rhs
             }
         }
-        let viaIds: Set<String> = Set(filtered.compactMap { $0.addedViaConversationId })
-        let sources: [String: ContactSourceConversation] = (try? contactsRepository.sourceConversations(forIds: viaIds)) ?? [:]
+        let sources = sourceConversationsCache
         var rebuilt: [Section] = sortedKeys.map { key in
             let rows = (grouped[key] ?? []).map { contact in
                 Row(id: contact.inboxId, contact: contact, subtitle: contact.listSubtitle(sources: sources))

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -30,6 +30,10 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     let environment: AppEnvironment
     private let backgroundUploadManager: any BackgroundUploadManagerProtocol
     internal let coreActions: any CoreActions
+    /// Single shared instance so render-path resolvers (`contact(for:)`)
+    /// hit one warm in-memory contacts cache instead of constructing a
+    /// fresh repository per SwiftUI body evaluation.
+    private let sharedContactsRepository: ContactsRepository
     private var cancellables: Set<AnyCancellable> = []
 
     // swiftlint:disable:next function_parameter_count
@@ -89,6 +93,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         self.clientId = authorizationOperation.stateMachine.initialClientId
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
+        self.sharedContactsRepository = ContactsRepository(databaseReader: databaseReader)
         self.deviceInfoProvider = deviceInfoProvider
         self.environment = environment
         self.backgroundUploadManager = backgroundUploadManager
@@ -120,6 +125,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         self.clientId = ""
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
+        self.sharedContactsRepository = ContactsRepository(databaseReader: databaseReader)
         self.deviceInfoProvider = deviceInfoProvider
         self.environment = environment
         self.backgroundUploadManager = backgroundUploadManager
@@ -335,7 +341,7 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     // MARK: Contacts
 
     func contactsRepository() -> any ContactsRepositoryProtocol {
-        ContactsRepository(databaseReader: databaseReader)
+        sharedContactsRepository
     }
 
     func contactsWriter() -> any ContactsWriterProtocol {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -171,11 +171,14 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
                 onError: { [weak self] error in
                     // The observation is dead after an error; drop the cache
                     // so callers fall back to live point reads rather than
-                    // serving a stale snapshot forever.
+                    // serving a stale snapshot forever, and clear the started
+                    // flag so the next call can restart the observation.
                     Log.error("Contacts cache observation failed: \(error)")
                     guard let self else { return }
                     self.cacheLock.lock()
                     self.contactsById = nil
+                    self.cacheObservationStarted = false
+                    self.cacheObservation = nil
                     self.cacheLock.unlock()
                 },
                 onChange: { [weak self] contacts in

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -44,6 +44,21 @@ public protocol ContactsRepositoryProtocol: Sendable {
     /// `addedViaConversationId`. Missing ids are absent from the result
     /// (conversation was deleted, or the contact has no source convo).
     func sourceConversations(forIds ids: Set<String>) throws -> [String: ContactSourceConversation]
+
+    /// Authoritative inbox-to-contact lookup for the UI's "contact data
+    /// overrides per-conversation profile data" rule. Returns the stored
+    /// contact when the inbox is a known contact, otherwise `nil` so the
+    /// caller's fallback (per-conversation profile) applies.
+    ///
+    /// This is the canonical entry point for the
+    /// `memberContactOverride: @Sendable (String) -> Contact?` resolver
+    /// passed through the SwiftUI environment and the chat-layer plumbing,
+    /// and it is called from render paths (list rows resolving member
+    /// names mid-body). Implementations must not block: the live
+    /// repository answers from an in-memory cache. Storage errors are
+    /// swallowed as `nil` since render-site callers cannot usefully handle
+    /// a thrown error mid-paint.
+    func contact(for inboxId: String) -> Contact?
 }
 
 /// Minimal snapshot of the conversation that promoted an inbox to a
@@ -59,19 +74,10 @@ public struct ContactSourceConversation: Sendable, Hashable {
 }
 
 extension ContactsRepositoryProtocol {
-    /// Authoritative inbox-to-contact lookup for the UI's "contact data
-    /// overrides per-conversation profile data" rule. Returns the
-    /// stored contact when the inbox is a known contact, otherwise
-    /// `nil` so the caller's fallback (per-conversation profile) applies.
-    ///
-    /// This is the canonical entry point for the
-    /// `memberContactOverride: @Sendable (String) -> Contact?` resolver
-    /// passed through the SwiftUI environment and the chat-layer
-    /// plumbing. UI sites adapt it as needed: text uses `?.displayName`
-    /// (with empty-string fallback), avatar rendering uses the full
-    /// contact for name + encrypted-image fields. Storage errors are
-    /// swallowed as `nil` since render-site callers cannot usefully
-    /// handle a thrown error mid-paint.
+    /// Default `contact(for:)` backed by a direct point read, so mock
+    /// conformers stay minimal. The live repository overrides this with an
+    /// in-memory cache — render-path callers must never block on the
+    /// database (app-hang CONVOS-IOS-3Q).
     public func contact(for inboxId: String) -> Contact? {
         try? fetchContact(inboxId: inboxId)
     }
@@ -106,6 +112,21 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
 
     let contactsPublisher: AnyPublisher<[Contact], Never>
 
+    /// In-memory mirror of the `contact` table keyed by inboxId, backing
+    /// the render-path `contact(for:)` resolver. `nil` until the lazily
+    /// started observation delivers its first value; until then
+    /// `contact(for:)` falls back to the same point read as before.
+    private let cacheLock = NSLock()
+    private var contactsById: [String: Contact]?
+    private var cacheObservationStarted = false
+    private var cacheObservation: AnyDatabaseCancellable?
+    /// Serial queue for cache observation delivery, keeping the initial
+    /// fetch and refreshes off the main thread.
+    private static let cacheQueue = DispatchQueue(
+        label: "org.convos.contacts-repository.cache",
+        qos: .userInitiated
+    )
+
     init(databaseReader: any DatabaseReader) {
         self.databaseReader = databaseReader
         self.contactsPublisher = ValueObservation
@@ -115,6 +136,62 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
             .publisher(in: databaseReader)
             .replaceError(with: [])
             .eraseToAnyPublisher()
+    }
+
+    /// Cache-backed override of the protocol's point-read default. Render
+    /// sites call this per member per row during SwiftUI body evaluation;
+    /// a database read there can stall on the reader pool for seconds
+    /// (app-hang CONVOS-IOS-3Q). The first call starts a table observation
+    /// and answers with a point read; once the observation delivers, every
+    /// call is a dictionary lookup.
+    func contact(for inboxId: String) -> Contact? {
+        cacheLock.lock()
+        let cached = contactsById
+        let shouldStart = !cacheObservationStarted
+        cacheObservationStarted = true
+        cacheLock.unlock()
+
+        if shouldStart {
+            startCacheObservation()
+        }
+        if let cached {
+            return cached[inboxId]
+        }
+        return try? fetchContact(inboxId: inboxId)
+    }
+
+    private func startCacheObservation() {
+        let cancellable = ValueObservation
+            .tracking { db in
+                try DBContact.fetchAll(db).map(Contact.init(dbContact:))
+            }
+            .start(
+                in: databaseReader,
+                scheduling: .async(onQueue: Self.cacheQueue),
+                onError: { [weak self] error in
+                    // The observation is dead after an error; drop the cache
+                    // so callers fall back to live point reads rather than
+                    // serving a stale snapshot forever.
+                    Log.error("Contacts cache observation failed: \(error)")
+                    guard let self else { return }
+                    self.cacheLock.lock()
+                    self.contactsById = nil
+                    self.cacheLock.unlock()
+                },
+                onChange: { [weak self] contacts in
+                    guard let self else { return }
+                    let byId = Dictionary(
+                        contacts.map { ($0.inboxId, $0) },
+                        uniquingKeysWith: { _, latest in latest }
+                    )
+                    self.cacheLock.lock()
+                    self.contactsById = byId
+                    self.cacheLock.unlock()
+                }
+            )
+        cacheLock.lock()
+        cacheObservation = cancellable
+        cacheLock.unlock()
     }
 
     func fetchAll() throws -> [Contact] {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ContactsRepository.swift
@@ -116,13 +116,13 @@ final class ContactsRepository: ContactsRepositoryProtocol, @unchecked Sendable 
     /// the render-path `contact(for:)` resolver. `nil` until the lazily
     /// started observation delivers its first value; until then
     /// `contact(for:)` falls back to the same point read as before.
-    private let cacheLock = NSLock()
+    private let cacheLock: NSLock = NSLock()
     private var contactsById: [String: Contact]?
-    private var cacheObservationStarted = false
+    private var cacheObservationStarted: Bool = false
     private var cacheObservation: AnyDatabaseCancellable?
     /// Serial queue for cache observation delivery, keeping the initial
     /// fetch and refreshes off the main thread.
-    private static let cacheQueue = DispatchQueue(
+    private static let cacheQueue: DispatchQueue = DispatchQueue(
         label: "org.convos.contacts-repository.cache",
         qos: .userInitiated
     )

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/CreditsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/CreditsRepository.swift
@@ -25,7 +25,13 @@ public final class CreditsRepository: CreditsRepositoryProtocol, Sendable {
                     .fetchOne(db)?
                     .hydrate()
             }
-            .publisher(in: databaseReader, scheduling: .immediate)
+            // Async scheduling (the default): subscriptions happen on the
+            // main thread during SwiftUI layout (`.onReceive` in MainTabView
+            // and ConversationMemberView), and `.immediate` performs a
+            // synchronous database read that can stall for seconds when the
+            // reader pool is busy (app-hang CONVOS-IOS-3Y). Consumers only
+            // assign state, so a deferred initial value is fine.
+            .publisher(in: databaseReader)
             .catch { error -> Just<CreditBalance?> in
                 Log.error("Credit balance observation failed: \(error)")
                 return Just(nil)

--- a/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
@@ -58,7 +58,8 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
     /// launch), so by the time an upload or cancel needs the session the
     /// rendezvous is normally a no-op.
     private func session() -> URLSession {
-        sessionQueue.sync { backgroundSession }
+        dispatchPrecondition(condition: .notOnQueue(sessionQueue))
+        return sessionQueue.sync { backgroundSession }
     }
 
     public func startUpload(

--- a/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
@@ -57,9 +57,11 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
     /// if it hasn't finished yet. Creation starts at singleton init (app
     /// launch), so by the time an upload or cancel needs the session the
     /// rendezvous is normally a no-op.
+    ///
+    /// - Warning: Never call from a closure running on `sessionQueue`;
+    ///   the `sync` rendezvous would deadlock.
     private func session() -> URLSession {
-        dispatchPrecondition(condition: .notOnQueue(sessionQueue))
-        return sessionQueue.sync { backgroundSession }
+        sessionQueue.sync { backgroundSession }
     }
 
     public func startUpload(

--- a/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
@@ -15,7 +15,7 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
     /// in `ConvosApp.init` (app-hang CONVOS-IOS-2Q). `init` schedules
     /// creation onto this queue and `session()` rendezvouses via `sync`,
     /// so the handshake never runs on the main thread.
-    private let sessionQueue = DispatchQueue(
+    private let sessionQueue: DispatchQueue = DispatchQueue(
         label: "com.convos.backgroundUpload.session",
         qos: .userInitiated
     )

--- a/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/BackgroundUploadManager.swift
@@ -9,6 +9,16 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
 
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var backgroundSession: URLSession!
+    /// Serial queue that owns `backgroundSession`. Creating a background
+    /// session blocks on a synchronous XPC handshake with nsurlsessiond,
+    /// which stalled the main thread at app launch when `init` ran inline
+    /// in `ConvosApp.init` (app-hang CONVOS-IOS-2Q). `init` schedules
+    /// creation onto this queue and `session()` rendezvouses via `sync`,
+    /// so the handshake never runs on the main thread.
+    private let sessionQueue = DispatchQueue(
+        label: "com.convos.backgroundUpload.session",
+        qos: .userInitiated
+    )
     private let lock: NSLock = NSLock()
 
     private var backgroundCompletionHandler: (@Sendable () -> Void)?
@@ -28,17 +38,27 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
     private override init() {
         super.init()
 
-        let config = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
-        config.isDiscretionary = false
-        config.sessionSendsLaunchEvents = true
-        config.allowsCellularAccess = true
-        config.shouldUseExtendedBackgroundIdleMode = true
+        sessionQueue.async { [self] in
+            let config = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+            config.isDiscretionary = false
+            config.sessionSendsLaunchEvents = true
+            config.allowsCellularAccess = true
+            config.shouldUseExtendedBackgroundIdleMode = true
 
-        backgroundSession = URLSession(
-            configuration: config,
-            delegate: self,
-            delegateQueue: nil
-        )
+            backgroundSession = URLSession(
+                configuration: config,
+                delegate: self,
+                delegateQueue: nil
+            )
+        }
+    }
+
+    /// The background session, waiting for the creation scheduled in `init`
+    /// if it hasn't finished yet. Creation starts at singleton init (app
+    /// launch), so by the time an upload or cancel needs the session the
+    /// rendezvous is normally a no-op.
+    private func session() -> URLSession {
+        sessionQueue.sync { backgroundSession }
     }
 
     public func startUpload(
@@ -51,7 +71,7 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
         request.httpMethod = "PUT"
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
 
-        let task = backgroundSession.uploadTask(with: request, fromFile: fileURL)
+        let task = session().uploadTask(with: request, fromFile: fileURL)
         task.taskDescription = taskId
         task.resume()
 
@@ -59,7 +79,7 @@ public final class BackgroundUploadManager: NSObject, BackgroundUploadManagerPro
     }
 
     public func cancelUpload(taskId: String) async {
-        let tasks = await backgroundSession.allTasks
+        let tasks = await session().allTasks
         if let task = tasks.first(where: { $0.taskDescription == taskId }) {
             task.cancel()
             Log.debug("Cancelled upload task \(taskId)")


### PR DESCRIPTION
## Summary

Fixes the four Sentry app-hang issues (production, "App hanging for at least 2000 ms") with definitively identified causes. Each was a main-thread stall captured with a full stack:

| Sentry issue | Root cause | Fix |
|---|---|---|
| [CONVOS-IOS-3T](https://ephemerahq.sentry.io/issues/?query=CONVOS-IOS-3T) | `ContactsViewModel.init` ran a synchronous `fetchAll()` during SwiftUI body evaluation and stalled on the GRDB reader-pool semaphore | Initial fetch runs detached; publisher-delivered data wins races. `rebuildSections()` also stops doing a synchronous `sourceConversations` read per keystroke — it reads an off-main-refreshed cache |
| [CONVOS-IOS-3Y](https://ephemerahq.sentry.io/issues/?query=CONVOS-IOS-3Y) | `CreditsRepository.balancePublisher` used `.immediate` scheduling → synchronous WAL-snapshot read at subscription time, subscribed during layout via `.onReceive` (MainTabView, ConversationMemberView) | Default async scheduler; all consumers just assign state |
| [CONVOS-IOS-3Q](https://ephemerahq.sentry.io/issues/?query=CONVOS-IOS-3Q) | Conversation-list rows resolve member names via `contact(for:)` — a DB point read **per member per row** mid-body (`ConversationsListItem.body` → `Conversation.computedDisplayName`) | `contact(for:)` is now a protocol requirement; the live repository answers from an in-memory contact-table mirror (lazily started observation, point-read fallback until warm). `MessagingService.contactsRepository()` returns a shared instance so the cache is reused across body evaluations |
| [CONVOS-IOS-2Q](https://ephemerahq.sentry.io/issues/?query=CONVOS-IOS-2Q) | `BackgroundUploadManager` created its background `URLSession` inline in `ConvosApp.init`; session creation blocks on a synchronous XPC handshake with `nsurlsessiond` | Session creation happens on a serial background queue; accessors rendezvous via `sync` (a no-op once created) |

Underlying all the GRDB hangs: the waits were on `Pool.get` — the reader pool was exhausted by long-running reads elsewhere, so even cheap main-thread reads stalled for seconds. This PR removes the main-thread reads; auditing what holds readers that long is a follow-up.

Not addressed (separate follow-ups): TextKit2 layout stall on a pathological message (CONVOS-IOS-2H/2M/3R — needs a product decision on truncation), SwiftUI body cost in ConversationView (3S), CoreUI glyph-catalog I/O stall (28).

## Test plan

- [ ] CI build + unit tests (local build blocked by disk space on the dev machine)
- [ ] Manual: Contacts tab first open shows list; search filtering works; "met in" subtitles populate
- [ ] Manual: credits badge appears in MainTabView; out-of-credits state in contact sheet
- [ ] Manual: conversation list renders member names; contact rename propagates
- [ ] Manual: photo send via background upload completes; upload resumes when app relaunched in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786556618&installation_id=128169237&pr_number=1168&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1168&signature=7480d727e6d14ef151397594303c5e5d087a5d0d1ff94420f49bc523df345fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix main-thread hangs in contacts, credits, and background upload initialization
> - Moves `ContactsViewModel` source-conversation lookups off the main thread using an in-memory cache populated by a `ValueObservation`, with a generation token to discard stale results; rebuilds now read from cache instead of hitting the database synchronously.
> - Adds an in-memory cache to `ContactsRepository.contact(for:)` backed by a lazy `ValueObservation`, falling back to a point read until the first observation delivers.
> - Defers `BackgroundUploadManager` background `URLSession` creation to an async task on a serial queue, eliminating a synchronous XPC handshake on the main thread at init.
> - Removes `.immediate` scheduling from `CreditsRepository.balancePublisher` so the initial value is delivered asynchronously rather than via a blocking main-thread read.
> - Behavioral Change: `CreditsRepository` subscribers and `ContactsViewModel` subtitles now receive their first value asynchronously instead of synchronously at subscription time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a8ecc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->