### PR TITLE
fix: mask attachment chips inside the agent builder summary card

### DIFF
--- a/Convos/Agent Builder/AgentBuilderSummaryView.swift
+++ b/Convos/Agent Builder/AgentBuilderSummaryView.swift
@@ -84,6 +84,10 @@ struct AgentBuilderSummaryView: View {
         }
         .padding(DesignConstants.Spacing.step4x)
         .frame(maxWidth: .infinity, alignment: .topLeading)
+        // The chip row disables scroll clipping and stretches edge-to-edge via
+        // negative padding, so the card itself must mask it -- without this,
+        // chips bleed past the border.
+        .clipShape(.rect(cornerRadius: Constant.cornerRadius))
         .background(
             RoundedRectangle(cornerRadius: Constant.cornerRadius)
                 .strokeBorder(.colorBorderSubtle, lineWidth: 1.0)


### PR DESCRIPTION
## Summary

Images (and other attachment chips) in the agent builder summary cell bleed past the card's rounded border.

The chip row's `ScrollView` intentionally uses `.scrollClipDisabled()` plus negative horizontal padding so chips can run edge-to-edge under the card's inner padding — it relies on the card itself to mask overflow. Before #1079 the glass-effect card did that with `.clipShape(.rect(cornerRadius: 24))`; the restyle to a 1pt stroke border dropped the clip, so nothing masks the chips anymore.

This restores a `.clipShape(.rect(cornerRadius: Constant.cornerRadius))` on the card content, matching the border radius.

## Verification

- Verified on simulator: created an agent with a prompt + 4 photo attachments; the chip row now clips at the card's rounded border (the overflowing 4th chip is masked at the trailing edge instead of bleeding to the screen edge)
- `Convos (Dev)` scheme builds clean for arm64 simulator, no type-check warnings
- SwiftLint passes
- ConvosCore untouched (view-only change), so the core test suite was not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)