### PR TITLE
ci: skip automatic Claude review on train-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.fork == false
+    # Train-authored PRs (release/hotfix branches and bot version bumps) don't
+    # need automatic review; @claude / /claude mentions still work to
+    # explicitly summon a review on any PR, including these.
+    if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'convos-conductor[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
Guards the automatic Claude Code Review job (`claude-code-review.yml`, `pull_request` trigger) so it no longer runs on PRs opened by the `convos-conductor[bot]` release train — release/hotfix PRs and version-bump PRs don't benefit from an automated review and were needlessly consuming review tokens.

The check is author-based (`github.event.pull_request.user.login != 'convos-conductor[bot]'`) rather than branch-based, so it covers `release/*`, `hotfix/*`, and `bot/bump-*` PRs in a single condition regardless of naming. Deliberately avoided `on.pull_request.branches-ignore`, since that filters on the PR's base branch, not its head — it would not have excluded these PRs, which all target `dev`.

The separate `/claude` mention-triggered workflow (`claude.yml`, `issue_comment` / `pull_request_review` / `pull_request_review_comment` / `issues` events) is untouched, so anyone can still explicitly summon a review on any PR, including train-authored ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHWYLAPmoBmF2XS9rrd8pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786899215&installation_id=128169237&pr_number=1195&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1195&signature=08cf19a8351b5508556255513769f74e95e96cba8a84cbb372d5f6cb6ffd0dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip automatic Claude code review on PRs authored by `convos-conductor[bot]`
> Updates the `if` condition in the `claude-review` job in [claude-code-review.yml](.github/workflows/claude-code-review.yml) to exclude PRs where the author is `convos-conductor[bot]`, since train-authored PRs don't need automated review.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec9fec1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->