### PR TITLE
[PROTOTYPE - DO NOT MERGE] feat(pr-build): no builder, an agent in every conversation, Things as its canvas

### DIFF
--- a/Convos/Config/config.pr.json
+++ b/Convos/Config/config.pr.json
@@ -15,5 +15,6 @@
   "siweUri": "https://dev.convos.org",
   "siweChainId": 1,
   "posthogHost": "https://us.i.posthog.com",
-  "noBuilder": true
+  "noBuilder": true,
+  "pinnedAgentVariantSlug": "pr-2855"
 }

--- a/Convos/Config/config.pr.json
+++ b/Convos/Config/config.pr.json
@@ -15,5 +15,5 @@
   "siweUri": "https://dev.convos.org",
   "siweChainId": 1,
   "posthogHost": "https://us.i.posthog.com",
-  "agentOnlyBuild": true
+  "noBuilder": true
 }

--- a/Convos/Config/config.pr.json
+++ b/Convos/Config/config.pr.json
@@ -14,5 +14,6 @@
   "siweDomain": "dev.convos.org",
   "siweUri": "https://dev.convos.org",
   "siweChainId": 1,
-  "posthogHost": "https://us.i.posthog.com"
+  "posthogHost": "https://us.i.posthog.com",
+  "agentOnlyBuild": true
 }

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -548,7 +548,10 @@ struct ContactsPickerActionsSection: View {
                     action: onSendInvite
                 )
             }
-            if let onMakeAgent = actions.onMakeAgent {
+            // Every picker call site routes its "Make an agent" row through
+            // here, so an agent-only build — which ships without the builder —
+            // drops the row for all of them in one place.
+            if let onMakeAgent = actions.onMakeAgent, !ConfigManager.shared.isAgentOnlyBuild {
                 ContactsPickerActionRow(
                     icon: .asset("addAgentIcon"),
                     title: "Make an agent",

--- a/Convos/Contacts/ContactsPickerView.swift
+++ b/Convos/Contacts/ContactsPickerView.swift
@@ -549,9 +549,9 @@ struct ContactsPickerActionsSection: View {
                 )
             }
             // Every picker call site routes its "Make an agent" row through
-            // here, so an agent-only build — which ships without the builder —
+            // here, so a no-builder build — which ships without the builder —
             // drops the row for all of them in one place.
-            if let onMakeAgent = actions.onMakeAgent, !ConfigManager.shared.isAgentOnlyBuild {
+            if let onMakeAgent = actions.onMakeAgent, !ConfigManager.shared.isNoBuilderBuild {
                 ContactsPickerActionRow(
                     icon: .asset("addAgentIcon"),
                     title: "Make an agent",

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -284,8 +284,9 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// Spawns the default agent into the conversation once it is ready.
     /// A default-agent join carries no template id, so it cannot ride
     /// `pendingAgentTemplateIds` and is tracked separately. Set by builds
-    /// that ship without the agent builder.
-    private let joinsDefaultAgent: Bool
+    /// that ship without the agent builder; defaulted so the tests-only
+    /// init doesn't have to name it.
+    @ObservationIgnored private var joinsDefaultAgent: Bool = false
     /// Set when a template QR is scanned before the messaging service
     /// (and `conversationStateManager`) has been acquired; the create is
     /// kicked off once configuration completes. Mirrors `pendingInviteCode`.

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -285,7 +285,6 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// A default-agent join carries no template id, so it cannot ride
     /// `pendingAgentTemplateIds` and is tracked separately. Set by builds
     /// that ship without the agent builder.
-    @ObservationIgnored
     private let joinsDefaultAgent: Bool
     /// Set when a template QR is scanned before the messaging service
     /// (and `conversationStateManager`) has been acquired; the create is

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -281,6 +281,12 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// path.
     @ObservationIgnored
     private var pendingAgentTemplateIds: [String] = []
+    /// Spawns the default agent into the conversation once it is ready.
+    /// A default-agent join carries no template id, so it cannot ride
+    /// `pendingAgentTemplateIds` and is tracked separately. Set by builds
+    /// that ship without the agent builder.
+    @ObservationIgnored
+    private let joinsDefaultAgent: Bool
     /// Set when a template QR is scanned before the messaging service
     /// (and `conversationStateManager`) has been acquired; the create is
     /// kicked off once configuration completes. Mirrors `pendingInviteCode`.
@@ -358,10 +364,12 @@ class NewConversationViewModel: Identifiable, Hashable {
         showsEmbeddedInvite: Bool = false,
         embeddedInviteInitialSegment: ScanInviteSegment = .invite,
         defersInviteVisibilityUntilEntered: Bool = false,
+        joinsDefaultAgent: Bool = false,
         coreActions: any CoreActions = NoOpCoreActions()
     ) {
         self.session = session
         self.coreActions = coreActions
+        self.joinsDefaultAgent = joinsDefaultAgent
         self.showsEmbeddedInvite = showsEmbeddedInvite
         self.embeddedInviteInitialSegment = embeddedInviteInitialSegment
         self.qrScannerViewModel = QRScannerViewModel()
@@ -1242,10 +1250,20 @@ extension NewConversationViewModel {
     /// re-emitted `.ready` can't request the joins twice. Uses the batched
     /// method -- the single-flight `requestAgentJoin(templateId:)` would cancel
     /// each prior call as the loop advances, leaving only the last to land.
+    ///
+    /// A default-agent join (`joinsDefaultAgent`) takes the single-flight
+    /// method with a nil template: there is exactly one join to make and no
+    /// id to batch, and the backend provisions its default agent when the
+    /// template is omitted.
     private func requestPendingAgentJoinsIfReady(conversationId: String? = nil) {
-        guard _reachedReadyState, !didTriggerAgentJoin, !pendingAgentTemplateIds.isEmpty else { return }
+        guard _reachedReadyState, !didTriggerAgentJoin else { return }
+        guard !pendingAgentTemplateIds.isEmpty || joinsDefaultAgent else { return }
         didTriggerAgentJoin = true
-        conversationViewModel?.requestAgentJoins(templateIds: pendingAgentTemplateIds)
+        if pendingAgentTemplateIds.isEmpty {
+            conversationViewModel?.requestAgentJoin(templateId: nil)
+        } else {
+            conversationViewModel?.requestAgentJoins(templateIds: pendingAgentTemplateIds)
+        }
         // A scanned agent lands in the conversation it was added to. The
         // `.ready` hook passes the id straight off the ready result: the state
         // manager's own `conversationId` is updated by a separate observer of
@@ -1379,9 +1397,10 @@ extension NewConversationViewModel {
                 claimedConversationId = result.conversationId
             }
 
-            // Agent-template spawn: the conversation now exists with a
-            // shareable invite, so request a fresh instance for each
-            // pending templateId (see `requestPendingAgentJoinsIfReady`).
+            // Agent spawn: the conversation now exists with a shareable
+            // invite, so request a fresh instance for each pending
+            // templateId, or the default agent when this VM was created
+            // with `joinsDefaultAgent` (see `requestPendingAgentJoinsIfReady`).
             requestPendingAgentJoinsIfReady(conversationId: result.conversationId)
 
         case .joinFailed(_, let error):

--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -37,9 +37,9 @@ struct AddToConversationMenu: View {
             }
             .accessibilityIdentifier("context-menu-add-from-contacts")
 
-            // The row opens the agent builder, which an agent-only build
+            // The row opens the agent builder, which a no-builder build
             // ships without.
-            if !ConfigManager.shared.isAgentOnlyBuild {
+            if !ConfigManager.shared.isNoBuilderBuild {
                 Button(action: onInviteAgent) {
                     Text("New agent")
                     Text(agentSubtitle)

--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -37,14 +37,18 @@ struct AddToConversationMenu: View {
             }
             .accessibilityIdentifier("context-menu-add-from-contacts")
 
-            Button(action: onInviteAgent) {
-                Text("New agent")
-                Text(agentSubtitle)
-                Image("addAgentIcon")
-                    .renderingMode(.template)
+            // The row opens the agent builder, which an agent-only build
+            // ships without.
+            if !ConfigManager.shared.isAgentOnlyBuild {
+                Button(action: onInviteAgent) {
+                    Text("New agent")
+                    Text(agentSubtitle)
+                    Image("addAgentIcon")
+                        .renderingMode(.template)
+                }
+                .disabled(isAgentActionDisabled)
+                .accessibilityIdentifier("context-menu-add-agent")
             }
-            .disabled(isAgentActionDisabled)
-            .accessibilityIdentifier("context-menu-add-agent")
 
             Button(action: onConvoCode) {
                 Text("Invite friends")

--- a/Convos/Conversation Detail/AgentFilesLinksView.swift
+++ b/Convos/Conversation Detail/AgentFilesLinksView.swift
@@ -39,6 +39,7 @@ class AgentFilesLinksViewModel {
     var searchText: String = ""
     var files: [AgentFile] = []
     var links: [AgentLink] = []
+    var canvasFile: AgentFile?
     var isLoading: Bool = true
     var fileOpenError: String?
 
@@ -52,6 +53,7 @@ class AgentFilesLinksViewModel {
         cancellables.removeAll()
         files = []
         links = []
+        canvasFile = nil
         filter = .all
         searchText = ""
         fileOpenError = nil
@@ -65,6 +67,7 @@ class AgentFilesLinksViewModel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newFiles in
                 self?.files = newFiles
+                self?.canvasFile = AgentFilesLinksRepository.canvasFile(in: newFiles)
                 self?.isLoading = false
             }
             .store(in: &cancellables)
@@ -139,6 +142,12 @@ struct AttachmentPreviewPresentation: Identifiable {
     let sentAt: Date
 }
 
+private struct CanvasPresentation: Identifiable {
+    let id: String
+    let fileURL: URL
+    let prewarmerKey: String
+}
+
 struct AgentFilesLinksView: View {
     let conversationId: String
     let repository: AgentFilesLinksRepository
@@ -151,6 +160,12 @@ struct AgentFilesLinksView: View {
     @State private var presentingPreview: AttachmentPreviewPresentation?
     @State private var navState: AgentFilesLinksNavigatorImpl = .init()
     @State private var navigator: AgentFilesLinksCollector?
+    @State private var canvasPresentation: CanvasPresentation?
+    @State private var canvasLoadTask: Task<Void, Never>?
+    @State private var loadingCanvasPrewarmerKey: String?
+    @State private var canvasLoadGeneration: UUID = .init()
+    @State private var canvasBodyBackgroundColor: Color?
+    @State private var presentingFilesAndLinks: Bool = false
 
     private func ensureNavigator() {
         guard navigator == nil else { return }
@@ -174,17 +189,115 @@ struct AgentFilesLinksView: View {
         members.first { $0.profile.inboxId == inboxId }
     }
 
+    private func updateCanvas(to file: AgentFile?) {
+        guard usesInlineHeader else { return }
+
+        canvasLoadTask?.cancel()
+        canvasLoadTask = nil
+        if let loadingCanvasPrewarmerKey {
+            HTMLContentPrewarmer.shared.evict(attachmentKey: loadingCanvasPrewarmerKey)
+            self.loadingCanvasPrewarmerKey = nil
+        }
+
+        let generation = UUID()
+        canvasLoadGeneration = generation
+
+        guard let file else {
+            if let canvasPresentation {
+                HTMLContentPrewarmer.shared.evict(attachmentKey: canvasPresentation.prewarmerKey)
+            }
+            canvasPresentation = nil
+            canvasBodyBackgroundColor = nil
+            return
+        }
+        guard canvasPresentation?.id != file.id else { return }
+
+        let attachment = HydratedAttachment(
+            key: file.attachmentKey,
+            mimeType: file.mimeType,
+            thumbnailDataBase64: file.thumbnailDataBase64,
+            filename: QuietArtifactUpdate.canonicalFilename(file.filename)
+        )
+        let prewarmerKey = "canvas:\(file.id)"
+        loadingCanvasPrewarmerKey = prewarmerKey
+
+        canvasLoadTask = Task { @MainActor in
+            do {
+                let fileURL = try await FileAttachmentLoader.loadFile(for: attachment)
+                try Task.checkCancellation()
+                let isReady = await HTMLContentPrewarmer.shared.prewarmAndWait(
+                    attachmentKey: prewarmerKey,
+                    fileURL: fileURL
+                )
+                try Task.checkCancellation()
+                guard canvasLoadGeneration == generation,
+                      viewModel.canvasFile?.id == file.id else {
+                    HTMLContentPrewarmer.shared.evict(attachmentKey: prewarmerKey)
+                    return
+                }
+                guard isReady else {
+                    loadingCanvasPrewarmerKey = nil
+                    return
+                }
+
+                if let canvasPresentation {
+                    HTMLContentPrewarmer.shared.evict(attachmentKey: canvasPresentation.prewarmerKey)
+                }
+                canvasPresentation = CanvasPresentation(
+                    id: file.id,
+                    fileURL: fileURL,
+                    prewarmerKey: prewarmerKey
+                )
+                loadingCanvasPrewarmerKey = nil
+            } catch is CancellationError {
+                HTMLContentPrewarmer.shared.evict(attachmentKey: prewarmerKey)
+            } catch {
+                Log.error("Failed to load living canvas: \(error)")
+                if canvasLoadGeneration == generation {
+                    loadingCanvasPrewarmerKey = nil
+                }
+            }
+        }
+    }
+
+    private func resetCanvas() {
+        canvasLoadTask?.cancel()
+        canvasLoadTask = nil
+        canvasLoadGeneration = UUID()
+        if let loadingCanvasPrewarmerKey {
+            HTMLContentPrewarmer.shared.evict(attachmentKey: loadingCanvasPrewarmerKey)
+            self.loadingCanvasPrewarmerKey = nil
+        }
+        if let canvasPresentation {
+            HTMLContentPrewarmer.shared.evict(attachmentKey: canvasPresentation.prewarmerKey)
+            self.canvasPresentation = nil
+        }
+        canvasBodyBackgroundColor = nil
+    }
+
     var body: some View {
         bodyContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(.colorBackgroundRaisedSecondary)
+            .background {
+                if canvasPresentation != nil {
+                    canvasBodyBackgroundColor ?? Color.clear
+                } else {
+                    Color.colorBackgroundRaisedSecondary
+                }
+            }
             .applyTitle(usesInlineHeader: usesInlineHeader)
             .safeAreaBar(edge: .bottom) {
-                ThingsSearchBar(
-                    searchText: $viewModel.searchText,
-                    filter: $viewModel.filter,
-                    focusBinding: focusBinding
-                )
+                if usesInlineHeader, canvasPresentation != nil {
+                    CanvasFilesLinksButton {
+                        presentingFilesAndLinks = true
+                    }
+                } else {
+                    ThingsSearchBar(
+                        searchText: $viewModel.searchText,
+                        filter: $viewModel.filter,
+                        focusBinding: focusBinding
+                    )
+                }
             }
             .sheet(item: $presentingPreview) { preview in
                 AttachmentPreviewSheet(
@@ -192,6 +305,15 @@ struct AgentFilesLinksView: View {
                     fileURL: preview.fileURL,
                     sender: preview.sender,
                     sentAt: preview.sentAt,
+                    profileSheetContent: profileSheetContent
+                )
+                .presentationDetents([.large])
+            }
+            .sheet(isPresented: $presentingFilesAndLinks) {
+                CanvasFilesLinksSheet(
+                    conversationId: conversationId,
+                    repository: repository,
+                    members: members,
                     profileSheetContent: profileSheetContent
                 )
                 .presentationDetents([.large])
@@ -210,8 +332,10 @@ struct AgentFilesLinksView: View {
             // whenever the active conversation changes — the same view model
             // instance follows the selection instead of being torn down via `.id`.
             .onChange(of: conversationId, initial: true) {
+                resetCanvas()
                 viewModel.observe(repository)
                 presentingPreview = nil
+                presentingFilesAndLinks = false
             }
             .onAppear {
                 ensureNavigator()
@@ -219,6 +343,9 @@ struct AgentFilesLinksView: View {
             }
             .onDisappear {
                 navigator?.closed(context: navState.closeContext())
+            }
+            .onChange(of: viewModel.canvasFile) { _, newCanvas in
+                updateCanvas(to: newCanvas)
             }
             .onChange(of: presentingPreview?.id) { oldId, newId in
                 guard oldId == nil, newId != nil else { return }
@@ -228,7 +355,7 @@ struct AgentFilesLinksView: View {
 
     @ViewBuilder
     private var bodyContent: some View {
-        if usesInlineHeader {
+        if usesInlineHeader, canvasPresentation == nil {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Things")
                     .font(.largeTitle.bold())
@@ -245,7 +372,18 @@ struct AgentFilesLinksView: View {
 
     @ViewBuilder
     private var content: some View {
-        if viewModel.isLoading {
+        if usesInlineHeader, let canvasPresentation {
+            AttachmentHTMLContent(
+                fileURL: canvasPresentation.fileURL,
+                attachmentKey: canvasPresentation.prewarmerKey,
+                onBodyBackgroundColor: { color in
+                    guard self.canvasPresentation?.id == canvasPresentation.id else { return }
+                    canvasBodyBackgroundColor = color
+                }
+            )
+            .id(canvasPresentation.id)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.isLoading {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if viewModel.filteredItems.isEmpty {
@@ -563,6 +701,51 @@ private extension View {
             self
                 .navigationTitle("Things")
                 .toolbarTitleDisplayMode(.large)
+        }
+    }
+}
+
+private struct CanvasFilesLinksButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label("Files & Links", systemImage: "folder")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.colorTextPrimary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+                .padding(.vertical, DesignConstants.Spacing.step3x)
+        }
+        .buttonStyle(.plain)
+        .glassEffect(.regular.interactive(), in: .capsule)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .accessibilityIdentifier("canvas-files-links-button")
+    }
+}
+
+private struct CanvasFilesLinksSheet: View {
+    let conversationId: String
+    let repository: AgentFilesLinksRepository
+    let members: [ConversationMember]
+    var profileSheetContent: ((ConversationMember) -> AnyView)?
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        NavigationStack {
+            AgentFilesLinksView(
+                conversationId: conversationId,
+                repository: repository,
+                members: members,
+                profileSheetContent: profileSheetContent
+            )
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
         }
     }
 }

--- a/Convos/Conversation Detail/AgentFilesLinksView.swift
+++ b/Convos/Conversation Detail/AgentFilesLinksView.swift
@@ -165,7 +165,6 @@ struct AgentFilesLinksView: View {
     @State private var loadingCanvasPrewarmerKey: String?
     @State private var canvasLoadGeneration: UUID = .init()
     @State private var canvasBodyBackgroundColor: Color?
-    @State private var presentingFilesAndLinks: Bool = false
 
     private func ensureNavigator() {
         guard navigator == nil else { return }
@@ -287,11 +286,7 @@ struct AgentFilesLinksView: View {
             }
             .applyTitle(usesInlineHeader: usesInlineHeader)
             .safeAreaBar(edge: .bottom) {
-                if usesInlineHeader, canvasPresentation != nil {
-                    CanvasFilesLinksButton {
-                        presentingFilesAndLinks = true
-                    }
-                } else {
+                if !usesInlineHeader || canvasPresentation == nil {
                     ThingsSearchBar(
                         searchText: $viewModel.searchText,
                         filter: $viewModel.filter,
@@ -305,15 +300,6 @@ struct AgentFilesLinksView: View {
                     fileURL: preview.fileURL,
                     sender: preview.sender,
                     sentAt: preview.sentAt,
-                    profileSheetContent: profileSheetContent
-                )
-                .presentationDetents([.large])
-            }
-            .sheet(isPresented: $presentingFilesAndLinks) {
-                CanvasFilesLinksSheet(
-                    conversationId: conversationId,
-                    repository: repository,
-                    members: members,
                     profileSheetContent: profileSheetContent
                 )
                 .presentationDetents([.large])
@@ -335,7 +321,6 @@ struct AgentFilesLinksView: View {
                 resetCanvas()
                 viewModel.observe(repository)
                 presentingPreview = nil
-                presentingFilesAndLinks = false
             }
             .onAppear {
                 ensureNavigator()
@@ -383,6 +368,7 @@ struct AgentFilesLinksView: View {
             )
             .id(canvasPresentation.id)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .ignoresSafeArea(.container, edges: .vertical)
         } else if viewModel.isLoading {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -701,51 +687,6 @@ private extension View {
             self
                 .navigationTitle("Things")
                 .toolbarTitleDisplayMode(.large)
-        }
-    }
-}
-
-private struct CanvasFilesLinksButton: View {
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Label("Files & Links", systemImage: "folder")
-                .font(.callout.weight(.medium))
-                .foregroundStyle(.colorTextPrimary)
-                .padding(.horizontal, DesignConstants.Spacing.step4x)
-                .padding(.vertical, DesignConstants.Spacing.step3x)
-        }
-        .buttonStyle(.plain)
-        .glassEffect(.regular.interactive(), in: .capsule)
-        .padding(.vertical, DesignConstants.Spacing.step2x)
-        .accessibilityIdentifier("canvas-files-links-button")
-    }
-}
-
-private struct CanvasFilesLinksSheet: View {
-    let conversationId: String
-    let repository: AgentFilesLinksRepository
-    let members: [ConversationMember]
-    var profileSheetContent: ((ConversationMember) -> AnyView)?
-
-    @Environment(\.dismiss) private var dismiss: DismissAction
-
-    var body: some View {
-        NavigationStack {
-            AgentFilesLinksView(
-                conversationId: conversationId,
-                repository: repository,
-                members: members,
-                profileSheetContent: profileSheetContent
-            )
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        dismiss()
-                    }
-                }
-            }
         }
     }
 }

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -271,7 +271,7 @@ struct AttachmentHTMLContent: UIViewRepresentable {
     private func configureScrolling(_ webView: WKWebView) {
         // Directional locking lets the canvas keep vertical momentum while a
         // deliberate horizontal drag can continue into ConversationPager.
-        webView.scrollView.directionalLockEnabled = true
+        webView.scrollView.isDirectionalLockEnabled = true
         webView.scrollView.alwaysBounceHorizontal = false
         webView.scrollView.showsHorizontalScrollIndicator = false
     }

--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -234,6 +234,7 @@ struct AttachmentHTMLContent: UIViewRepresentable {
             prewarmed.webView.navigationDelegate = context.coordinator
             context.coordinator.usingPrewarmedWebView = true
             context.coordinator.loadedFileURL = fileURL
+            configureScrolling(prewarmed.webView)
             DispatchQueue.main.async {
                 self.onBodyBackgroundColor?(prewarmed.bodyBackgroundColor)
             }
@@ -247,6 +248,7 @@ struct AttachmentHTMLContent: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
         webView.navigationDelegate = context.coordinator
+        configureScrolling(webView)
         return webView
     }
 
@@ -264,6 +266,14 @@ struct AttachmentHTMLContent: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onBodyBackgroundColor: onBodyBackgroundColor)
+    }
+
+    private func configureScrolling(_ webView: WKWebView) {
+        // Directional locking lets the canvas keep vertical momentum while a
+        // deliberate horizontal drag can continue into ConversationPager.
+        webView.scrollView.directionalLockEnabled = true
+        webView.scrollView.alwaysBounceHorizontal = false
+        webView.scrollView.showsHorizontalScrollIndicator = false
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -11,17 +11,11 @@ enum ConversationPagerPage: Int, CaseIterable, Identifiable {
 
 struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
     @Binding var selectedPage: ConversationPagerPage
-    /// Whether the dots are mounted at all. Drives the `safeAreaInset`
-    /// itself, so flipping this resizes the pager content — only set it
-    /// based on keyboard presence, which already animates via the
-    /// system. Don't piggyback context-menu-driven hiding on this flag
-    /// or the bottom bar's own fade-out animation has to compete with a
-    /// layout reflow inside MessagesView.
+    /// Whether the dots are mounted at all. Only set it based on keyboard
+    /// presence, which already animates via the system.
     let showsPageDots: Bool
-    /// Hides the dots in-place when true (opacity + scale only, layout
-    /// space preserved). Used while the long-press context menu is
-    /// presented so the dots fade out without resizing anything around
-    /// them.
+    /// Hides the dots in-place when true (opacity + scale only). Used while
+    /// the long-press context menu is presented so the dots fade out.
     var dotsHidden: Bool = false
     /// When true, horizontal paging between `messages` and `things` is
     /// blocked. Used while the message long-press context menu is
@@ -57,7 +51,7 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
                 scrollView.bounces = false
             }
         }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
+        .overlay(alignment: .bottom) {
             if showsPageDots {
                 ConversationPagerDots(selectedPage: $selectedPage)
                     .opacity(dotsHidden ? 0 : 1)

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -11,11 +11,17 @@ enum ConversationPagerPage: Int, CaseIterable, Identifiable {
 
 struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
     @Binding var selectedPage: ConversationPagerPage
-    /// Whether the dots are mounted at all. Only set it based on keyboard
-    /// presence, which already animates via the system.
+    /// Whether the dots are mounted at all. Drives the `safeAreaInset`
+    /// itself, so flipping this resizes the pager content — only set it
+    /// based on keyboard presence, which already animates via the
+    /// system. Don't piggyback context-menu-driven hiding on this flag
+    /// or the bottom bar's own fade-out animation has to compete with a
+    /// layout reflow inside MessagesView.
     let showsPageDots: Bool
-    /// Hides the dots in-place when true (opacity + scale only). Used while
-    /// the long-press context menu is presented so the dots fade out.
+    /// Hides the dots in-place when true (opacity + scale only, layout
+    /// space preserved). Used while the long-press context menu is
+    /// presented so the dots fade out without resizing anything around
+    /// them.
     var dotsHidden: Bool = false
     /// When true, horizontal paging between `messages` and `things` is
     /// blocked. Used while the message long-press context menu is
@@ -51,7 +57,7 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
                 scrollView.bounces = false
             }
         }
-        .overlay(alignment: .bottom) {
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             if showsPageDots {
                 ConversationPagerDots(selectedPage: $selectedPage)
                     .opacity(dotsHidden ? 0 : 1)

--- a/Convos/Conversation Detail/ConversationStartersView.swift
+++ b/Convos/Conversation Detail/ConversationStartersView.swift
@@ -1,0 +1,85 @@
+import ConvosCore
+import SwiftUI
+
+/// Tappable openers offered while a fresh agent is waiting to be told what it
+/// should be. Tapping one sends it as the user's first message, which is the
+/// answer the agent's greeting asked for — so the starters double as examples
+/// of the kind of answer that works.
+///
+/// Shown only in a no-builder build, and only before the user has said
+/// anything: once they reply, whether by tap or by typing, the agent owns the
+/// conversation and a menu of openers would compete with its own follow-ups.
+struct ConversationStartersView: View {
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step3x) {
+            ForEach(Constant.starters, id: \.self) { starter in
+                Button {
+                    onSelect(starter)
+                } label: {
+                    starterRow(starter)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(starter)
+                .accessibilityHint("Sends this as your first message")
+            }
+
+            // Not a starter — an attachment is something you do, not something
+            // you say, so this one tells rather than sends.
+            HStack(alignment: .top, spacing: DesignConstants.Spacing.step2x) {
+                Image(systemName: "bolt.fill")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(width: Constant.iconWidth, alignment: .center)
+
+                Text(Constant.attachmentHint)
+                    .font(.callout)
+                    .foregroundStyle(.colorTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(DesignConstants.Spacing.step4x)
+        .background(
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge)
+                .fill(Color.colorFillMinimal)
+        )
+    }
+
+    private func starterRow(_ starter: String) -> some View {
+        HStack(alignment: .top, spacing: DesignConstants.Spacing.step2x) {
+            Image(systemName: "bubble.fill")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .frame(width: Constant.iconWidth, alignment: .center)
+
+            Text(starter)
+                .font(.callout)
+                .foregroundStyle(.colorTextPrimary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(.rect)
+    }
+
+    private enum Constant {
+        /// Deliberately broad, and one of them deliberately has no task in it:
+        /// an agent should be worth starting even when the group doesn't
+        /// already know what they want from it.
+        static let starters: [String] = [
+            "Plan a trip",
+            "Help organize our household",
+            "No agenda — just hanging out"
+        ]
+        static let attachmentHint: String =
+            "Dump some files or screenshots with context and I'll figure out what to do next"
+        static let iconWidth: CGFloat = 16.0
+    }
+}
+
+#Preview {
+    ConversationStartersView(onSelect: { _ in })
+        .padding()
+}

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -353,6 +353,15 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     bottomBarContent()
 
+                    // Openers for an agent still waiting to be told what it is.
+                    // Suppressed while onboarding is up so the two prompts
+                    // don't stack — both want the same brand-new conversation.
+                    if viewModel.showsConversationStarters,
+                       !onboardingCoordinator.showOnboardingView {
+                        ConversationStartersView(onSelect: sendConversationStarter)
+                            .transition(.blurReplace)
+                    }
+
                     // Capability requests no longer auto-present a card here:
                     // the transcript's connect pill is the single entry point
                     // and opens the approval sheet. The slot keeps the
@@ -375,6 +384,15 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
             }
         )
+    }
+
+    /// Sends a tapped opener as the user's own message. Routed through the
+    /// composer rather than the message writer so the tap behaves exactly like
+    /// typing it: the transcript scrolls, the typing indicator stops, and the
+    /// starters clear themselves once the message lands.
+    private func sendConversationStarter(_ starter: String) {
+        viewModel.messageText = starter
+        viewModel.onSendMessage(focusCoordinator: focusCoordinator)
     }
 
     @ToolbarContentBuilder

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -354,10 +354,12 @@ struct ConversationView<MessagesBottomBar: View>: View {
                     bottomBarContent()
 
                     // Openers for an agent still waiting to be told what it is.
-                    // Suppressed while onboarding is up so the two prompts
-                    // don't stack — both want the same brand-new conversation.
-                    if viewModel.showsConversationStarters,
-                       !onboardingCoordinator.showOnboardingView {
+                    // Deliberately not gated on the onboarding view: that goes
+                    // non-idle the moment a creator opens their own new
+                    // conversation, which is every conversation these openers
+                    // exist for, and only clears once profile and notification
+                    // setup resolve. Hiding behind it hid them outright.
+                    if viewModel.showsConversationStarters {
                         ConversationStartersView(onSelect: sendConversationStarter)
                             .transition(.blurReplace)
                     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1059,12 +1059,12 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// is what the agent receives. Surfaces nested inside another sheet (the
     /// Info sheet, Members list) present this from their own `.sheet` so it
     /// stacks on top; the top-level chat menu uses `presentAgentBuilder()`.
-    /// Nil in an agent-only build, which ships without the agent builder.
+    /// Nil in a no-builder build, which ships without the agent builder.
     /// Every in-chat builder surface assigns the result into an optional
     /// presentation binding, so returning nil here leaves all of them inert
     /// without each having to carry the check.
     func makeAgentBuilderViewModel() -> AgentBuilderViewModel? {
-        guard !ConfigManager.shared.isAgentOnlyBuild else { return nil }
+        guard !ConfigManager.shared.isNoBuilderBuild else { return nil }
         return AgentBuilderViewModel(session: session, existingConversationId: conversation.id, coreActions: coreActions)
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -920,6 +920,27 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// request, the request was answered here, or observation reset).
     var presentingCapabilityApproval: Bool = false
     var showsCapabilityApprovedToast: Bool = false
+
+    /// True while a fresh agent has greeted and the user has yet to answer, so
+    /// the conversation can offer openers. `messages` carries dates, updates,
+    /// join status and typing indicators alongside real messages, so both
+    /// halves pattern-match `.messages` rather than counting entries.
+    ///
+    /// Scoped to the no-builder build, which is the only one where a
+    /// conversation opens on a question the user is expected to answer. Reading
+    /// the build config rather than probing the agent's profile for a missing
+    /// `templateId` also avoids a race: the runtime writes that metadata after
+    /// the join, so it is briefly absent for template-backed agents too.
+    var showsConversationStarters: Bool {
+        guard ConfigManager.shared.isNoBuilderBuild else { return false }
+        var someoneElseSpoke = false
+        for item in messages {
+            guard case .messages(let group) = item else { continue }
+            if group.sender.isCurrentUser { return false }
+            someoneElseSpoke = true
+        }
+        return someoneElseSpoke
+    }
     var presentingProfileForMember: ConversationMember?
     var presentingNewConversationForInvite: NewConversationViewModel? {
         didSet { oldValue?.cleanUpIfNeeded() }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1059,8 +1059,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// is what the agent receives. Surfaces nested inside another sheet (the
     /// Info sheet, Members list) present this from their own `.sheet` so it
     /// stacks on top; the top-level chat menu uses `presentAgentBuilder()`.
-    func makeAgentBuilderViewModel() -> AgentBuilderViewModel {
-        AgentBuilderViewModel(session: session, existingConversationId: conversation.id, coreActions: coreActions)
+    /// Nil in an agent-only build, which ships without the agent builder.
+    /// Every in-chat builder surface assigns the result into an optional
+    /// presentation binding, so returning nil here leaves all of them inert
+    /// without each having to carry the check.
+    func makeAgentBuilderViewModel() -> AgentBuilderViewModel? {
+        guard !ConfigManager.shared.isAgentOnlyBuild else { return nil }
+        return AgentBuilderViewModel(session: session, existingConversationId: conversation.id, coreActions: coreActions)
     }
 
     private static let hasShownAgentsIntroKey: String = "hasShownAgentsIntro"

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -80,11 +80,12 @@ struct ConversationsView: View {
     }
 
     /// Empty chats state: the new-user CTA (animated mock conversations,
-    /// headline, "Make an agent", "Explore agents in Contacts"). The Make
-    /// button opens the same agent-builder sheet the builder bar opens.
+    /// headline, primary action, "Explore agents in Contacts"). The primary
+    /// button opens the same agent-builder sheet the builder bar opens; in an
+    /// agent-only build it starts a conversation with an agent instead.
     var emptyConversationsView: some View {
         ConversationsEmptyStateView(
-            onMakeAgent: { viewModel.onStartAgent() },
+            onMakeAgent: { viewModel.onEmptyStatePrimaryAction() },
             onExploreAgents: onExploreAgents
         )
     }

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -82,7 +82,7 @@ struct ConversationsView: View {
     /// Empty chats state: the new-user CTA (animated mock conversations,
     /// headline, primary action, "Explore agents in Contacts"). The primary
     /// button opens the same agent-builder sheet the builder bar opens; in an
-    /// agent-only build it starts a conversation with an agent instead.
+    /// no-builder build it starts a conversation with an agent instead.
     var emptyConversationsView: some View {
         ConversationsEmptyStateView(
             onMakeAgent: { viewModel.onEmptyStatePrimaryAction() },

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -427,6 +427,12 @@ final class ConversationsViewModel {
     /// the picker would be pointless -- so we skip it and open the
     /// new-conversation view directly, like the pre-picker flow.
     func onStartConvo() {
+        // An agent-only build skips the picker entirely: Compose lands the
+        // user straight in a conversation the agent is already joining.
+        guard !ConfigManager.shared.isAgentOnlyBuild else {
+            startConversationWithDefaultAgent()
+            return
+        }
         // Count the contacts the picker would actually show (excludes agents,
         // blocked, and unnamed) -- the raw contact count includes those, so
         // it can't decide whether the picker is worth showing.
@@ -479,8 +485,34 @@ final class ConversationsViewModel {
         newConversationViewModel = viewModel
     }
 
+    /// Primary action of the Chats and Things empty states. An agent-only
+    /// build has no builder to open, so the CTA starts a conversation --
+    /// which arrives with an agent already in it, reaching the same place
+    /// the builder would have.
+    func onEmptyStatePrimaryAction() {
+        if ConfigManager.shared.isAgentOnlyBuild {
+            onStartConvo()
+        } else {
+            onStartAgent()
+        }
+    }
+
     func onStartAgent(entryMode: AgentBuilderEntryMode = .composer) {
+        guard !ConfigManager.shared.isAgentOnlyBuild else { return }
         agentBuilderViewModel = AgentBuilderViewModel(session: session, entryMode: entryMode, coreActions: coreActions)
+    }
+
+    /// Opens a new conversation and, once it is ready, requests the default
+    /// agent into it. The agent-only build's Compose entry point: there is no
+    /// builder to describe an agent with and no template to pick, so the
+    /// conversation simply arrives with an agent in it.
+    private func startConversationWithDefaultAgent() {
+        newConversationViewModel = NewConversationViewModel(
+            session: session,
+            mode: .newConversation,
+            joinsDefaultAgent: true,
+            coreActions: coreActions
+        )
     }
 
     private func join(from inviteCode: String) {

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -427,9 +427,9 @@ final class ConversationsViewModel {
     /// the picker would be pointless -- so we skip it and open the
     /// new-conversation view directly, like the pre-picker flow.
     func onStartConvo() {
-        // An agent-only build skips the picker entirely: Compose lands the
+        // A no-builder build skips the picker entirely: Compose lands the
         // user straight in a conversation the agent is already joining.
-        guard !ConfigManager.shared.isAgentOnlyBuild else {
+        guard !ConfigManager.shared.isNoBuilderBuild else {
             startConversationWithDefaultAgent()
             return
         }
@@ -485,12 +485,11 @@ final class ConversationsViewModel {
         newConversationViewModel = viewModel
     }
 
-    /// Primary action of the Chats and Things empty states. An agent-only
-    /// build has no builder to open, so the CTA starts a conversation --
-    /// which arrives with an agent already in it, reaching the same place
-    /// the builder would have.
+    /// Primary action of the Chats and Things empty states. With no builder
+    /// to open, the CTA starts a conversation instead -- which arrives with
+    /// an agent already in it, reaching the same place the builder would have.
     func onEmptyStatePrimaryAction() {
-        if ConfigManager.shared.isAgentOnlyBuild {
+        if ConfigManager.shared.isNoBuilderBuild {
             onStartConvo()
         } else {
             onStartAgent()
@@ -498,12 +497,12 @@ final class ConversationsViewModel {
     }
 
     func onStartAgent(entryMode: AgentBuilderEntryMode = .composer) {
-        guard !ConfigManager.shared.isAgentOnlyBuild else { return }
+        guard !ConfigManager.shared.isNoBuilderBuild else { return }
         agentBuilderViewModel = AgentBuilderViewModel(session: session, entryMode: entryMode, coreActions: coreActions)
     }
 
     /// Opens a new conversation and, once it is ready, requests the default
-    /// agent into it. The agent-only build's Compose entry point: there is no
+    /// agent into it. The no-builder build's Compose entry point: there is no
     /// builder to describe an agent with and no template to pick, so the
     /// conversation simply arrives with an agent in it.
     private func startConversationWithDefaultAgent() {

--- a/Convos/Conversations List/Empty State/EmptyStateCTAView.swift
+++ b/Convos/Conversations List/Empty State/EmptyStateCTAView.swift
@@ -1,3 +1,4 @@
+import ConvosCore
 import SwiftUI
 
 /// Shared scaffold for the new-user empty states on the Chats and Things
@@ -69,7 +70,9 @@ struct EmptyStateCTAView<MockContent: View>: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: Constant.agentIconSize, height: Constant.agentIconSize)
-                Text("Make an agent")
+                // An agent-only build has no builder; the same button starts
+                // a conversation that already has an agent in it.
+                Text(ConfigManager.shared.isAgentOnlyBuild ? "Start a conversation" : "Make an agent")
                     .font(.callout)
             }
         }

--- a/Convos/Conversations List/Empty State/EmptyStateCTAView.swift
+++ b/Convos/Conversations List/Empty State/EmptyStateCTAView.swift
@@ -70,9 +70,9 @@ struct EmptyStateCTAView<MockContent: View>: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: Constant.agentIconSize, height: Constant.agentIconSize)
-                // An agent-only build has no builder; the same button starts
-                // a conversation that already has an agent in it.
-                Text(ConfigManager.shared.isAgentOnlyBuild ? "Start a conversation" : "Make an agent")
+                // With no builder to open, the same button starts a
+                // conversation that already has an agent in it.
+                Text(ConfigManager.shared.isNoBuilderBuild ? "Start a conversation" : "Make an agent")
                     .font(.callout)
             }
         }

--- a/Convos/Conversations List/ThingsTabView.swift
+++ b/Convos/Conversations List/ThingsTabView.swift
@@ -182,7 +182,7 @@ struct ThingsTabView: View {
     /// "Make an agent" button or the surrounding components.
     private var emptyState: some View {
         ThingsEmptyStateView(
-            onMakeAgent: { conversationsViewModel.onStartAgent() },
+            onMakeAgent: { conversationsViewModel.onEmptyStatePrimaryAction() },
             onExploreAgents: onSeeSuggestedAgents
         )
     }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -408,7 +408,7 @@ struct MainTabView: View {
                 // reflowed the list mid-transition. The bar also stays up
                 // during the empty-state CTA (it is the same builder entry
                 // point the CTA's "Make an agent" button opens).
-                if tab != .contacts {
+                if tab != .contacts, !ConfigManager.shared.isAgentOnlyBuild {
                     builderBar
                         .transition(.blurReplace)
                 }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -408,7 +408,7 @@ struct MainTabView: View {
                 // reflowed the list mid-transition. The bar also stays up
                 // during the empty-state CTA (it is the same builder entry
                 // point the CTA's "Make an agent" button opens).
-                if tab != .contacts, !ConfigManager.shared.isAgentOnlyBuild {
+                if tab != .contacts, !ConfigManager.shared.isNoBuilderBuild {
                     builderBar
                         .transition(.blurReplace)
                 }

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
@@ -37,6 +37,21 @@ public final class HTMLContentPrewarmer {
         public let bodyBackgroundColor: Color?
     }
 
+    private struct RequestToken: Hashable {
+        let attachmentKey: String
+        let generation: Int
+    }
+
+    private struct PendingRequest {
+        let token: RequestToken
+        let fileURL: URL
+    }
+
+    private struct ActivePrewarm {
+        let webView: WKWebView
+        let coordinator: PrewarmCoordinator
+    }
+
     private static let cacheLimit: Int = 5
     private static let loadTimeout: TimeInterval = 15.0
     /// Mirrors `HTMLThumbnailRenderer.paintDelay` - the WebView paints a
@@ -55,11 +70,14 @@ public final class HTMLContentPrewarmer {
     /// FIFO of pending `(attachmentKey, fileURL)` requests. We pop one
     /// at a time; appended duplicates are coalesced before they enter
     /// the queue.
-    private var pendingQueue: [(key: String, fileURL: URL)] = []
-    /// Set of keys for entries currently queued or being processed.
-    /// Used to coalesce repeat calls so a single attachment never
-    /// occupies more than one slot end-to-end.
-    private var queuedKeys: Set<String> = []
+    private var pendingQueue: [PendingRequest] = []
+    /// Tokens currently queued or being processed. A generation lets an
+    /// eviction invalidate in-flight work without preventing a later load
+    /// for the same attachment key.
+    private var queuedTokens: Set<RequestToken> = []
+    private var generations: [String: Int] = [:]
+    private var waiters: [RequestToken: [CheckedContinuation<Bool, Never>]] = [:]
+    private var activePrewarms: [RequestToken: ActivePrewarm] = [:]
     private var isProcessing: Bool = false
     /// Reused off-screen host window - same pattern as
     /// `HTMLThumbnailRenderer`. Allocating a fresh window per prewarm
@@ -116,14 +134,24 @@ public final class HTMLContentPrewarmer {
         // Extensions skip prewarming entirely: WKWebView pools blow the appex
         // memory budget and the scene lookup below uses app-only API.
         guard !ComposerHostContext.isAppExtension else { return }
+        enqueue(attachmentKey: attachmentKey, fileURL: fileURL)
+    }
+
+    /// Waits until the requested content has either painted into the cache or
+    /// failed its bounded load. Callers can keep existing content visible
+    /// until this returns, then borrow the resulting WebView without a blank
+    /// transition frame.
+    public func prewarmAndWait(attachmentKey: String, fileURL: URL) async -> Bool {
+        guard !ComposerHostContext.isAppExtension else { return false }
         if cache.contains(where: { $0.key == attachmentKey }) {
             promote(attachmentKey: attachmentKey)
-            return
+            return true
         }
-        if queuedKeys.contains(attachmentKey) { return }
-        queuedKeys.insert(attachmentKey)
-        pendingQueue.append((key: attachmentKey, fileURL: fileURL))
-        processQueueIfIdle()
+        let token = requestToken(for: attachmentKey)
+        return await withCheckedContinuation { continuation in
+            waiters[token, default: []].append(continuation)
+            enqueue(attachmentKey: attachmentKey, fileURL: fileURL, token: token)
+        }
     }
 
     /// Removes and returns the cached `PrewarmedContent` if one exists.
@@ -136,10 +164,66 @@ public final class HTMLContentPrewarmer {
         return entry.content
     }
 
+    /// Invalidates cached, queued, and in-flight content for an attachment
+    /// identity. Any later prewarm receives a fresh generation.
+    public func evict(attachmentKey: String) {
+        generations[attachmentKey] = (generations[attachmentKey] ?? 0) + 1
+
+        let cachedEntries = cache.filter { $0.key == attachmentKey }
+        cache.removeAll { $0.key == attachmentKey }
+        for entry in cachedEntries {
+            entry.content.webView.stopLoading()
+            entry.content.webView.removeFromSuperview()
+        }
+
+        let invalidatedTokens = queuedTokens.filter { $0.attachmentKey == attachmentKey }
+        pendingQueue.removeAll { $0.token.attachmentKey == attachmentKey }
+        queuedTokens.subtract(invalidatedTokens)
+        for token in invalidatedTokens {
+            resumeWaiters(for: token, success: false)
+        }
+
+        let activeTokens = activePrewarms.keys.filter { $0.attachmentKey == attachmentKey }
+        for token in activeTokens {
+            guard let active = activePrewarms.removeValue(forKey: token) else { continue }
+            active.webView.stopLoading()
+            active.webView.removeFromSuperview()
+            active.coordinator.cancel()
+        }
+        if activeTokens.isEmpty {
+            cleanUpGenerationIfUnused(for: attachmentKey)
+        }
+    }
+
     private func promote(attachmentKey: String) {
         guard let index = cache.firstIndex(where: { $0.key == attachmentKey }) else { return }
         let entry = cache.remove(at: index)
         cache.append(entry)
+    }
+
+    private func requestToken(for attachmentKey: String) -> RequestToken {
+        RequestToken(
+            attachmentKey: attachmentKey,
+            generation: generations[attachmentKey] ?? 0
+        )
+    }
+
+    private func enqueue(
+        attachmentKey: String,
+        fileURL: URL,
+        token: RequestToken? = nil
+    ) {
+        if cache.contains(where: { $0.key == attachmentKey }) {
+            promote(attachmentKey: attachmentKey)
+            if let token {
+                resumeWaiters(for: token, success: true)
+            }
+            return
+        }
+        let resolvedToken = token ?? requestToken(for: attachmentKey)
+        guard queuedTokens.insert(resolvedToken).inserted else { return }
+        pendingQueue.append(PendingRequest(token: resolvedToken, fileURL: fileURL))
+        processQueueIfIdle()
     }
 
     private func processQueueIfIdle() {
@@ -148,17 +232,20 @@ public final class HTMLContentPrewarmer {
         let next = pendingQueue.removeFirst()
         isProcessing = true
         Task { @MainActor [weak self] in
-            await self?.performPrewarm(attachmentKey: next.key, fileURL: next.fileURL)
-            self?.queuedKeys.remove(next.key)
-            self?.isProcessing = false
-            self?.processQueueIfIdle()
+            guard let self else { return }
+            let success = await performPrewarm(token: next.token, fileURL: next.fileURL)
+            queuedTokens.remove(next.token)
+            resumeWaiters(for: next.token, success: success)
+            cleanUpGenerationIfUnused(for: next.token.attachmentKey)
+            isProcessing = false
+            processQueueIfIdle()
         }
     }
 
-    private func performPrewarm(attachmentKey: String, fileURL: URL) async {
+    private func performPrewarm(token: RequestToken, fileURL: URL) async -> Bool {
         guard let window = offscreenWindow else {
-            Log.error("HTMLContentPrewarmer: no offscreen window available; skipping prewarm of \(attachmentKey)")
-            return
+            Log.error("HTMLContentPrewarmer: no offscreen window available; skipping prewarm of \(token.attachmentKey)")
+            return false
         }
         let coordinator = PrewarmCoordinator()
         let config = WKWebViewConfiguration()
@@ -174,19 +261,27 @@ public final class HTMLContentPrewarmer {
         webView.scrollView.backgroundColor = .clear
         webView.navigationDelegate = coordinator
         window.addSubview(webView)
+        activePrewarms[token] = ActivePrewarm(webView: webView, coordinator: coordinator)
         let readAccessURL = fileURL.deletingLastPathComponent()
         webView.loadFileURL(fileURL, allowingReadAccessTo: readAccessURL)
         let success: Bool = await coordinator.waitForLoad(timeout: Self.loadTimeout, paintDelay: Self.paintDelay)
+        activePrewarms.removeValue(forKey: token)
         guard success else {
             webView.stopLoading()
             webView.removeFromSuperview()
-            return
+            return false
+        }
+        guard requestToken(for: token.attachmentKey) == token else {
+            webView.stopLoading()
+            webView.removeFromSuperview()
+            return false
         }
         let entry: PrewarmedContent = PrewarmedContent(
             webView: webView,
             bodyBackgroundColor: coordinator.bodyBackgroundColor
         )
-        insert(attachmentKey: attachmentKey, content: entry)
+        insert(attachmentKey: token.attachmentKey, content: entry)
+        return true
     }
 
     private func insert(attachmentKey: String, content: PrewarmedContent) {
@@ -198,15 +293,33 @@ public final class HTMLContentPrewarmer {
             dropped.content.webView.removeFromSuperview()
         }
     }
+
+    private func resumeWaiters(for token: RequestToken, success: Bool) {
+        let continuations = waiters.removeValue(forKey: token) ?? []
+        for continuation in continuations {
+            continuation.resume(returning: success)
+        }
+    }
+
+    private func cleanUpGenerationIfUnused(for attachmentKey: String) {
+        guard !queuedTokens.contains(where: { $0.attachmentKey == attachmentKey }),
+              !activePrewarms.keys.contains(where: { $0.attachmentKey == attachmentKey }),
+              !waiters.keys.contains(where: { $0.attachmentKey == attachmentKey }) else { return }
+        generations.removeValue(forKey: attachmentKey)
+    }
 }
 
 private final class PrewarmCoordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
     private(set) var bodyBackgroundColor: Color?
     private var didFinishContinuation: CheckedContinuation<Bool, Never>?
-    private var finished: Bool = false
+    private var completionResult: Bool?
 
     func waitForLoad(timeout: TimeInterval, paintDelay: TimeInterval) async -> Bool {
         let success: Bool = await withCheckedContinuation { continuation in
+            if let completionResult {
+                continuation.resume(returning: completionResult)
+                return
+            }
             self.didFinishContinuation = continuation
             DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
                 self?.complete(success: false)
@@ -215,6 +328,10 @@ private final class PrewarmCoordinator: NSObject, WKNavigationDelegate, WKScript
         guard success else { return false }
         try? await Task.sleep(for: .seconds(paintDelay))
         return true
+    }
+
+    func cancel() {
+        complete(success: false)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
@@ -245,8 +362,8 @@ private final class PrewarmCoordinator: NSObject, WKNavigationDelegate, WKScript
     }
 
     private func complete(success: Bool) {
-        guard !finished else { return }
-        finished = true
+        guard completionResult == nil else { return }
+        completionResult = success
         didFinishContinuation?.resume(returning: success)
         didFinishContinuation = nil
     }

--- a/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
@@ -219,8 +219,8 @@ public final class ConfigManager: @unchecked Sendable {
     /// single build configuration opts in without a compile-time flag —
     /// `#if DEBUG` does not propagate into this package, and the runtime
     /// `environment` is shared with builds that must keep the builder.
-    public var isAgentOnlyBuild: Bool {
-        config["agentOnlyBuild"] as? Bool ?? false
+    public var isNoBuilderBuild: Bool {
+        config["noBuilder"] as? Bool ?? false
     }
 
     /// Agent-variant slug pinned at build time via config.json. When set, agent

--- a/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
@@ -213,6 +213,16 @@ public final class ConfigManager: @unchecked Sendable {
         return name
     }
 
+    /// True when this build ships without the agent builder: every new
+    /// conversation is created with an agent already joining it, and the
+    /// "Make an agent" affordances are removed. Read from config.json so a
+    /// single build configuration opts in without a compile-time flag —
+    /// `#if DEBUG` does not propagate into this package, and the runtime
+    /// `environment` is shared with builds that must keep the builder.
+    public var isAgentOnlyBuild: Bool {
+        config["agentOnlyBuild"] as? Bool ?? false
+    }
+
     /// Agent-variant slug pinned at build time via config.json. When set, agent
     /// joins fall back to this variant, so a build carrying the key routes to its
     /// paired agent variant without the tester choosing one in the selector. Absent

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContent.swift
@@ -86,6 +86,12 @@ public enum MessageContent: Hashable, Codable, Sendable {
         switch self {
         case .update(let update):
             return update.showsInMessagesList
+        case .attachments(let attachments):
+            // A quiet artifact update keeps Files & Links and Things current
+            // without spending another card in the transcript. The row still
+            // exists and still wins the filename dedupe on those surfaces —
+            // it just isn't drawn here.
+            return !attachments.contains { QuietArtifactUpdate.isQuiet(filename: $0.filename) }
         default:
             return true
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/QuietArtifactUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/QuietArtifactUpdate.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A quiet artifact update: the agent re-sent an artifact to keep it current
+/// without asking for the group's attention.
+///
+/// The intent rides the attachment's filename because an attachment message
+/// carries nothing else the sender controls — no metadata bag, and
+/// `contentDigest` is a digest of the encrypted payload that changes on every
+/// send. The runtime stages a copy named `notes~quiet.html` and sends that;
+/// this type is the client half of that agreement.
+///
+/// Two consequences follow from stripping the sentinel back off:
+/// the update still supersedes its predecessor in Files & Links and the Things
+/// view, because those dedupe on filename and the canonical name is unchanged;
+/// and the transcript skips drawing another card for it.
+///
+/// The durable version of this is a silent control message naming the
+/// superseded message id, the way `BuilderBundleManifest` already hides
+/// builder briefs from the transcript on every client.
+public enum QuietArtifactUpdate {
+    static let sentinel: String = "~quiet"
+
+    /// True when this filename marks a quiet update.
+    public static func isQuiet(filename: String?) -> Bool {
+        guard let filename else { return false }
+        return (filename as NSString).deletingPathExtension.hasSuffix(sentinel)
+    }
+
+    /// The artifact's real filename, with the sentinel removed. Returns the
+    /// input unchanged when there is none, so callers can apply it blindly.
+    public static func canonicalFilename(_ filename: String?) -> String? {
+        guard let filename, isQuiet(filename: filename) else { return filename }
+        let name = filename as NSString
+        let ext = name.pathExtension
+        let stem = String(name.deletingPathExtension.dropLast(sentinel.count))
+        return ext.isEmpty ? stem : "\(stem).\(ext)"
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentFilesLinksRepository.swift
@@ -12,8 +12,10 @@ public struct AgentFile: Sendable, Hashable, Identifiable {
     public let attachmentKey: String
     public let thumbnailDataBase64: String?
 
+    /// The sentinel is plumbing, not part of the artifact's name — a file the
+    /// group opens should never read `notes~quiet.html`.
     public var displayName: String {
-        filename ?? "Untitled"
+        QuietArtifactUpdate.canonicalFilename(filename) ?? "Untitled"
     }
 
     public var formattedDate: String {
@@ -126,10 +128,14 @@ public final class AgentFilesLinksRepository: Sendable {
         // Rows arrive newest first, so the first occurrence of each filename is the
         // most recent send. Files with no filename pass through individually since
         // we can't tell duplicates apart.
+        //
+        // Deduping on the canonical name means a quiet update supersedes the
+        // loud send it follows: both are the same artifact, and only the newer
+        // one survives here even though the transcript ignored the quiet one.
         var seenFilenames: Set<String> = []
         var deduped: [AgentFile] = []
         for file in files {
-            if let filename = file.filename {
+            if let filename = QuietArtifactUpdate.canonicalFilename(file.filename) {
                 if seenFilenames.insert(filename).inserted {
                     deduped.append(file)
                 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentFilesLinksRepository.swift
@@ -80,6 +80,17 @@ public final class AgentFilesLinksRepository: Sendable {
             .eraseToAnyPublisher()
     }
 
+    /// Returns the newest living canvas from a files observation.
+    ///
+    /// Files normally arrive newest first and are already deduplicated by
+    /// canonical filename. Comparing dates here keeps the selection correct
+    /// for callers that provide an independently assembled collection.
+    public static func canvasFile(in files: [AgentFile]) -> AgentFile? {
+        files
+            .filter { QuietArtifactUpdate.canonicalFilename($0.filename) == "canvas.html" }
+            .max { $0.date < $1.date }
+    }
+
     /// Agent-sent files for a conversation.
     ///
     /// The sender check reads `profile`, the unified per-inbox table, because

--- a/ConvosCore/Tests/ConvosCoreTests/AgentFilesLinksRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentFilesLinksRepositoryTests.swift
@@ -20,7 +20,10 @@ struct AgentFilesLinksRepositoryTests {
     nonisolated private static func seedAgentAttachment(
         db: Database,
         verifiedKindOnUnifiedProfile: DBMemberKind?,
-        kindOnLegacyMemberProfile: DBMemberKind?
+        kindOnLegacyMemberProfile: DBMemberKind?,
+        messageId: String = "msg-1",
+        filename: String = "notes.html",
+        date: Date = Date(timeIntervalSince1970: 0)
     ) throws {
         try DBMember(inboxId: Self.agentInboxId).save(db, onConflict: .ignore)
         try DBMember(inboxId: "creator").save(db, onConflict: .ignore)
@@ -68,12 +71,12 @@ struct AgentFilesLinksRepositoryTests {
             .save(db)
         }
         try DBMessage(
-            id: "msg-1",
-            clientMessageId: "msg-1",
+            id: messageId,
+            clientMessageId: messageId,
             conversationId: Self.conversationId,
             senderId: Self.agentInboxId,
-            dateNs: 1,
-            date: Date(timeIntervalSince1970: 0),
+            dateNs: Int64(date.timeIntervalSince1970 * 1_000_000_000),
+            date: date,
             sortId: nil,
             status: .published,
             messageType: .original,
@@ -85,7 +88,7 @@ struct AgentFilesLinksRepositoryTests {
             sourceMessageId: nil,
             // A row with no attachment key is dropped before the sender
             // check is reached, which would make this test pass for the wrong reason.
-            attachmentUrls: ["notes.html"],
+            attachmentUrls: ["file:///tmp/\(messageId)_\(filename)"],
             update: nil
         ).insert(db)
     }
@@ -145,6 +148,63 @@ struct AgentFilesLinksRepositoryTests {
             )
         }
         #expect(await files(fixtures).isEmpty)
+    }
+
+    @Test("the canvas is selected by canonical filename")
+    func canvasSelectedByCanonicalFilename() async throws {
+        let fixtures = try await makeTestFixtures()
+        try await fixtures.dbWriter.write { db in
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .verifiedConvos,
+                kindOnLegacyMemberProfile: .agent,
+                filename: "canvas~quiet.html"
+            )
+        }
+
+        let canvas = AgentFilesLinksRepository.canvasFile(in: await files(fixtures))
+        #expect(canvas?.id == "msg-1")
+        #expect(canvas?.displayName == "canvas.html")
+    }
+
+    @Test("the newest canvas update wins")
+    func newestCanvasWins() async throws {
+        let fixtures = try await makeTestFixtures()
+        try await fixtures.dbWriter.write { db in
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .verifiedConvos,
+                kindOnLegacyMemberProfile: .agent,
+                messageId: "canvas-old",
+                filename: "canvas.html",
+                date: Date(timeIntervalSince1970: 1)
+            )
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .verifiedConvos,
+                kindOnLegacyMemberProfile: .agent,
+                messageId: "canvas-new",
+                filename: "canvas~quiet.html",
+                date: Date(timeIntervalSince1970: 2)
+            )
+        }
+
+        let canvas = AgentFilesLinksRepository.canvasFile(in: await files(fixtures))
+        #expect(canvas?.id == "canvas-new")
+    }
+
+    @Test("canvas selection is nil when the conversation has no canvas")
+    func canvasAbsent() async throws {
+        let fixtures = try await makeTestFixtures()
+        try await fixtures.dbWriter.write { db in
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .verifiedConvos,
+                kindOnLegacyMemberProfile: .agent
+            )
+        }
+
+        #expect(AgentFilesLinksRepository.canvasFile(in: await files(fixtures)) == nil)
     }
 
     // MARK: - Test Helpers

--- a/ConvosCore/Tests/ConvosCoreTests/QuietArtifactUpdateTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/QuietArtifactUpdateTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import ConvosCore
+
+struct QuietArtifactUpdateTests {
+    @Test("recognizes the sentinel before the extension")
+    func recognizesSentinel() {
+        #expect(QuietArtifactUpdate.isQuiet(filename: "notes~quiet.html"))
+        #expect(!QuietArtifactUpdate.isQuiet(filename: "notes.html"))
+        #expect(!QuietArtifactUpdate.isQuiet(filename: nil))
+    }
+
+    @Test("a filename merely containing the sentinel is not quiet")
+    func sentinelMustBeTerminal() {
+        // The sentinel marks the end of the stem; anywhere else it is just
+        // part of a name the agent chose.
+        #expect(!QuietArtifactUpdate.isQuiet(filename: "~quiet-notes.html"))
+        #expect(!QuietArtifactUpdate.isQuiet(filename: "notes~quiet-2.html"))
+    }
+
+    @Test("strips the sentinel back to the artifact's real name")
+    func stripsToCanonical() {
+        #expect(QuietArtifactUpdate.canonicalFilename("notes~quiet.html") == "notes.html")
+        #expect(QuietArtifactUpdate.canonicalFilename("trip.plan~quiet.html") == "trip.plan.html")
+    }
+
+    @Test("leaves ordinary filenames untouched")
+    func passesThroughOrdinary() {
+        #expect(QuietArtifactUpdate.canonicalFilename("notes.html") == "notes.html")
+        #expect(QuietArtifactUpdate.canonicalFilename(nil) == nil)
+    }
+
+    @Test("a quiet update and its loud original share one identity")
+    func quietAndLoudDedupeTogether() {
+        // This is what makes the update supersede rather than accumulate in
+        // Files & Links and the Things view.
+        #expect(
+            QuietArtifactUpdate.canonicalFilename("notes~quiet.html")
+                == QuietArtifactUpdate.canonicalFilename("notes.html")
+        )
+    }
+
+    @Test("handles an extensionless name")
+    func handlesNoExtension() {
+        #expect(QuietArtifactUpdate.canonicalFilename("notes~quiet") == "notes")
+    }
+}

--- a/prototype.yml
+++ b/prototype.yml
@@ -1,0 +1,4 @@
+prototypeId: "agent-first-app"
+side: "app"
+requestedLifetime: "standing — a long-running prototype pair, extended before each expiry"
+whatToTest: "Agent-first Convos: no builder affordances; every new conversation starts with an agent joining, pinned to the paired runtime variant."


### PR DESCRIPTION
The app half of the standing **agent-first** prototype pair (`prototypeId: agent-first-app`), paired with xmtplabs/convos-assistants#2855 through `pinnedAgentVariantSlug: "pr-2855"`. A long-running soft fork of `dev`: single branch, rebased as dev advances, never merges — the pairing is by slug, so rebases on either side don't break it.

## What the build changes

- **No builder.** `noBuilder` in `config.pr.json` removes every "Make an agent" affordance, and each new conversation starts by bare-joining the default agent — pinned to the `pr-2855` runtime variant, where it works out what it should be.
- **Openers.** Tappable conversation starters carry the group while the agent finds its purpose.
- **Quiet artifact updates.** The `~quiet` filename sentinel supersedes an artifact in Files & Links and Things without spending a transcript card — the client half of the runtime's `MEDIA-QUIET:` marker.
- **Things is the canvas.** The conversation's Things page renders the agent's `canvas.html` full-bleed in a live webview with reload-on-supersede; the file and link list moves behind a sheet.

## Testing

Install the Firebase PR build (the `adhoc-build` label keeps it fresh on every push). Every new conversation exercises the flow end-to-end against the paired runtime.

## Lifecycle

Permanent draft under the shared prototype contract (`prototype.yml`, standing lifetime — extended before each expiry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULTXgEXzig3qjsjkhoynjH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787186480&installation_model_id=20076&pr_number=1200&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1200&signature=cfd4d9a6be07788351a476bd4aa06a962de1e9ae3d7a51f0ad6c0bf8eaf58f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship PR build without agent builder by adding agent-only build mode
> - Adds `isAgentOnlyBuild` and `pinnedAgentVariantSlug` config flags to `ConfigManager`, driven by a new `agentOnlyBuild` key in [config.pr.json](https://github.com/xmtplabs/convos-ios/pull/1200/files#diff-d481f925ffca34a9bfb0028c6a8ad7da4684166745ebfb715ce603003a338109).
> - Hides agent builder entry points (contacts picker, add-to-conversation menu, builder bar, empty-state CTA) when `isAgentOnlyBuild` is true.
> - In agent-only builds, the compose action and empty-state CTA bypass the contacts picker and immediately open a new conversation that auto-joins the default agent via `joinsDefaultAgent: true` on `NewConversationViewModel`.
> - `ConversationViewModel.selectedAgentVariantSlug` falls back to `pinnedAgentVariantSlug` from config when the variant selector is disabled or unset.
> - Behavioral Change: the PR build (`config.pr.json`) sets `agentOnlyBuild: true`, so all agent builder surfaces are hidden and conversation creation skips the contacts picker in that build.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3780814. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
