### PR TITLE
chore: bump convos-releases to 41eaa61a (store-rendered release notes)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784210920,
-        "narHash": "sha256-mDrIKcO7K/mpbEQgEy4KXt027ht8yp468Arxw6Br3F0=",
+        "lastModified": 1784228574,
+        "narHash": "sha256-tAuVvVda+dX0uVipxNZAo9fjZigsVMWarrrCYerxen0=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "71ad39ed81476c2d057064da1d64b90d6070750b",
+        "rev": "41eaa61a3ace25541f10a6b1814048b898ea17d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pin pickup for the release-notes renderer (convos-releases #19): promotion stages store-ready plain text (markdown → Header:/•/link-text, HTML stripped, entities decoded), Play's 500-char limit fails before the tag push, reviewer notes keep URLs.

Merging before today's cut puts the renderer on release/2.1.0; after works too (the pin pairs train+lanes, so either way is internally consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786820662&installation_id=128169237&pr_number=1190&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1190&signature=74f19aa382e1708243c3d017232c6fe79aba0306db48fcededdc5729dd7f5568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump convos-releases to 41eaa61a with store-rendered release notes
> Updates [flake.lock](https://github.com/xmtplabs/convos-ios/pull/1190/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to pin the `convos-releases` input to commit `41eaa61a`, which includes store-rendered release notes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78555ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->