### PR TITLE
Share extension: conversation picker for targetless shares

### DIFF
--- a/Convos/Contacts/AgentTemplateConversationsSections.swift
+++ b/Convos/Contacts/AgentTemplateConversationsSections.swift
@@ -1,3 +1,4 @@
+import ConvosComposer
 import ConvosCore
 import SwiftUI
 

--- a/Convos/Contacts/ContactsView.swift
+++ b/Convos/Contacts/ContactsView.swift
@@ -1,3 +1,4 @@
+import ConvosComposer
 import ConvosCore
 import ConvosMetrics
 import SwiftUI

--- a/ConvosCore/Sources/ConvosComposer/ContactsPickerActionRow.swift
+++ b/ConvosCore/Sources/ConvosComposer/ContactsPickerActionRow.swift
@@ -1,4 +1,4 @@
-import ConvosCore
+#if canImport(UIKit)
 import SwiftUI
 
 /// One of the "top three" invite actions rendered above the contacts list in
@@ -11,8 +11,8 @@ import SwiftUI
 /// The leading icon is either an SF Symbol (`qrcode`, `square.and.arrow.up`)
 /// or a bundled asset image (the custom `addAgentIcon` agent glyph), rendered
 /// white-on-black.
-struct ContactsPickerActionRow: View {
-    enum Icon {
+public struct ContactsPickerActionRow: View {
+    public enum Icon {
         case system(String)
         case asset(String)
     }
@@ -27,7 +27,7 @@ struct ContactsPickerActionRow: View {
     let showsProgress: Bool
     let action: () -> Void
 
-    init(
+    public init(
         icon: Icon,
         title: String,
         subtitle: String? = nil,
@@ -43,7 +43,7 @@ struct ContactsPickerActionRow: View {
         self.action = action
     }
 
-    var body: some View {
+    public var body: some View {
         Button(action: action) {
             HStack(spacing: DesignConstants.Spacing.step3x) {
                 iconTile
@@ -94,7 +94,7 @@ struct ContactsPickerActionRow: View {
             // A bundled template asset renders at its (small) intrinsic size and
             // ignores `.font`, so it has to be resized explicitly to fill the
             // tile like the SF Symbols in the sibling rows do.
-            Image(name)
+            Image(name, bundle: .module)
                 .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
@@ -136,3 +136,4 @@ struct ContactsPickerActionRow: View {
     }
     .padding()
 }
+#endif

--- a/ConvosCore/Sources/ConvosComposer/ConversationsListItem.swift
+++ b/ConvosCore/Sources/ConvosComposer/ConversationsListItem.swift
@@ -1,8 +1,8 @@
-import ConvosComposer
+#if canImport(UIKit)
 import ConvosCore
 import SwiftUI
 
-extension Conversation {
+public extension Conversation {
     var title: String {
         title(memberNameOverride: { _ in nil })
     }
@@ -23,7 +23,7 @@ extension Conversation {
     }
 }
 
-struct ListItemView<LeadingContent: View, SubtitleContent: View, AccessoryContent: View>: View {
+public struct ListItemView<LeadingContent: View, SubtitleContent: View, AccessoryContent: View>: View {
     let title: String
     let isMuted: Bool
     let isUnread: Bool
@@ -31,7 +31,23 @@ struct ListItemView<LeadingContent: View, SubtitleContent: View, AccessoryConten
     @ViewBuilder let subtitle: () -> SubtitleContent
     @ViewBuilder let accessoryContent: () -> AccessoryContent
 
-    var body: some View {
+    public init(
+        title: String,
+        isMuted: Bool,
+        isUnread: Bool,
+        @ViewBuilder leadingContent: @escaping () -> LeadingContent,
+        @ViewBuilder subtitle: @escaping () -> SubtitleContent,
+        @ViewBuilder accessoryContent: @escaping () -> AccessoryContent
+    ) {
+        self.title = title
+        self.isMuted = isMuted
+        self.isUnread = isUnread
+        self.leadingContent = leadingContent
+        self.subtitle = subtitle
+        self.accessoryContent = accessoryContent
+    }
+
+    public var body: some View {
         HStack(spacing: DesignConstants.Spacing.step3x) {
             leadingContent()
                 .frame(width: 56.0, height: 56.0)
@@ -77,8 +93,12 @@ struct ListItemView<LeadingContent: View, SubtitleContent: View, AccessoryConten
     }
 }
 
-struct ConversationsListItem: View {
+public struct ConversationsListItem: View {
     let conversation: Conversation
+
+    public init(conversation: Conversation) {
+        self.conversation = conversation
+    }
 
     @Environment(\.memberNameOverride) private var memberNameOverride: @Sendable (String) -> String?
 
@@ -108,7 +128,7 @@ struct ConversationsListItem: View {
         return parts.joined(separator: ", ")
     }
 
-    var body: some View {
+    public var body: some View {
         ListItemView(
             title: title,
             isMuted: isPendingInvite ? false : isMuted,
@@ -152,3 +172,4 @@ struct ConversationsListItem: View {
 #Preview("Pending Invite") {
     ConversationsListItem(conversation: .mockPendingInvite())
 }
+#endif

--- a/ConvosCore/Sources/ConvosComposer/DesignConstants.swift
+++ b/ConvosCore/Sources/ConvosComposer/DesignConstants.swift
@@ -62,6 +62,8 @@ public enum DesignConstants {
         /// the color the agent builder floats over before Make reveals the
         /// conversation beneath it.
         public static let backgroundRaisedSecondary: Color = .colorBackgroundRaisedSecondary
+        /// The chats list background (Figma `color/background/surfaceless`).
+        public static let backgroundSurfaceless: Color = .colorBackgroundSurfaceless
     }
 
     public enum Fonts {

--- a/ConvosCore/Sources/ConvosComposer/RelativeDateLabel.swift
+++ b/ConvosCore/Sources/ConvosComposer/RelativeDateLabel.swift
@@ -1,11 +1,16 @@
+#if canImport(UIKit)
 import ConvosCore
 import SwiftUI
 
-struct RelativeDateLabel: View {
+public struct RelativeDateLabel: View {
     let date: Date
+
+    public init(date: Date) {
+        self.date = date
+    }
     @State private var dateString: String = ""
 
-    var body: some View {
+    public var body: some View {
         Text(dateString)
             .textCase(.lowercase)
             .onAppear {
@@ -39,3 +44,4 @@ struct RelativeDateLabel: View {
         }
     }
 }
+#endif

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -221,10 +221,17 @@ final class ShareComposeModel: AgentDraftComposing {
     /// A shared URL rendered as the composer's link-preview chip (mirrors the
     /// in-app pasted-link flow); sent as its own message ahead of typed text.
     var pendingLinkPreview: LinkPreview?
-    /// True when the share carried no donated conversation target: sending
-    /// stages the content for the app, which opens the agent builder with it
-    /// pre-seeded on its next foreground.
+    /// True when the share carried no donated conversation target and the
+    /// user chose "Make an agent" from the picker: the sheet hosts the
+    /// agent builder and Make finishes the agent in place.
     var isNewAgentTarget: Bool = false
+    /// True while the targetless share shows the conversation picker (all
+    /// of the user's conversations plus the Make-an-agent action row).
+    /// Cleared when the user picks a conversation or the agent builder.
+    var isPickingTarget: Bool = false
+    /// The pickable conversations, in the same order the app's chats list
+    /// shows them.
+    var pickerConversations: [Conversation] = []
     /// Set after a successful Make: the sheet morphs into the new
     /// conversation's transcript with the agent-join progress cell,
     /// mirroring the app's post-Make reveal, for a beat before it closes.
@@ -333,23 +340,12 @@ final class ShareComposeModel: AgentDraftComposing {
                     unavailableReason = "This convo is no longer available."
                 }
             } else {
-                // No donated target: the share starts a new agent. The
-                // content is staged for the app, which opens the agent
-                // builder pre-seeded on its next foreground.
+                // No donated target: show the conversation picker. The user
+                // either sends into an existing conversation or taps the
+                // Make-an-agent row, which swaps the sheet to the builder.
                 target = nil
-                isNewAgentTarget = true
-                let session = client.session
-                draftConversationTask = Task { [weak self] in
-                    let draft = try await AgentCreationFlow.prepareDraftConversation(session: session)
-                    Log.info("draft conversation ready \(draft.conversationId)")
-                    // Mount the transcript now, hidden beneath the draft
-                    // composer, so the collection view's expensive first
-                    // layout is long done when Make crossfades to it -
-                    // mounting at reveal time made the fade land on an
-                    // empty, still-laying-out list.
-                    await self?.mountDraftTranscript(id: draft.conversationId, client: client)
-                    return draft
-                }
+                isPickingTarget = true
+                pickerConversations = conversations
             }
             targetConversationId = target?.id
             targetConversation = target
@@ -384,7 +380,7 @@ final class ShareComposeModel: AgentDraftComposing {
                     Log.info("shared text loaded (no link parsed): \(sharedText.count) chars")
                 }
             }
-            isReady = targetConversationId != nil || isNewAgentTarget
+            isReady = targetConversationId != nil || isNewAgentTarget || isPickingTarget
         } catch {
             Log.error("prepare failed: \(error.localizedDescription)")
             unavailableReason = "Convos could not start. Try again."
@@ -407,6 +403,42 @@ final class ShareComposeModel: AgentDraftComposing {
             }
             ExtensionProcessRetirement.runwayEnded()
             ExtensionProcessRetirement.retireIfIdle(after: 1.0, reason: "prompt published")
+        }
+    }
+
+    /// Picker row tap: the share becomes a normal conversation-target
+    /// compose, identical to arriving via a donated share-sheet suggestion.
+    func selectShareTarget(_ conversation: Conversation) {
+        guard let client else { return }
+        isPickingTarget = false
+        targetConversationId = conversation.id
+        targetConversation = conversation
+        targetTitle = conversation.computedDisplayName(memberNameOverride: { _ in nil })
+        if let myProfile = conversation.members.first(where: { $0.isCurrentUser })?.profile {
+            profile = myProfile
+        }
+        startObservingMessages(for: conversation, client: client)
+    }
+
+    /// Make-an-agent row tap: swap the sheet to the agent builder with the
+    /// shared attachments already staged in the composer, and start
+    /// pre-creating the hidden draft conversation so Make is instant.
+    /// Creation starts here - not at sheet open - so shares that target an
+    /// existing conversation never mint an unused row.
+    func chooseMakeAgent() {
+        guard let client else { return }
+        isPickingTarget = false
+        isNewAgentTarget = true
+        targetTitle = "New Agent"
+        let session = client.session
+        draftConversationTask = Task { [weak self] in
+            let draft = try await AgentCreationFlow.prepareDraftConversation(session: session)
+            Log.info("draft conversation ready \(draft.conversationId)")
+            // Mount the transcript now, hidden beneath the draft composer,
+            // so the collection view's expensive first layout is long done
+            // when Make crossfades to it.
+            await self?.mountDraftTranscript(id: draft.conversationId, client: client)
+            return draft
         }
     }
 
@@ -903,7 +935,7 @@ struct ShareComposeView: View {
             transcript
                 .ignoresSafeArea()
                 .safeAreaBar(edge: .bottom) {
-                    if !model.isNewAgentTarget {
+                    if !model.isNewAgentTarget && !model.isPickingTarget {
                         composerBar
                     }
                 }
@@ -984,7 +1016,9 @@ struct ShareComposeView: View {
 
     @ViewBuilder
     private var transcript: some View {
-        if model.isNewAgentTarget {
+        if model.isPickingTarget {
+            conversationPicker
+        } else if model.isNewAgentTarget {
             newAgentStack
         } else if let conversation = model.targetConversation {
             conversationTranscript(for: conversation)
@@ -993,6 +1027,64 @@ struct ShareComposeView: View {
         } else {
             Spacer(minLength: 0)
         }
+    }
+
+    /// Targetless-share landing surface: the Make-an-agent action row (the
+    /// same `ContactsPickerActionRow` the contacts compose picker uses)
+    /// above every conversation, in chats-list order. Rows mirror the
+    /// contacts picker's 56pt-tile layout so the two pickers read the same.
+    private var conversationPicker: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Share to…")
+                    .font(.title2.bold())
+                    .foregroundStyle(DesignConstants.Colors.textPrimary)
+                    .padding(.top, 72)
+                    .padding(.bottom, DesignConstants.Spacing.step4x)
+                let makeAgentAction = { model.chooseMakeAgent() }
+                ContactsPickerActionRow(
+                    icon: .asset("addAgentIcon"),
+                    title: "Make an agent",
+                    accessibilityIdentifier: "share-picker-make-agent",
+                    action: makeAgentAction
+                )
+                ForEach(model.pickerConversations) { conversation in
+                    conversationPickerRow(for: conversation)
+                }
+            }
+            .padding(.horizontal, DesignConstants.Spacing.step6x)
+        }
+        .scrollDismissesKeyboard(.immediately)
+    }
+
+    private func conversationPickerRow(for conversation: Conversation) -> some View {
+        let title: String = conversation.computedDisplayName(memberNameOverride: { _ in nil })
+        let displayTitle: String = title.isEmpty ? "Convo" : title
+        let action = {
+            model.selectShareTarget(conversation)
+            focusState = .message
+        }
+        return Button(action: action) {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                ConversationAvatarView(conversation: conversation, conversationImage: nil, size: 56)
+                    .frame(width: 56, height: 56)
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                    Text(displayTitle)
+                        .font(.body)
+                        .foregroundStyle(DesignConstants.Colors.textPrimary)
+                        .lineLimit(1)
+                    Text(conversation.membersCountString)
+                        .font(.subheadline)
+                        .foregroundStyle(DesignConstants.Colors.textSecondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("share-picker-conversation-\(conversation.id)")
     }
 
     /// The new-agent surface: the transcript of the (pre-created, hidden)

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -940,6 +940,7 @@ struct ShareComposeView: View {
                     }
                 }
                 .toolbar { closeToolbarItem }
+                .navigationTitle(model.isPickingTarget ? "Share to…" : "")
                 .toolbarTitleDisplayMode(.inline)
         }
         .overlay(alignment: .top) {
@@ -1031,16 +1032,14 @@ struct ShareComposeView: View {
 
     /// Targetless-share landing surface: the Make-an-agent action row (the
     /// same `ContactsPickerActionRow` the contacts compose picker uses)
-    /// above every conversation, in chats-list order. Rows mirror the
-    /// contacts picker's 56pt-tile layout so the two pickers read the same.
+    /// above every conversation, rendered with the exact chats-tab list
+    /// styling: the same `ConversationsListItem` rows the Convos tab shows
+    /// (title, relative-date + last-message subtitle, unread/muted/countdown
+    /// accessories), no separators, rows owning their own padding, over the
+    /// surfaceless background.
     private var conversationPicker: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                Text("Share to…")
-                    .font(.title2.bold())
-                    .foregroundStyle(DesignConstants.Colors.textPrimary)
-                    .padding(.top, 72)
-                    .padding(.bottom, DesignConstants.Spacing.step4x)
+            LazyVStack(alignment: .leading, spacing: 0) {
                 let makeAgentAction = { model.chooseMakeAgent() }
                 ContactsPickerActionRow(
                     icon: .asset("addAgentIcon"),
@@ -1048,40 +1047,25 @@ struct ShareComposeView: View {
                     accessibilityIdentifier: "share-picker-make-agent",
                     action: makeAgentAction
                 )
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
                 ForEach(model.pickerConversations) { conversation in
                     conversationPickerRow(for: conversation)
                 }
             }
-            .padding(.horizontal, DesignConstants.Spacing.step6x)
+            .padding(.vertical, DesignConstants.Spacing.step3x)
         }
+        .background(DesignConstants.Colors.backgroundSurfaceless)
         .scrollDismissesKeyboard(.immediately)
     }
 
     private func conversationPickerRow(for conversation: Conversation) -> some View {
-        let title: String = conversation.computedDisplayName(memberNameOverride: { _ in nil })
-        let displayTitle: String = title.isEmpty ? "Convo" : title
         let action = {
             model.selectShareTarget(conversation)
             focusState = .message
         }
         return Button(action: action) {
-            HStack(spacing: DesignConstants.Spacing.step3x) {
-                ConversationAvatarView(conversation: conversation, conversationImage: nil, size: 56)
-                    .frame(width: 56, height: 56)
-                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                    Text(displayTitle)
-                        .font(.body)
-                        .foregroundStyle(DesignConstants.Colors.textPrimary)
-                        .lineLimit(1)
-                    Text(conversation.membersCountString)
-                        .font(.subheadline)
-                        .foregroundStyle(DesignConstants.Colors.textSecondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-            }
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .contentShape(Rectangle())
+            ConversationsListItem(conversation: conversation)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("share-picker-conversation-\(conversation.id)")

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -933,7 +933,6 @@ struct ShareComposeView: View {
     var body: some View {
         NavigationStack {
             transcript
-                .ignoresSafeArea()
                 .safeAreaBar(edge: .bottom) {
                     if !model.isNewAgentTarget && !model.isPickingTarget {
                         composerBar
@@ -1017,12 +1016,16 @@ struct ShareComposeView: View {
 
     @ViewBuilder
     private var transcript: some View {
+        // The messages surfaces run full-bleed under the top pill; the
+        // picker is a normal list and must respect the navigation bar.
         if model.isPickingTarget {
             conversationPicker
         } else if model.isNewAgentTarget {
             newAgentStack
+                .ignoresSafeArea()
         } else if let conversation = model.targetConversation {
             conversationTranscript(for: conversation)
+                .ignoresSafeArea()
         } else if let reason = model.unavailableReason {
             ContentUnavailableView(reason, systemImage: "bubble.left.and.exclamationmark.bubble.right")
         } else {


### PR DESCRIPTION
## What

Tapping the Convos icon in the share sheet (a share with no donated conversation target) previously jumped straight into the Make-an-agent flow. It now lands on a conversation picker:

- **"Make an agent" action row on top** - the same `ContactsPickerActionRow` component the contacts compose picker uses (56pt black tile + `addAgentIcon` glyph), moved into ConvosComposer so the app and the extension render one component.
- **Every conversation beneath it**, in chats-list order, with real avatars (shared `ConversationAvatarView`) and member counts, mirroring the contacts picker's row layout.

Picking a conversation turns the share into the normal compose flow (live transcript + the app's composer), identical to arriving via a share-sheet conversation suggestion. Picking Make an agent swaps the sheet to the agent builder with the shared attachments already staged in its composer.

## Notes

- The hidden draft conversation (which makes Make instant) now pre-creates when the Make-an-agent row is tapped rather than at sheet open, so shares that target an existing conversation never mint an unused row.
- `ContactsPickerActionRow` is public in ConvosComposer with its asset resolved from the package catalog; app call sites are unchanged.
- Donated-intent shares (tapping a suggested conversation) bypass the picker exactly as before.

## Validation

- Full ConvosCore suite green (1624 tests / 228 suites); device build green.
- Follows directly on the merged share-extension work in #1027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786922906&installation_id=128169237&pr_number=1197&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1197&signature=b5e8af8e82e8e3465b37ef9343f191bfb99676d265fecb995c82290f436a5a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add conversation picker to share extension for targetless shares
> - When no conversation target is donated to the share extension, a scrollable picker now appears showing a "Make an agent" row and the user's conversation list, rather than immediately opening a new agent draft.
> - Selecting a conversation from the picker converts the share sheet into a normal compose flow for that conversation; selecting "Make an agent" switches to the agent builder and pre-creates the draft transcript asynchronously.
> - Several components (`ContactsPickerActionRow`, `ConversationsListItem`, `RelativeDateLabel`) are moved into the `ConvosComposer` package and made `public` to support the picker UI in the share extension.
> - The composer bar and transcript are hidden until a target is chosen.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f906995.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->