### PR TITLE
Re-enable HealthKit connection for Firebase PR-build testing

### DIFF
--- a/Convos/Config/Info.Dev.plist
+++ b/Convos/Config/Info.Dev.plist
@@ -11,6 +11,10 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Convos uses Apple Health when an agent asks about your activity, workouts, or sleep.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Convos uses Apple Health when an agent logs a workout or activity for you.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Convos needs access to your Photo Library to save photos from conversations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Convos/Config/Info.Local.plist
+++ b/Convos/Config/Info.Local.plist
@@ -13,6 +13,10 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Convos needs local network access to connect to development backend and XMTP node</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Convos uses Apple Health when an agent asks about your activity, workouts, or sleep.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Convos uses Apple Health when an agent logs a workout or activity for you.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Convos needs access to your Photo Library to save photos from conversations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Convos/Config/Info.Prod.plist
+++ b/Convos/Config/Info.Prod.plist
@@ -11,6 +11,10 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Convos uses Apple Health when an agent asks about your activity, workouts, or sleep.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Convos uses Apple Health when an agent logs a workout or activity for you.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Convos needs access to your Photo Library to save photos from conversations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/Convos/Convos.entitlements
+++ b/Convos/Convos.entitlements
@@ -12,6 +12,10 @@
 	</array>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>$(APP_ATTEST_ENVIRONMENT)</string>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_IDENTIFIER)</string>

--- a/ConvosAppClip/ConvosAppClipApp.swift
+++ b/ConvosAppClip/ConvosAppClipApp.swift
@@ -33,7 +33,7 @@ struct ConvosAppClipApp: App {
             // sink rather than threading a real CoreActions across processes.
             ClipIdentityBootstrap.bootstrap(
                 environment: environment,
-                platformProviders: .iOS,
+                platformProviders: .iOSAppClip,
                 coreActions: NoOpCoreActions()
             )
         }

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -71,6 +71,11 @@ let package = Package(
             name: "ConvosCoreiOS",
             dependencies: [
                 .target(name: "ConvosCore", condition: .when(platforms: [.iOS])),
+                .product(
+                    name: "ConvosConnectionsHealth",
+                    package: "ConvosConnections",
+                    condition: .when(platforms: [.iOS])
+                ),
             ],
             path: "Sources/ConvosCoreiOS",
             swiftSettings: [

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift
@@ -8,14 +8,12 @@ import Foundation
 /// a non-breaking expansion — the reverse hides a previously-shown option, so
 /// keep the rollout intentional.
 public enum SupportedConnections {
-    // v1 ships cloud-only (Google Calendar via Composio). No device kinds
-    // surface in the picker or the conversation-info connections list.
-    // The host (Convos main target) also doesn't link any per-kind
-    // ConvosConnections product, so the corresponding Apple-framework
-    // symbols don't enter the binary. Re-introduce a kind here AND link
-    // the matching product in Convos's Package dependencies to bring it
-    // back.
-    public static let supportedDeviceKinds: Set<ConnectionKind> = []
+    // Health is re-enabled for testing: the host links ConvosConnectionsHealth
+    // (via ConvosCoreiOS) and injects the HealthKit runtime through
+    // `PlatformProviders.iOS`. Every other device kind stays off; adding one
+    // requires listing it here AND linking the matching per-kind product so
+    // its Apple-framework symbols enter the binary.
+    public static let supportedDeviceKinds: Set<ConnectionKind> = [.health]
 
     public static let supportedCloudServiceIds: Set<String> = [
         "googlecalendar",

--- a/ConvosCore/Sources/ConvosCoreiOS/ConvosCoreiOS.swift
+++ b/ConvosCore/Sources/ConvosCoreiOS/ConvosCoreiOS.swift
@@ -22,7 +22,10 @@
 // }
 // ```
 
+import ConvosConnections
+import ConvosConnectionsHealth
 import Foundation
+import HealthKit
 import UserNotifications
 
 // MARK: - iOS Platform Providers Extension
@@ -38,6 +41,19 @@ extension PlatformProviders {
     /// Must be called from the main actor (typically during app initialization).
     @MainActor
     public static var iOS: PlatformProviders {
+        iOS(deviceConnections: healthDeviceConnections)
+    }
+
+    /// App Clip variant: identical to `.iOS` but opts out of every device
+    /// connection. App Clips cannot use HealthKit, and the clip has no
+    /// connections UI.
+    @MainActor
+    public static var iOSAppClip: PlatformProviders {
+        iOS(deviceConnections: .none)
+    }
+
+    @MainActor
+    private static func iOS(deviceConnections: DeviceConnectionsBundle) -> PlatformProviders {
         let appLifecycle = IOSAppLifecycleProvider()
         let deviceInfo = IOSDeviceInfo()
         let pushNotificationRegistrar = IOSPushNotificationRegistrar()
@@ -53,7 +69,25 @@ extension PlatformProviders {
             pushNotificationRegistrar: pushNotificationRegistrar,
             notificationCenter: UNUserNotificationCenter.current(),
             backgroundUploadManager: BackgroundUploadManager.shared,
-            oauthSessionProvider: IOSOAuthSessionProvider()
+            oauthSessionProvider: IOSOAuthSessionProvider(),
+            deviceConnections: deviceConnections
+        )
+    }
+
+    /// Health is the only device kind the app links. A single `HKHealthStore`
+    /// backs the four background-delivery runtime implementations so anchors,
+    /// observer queries, and delivery toggles all see the same store.
+    private static var healthDeviceConnections: DeviceConnectionsBundle {
+        let store = HKHealthStore()
+        return DeviceConnectionsBundle(
+            dataSources: [HealthDataSource()],
+            dataSinks: [HealthDataSink()],
+            health: HealthRuntimeImpls(
+                backgroundDeliveryGateway: HKHealthStoreBackgroundDeliveryGateway(store: store),
+                backfillReader: HKHealthStoreBackfillReader(store: store),
+                deltaReader: HKHealthStoreDeltaReader(store: store),
+                observerRegistrar: HKHealthStoreObserverRegistrar(store: store)
+            )
         )
     }
 


### PR DESCRIPTION
Re-enables the HealthKit device connection so it can be exercised end-to-end via Firebase PR builds (`adhoc-build` label). Health was deliberately parked for v1 in #865 / #1014 after the App Store HealthKit-reference rejection; the background-subscription engine (manager, observer routine, GRDB store, invocation router) has been on `dev` and unit-tested the whole time — this PR just reconnects the four gates that were closed.

## What changed

- **UI allowlist** — `SupportedConnections.supportedDeviceKinds` is `[.health]` again, so Health surfaces in the connections picker, App Settings, agent builder, and the capability manifest agents receive.
- **Product linkage + runtime injection** — `ConvosCoreiOS` now links the opt-in `ConvosConnectionsHealth` product and `PlatformProviders.iOS` constructs the `DeviceConnectionsBundle`: `HealthDataSource` + `HealthDataSink` plus the four `HKHealthStore`-backed impls (`HealthRuntimeImpls`) that `ConnectionInvocationRuntime` needs to build `HealthInvocationRouter` and boot the background observer routine. One shared `HKHealthStore` backs all four.
- **App Clip stays health-free at runtime** — new `PlatformProviders.iOSAppClip` passes `.none` (App Clips cannot use HealthKit). Note the clip binary still links the symbols transitively via ConvosCoreiOS; if this ever ships to App Review we should split the product or move the wiring into the app target.
- **Entitlements** — restores `com.apple.developer.healthkit` (removed in #865) and adds `com.apple.developer.healthkit.background-delivery` (never present; required for `enableBackgroundDelivery` observer wakeups).
- **Purpose strings** — restores `NSHealthShareUsageDescription` / `NSHealthUpdateUsageDescription` to `Info.{Dev,Local,Prod}.plist` (same agent wording #1014 removed). The PR configuration uses `Info.Dev.plist`, so Firebase PR builds are covered.

## Before the Firebase build can sign ⚠️

The match provisioning profiles don't include the HealthKit entitlements yet. Someone with portal access needs to:

1. Enable the **HealthKit** capability on the `org.convos.ios-preview.pr` App ID (and `org.convos.ios-preview` if we want Dev TestFlight builds too).
2. Regenerate/refresh the match profiles in `convos-certificates`.

Until then the `firebase_pr` lane will fail at codesign with a "profile doesn't include entitlement" error.

## Testing done

- `Convos (Dev)` scheme builds clean for iOS Simulator (warnings-as-errors, 100 ms type-check budget).
- `swift test --package-path ConvosConnections` — 110 tests pass (all Health suites).
- `swift test --package-path ConvosCore` — full suite against the local Docker XMTP stack.

## How to test the build

- Foreground: add the Health connection in a conversation → authorize → have an agent call `fetch_summary_last_24h` / `log_water`.
- Background subscriptions: agent sends `subscribe_background_delivery` for a type → expect a backfill payload, then deltas when iOS wakes the app. Background delivery never fires on the Simulator — use a physical device.
- The DEBUG-only connection injector sheet can push synthetic Health payloads into a conversation without HealthKit at all.

## Known follow-ups (not blockers for testing)

- `HealthDataSource` still contains the legacy pre-plan observer path (`start(emit:)`), but nothing in the app calls `ConnectionsManager.start()`, so it never arms — no double-registration. Should be reconciled with the routine before shipping.
- The observer routine boots lazily on the first inbound invocation, not at app launch (the plan doc calls for launch-time registration).
- `HealthDataSource`/`HealthDataSink` have no `HKHealthStore` seam and no unit tests; ConvosConnections tests aren't in CI.
- App Review posture (visible in-app Health functionality) needs an answer before this rides to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786645122&installation_id=128169237&pr_number=1174&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1174&signature=9c90a5e5ff6bcb37676b672c0b2a416aceb978406538dd7bfc6c7d716cc9e2fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-enable HealthKit connection for iOS platform providers in Firebase PR-build testing
> - Adds HealthKit entitlements and usage description strings to all environment plist/entitlement configs ([Convos.entitlements](https://github.com/xmtplabs/convos-ios/pull/1174/files#diff-c9469000f5c59bd8c7c2be4f0a2c690c2bea807a2a47b4ff6d48d7505dbbd74e), [Info.Dev.plist](https://github.com/xmtplabs/convos-ios/pull/1174/files#diff-141e7d6debfeae43e3632fefc27682e3c4b502e8ccf1fbb70ea8e88975923390), etc.).
> - `PlatformProviders.iOS` now wires a `healthDeviceConnections` bundle, creating an `HKHealthStore` and connecting Health data sources, sinks, background delivery, and observer registration.
> - Introduces `PlatformProviders.iOSAppClip` as a separate factory with no device connections, fixing the App Clip bootstrap in [ConvosAppClipApp.swift](https://github.com/xmtplabs/convos-ios/pull/1174/files#diff-501efbb542a0ae4b68079c5b09e78f3356b63f36223499f8ff569ad9b8f0169e) to use `.iOSAppClip` instead of `.iOS`.
> - `SupportedConnections` now includes `.health` in its supported device kinds set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fa7889.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->