### PR TITLE
Add debug toggle to enable XMTP bidi streaming on next launch

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.11.0-nightly.20260714.41b9afb",
-        "revision" : "96506c8c08b85aec3f66d6ab4fd177c79f680fb9"
+        "branch" : "ios-4.11.0-nightly.20260715.b951280",
+        "revision" : "60c83c48c82b21d4ffc8a79eb0d314c4a78ca2ac"
       }
     },
     {

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -42,15 +42,15 @@ final class FeatureFlags {
 
     /// Off by default -- opts libxmtp streams onto the shared bidi wire by
     /// exporting `XMTP_BIDI_STREAMS_ENABLED` at launch (see `ConvosApp.init`;
-    /// flips take effect on the next launch). Hard-locked off in production
-    /// until the production backend serves the bidi surface.
+    /// flips take effect on the next launch). Deliberately not prod-locked
+    /// like the flags above: the production backend serves the bidi surface
+    /// as of 2026-07-15, and this toggle exists to dogfood it there.
+    /// Default-off keeps everyone else on the legacy stream path.
     var isXMTPBidiStreamsEnabled: Bool {
         get {
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.xmtpBidiStreamsEnabledKey)
         }
         set {
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
             UserDefaults.standard.set(newValue, forKey: Constant.xmtpBidiStreamsEnabledKey)
         }
     }

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -40,6 +40,21 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- opts libxmtp streams onto the shared bidi wire by
+    /// exporting `XMTP_BIDI_STREAMS_ENABLED` at launch (see `ConvosApp.init`;
+    /// flips take effect on the next launch). Hard-locked off in production
+    /// until the production backend serves the bidi surface.
+    var isXMTPBidiStreamsEnabled: Bool {
+        get {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+            return UserDefaults.standard.bool(forKey: Constant.xmtpBidiStreamsEnabledKey)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            UserDefaults.standard.set(newValue, forKey: Constant.xmtpBidiStreamsEnabledKey)
+        }
+    }
+
     /// Mock credits/subscription state used by the in-app paywall preview surface
     /// in the Debug menu. Non-production only; defaults to `.plusAmple`.
     var mockCreditsPreset: CreditsStatePreset {
@@ -80,5 +95,6 @@ final class FeatureFlags {
         static let mockCreditsPresetKey: String = "featureFlags.mockCreditsPreset"
         static let selectedAgentVariantKey: String = "featureFlags.selectedAgentVariant"
         static let agentVariantSelectorEnabledKey: String = "featureFlags.agentVariantSelectorEnabled"
+        static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
     }
 }

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -32,6 +32,21 @@ struct ConvosApp: App {
         let environment = ConfigManager.shared.currentEnvironment
         ConvosLog.configure(environment: environment)
 
+        // Export the persisted bidi-streams opt-in while the process is still
+        // effectively single-threaded (setenv racing a native getenv from a
+        // spawned thread is undefined behavior) and before anything touches
+        // libxmtp, which latches the gate env var once, before the first
+        // stream -- so a Debug-menu flip takes effect here, on the next
+        // launch. Runtime setenv works for the Rust layer because it reads
+        // getenv, unlike the AppCheck case documented in FirebaseHelper.
+        // Main-app process only, deliberately: the NotificationService
+        // extension and App Clip run their own processes (with their own
+        // defaults containers) and stay on the legacy stream path.
+        if FeatureFlags.shared.isXMTPBidiStreamsEnabled {
+            setenv("XMTP_BIDI_STREAMS_ENABLED", "1", 1)
+            Log.info("XMTP bidi streams enabled for this launch")
+        }
+
         // Start Sentry as early as possible so crashes during the rest of app
         // init (database setup, Firebase, client creation) are captured. The
         // SwiftUI App initializer runs before the app delegate's

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -73,6 +73,7 @@ struct DebugViewSection: View {
         Section("Features") {
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
             Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
+            Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
 
             let showInfoAction = { showingAgentsInfoSheet = true }
             Button(action: showInfoAction) {

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -20,7 +20,10 @@ import UserNotifications
 //
 // Hard rules enforced here:
 // - No mutating controls (no "Request Now", no "Register Device Again", no
-//   purchase / change-plan CTAs, no mock-credit toggles).
+//   purchase / change-plan CTAs, no mock-credit toggles). One deliberate
+//   exception: the XMTP bidi streaming opt-in flips only a local default
+//   that selects the stream transport at next launch -- nothing account- or
+//   network-mutating -- and exists to dogfood bidi in production.
 // - The live `BackendAuthProbe` (JWT minter) is never imported or instantiated
 //   here. The identity readout uses `DeviceIdentitySnapshot`, which is
 //   network-free and carries no JWT.
@@ -161,13 +164,16 @@ struct ProdDebugMenuView: View {
         }
     }
 
-    // MARK: - Feature flags (display only)
+    // MARK: - Feature flags (display only, except the bidi opt-in)
 
     @ViewBuilder
     private var featureFlagsSection: some View {
         let injectorEnabled: Bool = FeatureFlags.shared.isDebugInjectorEnabled
         Section("Feature flags") {
             labeledRow("Debug injector", injectorEnabled ? "On" : "Off")
+            // The one interactive control in this curated menu; see the
+            // module overview for why it is allowed here.
+            Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
         }
     }
 

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.11.0-nightly.20260714.41b9afb",
-        "revision" : "96506c8c08b85aec3f66d6ab4fd177c79f680fb9"
+        "branch" : "ios-4.11.0-nightly.20260715.b951280",
+        "revision" : "60c83c48c82b21d4ffc8a79eb0d314c4a78ca2ac"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift.git", exact: "7.5.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.11.0-nightly.20260714.41b9afb"
+            revision: "ios-4.11.0-nightly.20260715.b951280"
         ),
         .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", from: "0.2.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.8.0"),

--- a/ConvosInvites/Package.resolved
+++ b/ConvosInvites/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/libxmtp.git",
       "state" : {
-        "branch" : "ios-4.11.0-nightly.20260714.41b9afb",
-        "revision" : "96506c8c08b85aec3f66d6ab4fd177c79f680fb9"
+        "branch" : "ios-4.11.0-nightly.20260715.b951280",
+        "revision" : "60c83c48c82b21d4ffc8a79eb0d314c4a78ca2ac"
       }
     },
     {

--- a/ConvosInvites/Package.swift
+++ b/ConvosInvites/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.6.0"),
         .package(
             url: "https://github.com/xmtp/libxmtp.git",
-            revision: "ios-4.11.0-nightly.20260714.41b9afb"
+            revision: "ios-4.11.0-nightly.20260715.b951280"
         ),
         .package(path: "../ConvosAppData"),
     ],


### PR DESCRIPTION
## Summary

Adds a Debug-menu toggle that opts the app onto XMTP's bidi streaming wire on the next launch, bumps libxmtp to a nightly carrying the bidi delivery fixes, and makes the toggle available in production now that the production backend serves the bidi surface.

**Commit 1 — debug toggle**
- New `FeatureFlags.isXMTPBidiStreamsEnabled` (UserDefaults-backed) and a "XMTP bidi streaming (applies next launch)" toggle under App Settings → Debug → Features.
- `ConvosApp.init` exports `XMTP_BIDI_STREAMS_ENABLED=1` when the flag is set. The export sits immediately after `ConfigManager`/logging setup and **before** Sentry starts: `setenv` racing a native `getenv` from a spawned thread is undefined behavior, so it runs while the process is still effectively single-threaded, and provably before the first libxmtp call (the detached log-writer task).
- libxmtp latches the gate env var once, before the first stream, which is what gives the toggle its "applies on next launch" semantics. Against a backend that does not serve the bidi surface, libxmtp's fallback latch transparently keeps the legacy per-stream path.

**Commit 2 — libxmtp bump**
- `ios-4.11.0-nightly.20260714.41b9afb` → `ios-4.11.0-nightly.20260715.b951280`. The 0714 nightly carries the two bidi ledger loss bugs fixed in libxmtp #3852/#3853; 0715 is the first nightly with the fixes (plus `catch_up_to_live`, #3854). This is the prerequisite for any production exposure, which commit 3 depends on.

**Commit 3 — allow the toggle in production**
- The production backend now serves the XIP-83 bidi Subscribe surface (node-go deployed and wire-verified 2026-07-15), so the production hard-lock on the flag is removed and the toggle is surfaced in the curated `ProdDebugMenuView` (the only debug surface reachable in production, behind the version-tap opt-in).
- This is the curated menu's one interactive control; the module-overview charter documents the carve-out (the toggle flips only a local default selecting the stream transport — nothing account- or network-mutating).
- The toggle stays off by default; only users who explicitly flip it opt onto the bidi wire, and libxmtp's latch still falls back to the legacy path if the backend ever refuses.

## Scope notes

- Main-app process only, deliberately: the NotificationService extension and App Clip run their own processes (with their own defaults containers) and stay on the legacy stream path. Documented at the export site. Mixed wire generations are safe by design — durable cursor authority lives in the DB.

## Testing

- Full `Convos (Prod)` scheme build succeeds (arm64 simulator) on the bumped pin with the unlock in place.
- Gate semantics verified against libxmtp source: the env var is read once at the first stream call (`router_callbacks.rs`), so an init-time export always wins and mid-process flips are inert until relaunch.
- Reviewed for export-ordering (thread-safety), process coverage, and comment conventions per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkZpajnDV829SVuW9danrW
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786653514&installation_id=128169237&pr_number=1176&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1176&signature=c07b24f17c4508f023d71759885451975da792be2509fd484eecaf4a7f044d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add debug toggle to enable XMTP bidi streaming on next launch
> - Adds `isXMTPBidiStreamsEnabled` to `FeatureFlags`, persisted via UserDefaults under `featureFlags.xmtpBidiStreamsEnabled`.
> - Exposes a toggle in both the debug view and production debug menu labeled "XMTP bidi streaming (applies next launch)".
> - On app launch, if the flag is enabled, sets the `XMTP_BIDI_STREAMS_ENABLED` environment variable to `1` before any libxmtp initialization.
> - Also bumps the XMTP dependency to nightly `ios-4.11.0-nightly.20260715.b951280`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7e213b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
