### PR TITLE
ci: TestFlight RC caller for release trains + train in devshell

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+# Custom runner labels (WarpBuild) so actionlint accepts them in runs-on.
+self-hosted-runner:
+  labels:
+    - warp-ubuntu-latest-x64-8x
+    - warp-macos-latest-arm64-12x

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,19 @@
+# TestFlight RC uploads for release trains: every push to a release or
+# hotfix branch. The scheduled dev stream stays in testflight-prod.yml.
+name: TestFlight RC
+
+on:
+  push:
+    branches: ["release/**", "hotfix/**"]
+
+jobs:
+  testflight_rc:
+    permissions:
+      id-token: write
+      contents: read
+    uses: xmtplabs/convos-releases/.github/workflows/ios-testflight-prod.yml@main
+    with:
+      runner: warp-macos-latest-arm64-12x
+      xcode-app-path: /Applications/Xcode_26.3.app
+      xcode-nix-path: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app
+    secrets: inherit

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783964180,
-        "narHash": "sha256-YSZOkFVYQzq5prx0hWFpB5Ch0MsF3OeQH6QFNF0ptqE=",
+        "lastModified": 1784059942,
+        "narHash": "sha256-CU6e5aoefzgDPd4mqslBz9lDiRYrQQqV2t9bRLvLADY=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "de23b401de869840f818de6ee2e73248e4510c9c",
+        "rev": "3eeda88e0faac8a6393f1ec30dd002fd1971b0a0",
         "type": "github"
       },
       "original": {

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -21,6 +21,8 @@ _: {
           # fastlane + lanes from convos-releases; the wrapper exports
           # CONVOS_LANES for the stub Fastfile.
           inputs'.convos-releases.packages.fastlane
+          # train CLI from convos-releases (release-train orchestration).
+          inputs'.convos-releases.packages.train
           # dSYM upload to Sentry in the prod TestFlight workflow
           pkgs.sentry-cli
         ];


### PR DESCRIPTION
## Summary

- Add `release-rc.yml`: a push-triggered caller (`release/**` and `hotfix/**` branches) into `xmtplabs/convos-releases/.github/workflows/ios-testflight-prod.yml@main`, giving release trains their own TestFlight RC uploads. Runner/xcode `with:` values copied verbatim from the existing scheduled `testflight-prod.yml` caller. The scheduled dev-stream build is unaffected and stays in `testflight-prod.yml`.
- Add `.github/actionlint.yaml` (warp runner labels), matching convos-client's copy, so actionlint accepts the custom self-hosted labels.
- Bump the `convos-releases` flake input to `3eeda88e` (merged release-train PR — adds `packages.train`) and add `inputs'.convos-releases.packages.train` to the devshell alongside `fastlane`.

This pairs with a matching PR in `convos-client`. The `testflight_rc` caller job name is what a later required-check update (Task 11) references.

References xmtplabs/convos-releases#6.

## Test plan

- [x] `nix flake update convos-releases`; `jj diff -- flake.lock` shows only the convos-releases node (rev → 3eeda88e0faac8a6393f1ec30dd002fd1971b0a0) changed, nixpkgs untouched
- [x] `nix eval .#devShells.x86_64-linux.default` evaluates; its `nativeBuildInputs` include `fastlane`, `train`, `sentry-cli` (full `nix develop` not verifiable on this Linux box — the flake is darwin-oriented; darwin build was not exercised)
- [x] `actionlint` on `release-rc.yml` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786652427&installation_id=128169237&pr_number=1175&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1175&signature=60b13017b0302b3b5de03e10630956eb578aa39af43fc668c259a637bc0a09cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TestFlight RC workflow for release branches and `train` CLI to devshell
> - Adds [release-rc.yml](.github/workflows/release-rc.yml) workflow that triggers on pushes to `release/**` and `hotfix/**` branches, calling the reusable `ios-testflight-prod` workflow from `xmtplabs/convos-releases` with a custom macOS ARM runner and specified Xcode paths.
> - Adds the `train` CLI from `convos-releases` to the Nix dev shell in [devshell.nix](https://github.com/xmtplabs/convos-ios/pull/1175/files#diff-1e5783619ee2f48a2cce46f329c85250bf7be1a1c21e9bc96b75c9463bc5c2e9).
> - Updates [actionlint.yaml](https://github.com/xmtplabs/convos-ios/pull/1175/files#diff-2f3192c2d25d2b15166a77ea94cd49e18cd97a7862b6e3d67ff5062c097bacb4) to accept the custom self-hosted runner labels used by the new workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b74c328.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->