### PR TITLE
fix(connections): attest capability-request sender against XMTP envelope

### DIFF
--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
@@ -27,6 +27,10 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     /// agree on the asking identity even when the message hasn't been verified yet —
     /// and so that the persisted grant row, the connection_event credit, and the
     /// resolver lookup all key off the same value the sender chose to publish.
+    ///
+    /// On iOS this is not trusted blindly: `validateCapabilityRequest` drops the
+    /// message at persist time unless `askerInboxId` matches the XMTP-attested
+    /// sender, so a hostile member cannot claim another agent's inbox.
     public let askerInboxId: String
     public let subject: CapabilitySubject
     public let capability: ConnectionCapability

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -594,6 +594,11 @@ extension XMTPiOS.DecodedMessage {
         guard let request = content as? CapabilityRequest else {
             throw DecodedMessageDBRepresentationError.mismatchedContentType
         }
+        try Self.validateCapabilityRequest(
+            request,
+            senderInboxId: senderInboxId,
+            messageId: id
+        )
         let json = try JSONEncoder().encode(request)
         let text = String(data: json, encoding: .utf8)
         return DBMessageComponents(
@@ -605,6 +610,28 @@ extension XMTPiOS.DecodedMessage {
             text: text,
             update: nil
         )
+    }
+
+    /// Validates a `CapabilityRequest` against its actual sender. Throws
+    /// `untrustedSender` when the payload's `askerInboxId` does not match the
+    /// XMTP-attested sender. The asker identity is bound on the wire so the
+    /// runtime, CLI, and iOS agree on it, but a hostile group member on a
+    /// custom client could otherwise claim a verified agent's inbox and trick
+    /// the user into approving a real grant the agent never requested. The
+    /// legitimate Herald path stamps the authenticated agent inbox as sender,
+    /// so this check passes for genuine requests. Mirrors
+    /// `validateConnectionGrantRequest`.
+    static func validateCapabilityRequest(
+        _ request: CapabilityRequest,
+        senderInboxId: String,
+        messageId: String
+    ) throws {
+        guard request.askerInboxId == senderInboxId else {
+            Log.warning(
+                "Dropping CapabilityRequest \(messageId): sender \(senderInboxId) does not match askerInboxId \(request.askerInboxId)"
+            )
+            throw DecodedMessageDBRepresentationError.untrustedSender
+        }
     }
 
     /// Result rows are persisted verbatim; legitimacy is enforced at derivation

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestCodecTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestCodecTests.swift
@@ -122,6 +122,42 @@ struct CapabilityRequestCodecTests {
         )
         #expect(try codec.shouldPush(content: request) == false)
     }
+
+    @Test("validateCapabilityRequest rejects spoofed askerInboxId")
+    func validateRejectsSpoofedSender() throws {
+        let spoofed = CapabilityRequest(
+            requestId: "req-1",
+            askerInboxId: "trusted_agent_inbox",
+            subject: .calendar,
+            capability: .writeCreate,
+            rationale: "hostile rationale"
+        )
+
+        #expect(throws: XMTPiOS.DecodedMessage.DecodedMessageDBRepresentationError.self) {
+            try XMTPiOS.DecodedMessage.validateCapabilityRequest(
+                spoofed,
+                senderInboxId: "hostile_member_inbox",
+                messageId: "msg-1"
+            )
+        }
+    }
+
+    @Test("validateCapabilityRequest passes when sender matches askerInboxId")
+    func validateAcceptsMatchingSender() throws {
+        let legitimate = CapabilityRequest(
+            requestId: "req-2",
+            askerInboxId: "agent_inbox",
+            subject: .calendar,
+            capability: .writeCreate,
+            rationale: "I can add events to your calendar."
+        )
+
+        try XMTPiOS.DecodedMessage.validateCapabilityRequest(
+            legitimate,
+            senderInboxId: "agent_inbox",
+            messageId: "msg-2"
+        )
+    }
 }
 
 @Suite("CapabilityRequestResult codec")


### PR DESCRIPTION
## Summary

Fixes the HIGH finding from neekolas's [Connections research gist](https://gist.github.com/neekolas/a3fc82a1a1779717a9415457b49c7cfd), verified against the current `dev` tip.

`CapabilityRequest.askerInboxId` is a **sender-chosen wire field**. Today it is persisted, displayed, and used to issue a real backend grant without ever being compared to the XMTP-attested `senderInboxId`:

- **Persist** — `handleCapabilityRequestContent` serialized the request verbatim, no sender check (~40 lines below the legacy handler that *does* validate).
- **Display** — the approval sheet resolves the *claimed* inbox to a member profile, so it shows the impersonated agent's real display name.
- **Approve** — `askerInboxId` flows straight into the backend grant's `granteeInboxId`.

A hostile group member on a custom XMTP client can submit a capability request claiming a verified agent's inbox. If the user approves the card, iOS creates a genuine backend grant for that agent even though the agent never asked (confused-deputy consent). Backend execution stays confined to the real agent/conversation/owner/bundle, so no credentials leak directly — the defect is **consent provenance**.

## Fix

Adds `validateCapabilityRequest`, mirroring the existing `validateConnectionGrantRequest`, and calls it from `handleCapabilityRequestContent`. A request whose `askerInboxId` != the envelope sender throws `untrustedSender` and is dropped at persist time, so it never reaches the picker.

The legitimate Herald path stamps the authenticated agent inbox as the message sender, so genuine requests pass unchanged. This is exactly the invariant the gist recommends.

## Tests

Adds two adversarial tests to `CapabilityRequestCodecTests`, matching the legacy `ConnectionGrantRequestCodecTests` shape:
- rejects a spoofed `askerInboxId`
- passes when sender matches `askerInboxId`

## Verification note

SwiftFormat (0/3) and SwiftLint `--strict` pass clean on the changed files, and the pre-push lint hook passed. A **full local `swift test` build could not be run** because this machine's disk was down to ~640 MB free (a convos build cycle needs gigabytes). CI should be treated as the build/test gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786819683&installation_id=128169237&pr_number=1189&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1189&signature=a2070d0e36a75c42267ade711cde4988656eab1b100ac5082f73070e4555ce46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate capability-request sender against XMTP-attested inbox ID before persisting
> - Adds `validateCapabilityRequest` in [`DecodedMessage+DBRepresentation.swift`](https://github.com/xmtplabs/convos-ios/pull/1189/files#diff-506364f62b39595ed5e23f0dcfed112f9c4cf3e1f1fd7b263dbe1e386dbf2934) that compares `request.askerInboxId` against the XMTP-attested `senderInboxId`.
> - `handleCapabilityRequestContent` now calls this validator before encoding, throwing `untrustedSender` and discarding the message if the IDs don't match.
> - Behavioral Change: `CapabilityRequest` messages where `askerInboxId` differs from the XMTP envelope sender are no longer persisted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e1efe3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->