### PR TITLE
ci: RC uploads only for numeric train branches

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,10 +1,12 @@
 # TestFlight RC uploads for release trains: every push to a release or
-# hotfix branch. The scheduled dev stream stays in testflight-prod.yml.
+# hotfix branch. The scheduled dev stream stays in testflight-prod.yml. Only
+# the train's numeric branch shapes upload RCs — a feature branch named
+# hotfix/* must not displace the recorded RC on TestFlight.
 name: TestFlight RC
 
 on:
   push:
-    branches: ["release/**", "hotfix/**"]
+    branches: ["release/[0-9]*.[0-9]*.[0-9]*", "hotfix/[0-9]*.[0-9]*.[0-9]*"]
 
 jobs:
   testflight_rc:


### PR DESCRIPTION
## Why

In the sibling convos-client repo, a developer pushed a feature branch named `hotfix/refresh-app-icon-on-first-load-to-prof-image`, and the RC uploader fired on the `hotfix/**` glob, built it, and uploaded a build that displaced the release train's recorded RC — breaking that version's promotion (which correctly fail-closed on its exact-build match). The same trigger shape exists here for TestFlight RC uploads. Train branches are always `release/X.Y.Z` or `hotfix/X.Y.Z`, so the trigger should match only those numeric shapes.

## Change

Tightens `release-rc.yml`'s push trigger from `["release/**", "hotfix/**"]` to `["release/[0-9]*.[0-9]*.[0-9]*", "hotfix/[0-9]*.[0-9]*.[0-9]*"]`, so conventionally-named feature branches (e.g. `hotfix/some-fix-description`) can no longer trigger an RC upload to TestFlight. Also extends the header comment to state this constraint explicitly for future readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHWYLAPmoBmF2XS9rrd8pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786911128&installation_id=128169237&pr_number=1196&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1196&signature=dd2cfd33de06bd8200a44cf62f5ae8ef781d58a6659ce199017567030737c773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict RC upload workflow to numeric semantic-version branch names
> Updates push branch filters in [release-rc.yml](.github/workflows/release-rc.yml) from broad glob patterns (`release/**`, `hotfix/**`) to patterns requiring numeric semver segments (e.g. `release/[0-9]*.[0-9]*.[0-9]*`). This prevents feature branches like `hotfix/my-feature` from triggering RC uploads and displacing recorded RCs.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 82a83a1. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->