### PR TITLE
fix(avatars): show cached group photos instantly on cold launch

### DIFF
--- a/Convos/Shared Views/AvatarView.swift
+++ b/Convos/Shared Views/AvatarView.swift
@@ -100,6 +100,15 @@ struct ConversationAvatarView: View {
     @State private var cachedImage: UIImage?
     @Environment(\.memberNameOverride) private var memberNameOverride: @Sendable (String) -> String?
 
+    init(conversation: Conversation, conversationImage: UIImage?, size: CGFloat? = nil) {
+        self.conversation = conversation
+        self.conversationImage = conversationImage
+        self.size = size
+        // Seed synchronously (like AvatarView) so the first frame after a cold
+        // launch shows the cached photo instead of flashing the fallback.
+        _cachedImage = State(initialValue: ImageCache.shared.image(for: conversation))
+    }
+
     private var hasForcedAgentStyle: Bool {
         forcedVerification?.isVerified == true
     }
@@ -246,6 +255,15 @@ struct MessageAvatarView: View {
     var agentVerification: AgentVerification = .unverified
 
     @State private var cachedImage: UIImage?
+
+    init(profile: Profile, size: CGFloat, agentVerification: AgentVerification = .unverified) {
+        self.profile = profile
+        self.size = size
+        self.agentVerification = agentVerification
+        // Seed synchronously (like AvatarView) so the first frame after a cold
+        // launch shows the cached photo instead of flashing the fallback.
+        _cachedImage = State(initialValue: ImageCache.shared.image(for: profile))
+    }
 
     var body: some View {
         Group {

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -922,6 +922,10 @@ extension ImageCache {
 
     private func clearLastShown(for identifier: String) {
         lastShownLock.withLock { $0.removeValue(forKey: identifier) }
+        // Mark the identifier as missing before the async file deletion runs,
+        // so a concurrent lastShownFromDiskSync cannot decode the not-yet-
+        // deleted file and resurrect the cleared hint in memory.
+        lastShownMissesLock.withLock { _ = $0.insert(identifier) }
         Task {
             await performDiskOperation { cache in
                 let fileURL = cache.lastShownCacheURL.appendingPathComponent(

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -141,6 +141,11 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
     // the lock and the surrounding @unchecked Sendable contract.
     private let lastShownLock: OSAllocatedUnfairLock<[String: UIImage]> = OSAllocatedUnfairLock(uncheckedState: [:])
 
+    // Identities whose continuity hint is known to be absent on disk, so the
+    // synchronous cold-start read probes the filesystem at most once per
+    // identity per process.
+    private let lastShownMissesLock: OSAllocatedUnfairLock<Set<String>> = OSAllocatedUnfairLock(initialState: [])
+
     // Pending pre-upload images: identity -> staged image, for objects whose
     // imageCacheURL is still nil (e.g. an invite or avatar mid-upload). Kept
     // separate from the continuity hint so a nil URL only ever shows an
@@ -216,8 +221,14 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             rememberLastShown(memoryImage, for: object.imageCacheIdentifier, persist: false)
             return memoryImage
         }
-        // Non-nil URL not cached yet: bridge with the continuity hint.
-        return lastShownInMemory(for: object.imageCacheIdentifier)
+        // Non-nil URL not cached yet: bridge with the continuity hint. On a cold
+        // launch the in-memory hint is empty, so fall through to a synchronous
+        // read of the small disk hint - this is what lets the first render after
+        // a fresh process start show the photo instead of a placeholder.
+        if let memoryHint = lastShownInMemory(for: object.imageCacheIdentifier) {
+            return memoryHint
+        }
+        return lastShownFromDiskSync(for: object.imageCacheIdentifier)
     }
 
     /// Continuity placeholder for an identity (memory hint, then disk hint).
@@ -483,74 +494,6 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             Log.error("Failed to inline decrypt image for \(urlKey): \(error)")
             return nil
         }
-    }
-
-    // MARK: - Continuity hint (identity-keyed, read-only display fallback)
-
-    private func lastShownInMemory(for identifier: String) -> UIImage? {
-        lastShownLock.withLock { $0[identifier] }
-    }
-
-    private func stagedInMemory(for identifier: String) -> UIImage? {
-        stagedLock.withLock { $0[identifier] }
-    }
-
-    private func rememberStaged(_ image: UIImage, for identifier: String) {
-        stagedLock.withLock { $0[identifier] = image }
-    }
-
-    private func clearStaged(for identifier: String) {
-        stagedLock.withLock { $0.removeValue(forKey: identifier) }
-    }
-
-    /// Records the last-shown image for an identity. Memory always; disk only on
-    /// `persist` (a genuinely new image arriving), to avoid disk churn on every
-    /// render. Never fetches and never affects byte-cache truth.
-    private func rememberLastShown(_ image: UIImage, for identifier: String, persist: Bool) {
-        lastShownLock.withLock { $0[identifier] = image }
-        guard persist else { return }
-        Task { await saveLastShownToDisk(image, for: identifier) }
-    }
-
-    private func clearLastShown(for identifier: String) {
-        lastShownLock.withLock { $0.removeValue(forKey: identifier) }
-        Task {
-            await performDiskOperation { cache in
-                let fileURL = cache.lastShownCacheURL.appendingPathComponent(
-                    cache.sanitizedFilename(for: identifier, fileExtension: ".jpg")
-                )
-                guard cache.fileManager.fileExists(atPath: fileURL.path) else { return }
-                try? cache.fileManager.removeItem(at: fileURL)
-            }
-        }
-    }
-
-    private func saveLastShownToDisk(_ image: UIImage, for identifier: String) async {
-        guard let data = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.7) else { return }
-        await performDiskOperation { cache in
-            let fileURL = cache.lastShownCacheURL.appendingPathComponent(
-                cache.sanitizedFilename(for: identifier, fileExtension: ".jpg")
-            )
-            do {
-                try data.write(to: fileURL, options: .atomic)
-            } catch {
-                Log.error("Failed to save continuity hint: \(identifier) - \(error)")
-            }
-        }
-    }
-
-    private func loadLastShownFromDisk(for identifier: String) async -> UIImage? {
-        let fileURL = lastShownCacheURL.appendingPathComponent(
-            sanitizedFilename(for: identifier, fileExtension: ".jpg")
-        )
-        let exists: Bool = await performDiskOperation(default: false) { cache in
-            cache.fileManager.fileExists(atPath: fileURL.path)
-        }
-        guard exists, let image = BoundedImageDecode.image(contentsOf: fileURL) else { return nil }
-        lastShownLock.withLock { storage in
-            if storage[identifier] == nil { storage[identifier] = image }
-        }
-        return image
     }
 
     // MARK: - Identifier-based Methods (QR codes, generated images)
@@ -922,6 +865,100 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             return
         }
         cache.setObject(resizedImage, forKey: key as NSString, cost: memoryCost(for: resizedImage))
+    }
+}
+
+// MARK: - Continuity hint (identity-keyed, read-only display fallback)
+
+extension ImageCache {
+    private func lastShownInMemory(for identifier: String) -> UIImage? {
+        lastShownLock.withLock { $0[identifier] }
+    }
+
+    /// Synchronous continuity-hint read used to seed the first render after a
+    /// cold launch, when the in-memory hint is empty but the thumbnail is on
+    /// disk. Reads the file directly instead of hopping to `diskCacheQueue`
+    /// (which is busy with cleanup and prefetch writes at launch); the hint is
+    /// a small bounded-decode JPEG, so the read costs a few milliseconds once
+    /// per identity. Identities with no hint file are remembered so repeated
+    /// renders don't re-probe the filesystem.
+    private func lastShownFromDiskSync(for identifier: String) -> UIImage? {
+        let alreadyMissed = lastShownMissesLock.withLock { $0.contains(identifier) }
+        guard !alreadyMissed else { return nil }
+        let fileURL = lastShownCacheURL.appendingPathComponent(
+            sanitizedFilename(for: identifier, fileExtension: ".jpg")
+        )
+        guard let image = BoundedImageDecode.image(contentsOf: fileURL) else {
+            lastShownMissesLock.withLock { _ = $0.insert(identifier) }
+            return nil
+        }
+        lastShownLock.withLock { storage in
+            if storage[identifier] == nil { storage[identifier] = image }
+        }
+        return image
+    }
+
+    private func stagedInMemory(for identifier: String) -> UIImage? {
+        stagedLock.withLock { $0[identifier] }
+    }
+
+    private func rememberStaged(_ image: UIImage, for identifier: String) {
+        stagedLock.withLock { $0[identifier] = image }
+    }
+
+    private func clearStaged(for identifier: String) {
+        stagedLock.withLock { $0.removeValue(forKey: identifier) }
+    }
+
+    /// Records the last-shown image for an identity. Memory always; disk only on
+    /// `persist` (a genuinely new image arriving), to avoid disk churn on every
+    /// render. Never fetches and never affects byte-cache truth.
+    private func rememberLastShown(_ image: UIImage, for identifier: String, persist: Bool) {
+        lastShownLock.withLock { $0[identifier] = image }
+        lastShownMissesLock.withLock { _ = $0.remove(identifier) }
+        guard persist else { return }
+        Task { await saveLastShownToDisk(image, for: identifier) }
+    }
+
+    private func clearLastShown(for identifier: String) {
+        lastShownLock.withLock { $0.removeValue(forKey: identifier) }
+        Task {
+            await performDiskOperation { cache in
+                let fileURL = cache.lastShownCacheURL.appendingPathComponent(
+                    cache.sanitizedFilename(for: identifier, fileExtension: ".jpg")
+                )
+                guard cache.fileManager.fileExists(atPath: fileURL.path) else { return }
+                try? cache.fileManager.removeItem(at: fileURL)
+            }
+        }
+    }
+
+    private func saveLastShownToDisk(_ image: UIImage, for identifier: String) async {
+        guard let data = ImageCompression.resizeAndCompressToJPEG(image, compressionQuality: 0.7) else { return }
+        await performDiskOperation { cache in
+            let fileURL = cache.lastShownCacheURL.appendingPathComponent(
+                cache.sanitizedFilename(for: identifier, fileExtension: ".jpg")
+            )
+            do {
+                try data.write(to: fileURL, options: .atomic)
+            } catch {
+                Log.error("Failed to save continuity hint: \(identifier) - \(error)")
+            }
+        }
+    }
+
+    private func loadLastShownFromDisk(for identifier: String) async -> UIImage? {
+        let fileURL = lastShownCacheURL.appendingPathComponent(
+            sanitizedFilename(for: identifier, fileExtension: ".jpg")
+        )
+        let exists: Bool = await performDiskOperation(default: false) { cache in
+            cache.fileManager.fileExists(atPath: fileURL.path)
+        }
+        guard exists, let image = BoundedImageDecode.image(contentsOf: fileURL) else { return nil }
+        lastShownLock.withLock { storage in
+            if storage[identifier] == nil { storage[identifier] = image }
+        }
+        return image
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the cold-launch avatar flash reported by Caroline: when the app is fully closed (not backgrounded) and reopened, group photos in the conversations list show as monogram initials for a couple of seconds before self-correcting.

## Root cause

The only synchronous image lookup, `ImageCache.image(for:)`, checked memory only — the URL-keyed `NSCache` plus the in-memory continuity hint. Both are empty in a fresh process, so the first render always fell through to the monogram placeholder, and recovery waited on the async resolve path, which queues behind the launch-time LRU cleanup scan and prefetch writes on the single serial `.utility` disk queue (and re-downloads over the network if the purgeable `Caches/` copies were reaped). On a warm resume the memory cache survives, which is why backgrounding never flashed.

Groups became visibly exposed to this by #1140, which renders member-photo clusters (and group photos) where an instant emoji avatar previously won.

## Fix

- `ImageCache.image(for:)` now falls back to a synchronous read of the identity-keyed continuity thumbnail on disk (small bounded-decode JPEG), bypassing the busy serial queue, with a per-identity negative cache so absent hints are only probed once per process.
- `ConversationAvatarView` and `MessageAvatarView` seed their `@State` cached image at init — matching what `AvatarView` already did — so the very first frame shows the photo.
- Continuity-hint helpers moved from the class body to a same-file extension to stay under the `type_body_length` lint limit (pure move, no behavior change).

## Verification

- `Convos (Dev)` simulator build succeeds with zero `type-check` warnings.
- SwiftLint `--strict` clean on both changed files.
- ConvosCore test suite: 1619 tests in 227 suites, all passed (local XMTP Docker stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786740162&installation_id=128169237&pr_number=1185&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1185&signature=1186da573367afc50e765cd8e1f970f0e10b957f4ab8b1d9336c74e7dd3838eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show cached group photos instantly on cold launch in avatar views
> - Adds explicit initializers to `ConversationAvatarView` and `MessageAvatarView` that synchronously seed `@State cachedImage` from `ImageCache.shared` before the first frame renders, eliminating fallback flashes on cold start.
> - Extends `ImageCache` with a synchronous disk-read path (`lastShownFromDiskSync`) so continuity-hint thumbnails are available immediately even when the in-memory cache is empty.
> - Adds `lastShownMissesLock`, a thread-safe set that memoizes identities with no hint on disk, preventing repeated filesystem probes for the same missing entry.
> - `rememberLastShown` removes an identity from the miss set when a new image is stored; `clearLastShown` adds it to the miss set before deleting the file to prevent a race that could reload a cleared hint.
> - Risk: The synchronous disk read in `lastShownFromDiskSync` runs on the calling thread during initial render, which may add latency if the hint file is large or the storage is slow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2aeb487.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->