### PR TITLE
add ShareExtension to Matchfile

### DIFF
--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -12,7 +12,9 @@ app_identifier([
   "org.convos.ios-preview.ConvosNSE",
   "org.convos.ios-preview.pr.ConvosNSE",
   "org.convos.ios-testnet.ConvosNSE",
-  "org.convos.ios-preview.Clip"
+  "org.convos.ios-preview.Clip",
+  "org.convos.ios.ShareExtension",
+  "org.convos.ios-preview.pr.ShareExtension"
 ])
 
 team_id("FY4NZR34Z3")


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722203&installation_id=128169237&pr_number=1181&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1181&signature=41d336a4fe158b3c39cff8e6b800be281293ce3e998ded944285b53389a44dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ShareExtension bundle identifiers to Matchfile
> Adds `org.convos.ios.ShareExtension` and `org.convos.ios-preview.pr.ShareExtension` to the `app_identifier` array in [Matchfile](https://github.com/xmtplabs/convos-ios/pull/1181/files#diff-6e8493c966d23e6af48d3b1f2412c68de0511a785ecbe628ff12f41a5f1c40f0) so that `fastlane match` includes provisioning and certificate management for the Share Extension targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97a2d10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->