### PR TITLE
fix: create, persist, and resend a join idempotency key on agent-builder invites

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -173,10 +173,57 @@ public enum ConvosAPI {
     // addMembers and is done — the runtime observes the resulting group
     // welcome and attaches, with no confirmation call.
 
+    /// Idempotency key for `POST /v2/agents/join`: a lowercase v4 UUID stable
+    /// across retries of one logical join. The assistants service uses it as
+    /// the workflow instance id, so a retry of a join whose response was lost
+    /// adopts the already-provisioned instance instead of creating a duplicate.
+    ///
+    /// A dedicated type rather than `String` so another identifier (e.g. the
+    /// generation idempotency key, which is uppercase) cannot be wired in by
+    /// accident, and rather than Foundation's `UUID` because `UUID` encodes as
+    /// its uppercase `uuidString` while the server contract is lowercase-only
+    /// (the key becomes the assistant instance id).
+    public struct JoinIdempotencyKey: Hashable, Sendable, Codable {
+        public let rawValue: String
+
+        /// Mints a fresh key - the only way to produce a new key value.
+        public static func mint() -> JoinIdempotencyKey {
+            JoinIdempotencyKey(validated: UUID().uuidString.lowercased())
+        }
+
+        /// Rehydrates a persisted key, normalizing to lowercase; `nil` for
+        /// anything that is not a UUID.
+        public init?(rawValue: String) {
+            guard UUID(uuidString: rawValue) != nil else { return nil }
+            self.init(validated: rawValue.lowercased())
+        }
+
+        private init(validated: String) {
+            rawValue = validated
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            guard let key = JoinIdempotencyKey(rawValue: raw) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid join idempotency key: \(raw)")
+            }
+            self = key
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
+    }
+
     public struct AgentJoinRequest: Codable {
         public let slug: String?
         public let conversationId: String?
         public let templateId: String?
+        /// Optional and nil-omitted by Codable, so default joins stay
+        /// byte-identical and the wire format remains backward-compatible.
+        public let idempotencyKey: JoinIdempotencyKey?
         public let options: AgentJoinOptions?
         /// IANA timezone identifier (e.g. "Europe/Paris") carrying the
         /// conversation creator's device timezone, used by the agent runtime as
@@ -192,12 +239,14 @@ public enum ConvosAPI {
             slug: String? = nil,
             conversationId: String? = nil,
             templateId: String? = nil,
+            idempotencyKey: JoinIdempotencyKey? = nil,
             options: AgentJoinOptions? = nil,
             timezone: String? = nil
         ) {
             self.slug = slug
             self.conversationId = conversationId
             self.templateId = templateId
+            self.idempotencyKey = idempotencyKey
             self.options = options
             self.timezone = timezone
         }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -88,14 +88,12 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// `inboxId`; the caller adds that inbox to the declared group with
     /// addMembers and the runtime attaches when it observes the resulting
     /// group welcome — no further calls.
-    /// `timezone` is the creator's device IANA timezone identifier, forwarded
-    /// to the agent runtime as the conversation's baseline/default zone.
+    /// `joinRequest` is the wire body (see `ConvosAPI.AgentJoinRequest` for
+    /// per-field semantics, including the retry-stable `idempotencyKey`).
+    /// `forceErrorCode` is a test/debug knob riding an HTTP header, which is
+    /// why it is a separate parameter and not part of the body type.
     func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
@@ -234,27 +232,21 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 
 extension ConvosAPIClientProtocol {
     func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(
-            slug: slug, conversationId: nil, templateId: nil, options: nil, timezone: nil, forceErrorCode: nil
-        )
+        try await requestAgentJoin(ConvosAPI.AgentJoinRequest(slug: slug), forceErrorCode: nil)
     }
 
     func requestAgentJoin(
         slug: String,
         options: ConvosAPI.AgentJoinOptions?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(
-            slug: slug, conversationId: nil, templateId: nil, options: options, timezone: nil, forceErrorCode: nil
-        )
+        try await requestAgentJoin(ConvosAPI.AgentJoinRequest(slug: slug, options: options), forceErrorCode: nil)
     }
 
     func requestAgentJoin(
         slug: String,
         templateId: String?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        try await requestAgentJoin(
-            slug: slug, conversationId: nil, templateId: templateId, options: nil, timezone: nil, forceErrorCode: nil
-        )
+        try await requestAgentJoin(ConvosAPI.AgentJoinRequest(slug: slug, templateId: templateId), forceErrorCode: nil)
     }
 
     /// Default so bespoke test doubles that don't exercise the builder don't
@@ -867,71 +859,8 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     // MARK: - Agents
 
-    func requestAgentJoin(
-        slug: String? = nil,
-        conversationId: String? = nil,
-        templateId: String? = nil,
-        options: ConvosAPI.AgentJoinOptions? = nil,
-        timezone: String? = nil,
-        forceErrorCode: Int? = nil
-    ) async throws -> ConvosAPI.AgentJoinResponse {
-        var request = try authenticatedRequest(for: "v2/agents/join", method: "POST")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        // Backend pool timeout is 30s; give 5s buffer so backend returns a proper 504 before iOS times out
-        request.timeoutInterval = 35
-
-        if let forceErrorCode {
-            request.setValue("\(forceErrorCode)", forHTTPHeaderField: "X-Force-Error")
-        }
-
-        // `timezone` is the creator's device IANA timezone, captured on the main
-        // actor by the caller. It seeds the agent's baseline/default zone and is
-        // distinct from the per-sender ProfileUpdate "timezone" metadata key.
-        // Prod backstop: strip a leaked dev variant slug from the join options.
-        let safeOptions = options.map {
-            ConvosAPI.AgentJoinOptions(onboarding: $0.onboarding, variantId: prodSafeVariantId($0.variantId))
-        }
-        request.httpBody = try JSONEncoder().encode(
-            ConvosAPI.AgentJoinRequest(
-                slug: slug,
-                conversationId: conversationId,
-                templateId: templateId,
-                options: safeOptions,
-                timezone: timezone
-            )
-        )
-
-        let (data, httpResponse) = try await performAuthenticatedRequest(request)
-
-        if !(200...299).contains(httpResponse.statusCode) {
-            Log.error("agents/join failed [\(httpResponse.statusCode)]: \(String(data: data, encoding: .utf8) ?? "nil data")")
-        }
-        switch httpResponse.statusCode {
-        case 200...299:
-            let decoder = JSONDecoder()
-            let response = try decoder.decode(ConvosAPI.AgentJoinResponse.self, from: data)
-            Log.info("agents/join succeeded: instanceId=\(response.instanceId ?? "nil") joined=\(response.joined) inboxIdPresent=\(response.inboxId != nil)")
-            return response
-        case 502:
-            throw APIError.agentProvisionFailed
-        case 503:
-            throw APIError.noAgentsAvailable
-        case 504:
-            throw APIError.agentPoolTimeout
-        case 400:
-            throw APIError.badRequest(parseErrorMessage(from: data))
-        case 403:
-            throw APIError.forbidden
-        case 404:
-            throw APIError.notFound
-        case 410:
-            // Template resolved but is archived - the backend won't
-            // provision an instance from it.
-            throw APIError.templateArchived
-        default:
-            throw APIError.serverError(parseErrorMessage(from: data))
-        }
-    }
+    // `requestAgentJoin` lives in the agent-template extension below to keep
+    // the class body under the type-length budget.
 
     func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse {
         let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
@@ -1206,7 +1135,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 }
 
-// MARK: - Agent template generation (split out to keep the class body length in check)
+// MARK: - Agent join + template generation (split out to keep the class body length in check)
 
 extension ConvosAPIClient {
     /// Defense-in-depth: drop any dev variant slug in production. The invariant
@@ -1222,6 +1151,67 @@ extension ConvosAPIClient {
     /// stays byte-identical to the pre-variant shape.
     static func agentJoinStatusQueryParameters(variantId: String?) -> [String: String]? {
         variantId.map { ["variantId": $0] }
+    }
+
+    func requestAgentJoin(
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
+        forceErrorCode: Int? = nil
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        var request = try authenticatedRequest(for: "v2/agents/join", method: "POST")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Backend pool timeout is 30s; give 5s buffer so backend returns a proper 504 before iOS times out
+        request.timeoutInterval = 35
+
+        if let forceErrorCode {
+            request.setValue("\(forceErrorCode)", forHTTPHeaderField: "X-Force-Error")
+        }
+
+        // Prod backstop: strip a leaked dev variant slug from the join options
+        // before the body is encoded.
+        let safeOptions = joinRequest.options.map {
+            ConvosAPI.AgentJoinOptions(onboarding: $0.onboarding, variantId: prodSafeVariantId($0.variantId))
+        }
+        request.httpBody = try JSONEncoder().encode(
+            ConvosAPI.AgentJoinRequest(
+                slug: joinRequest.slug,
+                conversationId: joinRequest.conversationId,
+                templateId: joinRequest.templateId,
+                idempotencyKey: joinRequest.idempotencyKey,
+                options: safeOptions,
+                timezone: joinRequest.timezone
+            )
+        )
+
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+
+        if !(200...299).contains(httpResponse.statusCode) {
+            Log.error("agents/join failed [\(httpResponse.statusCode)]: \(String(data: data, encoding: .utf8) ?? "nil data")")
+        }
+        switch httpResponse.statusCode {
+        case 200...299:
+            let decoder = JSONDecoder()
+            let response = try decoder.decode(ConvosAPI.AgentJoinResponse.self, from: data)
+            Log.info("agents/join succeeded: instanceId=\(response.instanceId ?? "nil") joined=\(response.joined) inboxIdPresent=\(response.inboxId != nil)")
+            return response
+        case 502:
+            throw APIError.agentProvisionFailed
+        case 503:
+            throw APIError.noAgentsAvailable
+        case 504:
+            throw APIError.agentPoolTimeout
+        case 400:
+            throw APIError.badRequest(parseErrorMessage(from: data))
+        case 403:
+            throw APIError.forbidden
+        case 404:
+            throw APIError.notFound
+        case 410:
+            // Template resolved but is archived - the backend won't
+            // provision an instance from it.
+            throw APIError.templateArchived
+        default:
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
     }
 
     func getAgentTemplateAttachmentPresignedURL(

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -1184,14 +1184,21 @@ extension ConvosAPIClient {
 
         let (data, httpResponse) = try await performAuthenticatedRequest(request)
 
+        // "join key <k>" / key annotations appear only on keyed joins so
+        // keyless joins keep their original log shape.
+        let keySuffix = joinRequest.idempotencyKey.map { " idempotencyKey=\($0.rawValue)" } ?? ""
         if !(200...299).contains(httpResponse.statusCode) {
-            Log.error("agents/join failed [\(httpResponse.statusCode)]: \(String(data: data, encoding: .utf8) ?? "nil data")")
+            Log.error("agents/join failed [\(httpResponse.statusCode)]\(keySuffix): \(String(data: data, encoding: .utf8) ?? "nil data")")
         }
         switch httpResponse.statusCode {
         case 200...299:
             let decoder = JSONDecoder()
             let response = try decoder.decode(ConvosAPI.AgentJoinResponse.self, from: data)
-            Log.info("agents/join succeeded: instanceId=\(response.instanceId ?? "nil") joined=\(response.joined) inboxIdPresent=\(response.inboxId != nil)")
+            // When a key was sent, the returned instanceId should equal it (the
+            // key is the workflow instance id); a match on a retry is the
+            // client-visible proof the server adopted rather than re-provisioned.
+            let matchSuffix = joinRequest.idempotencyKey.map { " idempotencyKey=\($0.rawValue) instanceIdMatchesKey=\(response.instanceId == $0.rawValue)" } ?? ""
+            Log.info("agents/join succeeded: instanceId=\(response.instanceId ?? "nil")\(matchSuffix) joined=\(response.joined) inboxIdPresent=\(response.inboxId != nil)")
             return response
         case 502:
             throw APIError.agentProvisionFailed

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -96,11 +96,7 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func requestAgentJoin(
-        slug: String? = nil,
-        conversationId: String? = nil,
-        templateId: String? = nil,
-        options: ConvosAPI.AgentJoinOptions? = nil,
-        timezone: String? = nil,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
         .init(success: true, joined: true, instanceId: "mock-instance", inboxId: "mock-agent-inbox")

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
@@ -136,18 +136,27 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
     /// API client when unset (e.g. in tests).
     private let joinHandler: OSAllocatedUnfairLock<AgentTemplateJoinHandler?> = .init(initialState: nil)
 
+    /// Sleep between retry attempts. Injectable so tests drive the backoff
+    /// without real waits (mirrors `awaitProvisionedAgentInbox`'s injectable
+    /// sleep); the default sleeps for real.
+    private let backoffSleep: @Sendable (TimeInterval) async -> Void
+
     public init(
         apiClient: any ConvosAPIClientProtocol,
         databaseWriter: any DatabaseWriter,
         databaseReader: any DatabaseReader,
         source: String,
-        clientDeviceIdProvider: @escaping @Sendable () -> String?
+        clientDeviceIdProvider: @escaping @Sendable () -> String?,
+        backoffSleep: @escaping @Sendable (TimeInterval) async -> Void = { seconds in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        }
     ) {
         self.apiClient = apiClient
         self.databaseWriter = databaseWriter
         self.databaseReader = databaseReader
         self.source = source
         self.clientDeviceIdProvider = clientDeviceIdProvider
+        self.backoffSleep = backoffSleep
     }
 
     // MARK: - Public
@@ -713,7 +722,7 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
 
     private func backoff(attempt: Int) async {
         let seconds: Double = min(Constant.baseBackoffSeconds * Double(attempt), Constant.maxBackoffSeconds)
-        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        await backoffSleep(seconds)
     }
 
     private static let terminalStatuses: [String] = [

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
@@ -376,13 +376,33 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
     /// lost response - including a relaunch resume - resends the same key and
     /// the server adopts the in-flight instance instead of provisioning a
     /// duplicate.
-    private func ensureJoinIdempotencyKey(row: DBAgentTemplateGeneration) async -> ConvosAPI.JoinIdempotencyKey {
+    ///
+    /// Returns `nil` only when the generation row no longer exists (e.g.
+    /// `clearGeneration` ran while the pipeline was between steps); the invite
+    /// is moot then and the caller exits. A persist that fails while the row
+    /// still exists proceeds with the in-memory key instead of blocking the
+    /// join: in-process retries still reuse it, and the residual relaunch
+    /// window degrades to the pre-key behavior rather than failing a build
+    /// that can succeed now.
+    private func ensureJoinIdempotencyKey(row: DBAgentTemplateGeneration) async -> ConvosAPI.JoinIdempotencyKey? {
         if let persisted = row.joinIdempotencyKey,
            let key = ConvosAPI.JoinIdempotencyKey(rawValue: persisted) {
+            Log.info("AgentTemplateRepository: join key reused from persistence \(key.rawValue) for generation \(row.idempotencyKey)")
             return key
         }
         let minted = ConvosAPI.JoinIdempotencyKey.mint()
-        _ = await updateRow(idempotencyKey: row.idempotencyKey) { $0.joinIdempotencyKey = minted.rawValue }
+        let persistedRow = await updateRow(idempotencyKey: row.idempotencyKey) { $0.joinIdempotencyKey = minted.rawValue }
+        if persistedRow != nil {
+            Log.info("AgentTemplateRepository: join key minted and persisted \(minted.rawValue) for generation \(row.idempotencyKey)")
+            return minted
+        }
+        // updateRow returning nil conflates "row gone" with "write failed";
+        // distinguish them so a cleared build stops here instead of joining.
+        guard await fetchRow(idempotencyKey: row.idempotencyKey) != nil else {
+            Log.info("AgentTemplateRepository: generation \(row.idempotencyKey) row gone before invite; skipping join")
+            return nil
+        }
+        Log.warning("AgentTemplateRepository: join key \(minted.rawValue) minted but persist failed for generation \(row.idempotencyKey); proceeding unpersisted (a relaunch resume would re-mint)")
         return minted
     }
 
@@ -398,8 +418,12 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
             _ = await markFailed(idempotencyKey: row.idempotencyKey, message: "Missing template id")
             return
         }
-        Log.info("AgentTemplateRepository: inviting template \(templateId) into conversation \(row.conversationId)")
-        var joinKey: ConvosAPI.JoinIdempotencyKey = await ensureJoinIdempotencyKey(row: row)
+        guard let ensuredKey = await ensureJoinIdempotencyKey(row: row) else {
+            // Row cleared while the pipeline was between steps; nothing to invite.
+            return
+        }
+        var joinKey: ConvosAPI.JoinIdempotencyKey = ensuredKey
+        Log.info("AgentTemplateRepository: inviting template \(templateId) into conversation \(row.conversationId) with join key \(joinKey.rawValue)")
         var attempt: Int = 0
         while attempt < Constant.maxInviteAttempts {
             do {
@@ -426,7 +450,7 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                         forceErrorCode: nil
                     )
                 }
-                Log.info("AgentTemplateRepository: invite succeeded for template \(templateId) in conversation \(row.conversationId)")
+                Log.info("AgentTemplateRepository: invite succeeded for template \(templateId) in conversation \(row.conversationId) with join key \(joinKey.rawValue)")
                 Self.cleanupAttachments(idempotencyKey: row.idempotencyKey)
                 _ = await updateRow(idempotencyKey: row.idempotencyKey) { $0.status = DBAgentTemplateGeneration.Status.invited.rawValue }
                 return
@@ -436,10 +460,17 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                     // Explicit provision failure: the server retains the failed
                     // instance under this key, so a same-key retry would adopt
                     // the corpse. Mint a fresh key for the next attempt.
-                    Log.error("AgentTemplateRepository: invite provision failed for template \(templateId); re-minting join key: \(error.localizedDescription)")
+                    let corpseKey = joinKey.rawValue
                     joinKey = ConvosAPI.JoinIdempotencyKey.mint()
                     let reminted = joinKey.rawValue
-                    _ = await updateRow(idempotencyKey: row.idempotencyKey) { $0.joinIdempotencyKey = reminted }
+                    Log.error("AgentTemplateRepository: invite provision failed for template \(templateId); join key re-minted \(corpseKey) -> \(reminted): \(error.localizedDescription)")
+                    let remintPersisted = await updateRow(idempotencyKey: row.idempotencyKey) { $0.joinIdempotencyKey = reminted }
+                    if remintPersisted == nil, await fetchRow(idempotencyKey: row.idempotencyKey) == nil {
+                        // Row cleared mid-invite; stop retrying a build that
+                        // no longer exists.
+                        Log.info("AgentTemplateRepository: generation \(row.idempotencyKey) row gone during invite; skipping retry")
+                        return
+                    }
                     attempt += 1
                     await backoff(attempt: attempt)
                     continue
@@ -447,7 +478,19 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                     // Ambiguous or no-instance failures: reuse the key so a
                     // provision that did land server-side is adopted, not
                     // duplicated.
-                    Log.error("AgentTemplateRepository: invite retryable failure for template \(templateId): \(error) - \(error.localizedDescription)")
+                    Log.error("AgentTemplateRepository: invite retryable failure for template \(templateId); reusing join key \(joinKey.rawValue): \(error) - \(error.localizedDescription)")
+                    attempt += 1
+                    await backoff(attempt: attempt)
+                    continue
+                case .forbidden:
+                    // A cold-launch resume can reach the backend before the
+                    // SIWE-bound JWT is ready, surfacing 403 "Account required"
+                    // as a readiness race rather than a real authorization
+                    // verdict. Retry with backoff reusing the key: once auth is
+                    // ready, the same key adopts any instance an earlier attempt
+                    // already provisioned. A genuinely unauthorized caller still
+                    // fails terminally once attempts are exhausted.
+                    Log.error("AgentTemplateRepository: invite got 403 (auth may not be ready yet); retrying with join key \(joinKey.rawValue): \(error.localizedDescription)")
                     attempt += 1
                     await backoff(attempt: attempt)
                     continue
@@ -460,7 +503,8 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                 // Transport-level failure (timeout, lost connection) - the
                 // ambiguous case the key exists for. Reuse it so the server
                 // adopts the possibly-provisioned instance.
-                Log.error("AgentTemplateRepository: invite threw for template \(templateId): \(error.localizedDescription)")
+                let urlErrorCode = (error as? URLError).map { " urlError=\($0.code.rawValue)" } ?? ""
+                Log.error("AgentTemplateRepository: invite threw (ambiguous) for template \(templateId); reusing join key \(joinKey.rawValue)\(urlErrorCode): \(error.localizedDescription)")
                 attempt += 1
                 await backoff(attempt: attempt)
                 continue

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift
@@ -45,8 +45,10 @@ public struct AgentTemplateGeneration: Sendable, Equatable {
 /// Performs the agent-join for a finished template. Routed through
 /// `SessionManager.addAgentToConversation` (not the raw API client) so the
 /// direct-add provision/add runs and the agent is added to the conversation
-/// the build targeted.
-public typealias AgentTemplateJoinHandler = @Sendable (_ conversationId: String, _ templateId: String, _ variantId: String?) async throws -> Void
+/// the build targeted. `joinIdempotencyKey` is the persisted key the
+/// repository mints per logical join; the handler must send it on the join
+/// POST so a retried join dedups server-side.
+public typealias AgentTemplateJoinHandler = @Sendable (_ conversationId: String, _ templateId: String, _ variantId: String?, _ joinIdempotencyKey: ConvosAPI.JoinIdempotencyKey?) async throws -> Void
 
 /// Errors an `AgentTemplateJoinHandler` can throw when it cannot perform the
 /// join. Surfacing these as thrown errors (rather than returning) keeps the
@@ -368,15 +370,36 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
         return await markFailed(idempotencyKey: row.idempotencyKey, message: "Timed out")
     }
 
+    /// Returns the row's persisted join idempotency key, minting and
+    /// persisting one first when absent (or when the persisted value is not a
+    /// valid key). Persisting before the POST is the point: a retry after a
+    /// lost response - including a relaunch resume - resends the same key and
+    /// the server adopts the in-flight instance instead of provisioning a
+    /// duplicate.
+    private func ensureJoinIdempotencyKey(row: DBAgentTemplateGeneration) async -> ConvosAPI.JoinIdempotencyKey {
+        if let persisted = row.joinIdempotencyKey,
+           let key = ConvosAPI.JoinIdempotencyKey(rawValue: persisted) {
+            return key
+        }
+        let minted = ConvosAPI.JoinIdempotencyKey.mint()
+        _ = await updateRow(idempotencyKey: row.idempotencyKey) { $0.joinIdempotencyKey = minted.rawValue }
+        return minted
+    }
+
     /// Invite the finished template into the conversation. Provision/pool
     /// errors are retried (the template exists, so a retry is cheap); archived
-    /// / not-found are terminal.
+    /// / not-found are terminal. Retries reuse the persisted join idempotency
+    /// key on ambiguous failures (timeout, lost connection) so the server
+    /// adopts the in-flight instance, and mint a fresh key after an explicit
+    /// provision failure because the server retains the failed instance under
+    /// the old key.
     private func invite(row: DBAgentTemplateGeneration) async {
         guard let templateId = row.templateId else {
             _ = await markFailed(idempotencyKey: row.idempotencyKey, message: "Missing template id")
             return
         }
         Log.info("AgentTemplateRepository: inviting template \(templateId) into conversation \(row.conversationId)")
+        var joinKey: ConvosAPI.JoinIdempotencyKey = await ensureJoinIdempotencyKey(row: row)
         var attempt: Int = 0
         while attempt < Constant.maxInviteAttempts {
             do {
@@ -387,18 +410,19 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                 // to the raw client when unset (tests).
                 let handler = joinHandler.withLock { $0 }
                 if let handler {
-                    try await handler(row.conversationId, templateId, row.variantId)
+                    try await handler(row.conversationId, templateId, row.variantId, joinKey)
                 } else {
                     // Reaching this outside tests means the agent gets provisioned
                     // but never direct-added, so it silently never joins.
                     Log.warning("AgentTemplateRepository: join handler unset; raw join without direct-add for template \(templateId)")
                     let options = row.variantId.map { ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0) }
                     _ = try await apiClient.requestAgentJoin(
-                        slug: nil,
-                        conversationId: row.conversationId,
-                        templateId: templateId,
-                        options: options,
-                        timezone: nil,
+                        ConvosAPI.AgentJoinRequest(
+                            conversationId: row.conversationId,
+                            templateId: templateId,
+                            idempotencyKey: joinKey,
+                            options: options
+                        ),
                         forceErrorCode: nil
                     )
                 }
@@ -408,7 +432,21 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                 return
             } catch let error as APIError {
                 switch error {
-                case .noAgentsAvailable, .agentPoolTimeout, .agentProvisionFailed, .serverError:
+                case .agentProvisionFailed:
+                    // Explicit provision failure: the server retains the failed
+                    // instance under this key, so a same-key retry would adopt
+                    // the corpse. Mint a fresh key for the next attempt.
+                    Log.error("AgentTemplateRepository: invite provision failed for template \(templateId); re-minting join key: \(error.localizedDescription)")
+                    joinKey = ConvosAPI.JoinIdempotencyKey.mint()
+                    let reminted = joinKey.rawValue
+                    _ = await updateRow(idempotencyKey: row.idempotencyKey) { $0.joinIdempotencyKey = reminted }
+                    attempt += 1
+                    await backoff(attempt: attempt)
+                    continue
+                case .noAgentsAvailable, .agentPoolTimeout, .serverError:
+                    // Ambiguous or no-instance failures: reuse the key so a
+                    // provision that did land server-side is adopted, not
+                    // duplicated.
                     Log.error("AgentTemplateRepository: invite retryable failure for template \(templateId): \(error) - \(error.localizedDescription)")
                     attempt += 1
                     await backoff(attempt: attempt)
@@ -419,6 +457,9 @@ public final class AgentTemplateRepository: AgentTemplateRepositoryProtocol {
                     return
                 }
             } catch {
+                // Transport-level failure (timeout, lost connection) - the
+                // ambiguous case the key exists for. Reuse it so the server
+                // adopts the possibly-provisioned instance.
                 Log.error("AgentTemplateRepository: invite threw for template \(templateId): \(error.localizedDescription)")
                 attempt += 1
                 await backoff(attempt: attempt)

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1304,6 +1304,28 @@ extension SessionManager {
         options: ConvosAPI.AgentJoinOptions? = nil,
         forceErrorCode: Int? = nil
     ) async throws -> ConvosAPI.AgentJoinResponse {
+        try await addAgentToConversation(
+            conversationId: conversationId,
+            templateId: templateId,
+            options: options,
+            forceErrorCode: forceErrorCode,
+            idempotencyKey: nil
+        )
+    }
+
+    /// Full direct-add join. `idempotencyKey` is the builder flow's persisted
+    /// join key (stable across retries of one logical join) so the backend
+    /// dedups a retried provision whose response was lost; `nil` (all
+    /// non-builder callers today) keeps the non-deduped behavior. Internal
+    /// because only the agent-template repository's wired join handler
+    /// threads a key; the public protocol surface stays as-is.
+    func addAgentToConversation(
+        conversationId: String,
+        templateId: String?,
+        options: ConvosAPI.AgentJoinOptions?,
+        forceErrorCode: Int?,
+        idempotencyKey: ConvosAPI.JoinIdempotencyKey?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
         // Capture the creator's device timezone on the main actor before any
         // async hop. This seeds the agent's baseline/default zone (Channel A);
         // it is distinct from the per-sender "timezone" ProfileUpdate metadata
@@ -1317,11 +1339,13 @@ extension SessionManager {
         let resolved = try await Self.awaitProvisionedAgentInbox(
             requestJoin: {
                 try await self.apiClient.requestAgentJoin(
-                    slug: nil,
-                    conversationId: conversationId.lowercased(),
-                    templateId: templateId,
-                    options: options,
-                    timezone: creatorTimezone,
+                    ConvosAPI.AgentJoinRequest(
+                        conversationId: conversationId.lowercased(),
+                        templateId: templateId,
+                        idempotencyKey: idempotencyKey,
+                        options: options,
+                        timezone: creatorTimezone
+                    ),
                     forceErrorCode: forceErrorCode
                 )
             },
@@ -1502,7 +1526,7 @@ extension SessionManager {
     /// provision/add runs, then resume any in-flight generations persisted
     /// across a relaunch.
     func wireAgentTemplateRepository() {
-        agentTemplateRepositoryInstance.configureJoinHandler { [weak self] conversationId, templateId, variantId in
+        agentTemplateRepositoryInstance.configureJoinHandler { [weak self] conversationId, templateId, variantId, joinIdempotencyKey in
             // Throw rather than letting optional chaining return a silent `nil`:
             // the invite step only detects failure via thrown errors, so a
             // no-op `nil` would be recorded as a false `.invited` with no agent
@@ -1512,7 +1536,13 @@ extension SessionManager {
             // byte-identical; when set, the same slug carries the join routing
             // and (via options.variantId) the load-bearing join-status poll.
             let options = variantId.map { ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0) }
-            _ = try await self.addAgentToConversation(conversationId: conversationId, templateId: templateId, options: options)
+            _ = try await self.addAgentToConversation(
+                conversationId: conversationId,
+                templateId: templateId,
+                options: options,
+                forceErrorCode: nil,
+                idempotencyKey: joinIdempotencyKey
+            )
         }
         agentTemplateRepositoryInstance.resumePendingGenerations()
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateGeneration.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentTemplateGeneration.swift
@@ -42,6 +42,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         static let attachments: Column = Column(CodingKeys.attachments)
         static let connections: Column = Column(CodingKeys.connections)
         static let variantId: Column = Column(CodingKeys.variantId)
+        static let joinIdempotencyKey: Column = Column(CodingKeys.joinIdempotencyKey)
         static let createdAt: Column = Column(CodingKeys.createdAt)
         static let updatedAt: Column = Column(CodingKeys.updatedAt)
     }
@@ -93,6 +94,15 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
     /// three consistent even when the build resumes after a relaunch. `nil` for
     /// default builds.
     let variantId: String?
+    /// Join idempotency key sent on `POST /v2/agents/join` so a retried join
+    /// whose response was lost adopts the already-provisioned instance instead
+    /// of creating a duplicate (see docs/adr/014-idempotent-agent-join.md).
+    /// Persisted raw value of a `ConvosAPI.JoinIdempotencyKey`, minted just
+    /// before the first join attempt; `nil` until then. Reused across
+    /// ambiguous failures (timeout, lost connection, relaunch resume) and
+    /// replaced with a fresh key after an explicit provision failure, because
+    /// the server retains terminated instance ids.
+    var joinIdempotencyKey: String?
     let createdAt: Date
     var updatedAt: Date
 
@@ -101,7 +111,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         case templateId, prompt
         case errorMessage = "error"
         case previewAgentName, previewEmoji, previewDescription, progressPhrases
-        case attachments, connections, variantId
+        case attachments, connections, variantId, joinIdempotencyKey
         case createdAt, updatedAt
     }
 
@@ -121,6 +131,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         attachments: String? = nil,
         connections: String? = nil,
         variantId: String? = nil,
+        joinIdempotencyKey: String? = nil,
         createdAt: Date,
         updatedAt: Date
     ) {
@@ -139,6 +150,7 @@ struct DBAgentTemplateGeneration: Codable, FetchableRecord, PersistableRecord, H
         self.attachments = attachments
         self.connections = connections
         self.variantId = variantId
+        self.joinIdempotencyKey = joinIdempotencyKey
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -538,6 +538,18 @@ extension SharedDatabaseMigrator {
         }
     }
 
+    /// Additive, nullable column holding the join idempotency key sent on
+    /// `POST /v2/agents/join` (lowercase v4 UUID). Persisted before the first
+    /// join attempt so a retry after a lost response - including a relaunch
+    /// resume - resends the same key and the server adopts the in-flight
+    /// instance instead of provisioning a duplicate. `nil` until the invite
+    /// step runs, so existing rows are unaffected.
+    private static func addAgentTemplateGenerationJoinIdempotencyKey(_ db: Database) throws {
+        try db.alter(table: "agentTemplateGeneration") { t in
+            t.add(column: "joinIdempotencyKey", .text)
+        }
+    }
+
     /// Registers the join-request ledger and the direct-builder generation
     /// table, in this order. Grouped into a helper to keep `makeMigrator`
     /// under the function-length budget; the registration position (last,
@@ -549,6 +561,7 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addAgentTemplateGenerationAttachments", migrate: Self.addAgentTemplateGenerationAttachments)
         migrator.registerMigration("addAgentTemplateGenerationConnections", migrate: Self.addAgentTemplateGenerationConnections)
         migrator.registerMigration("addAgentTemplateGenerationVariant", migrate: Self.addAgentTemplateGenerationVariant)
+        migrator.registerMigration("addAgentTemplateGenerationJoinIdempotencyKey", migrate: Self.addAgentTemplateGenerationJoinIdempotencyKey)
     }
 
     /// In-flight (or finished) agent-template generation kicked off by the

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -192,6 +192,9 @@ extension SharedDatabaseMigrator {
         Self.registerTailMigrations(on: &migrator)
         Self.registerMemberDepartureMigrations(on: &migrator)
 
+        migrator.registerMigration("addAgentTemplateGenerationJoinIdempotencyKey",
+                                   migrate: Self.addAgentTemplateGenerationJoinIdempotencyKey)
+
         return migrator
     }
 
@@ -551,9 +554,16 @@ extension SharedDatabaseMigrator {
     }
 
     /// Registers the join-request ledger and the direct-builder generation
-    /// table, in this order. Grouped into a helper to keep `makeMigrator`
-    /// under the function-length budget; the registration position (last,
-    /// before `return`) is unchanged so the migration order is preserved.
+    /// table, in this order. Grouped into a helper to keep `createMigrator`
+    /// under the function-length budget.
+    ///
+    /// Do not append new migrations here, even ones that touch these tables:
+    /// `createMigrator` registers other groups after this call, and a
+    /// migration added to this group therefore lands ahead of ones an
+    /// upgraded install has already applied. That is the divergence the
+    /// DEBUG `eraseDatabaseOnSchemaChange` replay treats as a schema change,
+    /// and it wipes the database. New migrations go at the end of
+    /// `createMigrator`.
     private static func registerJoinAndGenerationMigrations(on migrator: inout DatabaseMigrator) {
         migrator.registerMigration("createHandledJoinRequest", migrate: Self.createHandledJoinRequest)
         migrator.registerMigration("createAgentTemplateGeneration", migrate: Self.createAgentTemplateGeneration)
@@ -561,7 +571,6 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addAgentTemplateGenerationAttachments", migrate: Self.addAgentTemplateGenerationAttachments)
         migrator.registerMigration("addAgentTemplateGenerationConnections", migrate: Self.addAgentTemplateGenerationConnections)
         migrator.registerMigration("addAgentTemplateGenerationVariant", migrate: Self.addAgentTemplateGenerationVariant)
-        migrator.registerMigration("addAgentTemplateGenerationJoinIdempotencyKey", migrate: Self.addAgentTemplateGenerationJoinIdempotencyKey)
     }
 
     /// In-flight (or finished) agent-template generation kicked off by the

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
@@ -20,7 +20,12 @@ struct AgentTemplateRepositoryTests {
             databaseWriter: database,
             databaseReader: database,
             source: "test",
-            clientDeviceIdProvider: { "test-device" }
+            clientDeviceIdProvider: { "test-device" },
+            // No real waits between retry attempts: the retry tests assert on
+            // attempt counts and keys, not timing, and real backoffs are what
+            // let cooperative-pool starvation in the integration job push the
+            // pipeline past waitForStatus budgets.
+            backoffSleep: { _ in }
         )
     }
 
@@ -159,7 +164,9 @@ struct AgentTemplateRepositoryTests {
             try await Task.sleep(nanoseconds: 50_000_000)
         }
         #expect(api.joinCalls == 1)
-        try await Task.sleep(nanoseconds: 1_600_000_000)
+        // Backoff is a no-op in tests, so a would-be retry fires immediately;
+        // a short grace period is enough to catch it.
+        try await Task.sleep(nanoseconds: 500_000_000)
         #expect(api.joinCalls == 1)
         let row = try await database.read { db in
             try DBAgentTemplateGeneration

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
@@ -69,6 +69,83 @@ struct AgentTemplateRepositoryTests {
         #expect(api.joinedConversationId == "convo-1")
     }
 
+    /// Anchored (`^...$`) and case-sensitive on purpose: the key becomes the
+    /// assistant instance id, which is lowercase-only server-side, and
+    /// `UUID().uuidString` is uppercase - a factory regression would produce
+    /// mixed-case instance ids that break the server's lowercase assumption.
+    private static let lowercaseV4UUIDPattern = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+
+    @Test("Minted join keys are lowercase v4 UUIDs")
+    func joinKeyFactoryIsLowercaseV4() throws {
+        for _ in 0..<256 {
+            let key = ConvosAPI.JoinIdempotencyKey.mint().rawValue
+            #expect(key.range(of: Self.lowercaseV4UUIDPattern, options: .regularExpression) != nil)
+        }
+    }
+
+    @Test("Join key type rejects non-UUIDs and normalizes case on rehydrate")
+    func joinKeyValidatesAndNormalizes() throws {
+        #expect(ConvosAPI.JoinIdempotencyKey(rawValue: "not-a-uuid") == nil)
+        #expect(ConvosAPI.JoinIdempotencyKey(rawValue: "") == nil)
+        // An uppercase persisted value (e.g. a legacy or hand-edited row)
+        // rehydrates to the lowercase wire form rather than passing through.
+        let uppercase = "6F0F7A8E-1B2C-4D3E-8F4A-5B6C7D8E9F0A"
+        let key = try #require(ConvosAPI.JoinIdempotencyKey(rawValue: uppercase))
+        #expect(key.rawValue == uppercase.lowercased())
+    }
+
+    @Test("Join key is persisted lowercase and sent on the join request")
+    func joinKeyPersistedAndSent() async throws {
+        let database = try makeDatabase()
+        let api = HappyStubAPIClient()
+        let repository = makeRepository(database: database, apiClient: api)
+
+        repository.startGeneration(prompt: "build me a chef", conversationId: "convo-key", slug: "chef.abcd")
+
+        let row = try await waitForStatus(.invited, conversationId: "convo-key", in: database)
+        let persisted = try #require(row?.joinIdempotencyKey)
+        #expect(persisted.range(of: Self.lowercaseV4UUIDPattern, options: .regularExpression) != nil)
+        #expect(api.joinedIdempotencyKeys == [persisted])
+    }
+
+    @Test("Ambiguous join failure (timeout) reuses the persisted key on retry")
+    func joinKeyReusedOnAmbiguousFailure() async throws {
+        let database = try makeDatabase()
+        let api = RetryJoinStubAPIClient(firstJoinError: URLError(.timedOut))
+        let repository = makeRepository(database: database, apiClient: api)
+
+        repository.startGeneration(prompt: "build me a chef", conversationId: "convo-reuse", slug: "chef.abcd")
+
+        let row = try await waitForStatus(.invited, conversationId: "convo-reuse", in: database)
+        #expect(row?.statusValue == .invited)
+        let keys = api.capturedJoinKeys
+        #expect(keys.count == 2)
+        let first = try #require(keys.first ?? nil)
+        #expect(keys.last == first)
+        #expect(row?.joinIdempotencyKey == first)
+    }
+
+    @Test("Explicit provision failure re-mints a fresh key for the retry")
+    func joinKeyRemintedOnExplicitFailure() async throws {
+        let database = try makeDatabase()
+        let api = RetryJoinStubAPIClient(firstJoinError: APIError.agentProvisionFailed)
+        let repository = makeRepository(database: database, apiClient: api)
+
+        repository.startGeneration(prompt: "build me a chef", conversationId: "convo-remint", slug: "chef.abcd")
+
+        let row = try await waitForStatus(.invited, conversationId: "convo-remint", in: database)
+        #expect(row?.statusValue == .invited)
+        let keys = api.capturedJoinKeys
+        #expect(keys.count == 2)
+        let first = try #require(keys.first ?? nil)
+        let second = try #require(keys.last ?? nil)
+        #expect(first != second)
+        #expect(second.range(of: Self.lowercaseV4UUIDPattern, options: .regularExpression) != nil)
+        // The replacement key is persisted so a relaunch resume retries with
+        // it, not the corpse key.
+        #expect(row?.joinIdempotencyKey == second)
+    }
+
     @Test("Moderation rejection marks the row failed and never invites")
     func moderationFails() async throws {
         let database = try makeDatabase()
@@ -165,9 +242,11 @@ private final class HappyStubAPIClient: TestStubAPIClient {
     private let templateId: String = UUID().uuidString
     private var capturedTemplateId: String?
     private var capturedConversationId: String?
+    private var capturedIdempotencyKeys: [String?] = []
 
     var joinedTemplateId: String? { lock.withLock { capturedTemplateId } }
     var joinedConversationId: String? { lock.withLock { capturedConversationId } }
+    var joinedIdempotencyKeys: [String?] { lock.withLock { capturedIdempotencyKeys } }
 
     override func createAgentTemplateGeneration(
         inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
@@ -197,16 +276,13 @@ private final class HappyStubAPIClient: TestStubAPIClient {
     }
 
     override func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock {
-            capturedTemplateId = templateId
-            capturedConversationId = conversationId
+            capturedTemplateId = joinRequest.templateId
+            capturedConversationId = joinRequest.conversationId
+            capturedIdempotencyKeys.append(joinRequest.idempotencyKey?.rawValue)
         }
         return ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
@@ -231,11 +307,7 @@ private final class ModeratedStubAPIClient: TestStubAPIClient {
     }
 
     override func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock { joinCallCount += 1 }
@@ -278,14 +350,66 @@ private final class AttachmentUploadFailingStubAPIClient: TestStubAPIClient {
     }
 
     override func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock { joinCallCount += 1 }
+        return ConvosAPI.AgentJoinResponse(success: true, joined: true)
+    }
+}
+
+/// The first join attempt throws `firstJoinError`; the second succeeds.
+/// Parameterized by the error so both halves of the join-key policy are
+/// testable: ambiguous transport failures reuse the persisted key, explicit
+/// provision failures re-mint a fresh one.
+private final class RetryJoinStubAPIClient: TestStubAPIClient {
+    private let lock: NSLock = NSLock()
+    private let templateId: String = UUID().uuidString
+    private let firstJoinError: Error
+    private var joinKeys: [String?] = []
+
+    var capturedJoinKeys: [String?] { lock.withLock { joinKeys } }
+
+    init(firstJoinError: Error) {
+        self.firstJoinError = firstJoinError
+    }
+
+    override func createAgentTemplateGeneration(
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
+        source: String,
+        clientDeviceId: String?,
+        idempotencyKey: String,
+        connections: [String],
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
+        ConvosAPI.AgentTemplateGenerationResponse(
+            generationId: "gen-retry",
+            status: .pending,
+            templateId: nil,
+            error: nil
+        )
+    }
+
+    override func getAgentTemplateGeneration(
+        generationId: String
+    ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
+        ConvosAPI.AgentTemplateGenerationResponse(
+            generationId: generationId,
+            status: .done,
+            templateId: templateId,
+            error: nil
+        )
+    }
+
+    override func requestAgentJoin(
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
+        forceErrorCode: Int?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        let shouldThrow: Bool = lock.withLock {
+            joinKeys.append(joinRequest.idempotencyKey?.rawValue)
+            return joinKeys.count == 1
+        }
+        if shouldThrow { throw firstJoinError }
         return ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateRepositoryTests.swift
@@ -125,6 +125,50 @@ struct AgentTemplateRepositoryTests {
         #expect(row?.joinIdempotencyKey == first)
     }
 
+    @Test("403 during invite retries with the same key (cold-launch auth-readiness race)")
+    func joinKeyReusedOnForbidden() async throws {
+        let database = try makeDatabase()
+        let api = RetryJoinStubAPIClient(firstJoinError: APIError.forbidden)
+        let repository = makeRepository(database: database, apiClient: api)
+
+        repository.startGeneration(prompt: "build me a chef", conversationId: "convo-403", slug: "chef.abcd")
+
+        let row = try await waitForStatus(.invited, conversationId: "convo-403", in: database)
+        #expect(row?.statusValue == .invited)
+        let keys = api.capturedJoinKeys
+        #expect(keys.count == 2)
+        let first = try #require(keys.first ?? nil)
+        #expect(keys.last == first)
+        #expect(row?.joinIdempotencyKey == first)
+    }
+
+    @Test("Row cleared mid-invite stops the retry loop instead of re-joining")
+    func rowClearedMidInviteStopsRetries() async throws {
+        let database = try makeDatabase()
+        let api = RowDeletingProvisionFailStubAPIClient(database: database)
+        let repository = makeRepository(database: database, apiClient: api)
+
+        repository.startGeneration(prompt: "build me a chef", conversationId: "convo-cleared", slug: "chef.abcd")
+
+        // The stub deletes the row inside the first join call and then throws
+        // an explicit provision failure. The re-mint branch must notice the
+        // missing row and stop; wait past the first backoff (1s) to catch a
+        // would-be second attempt.
+        let deadline = Date().addingTimeInterval(20)
+        while api.joinCalls == 0, Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(api.joinCalls == 1)
+        try await Task.sleep(nanoseconds: 1_600_000_000)
+        #expect(api.joinCalls == 1)
+        let row = try await database.read { db in
+            try DBAgentTemplateGeneration
+                .filter(DBAgentTemplateGeneration.Columns.conversationId == "convo-cleared")
+                .fetchOne(db)
+        }
+        #expect(row == nil)
+    }
+
     @Test("Explicit provision failure re-mints a fresh key for the retry")
     func joinKeyRemintedOnExplicitFailure() async throws {
         let database = try makeDatabase()
@@ -355,6 +399,61 @@ private final class AttachmentUploadFailingStubAPIClient: TestStubAPIClient {
     ) async throws -> ConvosAPI.AgentJoinResponse {
         lock.withLock { joinCallCount += 1 }
         return ConvosAPI.AgentJoinResponse(success: true, joined: true)
+    }
+}
+
+/// Deletes the generation row (simulating `clearGeneration` racing the
+/// pipeline) inside the join call, then throws an explicit provision failure.
+/// The invite's re-mint branch must detect the missing row and stop instead
+/// of retrying a build that no longer exists.
+private final class RowDeletingProvisionFailStubAPIClient: TestStubAPIClient {
+    private let lock: NSLock = NSLock()
+    private let templateId: String = UUID().uuidString
+    private let database: DatabaseQueue
+    private var joinCallCount: Int = 0
+
+    var joinCalls: Int { lock.withLock { joinCallCount } }
+
+    init(database: DatabaseQueue) {
+        self.database = database
+    }
+
+    override func createAgentTemplateGeneration(
+        inputs: ConvosAPI.AgentTemplateGenerationRequest.Inputs,
+        source: String,
+        clientDeviceId: String?,
+        idempotencyKey: String,
+        connections: [String],
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
+        ConvosAPI.AgentTemplateGenerationResponse(
+            generationId: "gen-cleared",
+            status: .pending,
+            templateId: nil,
+            error: nil
+        )
+    }
+
+    override func getAgentTemplateGeneration(
+        generationId: String
+    ) async throws -> ConvosAPI.AgentTemplateGenerationResponse {
+        ConvosAPI.AgentTemplateGenerationResponse(
+            generationId: generationId,
+            status: .done,
+            templateId: templateId,
+            error: nil
+        )
+    }
+
+    override func requestAgentJoin(
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
+        forceErrorCode: Int?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        lock.withLock { joinCallCount += 1 }
+        _ = try? await database.write { db in
+            try DBAgentTemplateGeneration.deleteAll(db)
+        }
+        throw APIError.agentProvisionFailed
     }
 }
 

--- a/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentVariantPlumbingTests.swift
@@ -58,6 +58,24 @@ struct AgentVariantPlumbingTests {
         #expect(options?["variantId"] as? String == "pr-1234")
     }
 
+    @Test("Join request carries idempotencyKey top-level as a lowercase string, omitted when nil")
+    func joinRequestIdempotencyKeyEncoding() throws {
+        // Uppercase input proves the type normalizes before encoding: the
+        // wire value must be lowercase regardless of the raw value's casing.
+        let key = try #require(ConvosAPI.JoinIdempotencyKey(rawValue: "6F0F7A8E-1B2C-4D3E-8F4A-5B6C7D8E9F0A"))
+        let keyed = ConvosAPI.AgentJoinRequest(
+            conversationId: "convo-1",
+            templateId: "tmpl-1",
+            idempotencyKey: key
+        )
+        let object = try Self.jsonObject(keyed)
+        #expect(object["idempotencyKey"] as? String == "6f0f7a8e-1b2c-4d3e-8f4a-5b6c7d8e9f0a")
+
+        // Nil-omitted so default joins stay byte-identical to shipped builds.
+        let unkeyed = ConvosAPI.AgentJoinRequest(conversationId: "convo-1", templateId: "tmpl-1")
+        #expect(try Self.jsonObject(unkeyed).keys.contains("idempotencyKey") == false)
+    }
+
     @Test("Join options omit variantId when nil")
     func joinOptionsOmitNilVariantId() throws {
         let object = try Self.jsonObject(ConvosAPI.AgentJoinOptions(onboarding: "agent-builder"))
@@ -234,14 +252,10 @@ private final class VariantRecordingStubAPIClient: TestStubAPIClient {
     }
 
     override func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
-        lock.withLock { capturedJoinVariantId = options?.variantId }
+        lock.withLock { capturedJoinVariantId = joinRequest.options?.variantId }
         return ConvosAPI.AgentJoinResponse(success: true, joined: true)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/CreditBalanceWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CreditBalanceWriterTests.swift
@@ -171,8 +171,11 @@ private final class StubCreditBalanceAPIClient: ConvosAPIClientProtocol, @unchec
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
         try await delegate.renewAssetsBatch(assetKeys: assetKeys)
     }
-    func requestAgentJoin(slug: String, templateId: String?, forceErrorCode: Int?) async throws -> ConvosAPI.AgentJoinResponse {
-        try await delegate.requestAgentJoin(slug: slug, templateId: templateId, forceErrorCode: forceErrorCode)
+    func requestAgentJoin(
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
+        forceErrorCode: Int?
+    ) async throws -> ConvosAPI.AgentJoinResponse {
+        try await delegate.requestAgentJoin(joinRequest, forceErrorCode: forceErrorCode)
     }
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
         try await delegate.initiateCloudConnection(serviceId: serviceId, redirectUri: redirectUri)

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -29,18 +29,14 @@ extension ConvosAPIClientProtocol {
         throw CancellationError()
     }
 
-    /// Default for the post-`options:` `requestAgentJoin` signature so
+    /// Default for the request-struct `requestAgentJoin` signature so
     /// pre-existing test mocks (which still carry the old
     /// `slug:templateId:forceErrorCode:` shape) don't have to re-stub it
-    /// every time the protocol gains a parameter. Tests that exercise
+    /// every time the request body gains a field. Tests that exercise
     /// `requestAgentJoin` specifically should still override this on
     /// their fixture.
     func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         ConvosAPI.AgentJoinResponse(
@@ -202,11 +198,7 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
     /// Declared on the base class (not just the protocol-extension default) so
     /// the direct agent-builder repository's fixtures can `override` it.
     func requestAgentJoin(
-        slug: String?,
-        conversationId: String?,
-        templateId: String?,
-        options: ConvosAPI.AgentJoinOptions?,
-        timezone: String?,
+        _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse {
         ConvosAPI.AgentJoinResponse(

--- a/docs/adr/014-idempotent-agent-join.md
+++ b/docs/adr/014-idempotent-agent-join.md
@@ -1,0 +1,219 @@
+# ADR 014: Idempotent Agent Join
+
+> **Status**: Proposed (2026-07-02).
+> **Scope**: Cross-repo decision driven by the iOS/messaging team. Client
+> changes land in `convos-ios`; the passthrough lands in `convos-backend`; the
+> deduplicating change lands in `convos-assistants`.
+
+## Context
+
+Creating an agent occasionally produces **two back-to-back agents with the same
+name**: the first is orphaned (typically stuck retrying herald-attach and
+surfaced as a failed join), the second succeeds. It is largely invisible to
+users but pollutes agent-provisioning success metrics. It is triggered when the
+app is backgrounded mid-generation and returns during the join phase.
+
+An agent build is three calls:
+
+1. **Generation** — `POST /v2/agent-templates/generations` returns a
+   `generationId` immediately; the client polls to `done`, yielding a
+   `templateId`. Already retry-safe (it takes an `idempotencyKey`).
+2. **Join / provision** — `POST /v2/agents/join` with `templateId` +
+   `conversationId` provisions an agent instance and returns an `instanceId`.
+3. **Join-status poll** — `GET /v2/agents/join/:instanceId`, keyed on
+   `instanceId`.
+
+The failure we observe on the client is:
+
+```
+POST /v2/agents/join threw before returning an instance: NSURLError - The request timed out.
+```
+
+That is `NSURLErrorTimedOut` (-1001), raised by URLSession when the join POST's
+35s request timeout elapses / the connection is torn down on app suspension —
+**before** an `instanceId` comes back. Two facts make this unfixable on the
+client alone:
+
+- The request reached the server, so the backend may already have provisioned an
+  agent. The client cannot distinguish "provision failed" from "provision
+  succeeded, response lost."
+- A join is pollable only by `instanceId`, which is delivered solely in that lost
+  response. The client has no handle to the orphan, so its only recovery is to
+  POST again — creating a second instance.
+
+An iOS-side resume fix was tested (persist `agentInstanceId` once the POST
+returns it; resume on retry). It closes interruptions that happen **after** the
+id is returned, but not this one — the POST times out **before** returning an
+id, so nothing is persisted and the retry re-provisions. Reproduced with the
+resume fix in place.
+
+No client-side lever closes the remaining window: a longer timeout does not
+survive suspension; a background `URLSession` could complete the POST but still
+cannot un-create a duplicate once a connection dropped mid-request. The
+ambiguity can only be resolved by the server, which sees the request and owns
+the instance.
+
+## Decision Drivers
+
+- [x] Stop duplicate provisions so the agents page / success metrics reflect one
+      instance per build.
+- [x] Make the join retry-safe across lost responses (backgrounding, timeout,
+      dropped connection) — the actual failure mode.
+- [x] Do not break shipped iOS builds. The join request contract must stay
+      backward-compatible (any new field optional + tolerated when absent).
+- [x] Preserve the future ability to add multiple same-template agents to one
+      conversation — do not bake in a uniqueness constraint.
+- [x] Minimal new infrastructure; prefer reusing existing identifiers and
+      persistence over new tables/columns.
+
+## Decision
+
+Introduce a **join idempotency key**: a client-minted, stable identifier sent on
+every retry of a given join. The assistant service deduplicates on it and
+returns the already-provisioned instance instead of creating a new one.
+
+Chosen over **natural-key dedup** on `(ownerAccountId, conversationId,
+templateId)` because natural-key is a uniqueness constraint (forecloses
+intentional duplicates), needs `conversationId` written at instance-create time
+(today it is `NULL` until join), and models identity rather than retry-safety.
+The idempotency key directly models "this is a retry of one create," matches the
+generation endpoint's existing `idempotencyKey`, and keeps duplicates possible.
+
+Key design points:
+
+1. **The key is the assistant instance id.** In `convos-assistants`,
+   `POST /api/assistants` calls `CREATE_ASSISTANT_WORKFLOW.create({ id:
+   idempotencyKey, params })`. Cloudflare Workflows enforces instance-id
+   uniqueness, so a duplicate create throws → catch, `get(id)`, return that
+   instance. This gives dedup with **no new D1 column and no race window** (the
+   Workflows engine serializes concurrent creates). Today the instance id is a
+   Cloudflare-auto-generated v4 UUID; the client simply supplies it instead.
+2. **The key is a lowercase v4 UUID.** Instance ids are lowercase today
+   (Cloudflare auto-ids are lowercase; `db/assistant.ts` admin search relies on
+   `WHERE instance_id = LOWER(?1)`), and the id flows into the Herald webhook URL
+   path and `GET /api/assistants/:instanceId`'s `INSTANCE_ID_RE` validation.
+   `Foundation.UUID().uuidString` is **uppercase**, so the client must emit
+   `.lowercased()`, and the assistant boundary normalizes to lowercase as the
+   authoritative backstop.
+3. **Client reuse policy.** Reuse the same key on an **ambiguous** failure
+   (`NSURLErrorTimedOut`, connection lost) so the server adopts the in-flight
+   instance; mint a **new** key on an **explicit** failure
+   (`502 AGENT_PROVISION_FAILED`, or a `failed` poll) so the server provisions
+   fresh. This resolves liveness without server-side failure-remap and respects
+   Cloudflare retaining terminated instance ids (see Consequences).
+4. **Backend is a passthrough.** `convos-backend` accepts an optional
+   `idempotencyKey` on the join body and forwards it into the `/api/assistants`
+   dispatch; no other logic changes.
+
+## Consequences
+
+Positive:
+
+- One provision per build; the duplicate-agent metric pollution stops.
+- The join becomes retry-safe for the real failure mode (lost response), not
+  just the narrower post-instance-id window the shipped resume fix covered.
+- No new persistence in `convos-assistants` (the Workflows engine is the source
+  of uniqueness) and no new persistence in `convos-backend` (stays a proxy).
+- The invariant "instance ids are lowercase UUIDs" is enforced for **all**
+  callers because normalization happens where the value becomes the id.
+
+Negative / trade-offs:
+
+- Three-repo change (client mint/persist/resend, backend passthrough, assistants
+  dedup) rather than a single-repo patch.
+- Correctness now depends on the client emitting a **lowercase** UUID; a stray
+  uppercase path would produce mixed-case instance ids that break the lowercase
+  assumption. Mitigated by a single client factory + tests and server-side
+  normalization.
+- Cloudflare **retains terminated Workflow instances**, so a key whose instance
+  failed cannot be recycled (a same-key retry would `get()` the corpse). This is
+  why the client mints a new key on explicit failure; it must be enshrined, not
+  assumed.
+- The duplicate-create throw is **deployed-engine behavior only**. Miniflare's
+  local Workflows shim (used by `wrangler dev` and the vitest workers pool)
+  keeps no instance registry: `create()` fire-and-forgets an init onto a
+  name-derived Durable Object, swallows its errors, and unconditionally
+  resolves `{ id }`, so a duplicate create resolves instead of throwing and
+  the dedup branch never executes locally. (Locally the same key maps to the
+  same DO, so responses still coincidentally agree.) Consequences: the engine
+  contract cannot be integration-tested locally — it is pinned by the
+  documented API contract, by handler tests with a mocked duplicate throw,
+  and by same-key replay against a deployed environment (dev/staging run the
+  real engine; only local dev is simulated). That post-deploy replay check is
+  load-bearing, not optional.
+
+Neutral:
+
+- The key is optional end-to-end, so rollout is server-first and shipped clients
+  are unaffected (they simply get today's non-deduped behavior until updated).
+
+## Implementation Notes
+
+**`convos-ios`** — Represent the key as a dedicated
+`ConvosAPI.JoinIdempotencyKey` type rather than `String` or `UUID`: minting
+goes through `JoinIdempotencyKey.mint()` (`UUID().uuidString.lowercased()`),
+rehydration validates and lowercases, and the type is unconstructible from
+arbitrary strings — so the generation idempotency key (an uppercase UUID on
+the same row) cannot be wired in by accident, and Foundation `UUID`'s
+uppercase Codable encoding is avoided by design. Persist the raw value on
+`DBAgentTemplateGeneration` and resend it on every retry via
+`AgentTemplateRepository.invite()` → `requestAgentJoin`. Apply the
+reuse-on-ambiguous / new-on-explicit-failure policy. Tests: minted keys are
+lowercase v4 UUIDs (regex without `/i`, over many iterations); the type
+rejects non-UUIDs and normalizes case on rehydrate; the persisted key and the
+encoded wire value are lowercase; reused across an ambiguous-timeout retry and
+re-minted on explicit failure. Neighbors the existing
+`AgentTemplateRepositoryTests`.
+
+**`convos-backend`** — Add `idempotencyKey: z.string().uuid().optional()` to the
+join `bodySchema` (`src/api/v2/agents/handlers/join.ts`) and forward it into the
+dispatch body. Optional + tolerated-when-absent per the append-only
+request-contract rule; pin the legacy (no-key) shape with
+`assertLegacyShapeValidates`. May also lowercase-normalize as an earlier gate.
+
+**`convos-assistants`** — Add `idempotencyKey: z.string().uuid().transform(v =>
+v.toLowerCase())` (optional) to `CreateAssistantBodySchema` (`schemas.ts`); when
+present, `create({ id: idempotencyKey, params })` and handle the duplicate-id
+throw by returning the existing instance via `get(id)`. Normalize to lowercase
+here as the authoritative backstop; keep `.uuid()` validation for malformed
+input. Tests: the duplicate-id throw cannot be exercised in the local vitest
+workers pool (see Consequences), so pin the handler's dedup logic with a
+mocked duplicate throw in `api/assistants/index.test.ts`, and pin the `get()`
+disambiguation the catch path relies on (known id resolves, unknown id throws)
+in `create-assistant-workflow.test.ts`. Verify the real engine contract by
+same-key replay against dev after deploy. No schema migration required.
+
+## Alternatives Considered
+
+- **Natural-key dedup** `(owner, conversation, template)` — assistants-only, no
+  client change, but bakes in a uniqueness constraint (forecloses intentional
+  duplicates) and needs `conversationId` at create time (currently `NULL` until
+  `setJoined`). Rejected for flexibility and semantic correctness.
+- **D1 `idempotency_key` column + reservation** — more server-side control over
+  failure-remap, but adds a table/column and a race window the Workflows-id
+  approach avoids. Held as fallback if same-key failure-remap is ever needed.
+- **Bump the client join timeout (35s → 60s)** — does not survive app
+  suspension, so the reproduced case still fails; only helps genuinely-slow
+  foreground responses. Rejected as a fix; at best a marginal mitigation.
+
+## Related Decisions
+
+- [ADR 011 — Single-Inbox Identity Model](./011-single-inbox-identity-model.md)
+  (agents join as members of the single-inbox conversation).
+
+## References
+
+- Client join path: `ConvosCore/Sources/ConvosCore/AgentBuilder/AgentTemplateRepository.swift`,
+  `ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift` (`request.timeoutInterval = 35`).
+- Backend join handler: `convos-backend/src/api/v2/agents/handlers/join.ts`.
+- Assistants create + instance id: `convos-assistants/workers/assistant/src/api/assistants/index.ts`,
+  `.../src/workflows/create-assistant-workflow.ts`, `.../src/db/assistant.ts`
+  (`INSTANCE_ID_RE`, lowercase-instance-id assumption).
+- UUID format: RFC 4122 / RFC 9562 (v4 = random).
+- Workflows `create()` duplicate-id contract:
+  https://developers.cloudflare.com/workflows/build/workers-api/ ("an error is
+  thrown if the provided ID is already used by an existing instance that has
+  not yet passed its retention limit").
+- Local simulator gap: miniflare `dist/src/workers/workflows/binding.worker.js`
+  (`create()` resolves without a uniqueness check; errors swallowed). Observed
+  with miniflare 4.20260625 / `@cloudflare/vitest-pool-workers` 0.16.19.


### PR DESCRIPTION
Related PRs:
- https://github.com/xmtplabs/convos-assistants/pull/2668
- https://github.com/xmtplabs/convos-backend/pull/359

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786581065&installation_id=128169237&pr_number=1171&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1171&signature=4da98989aacbc9fd6f95117d05c5872663e366f0b88c63c1903e8b452c6ae0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist and resend a join idempotency key on agent-builder invites to support deduplication
> - Adds `ConvosAPI.JoinIdempotencyKey`, a validated lowercase UUID wrapper, and includes it as an optional field in `ConvosAPI.AgentJoinRequest` so the backend can deduplicate retried join requests.
> - Adds a `joinIdempotencyKey` nullable column to the `agentTemplateGeneration` table via a new database migration in [`SharedDatabaseMigrator`](https://github.com/xmtplabs/convos-ios/pull/1171/files#diff-1d28d03ee0fb38381b6052060082c7561fa8ccc71fda470214d763f53a4414df) and [`DBAgentTemplateGeneration`](https://github.com/xmtplabs/convos-ios/pull/1171/files#diff-f7c05cc1b679d5885c0ef7f778da361c0a4dc46a089698196059121022c20fb2).
> - Updates [`AgentTemplateRepository.invite`](https://github.com/xmtplabs/convos-ios/pull/1171/files#diff-15227895dd0730628bec8f4b2ef38d92b1f71976f391e4ae52fe99aea94172f7) to mint and persist a key before the first join attempt, reuse it on ambiguous/transport failures and 403s, and remint a fresh key only on explicit `agentProvisionFailed` errors.
> - Threads the idempotency key through [`SessionManager.addAgentToConversation`](https://github.com/xmtplabs/convos-ios/pull/1171/files#diff-047bb043999d66a7809a8ab86918296f5f449652df54267763f6ec8da0a71ca7) and the `AgentTemplateJoinHandler` so session-based joins also carry the key.
> - Risk: existing `agentTemplateGeneration` rows gain a nullable column; rows in flight during migration will have a `nil` key and the first retry will mint and persist one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bd797a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->