### PR TITLE
Brainstorm: per-agent side-thread tab in the conversation pager

### DIFF
--- a/Convos/Conversation Detail/BrainstormListProcessor.swift
+++ b/Convos/Conversation Detail/BrainstormListProcessor.swift
@@ -1,0 +1,135 @@
+import ConvosCore
+import Foundation
+
+/// Builds the `[MessagesListItemType]` snapshot rendered inside
+/// `BrainstormPageView`'s `MessagesViewController`. Parallels
+/// `ThinkingDetailListProcessor`, but instead of one session it interleaves,
+/// in chronological order (newest at the bottom):
+///
+/// - every thinking session the agent has recorded in this conversation,
+///   each preceded by the message it was "attached" to (the session's
+///   `targetMessageId`), rendered in the regular chat-bubble style
+/// - every brainstorm message in the agent's thread (the user's and the
+///   agent's replies), rendered in the thought-bubble style; the current
+///   user's messages sit on the trailing edge with the outgoing bubble color
+enum BrainstormListProcessor {
+    static func process(
+        agent: ConversationMember,
+        sessions: [ThinkingSessionRecord],
+        brainstormMessages: [BrainstormMessageRecord],
+        chatItems: [MessagesListItemType],
+        members: [ConversationMember]
+    ) -> [MessagesListItemType] {
+        let chatMessagesById: [String: AnyMessage] = messagesById(from: chatItems)
+
+        var entries: [(sortNs: Int64, items: [MessagesListItemType])] = []
+
+        let agentSessions = sessions.filter { $0.senderInboxId == agent.profile.inboxId }
+        for session in agentSessions {
+            var items: [MessagesListItemType] = []
+            if let target = chatMessagesById[session.targetMessageId] {
+                var group = MessagesGroup(
+                    id: "brainstorm-target-\(session.id)",
+                    sender: target.sender,
+                    messages: [target],
+                    isLastGroup: false,
+                    isLastGroupSentByCurrentUser: false
+                )
+                group.hidesSenderLabel = target.sender.isCurrentUser
+                items.append(.messages(group))
+            }
+            if let momentsGroup = momentsGroup(for: session, agent: agent) {
+                items.append(momentsGroup)
+            }
+            if !items.isEmpty {
+                entries.append((sortNs: session.startedAtNs, items: items))
+            }
+        }
+
+        let agentMessages = brainstormMessages.filter { $0.agentInboxId == agent.profile.inboxId }
+        for record in agentMessages {
+            guard let item = brainstormMessageGroup(for: record, members: members) else { continue }
+            entries.append((sortNs: record.sentAtNs, items: [item]))
+        }
+
+        let sorted = entries.sorted { $0.sortNs < $1.sortNs }
+        return sorted.flatMap(\.items)
+    }
+
+    private static func messagesById(from items: [MessagesListItemType]) -> [String: AnyMessage] {
+        var result: [String: AnyMessage] = [:]
+        for item in items {
+            guard case .messages(let group) = item else { continue }
+            for message in group.allMessages {
+                result[message.messageId] = message
+            }
+        }
+        return result
+    }
+
+    /// One thought-bubble group per session holding every `start` moment,
+    /// mirroring `ThinkingDetailListProcessor` (trailing pulsing bubble
+    /// while the session is active).
+    private static func momentsGroup(
+        for session: ThinkingSessionRecord,
+        agent: ConversationMember
+    ) -> MessagesListItemType? {
+        let starts = session.moments.filter { $0.state == .start }
+        let showsBubble: Bool = session.isActive
+        guard !starts.isEmpty || showsBubble else { return nil }
+
+        let messages: [AnyMessage] = starts.map { (moment: ThinkingMoment) -> AnyMessage in
+            let message = Message(
+                id: moment.id,
+                sender: agent,
+                source: .incoming,
+                status: .published,
+                content: .text(moment.content),
+                date: moment.sentAt,
+                reactions: []
+            )
+            return .message(message, .existing)
+        }
+
+        var group = MessagesGroup(
+            id: "brainstorm-session-\(session.id)",
+            sender: agent,
+            messages: messages,
+            isLastGroup: false,
+            isLastGroupSentByCurrentUser: false
+        )
+        group.hidesSenderLabel = true
+        group.showsThinkingIndicator = showsBubble
+        group.usesThoughtBubbleStyle = true
+        return .messages(group)
+    }
+
+    private static func brainstormMessageGroup(
+        for record: BrainstormMessageRecord,
+        members: [ConversationMember]
+    ) -> MessagesListItemType? {
+        guard let sender = members.first(where: { $0.profile.inboxId == record.senderInboxId }) else {
+            return nil
+        }
+        let source: MessageSource = sender.isCurrentUser ? .outgoing : .incoming
+        let message = Message(
+            id: record.id,
+            sender: sender,
+            source: source,
+            status: record.status,
+            content: .text(record.text),
+            date: record.sentAt,
+            reactions: []
+        )
+        var group = MessagesGroup(
+            id: "brainstorm-message-\(record.clientMessageId)",
+            sender: sender,
+            messages: [AnyMessage.message(message, .existing)],
+            isLastGroup: false,
+            isLastGroupSentByCurrentUser: false
+        )
+        group.hidesSenderLabel = true
+        group.usesThoughtBubbleStyle = true
+        return .messages(group)
+    }
+}

--- a/Convos/Conversation Detail/BrainstormListProcessor.swift
+++ b/Convos/Conversation Detail/BrainstormListProcessor.swift
@@ -28,15 +28,7 @@ enum BrainstormListProcessor {
         for session in agentSessions {
             var items: [MessagesListItemType] = []
             if let target = chatMessagesById[session.targetMessageId] {
-                var group = MessagesGroup(
-                    id: "brainstorm-target-\(session.id)",
-                    sender: target.sender,
-                    messages: [target],
-                    isLastGroup: false,
-                    isLastGroupSentByCurrentUser: false
-                )
-                group.hidesSenderLabel = target.sender.isCurrentUser
-                items.append(.messages(group))
+                items.append(targetItem(for: target, sessionId: session.id))
             }
             if let momentsGroup = momentsGroup(for: session, agent: agent) {
                 items.append(momentsGroup)
@@ -54,6 +46,38 @@ enum BrainstormListProcessor {
 
         let sorted = entries.sorted { $0.sortNs < $1.sortNs }
         return sorted.flatMap(\.items)
+    }
+
+    /// The chat message a thinking session was attached to, rendered in the
+    /// agent-builder summary card style (bordered quote box + sender footer)
+    /// so it reads as quoted chat context rather than a live thread message.
+    /// Non-text targets (attachments, invites) fall back to the regular chat
+    /// bubble, which can render any content type.
+    private static func targetItem(for target: AnyMessage, sessionId: String) -> MessagesListItemType {
+        if case .text(let text) = target.content {
+            let sender = target.sender
+            let footer: String = sender.isCurrentUser
+                ? "Sent by you in the chat"
+                : "Sent by \(sender.displayName) in the chat"
+            return .agentBuilderSummary(AgentBuilderCardContent(
+                id: "brainstorm-target-\(sessionId)",
+                prompt: text,
+                creatorIsCurrentUser: sender.isCurrentUser,
+                creatorDisplayName: sender.displayName,
+                creatorProfile: sender.profile,
+                promptHeaderOverride: "",
+                footerTextOverride: footer
+            ))
+        }
+        var group = MessagesGroup(
+            id: "brainstorm-target-\(sessionId)",
+            sender: target.sender,
+            messages: [target],
+            isLastGroup: false,
+            isLastGroupSentByCurrentUser: false
+        )
+        group.hidesSenderLabel = target.sender.isCurrentUser
+        return .messages(group)
     }
 
     private static func messagesById(from items: [MessagesListItemType]) -> [String: AnyMessage] {

--- a/Convos/Conversation Detail/BrainstormPageView.swift
+++ b/Convos/Conversation Detail/BrainstormPageView.swift
@@ -1,0 +1,192 @@
+import ConvosComposer
+import ConvosCore
+import SwiftUI
+
+/// One agent's brainstorm page inside `ConversationPager`. Renders the
+/// agent's full thinking history (each session preceded by the message it
+/// was attached to) interleaved with the brainstorm reply thread, plus a
+/// composer whose sends stay out of the main chat (see
+/// `ConversationViewModel+Brainstorm`).
+struct BrainstormPageView: View {
+    @Bindable var viewModel: ConversationViewModel
+    let agentInboxId: String
+
+    /// Local focus state, deliberately not shared with the chat composer:
+    /// every pager page stays mounted in the paging HStack, so a shared
+    /// `.message` focus value would fight with the chat page's text field.
+    @FocusState private var focusState: MessagesViewInputFocus?
+    @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: .compact)
+    @State private var messageText: String = ""
+    @State private var bottomBarHeight: CGFloat = 0.0
+    @State private var presentingMomentDetail: AnyMessage?
+
+    private var agent: ConversationMember? {
+        viewModel.brainstormAgent(inboxId: agentInboxId)
+    }
+
+    private var agentName: String {
+        agent?.displayName ?? "Agent"
+    }
+
+    private var items: [MessagesListItemType] {
+        viewModel.brainstormItems(for: agentInboxId)
+    }
+
+    private var hasContent: Bool {
+        viewModel.hasBrainstormContent(for: agentInboxId)
+    }
+
+    private var sendButtonEnabled: Bool {
+        !messageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        ZStack {
+            if hasContent {
+                messagesBody
+            } else {
+                BrainstormEmptyStateView(agentName: agentName, onStart: handleStartBrainstorming)
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            composer
+        }
+        .sheet(item: $presentingMomentDetail) { moment in
+            MessageDetailView(
+                message: moment,
+                onCopy: { text in UIPasteboard.general.string = text },
+                onReply: { _ in presentingMomentDetail = nil }
+            )
+        }
+    }
+
+    private func handleStartBrainstorming() {
+        focusState = .message
+    }
+
+    private func handleSendMessage() {
+        let text = messageText
+        messageText = ""
+        viewModel.sendBrainstormMessage(text: text, toAgentInboxId: agentInboxId)
+    }
+
+    private var composer: some View {
+        MessagesInputView(
+            displayName: .constant(""),
+            emptyDisplayNamePlaceholder: "",
+            messageText: $messageText,
+            messagePlaceholder: "Chat with \(agentName)",
+            pendingInviteConvoName: .constant(""),
+            pendingInviteImage: .constant(nil),
+            sendButtonEnabled: sendButtonEnabled,
+            focusState: $focusState,
+            messagesTextFieldEnabled: true,
+            onSendMessage: handleSendMessage,
+            onClearInvite: {},
+            fileAttachmentPreview: { _ in EmptyView() },
+            agentShareChip: { EmptyView() }
+        )
+        .fixedSize(horizontal: false, vertical: true)
+        .clipShape(.rect(cornerRadius: 26.0))
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.bottom, DesignConstants.Spacing.step3x)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newHeight in
+            bottomBarHeight = newHeight
+        }
+    }
+
+    private var messagesBody: some View {
+        MessagesViewRepresentable(
+            conversation: viewModel.conversation,
+            messages: items,
+            invite: .empty,
+            onUserInteraction: {},
+            hasLoadedAllMessages: false,
+            focusCoordinator: focusCoordinator,
+            onTapAvatar: { _ in },
+            onLoadPreviousMessages: {},
+            onTapInvite: { _ in },
+            onReaction: { _, _ in },
+            onToggleReaction: { _, _ in },
+            onTapReactions: { _ in },
+            onTapReadReceipts: { _ in },
+            onTapThinkingIndicator: { _ in },
+            onReply: { _ in },
+            onOpenMessageDetail: { presentingMomentDetail = $0 },
+            contextMenuState: .init(),
+            onPhotoDimensionsLoaded: { _, _, _ in },
+            onAgentOutOfCredits: {},
+            creditsDepleted: false,
+            onTapUpdateMember: { _ in },
+            onRetryMessage: { _ in },
+            onDeleteMessage: { _ in },
+            onRetryAgentJoin: {},
+            onCopyInviteLink: {},
+            onConvoCode: {},
+            onInviteAgent: {},
+            onRetryTranscript: { _ in },
+            profileSheetForMember: { _ in AnyView(EmptyView()) },
+            memberContactOverride: { _ in nil },
+            isAgentJoinPending: false,
+            bottomBarHeight: bottomBarHeight,
+            hasBottomBar: true,
+            topContentInset: 0.0,
+            scrollToBottomTrigger: { _ in },
+            messageInputFocusTrigger: { _ in }
+        )
+        .ignoresSafeArea()
+    }
+}
+
+/// Empty-state CTA for a brainstorm page with no thinking history and no
+/// thread yet. Mirrors the `EmptyStateCTAView` layout (fixed headline slot,
+/// subtitle, rounded CTA) without the mock carousel.
+private struct BrainstormEmptyStateView: View {
+    let agentName: String
+    let onStart: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            TightLineHeightText(
+                text: "Brainstorm with \(agentName)",
+                fontSize: Constant.headlineFontSize,
+                lineHeight: Constant.headlineLineHeight,
+                weight: .regular,
+                textAlignment: .center
+            )
+            Text("Without notifying the group")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.top, DesignConstants.Spacing.step2x)
+            startButton
+                .padding(.top, DesignConstants.Spacing.step5x)
+            Spacer(minLength: 0)
+        }
+        .offset(y: -DesignConstants.Spacing.step6x)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .background(.colorBackgroundSurfaceless)
+    }
+
+    private var startButton: some View {
+        Button(action: onStart) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                Image(systemName: "bubbles.and.sparkles")
+                Text("Start brainstorming")
+                    .font(.callout)
+            }
+        }
+        .convosButtonStyle(.rounded(fullWidth: false, backgroundColor: .colorLava))
+        .accessibilityIdentifier("brainstorm-empty-state-start-button")
+    }
+
+    private enum Constant {
+        static let headlineFontSize: CGFloat = 40.0
+        static let headlineLineHeight: CGFloat = 40.0
+    }
+}

--- a/Convos/Conversation Detail/BrainstormPageView.swift
+++ b/Convos/Conversation Detail/BrainstormPageView.swift
@@ -48,6 +48,10 @@ struct BrainstormPageView: View {
                 BrainstormEmptyStateView(agentName: agentName, onStart: handleStartBrainstorming)
             }
         }
+        // Same canvas as ThinkingDetailView's presentation background: the
+        // thought bubbles fill with colorBackgroundRaised, which disappears
+        // against the default page background.
+        .background(Color.colorBackgroundRaisedSecondary)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             composer
         }

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -2,15 +2,26 @@ import ConvosCore
 import SwiftUI
 import SwiftUIIntrospect
 
-enum ConversationPagerPage: Int, CaseIterable, Identifiable {
+enum ConversationPagerPage: Hashable, Identifiable {
     case messages
+    /// One page per agent member: that agent's brainstorm thread.
+    case brainstorm(agentInboxId: String)
     case things
 
-    var id: Int { rawValue }
+    var id: String {
+        switch self {
+        case .messages: return "messages"
+        case .brainstorm(let agentInboxId): return "brainstorm-\(agentInboxId)"
+        case .things: return "things"
+        }
+    }
 }
 
-struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
+struct ConversationPager<MessagesPage: View, BrainstormPage: View, ThingsPage: View>: View {
     @Binding var selectedPage: ConversationPagerPage
+    /// Ordered pages to render: `.messages` first, one `.brainstorm` per
+    /// agent member, `.things` last. Built by `ConversationView`.
+    let pages: [ConversationPagerPage]
     /// Whether the dots are mounted at all. Drives the `safeAreaInset`
     /// itself, so flipping this resizes the pager content — only set it
     /// based on keyboard presence, which already animates via the
@@ -23,25 +34,23 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
     /// presented so the dots fade out without resizing anything around
     /// them.
     var dotsHidden: Bool = false
-    /// When true, horizontal paging between `messages` and `things` is
-    /// blocked. Used while the message long-press context menu is
-    /// presented — without it the user can drag past the menu into the
-    /// things page mid-interaction.
+    /// When true, horizontal paging between pages is blocked. Used while
+    /// the message long-press context menu is presented — without it the
+    /// user can drag past the menu into another page mid-interaction.
     var scrollingDisabled: Bool = false
     @ViewBuilder let messagesPage: () -> MessagesPage
+    @ViewBuilder let brainstormPage: (String) -> BrainstormPage
     @ViewBuilder let thingsPage: () -> ThingsPage
 
     var body: some View {
         GeometryReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 0) {
-                    messagesPage()
-                        .frame(width: proxy.size.width, height: proxy.size.height)
-                        .id(ConversationPagerPage.messages)
-
-                    thingsPage()
-                        .frame(width: proxy.size.width, height: proxy.size.height)
-                        .id(ConversationPagerPage.things)
+                    ForEach(pages) { page in
+                        pageContent(for: page)
+                            .frame(width: proxy.size.width, height: proxy.size.height)
+                            .id(page)
+                    }
                 }
                 .scrollTargetLayout()
             }
@@ -59,7 +68,7 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if showsPageDots {
-                ConversationPagerDots(selectedPage: $selectedPage)
+                ConversationPagerDots(selectedPage: $selectedPage, pages: pages)
                     .opacity(dotsHidden ? 0 : 1)
                     .scaleEffect(dotsHidden ? 0.85 : 1)
                     .allowsHitTesting(!dotsHidden)
@@ -67,14 +76,27 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
             }
         }
     }
+
+    @ViewBuilder
+    private func pageContent(for page: ConversationPagerPage) -> some View {
+        switch page {
+        case .messages:
+            messagesPage()
+        case .brainstorm(let agentInboxId):
+            brainstormPage(agentInboxId)
+        case .things:
+            thingsPage()
+        }
+    }
 }
 
 private struct ConversationPagerDots: View {
     @Binding var selectedPage: ConversationPagerPage
+    let pages: [ConversationPagerPage]
 
     var body: some View {
         HStack(spacing: 10.0) {
-            ForEach(ConversationPagerPage.allCases) { page in
+            ForEach(pages) { page in
                 let isSelected: Bool = page == selectedPage
                 let action = {
                     withAnimation(.easeInOut(duration: 0.25)) {
@@ -106,6 +128,13 @@ private struct ConversationPagerDots: View {
                 bottomTrailing: 8.0,
                 topTrailing: 8.0
             ))
+        case .brainstorm:
+            return UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 8.0,
+                bottomLeading: 8.0,
+                bottomTrailing: 8.0,
+                topTrailing: 8.0
+            ))
         case .things:
             return UnevenRoundedRectangle(cornerRadii: .init(
                 topLeading: 2.0,
@@ -119,6 +148,7 @@ private struct ConversationPagerDots: View {
     private func label(for page: ConversationPagerPage) -> String {
         switch page {
         case .messages: return "Messages"
+        case .brainstorm: return "Brainstorm"
         case .things: return "Things"
         }
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -517,13 +517,30 @@ struct ConversationView<MessagesBottomBar: View>: View {
         isKeyboardVisible ? 0.0 : 24.0
     }
 
+    /// Pager layout: chat first, one brainstorm page per agent member, and
+    /// Things always last.
+    private var pagerPages: [ConversationPagerPage] {
+        var pages: [ConversationPagerPage] = [.messages]
+        for agent in viewModel.brainstormAgents {
+            pages.append(.brainstorm(agentInboxId: agent.profile.inboxId))
+        }
+        pages.append(.things)
+        return pages
+    }
+
+    private func brainstormPage(for agentInboxId: String) -> some View {
+        BrainstormPageView(viewModel: viewModel, agentInboxId: agentInboxId)
+    }
+
     var body: some View {
         ConversationPager(
             selectedPage: $pagerSelectedPage,
+            pages: pagerPages,
             showsPageDots: !isKeyboardVisible,
             dotsHidden: contextMenuState.isPresented,
             scrollingDisabled: contextMenuState.isPresented,
             messagesPage: { messagesView },
+            brainstormPage: { brainstormPage(for: $0) },
             thingsPage: { thingsPage }
         )
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in

--- a/Convos/Conversation Detail/ConversationViewModel+Brainstorm.swift
+++ b/Convos/Conversation Detail/ConversationViewModel+Brainstorm.swift
@@ -1,0 +1,76 @@
+import ConvosCore
+import Foundation
+
+/// Brainstorm: a per-agent side thread built from the agent's thinking
+/// history plus standard replies chained onto it. Outgoing brainstorm
+/// messages reply to the agent's most recent thinking message; when the
+/// agent has never thought, a silent brainstorm anchor is published first
+/// and the reply references that. Either way the reference id points at a
+/// row outside the chat table, which is what keeps brainstorm messages out
+/// of the main messages list (see `MessagesRepository`).
+extension ConversationViewModel {
+    /// Agent members that get a brainstorm page in the conversation pager,
+    /// in roster order.
+    var brainstormAgents: [ConversationMember] {
+        conversation.members.filter(\.isAgent)
+    }
+
+    func brainstormAgent(inboxId: String) -> ConversationMember? {
+        conversation.members.first { $0.profile.inboxId == inboxId }
+    }
+
+    /// Snapshot for one agent's brainstorm page: thinking sessions (with
+    /// their target messages) interleaved chronologically with the thread's
+    /// brainstorm messages.
+    func brainstormItems(for agentInboxId: String) -> [MessagesListItemType] {
+        guard let agent = brainstormAgent(inboxId: agentInboxId) else { return [] }
+        return BrainstormListProcessor.process(
+            agent: agent,
+            sessions: thinkingSessions,
+            brainstormMessages: brainstormFeed.messages,
+            chatItems: messages,
+            members: conversation.members
+        )
+    }
+
+    func hasBrainstormContent(for agentInboxId: String) -> Bool {
+        let hasSessions = thinkingSessions.contains { $0.senderInboxId == agentInboxId }
+        let hasMessages = brainstormFeed.messages.contains { $0.agentInboxId == agentInboxId }
+        return hasSessions || hasMessages
+    }
+
+    func sendBrainstormMessage(text: String, toAgentInboxId agentInboxId: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let messageWriter = cachedMessageWriter
+        let existingReferenceId = brainstormReferenceId(for: agentInboxId)
+        Task {
+            do {
+                let referenceId: String
+                if let existingReferenceId {
+                    referenceId = existingReferenceId
+                } else {
+                    referenceId = try await messageWriter.sendBrainstormAnchor(agentInboxId: agentInboxId)
+                }
+                try await messageWriter.sendBrainstormReply(text: trimmed, toReferenceId: referenceId)
+            } catch {
+                Log.error("Failed to send brainstorm message: \(error)")
+            }
+        }
+    }
+
+    /// The reply-chain reference for a new brainstorm message: the agent's
+    /// most recent thinking message, falling back to the newest anchor
+    /// already opened for this agent. Nil means the sender must publish an
+    /// anchor first.
+    private func brainstormReferenceId(for agentInboxId: String) -> String? {
+        let latestMoment: ThinkingMoment? = thinkingSessions
+            .filter { $0.senderInboxId == agentInboxId }
+            .flatMap(\.moments)
+            .max { $0.sentAtNs < $1.sentAtNs }
+        if let latestMoment {
+            return latestMoment.id
+        }
+        return brainstormFeed.anchors.last { $0.agentInboxId == agentInboxId }?.id
+    }
+}

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -155,7 +155,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     @ObservationIgnored
     private var _cachedMessageWriterConversationId: String?
 
-    private var cachedMessageWriter: any OutgoingMessageWriterProtocol {
+    var cachedMessageWriter: any OutgoingMessageWriterProtocol {
         if _cachedMessageWriterConversationId != conversation.id {
             Log.debug("[EagerUpload] Creating new message writer for conversation: \(conversation.id)")
             _cachedMessageWriter = messagingService.messageWriter(
@@ -243,6 +243,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     private var observedCapabilityRequestsConversationId: String?
     @ObservationIgnored
     private var thinkingSessionsCancellable: AnyCancellable?
+    private var brainstormFeedCancellable: AnyCancellable?
+    private var observedBrainstormConversationId: String?
     @ObservationIgnored
     private var observedThinkingSessionsConversationId: String?
     @ObservationIgnored
@@ -753,6 +755,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// `messagesWithIndicators`. Mirror of how `typingMembers` drives the
     /// typing bubble, but persisted in GRDB rather than in-memory.
     var thinkingSessions: [ThinkingSessionRecord] = []
+    var brainstormFeed: BrainstormFeed = .empty
 
     @ObservationIgnored
     var isTypingSent: Bool = false
@@ -1480,10 +1483,31 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             }
     }
 
+    /// Subscribe to the GRDB-backed brainstorm feed (anchors + reply-chain
+    /// messages) for this conversation. Backs the per-agent brainstorm pager
+    /// pages via `brainstormItems(for:)`.
+    func observeBrainstormFeed() {
+        observeBrainstormFeed(for: conversation.id)
+    }
+
+    func observeBrainstormFeed(for conversationId: String) {
+        guard conversationId != observedBrainstormConversationId else { return }
+        observedBrainstormConversationId = conversationId
+        brainstormFeed = .empty
+        brainstormFeedCancellable?.cancel()
+        brainstormFeedCancellable = session.brainstormRepository()
+            .feedPublisher(for: conversationId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] feed in
+                self?.brainstormFeed = feed
+            }
+    }
+
     private func observe() {
         messagesListRepository.startObserving()
         setupTypingIndicatorHandler()
         observeThinkingSessions()
+        observeBrainstormFeed()
         observeDirectBuildGeneration()
         setupVoiceMemoPlaybackObserver()
         observeCapabilityRequests()
@@ -1560,6 +1584,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     self.loadPhotoPreferences()
                     self.observeCapabilityRequests(for: conversation.id)
                     self.observeThinkingSessions(for: conversation.id)
+                    self.observeBrainstormFeed(for: conversation.id)
                     self.observeDirectBuildGeneration(for: conversation.id)
                     self.observeAgentBuilderSummary(for: conversation.id)
                     if wasViewingConversation {

--- a/ConvosCore/Sources/ConvosComposer/AgentBuilderSummaryView.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentBuilderSummaryView.swift
@@ -32,10 +32,20 @@ public struct AgentBuilderSummaryView: View {
     }
 
     private var footerText: String {
+        if let override = content.footerTextOverride {
+            return override
+        }
         if content.creatorIsCurrentUser || content.creatorDisplayName.isEmpty {
             return "You made an agent · They'll join soon"
         }
         return "\(content.creatorDisplayName) created an agent · They'll join soon"
+    }
+
+    private var promptHeaderText: String? {
+        guard let override = content.promptHeaderOverride else {
+            return Constant.promptHeader
+        }
+        return override.isEmpty ? nil : override
     }
 
     private var hasChips: Bool {
@@ -69,9 +79,11 @@ public struct AgentBuilderSummaryView: View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
             if !content.prompt.isEmpty {
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
-                    Text(Constant.promptHeader)
-                        .font(.caption2)
-                        .foregroundStyle(.colorTextSecondary)
+                    if let promptHeaderText {
+                        Text(promptHeaderText)
+                            .font(.caption2)
+                            .foregroundStyle(.colorTextSecondary)
+                    }
                     Text(content.prompt)
                         .font(.caption)
                         .lineSpacing(Constant.promptLineSpacing)

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -8,6 +8,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
     @Binding var displayName: String
     let emptyDisplayNamePlaceholder: String
     @Binding var messageText: String
+    var messagePlaceholder: String = "Chat"
     var pendingMediaAttachments: [PendingMediaAttachment] = []
     var composerLinkPreview: LinkPreview?
     var pendingInviteURL: String?
@@ -45,6 +46,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
         displayName: Binding<String>,
         emptyDisplayNamePlaceholder: String,
         messageText: Binding<String>,
+        messagePlaceholder: String = "Chat",
         pendingMediaAttachments: [PendingMediaAttachment] = [],
         composerLinkPreview: LinkPreview? = nil,
         pendingInviteURL: String? = nil,
@@ -69,6 +71,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
         _displayName = displayName
         self.emptyDisplayNamePlaceholder = emptyDisplayNamePlaceholder
         _messageText = messageText
+        self.messagePlaceholder = messagePlaceholder
         self.pendingMediaAttachments = pendingMediaAttachments
         self.composerLinkPreview = composerLinkPreview
         self.pendingInviteURL = pendingInviteURL
@@ -129,7 +132,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
     private var messageTextField: some View {
         Group {
             TextField(
-                "Chat",
+                messagePlaceholder,
                 text: $messageText,
                 axis: .vertical
             )

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/ThoughtBubble.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/ThoughtBubble.swift
@@ -19,6 +19,10 @@ import SwiftUI
 struct ThoughtBubble<Content: View>: View {
     @ViewBuilder let content: () -> Content
     var color: Color = .colorBackgroundRaised
+    /// Mirrors the tail to the bottom-trailing corner for messages sent by
+    /// the current user (brainstorm view). Incoming/default keeps the
+    /// bottom-leading tail.
+    var isOutgoing: Bool = false
 
     private let cornerRadius: CGFloat = 20.0
     private let bigCircleSize: CGFloat = 12.0
@@ -33,6 +37,10 @@ struct ThoughtBubble<Content: View>: View {
     private let smallCircleCornerOverlap: CGFloat = 1.0
 
     var body: some View {
+        let tailAlignment: Alignment = isOutgoing ? .bottomTrailing : .bottomLeading
+        let smallCircleXOffset: CGFloat = isOutgoing
+            ? smallCircleSize - smallCircleCornerOverlap
+            : -smallCircleSize + smallCircleCornerOverlap
         content()
             .padding(.horizontal, horizontalPadding)
             .padding(.vertical, verticalPadding)
@@ -40,26 +48,26 @@ struct ThoughtBubble<Content: View>: View {
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .fill(color)
             )
-            // Big circle: bbox bottom-left corner sits exactly on the
-            // rect's bottom-leading bbox corner. With `.bottomLeading`
+            // Big circle: bbox bottom corner sits exactly on the rect's
+            // bottom bbox corner on the tail side. With the tail-side
             // alignment and no offset, the circle's 12×12 bbox occupies
-            // the rect's bottom-leading corner area. The rect's 20pt
-            // rounded corner curves inward from there, so the circle's
-            // bottom-leading portion bleeds out past the curve as the
-            // tail.
-            .overlay(alignment: .bottomLeading) {
+            // that corner area. The rect's 20pt rounded corner curves
+            // inward from there, so the circle's outer portion bleeds out
+            // past the curve as the tail.
+            .overlay(alignment: tailAlignment) {
                 Circle()
                     .fill(color)
                     .frame(width: bigCircleSize, height: bigCircleSize)
             }
-            // Small circle: bbox top-right overlaps the big circle's bbox
-            // bottom-left by `smallCircleCornerOverlap` pt, diagonally.
-            .overlay(alignment: .bottomLeading) {
+            // Small circle: bbox inner-top corner overlaps the big circle's
+            // bbox outer-bottom corner by `smallCircleCornerOverlap` pt,
+            // diagonally, mirrored to the tail side.
+            .overlay(alignment: tailAlignment) {
                 Circle()
                     .fill(color)
                     .frame(width: smallCircleSize, height: smallCircleSize)
                     .offset(
-                        x: -smallCircleSize + smallCircleCornerOverlap,
+                        x: smallCircleXOffset,
                         y: smallCircleSize - smallCircleCornerOverlap
                     )
             }

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
@@ -485,11 +485,19 @@ struct MessagesGroupView: View {
     private func thoughtBubbleRow(message: AnyMessage, text: String, isLast: Bool) -> some View {
         let lengthClass: MessageLengthClass = MessageBodyClassifier.classify(text)
         let isBounded: Bool = lengthClass != .short
+        let isOutgoing: Bool = message.sender.isCurrentUser
+        let capAlignment: Alignment = isOutgoing ? .trailing : .leading
+        let bubbleColor: Color = isOutgoing ? .colorBubble : .colorBackgroundRaised
+        let trailingPad: CGFloat = isOutgoing ? DesignConstants.Spacing.step4x : 0
         ThoughtBubbleAppearance(animates: message.origin == .inserted) {
             HStack(spacing: 0.0) {
-                ThoughtBubble {
+                if isOutgoing {
+                    Spacer(minLength: 50.0)
+                        .layoutPriority(-1)
+                }
+                ThoughtBubble(content: {
                     VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
-                        thoughtBubbleText(text, bounded: isBounded)
+                        thoughtBubbleText(text, bounded: isBounded, isOutgoing: isOutgoing)
                         if isBounded {
                             let openDetail: () -> Void = { onOpenMessageDetail?(message) }
                             ReadMoreButton(
@@ -501,16 +509,19 @@ struct MessagesGroupView: View {
                             )
                         }
                     }
+                }, color: bubbleColor, isOutgoing: isOutgoing)
+                if !isOutgoing {
+                    Spacer(minLength: 50.0)
+                        .layoutPriority(-1)
                 }
-                Spacer(minLength: 50.0)
-                    .layoutPriority(-1)
             }
         }
-        .bubbleRowWidthCap(alignment: .leading)
+        .bubbleRowWidthCap(alignment: capAlignment)
+        .padding(.trailing, trailingPad)
         .zIndex(100)
         .id("messages-group-item-\(message.differenceIdentifier)")
         .overlay(alignment: .bottomLeading) {
-            if isLast && !displayGroup.sender.isCurrentUser {
+            if isLast && !isOutgoing {
                 avatarOverlay { onTapAvatar(message) }
             }
         }
@@ -523,13 +534,14 @@ struct MessagesGroupView: View {
     /// finite `lineLimit` caps the layout (no vertical `.fixedSize`, which would
     /// reintroduce the full-height measure).
     @ViewBuilder
-    private func thoughtBubbleText(_ text: String, bounded: Bool) -> some View {
+    private func thoughtBubbleText(_ text: String, bounded: Bool, isOutgoing: Bool = false) -> some View {
         let lineCap: Int? = bounded ? MessageBodyClassifier.longPreviewLineLimit : nil
+        let textColor: Color = isOutgoing ? .colorTextPrimaryInverted : .colorTextSecondary
         Text(text)
             .font(.callout)
             .tracking(0.3)
             .lineSpacing(5.0)
-            .foregroundStyle(.colorTextSecondary)
+            .foregroundStyle(textColor)
             .lineLimit(lineCap)
     }
 

--- a/ConvosCore/Sources/ConvosCore/Custom Content Types/BrainstormAnchorCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Custom Content Types/BrainstormAnchorCodec.swift
@@ -1,0 +1,87 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Payload of a `convos.org/brainstorm-anchor:1.0` message. Sent when a user
+/// starts a brainstorm thread with an agent that has not yet emitted any
+/// `convos.org/thinking:1.0` messages, so the thread's reply chain has a
+/// message id to reference. `agentInboxId` names the agent the thread
+/// belongs to; brainstorm replies referencing this anchor are routed to
+/// that agent's brainstorm tab.
+public struct BrainstormAnchorContent: Codable, Sendable, Equatable {
+    public let agentInboxId: String
+
+    public init(agentInboxId: String) {
+        self.agentInboxId = agentInboxId
+    }
+}
+
+public let ContentTypeBrainstormAnchor = ContentTypeID(
+    authorityID: "convos.org",
+    typeID: "brainstorm-anchor",
+    versionMajor: 1,
+    versionMinor: 0
+)
+
+public enum BrainstormAnchorCodecError: Error, LocalizedError {
+    case emptyContent
+    case invalidJSONFormat
+    case missingAgentInboxId
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyContent:
+            return "BrainstormAnchor content is empty"
+        case .invalidJSONFormat:
+            return "Invalid JSON format for BrainstormAnchor"
+        case .missingAgentInboxId:
+            return "BrainstormAnchor payload is missing agentInboxId"
+        }
+    }
+}
+
+/// Silent custom content type that opens a brainstorm reply chain. Mirrors
+/// `ThinkingCodec`: never written to the chat history table, never pushes a
+/// notification, routed through a side-channel handler (see
+/// `StreamProcessor.processBrainstormAnchor`) into the `brainstormAnchor`
+/// table so brainstorm replies can be recognized by their reference id.
+public struct BrainstormAnchorCodec: ContentCodec {
+    public typealias T = BrainstormAnchorContent
+
+    public var contentType: ContentTypeID = ContentTypeBrainstormAnchor
+
+    public init() {}
+
+    public func encode(content: BrainstormAnchorContent) throws -> EncodedContent {
+        var encoded = EncodedContent()
+        encoded.type = ContentTypeBrainstormAnchor
+        encoded.content = try JSONEncoder().encode(content)
+        return encoded
+    }
+
+    public func decode(content: EncodedContent) throws -> BrainstormAnchorContent {
+        guard !content.content.isEmpty else {
+            throw BrainstormAnchorCodecError.emptyContent
+        }
+        struct RawAnchor: Decodable {
+            let agentInboxId: String?
+        }
+        let raw: RawAnchor
+        do {
+            raw = try JSONDecoder().decode(RawAnchor.self, from: content.content)
+        } catch {
+            throw BrainstormAnchorCodecError.invalidJSONFormat
+        }
+        guard let agentInboxId = raw.agentInboxId, !agentInboxId.isEmpty else {
+            throw BrainstormAnchorCodecError.missingAgentInboxId
+        }
+        return BrainstormAnchorContent(agentInboxId: agentInboxId)
+    }
+
+    public func fallback(content: BrainstormAnchorContent) throws -> String? {
+        nil
+    }
+
+    public func shouldPush(content: BrainstormAnchorContent) throws -> Bool {
+        false
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MessagingService+PushNotifications.swift
@@ -446,6 +446,24 @@ extension MessagingService {
         }
     }
 
+    /// True when the just-stored message is a brainstorm reply: a standard
+    /// reply whose reference is a thinking moment or brainstorm anchor.
+    private func isBrainstormReply(messageId: String) async -> Bool {
+        let result = try? await databaseWriter.read { db -> Bool in
+            guard let row = try DBMessage.fetchOne(db, key: messageId),
+                  row.messageType == .reply,
+                  let sourceId = row.sourceMessageId else { return false }
+            let isThinkingReference = try DBThinkingMoment
+                .filter(DBThinkingMoment.Columns.id == sourceId)
+                .fetchCount(db) > 0
+            if isThinkingReference { return true }
+            return try DBBrainstormAnchor
+                .filter(DBBrainstormAnchor.Columns.id == sourceId)
+                .fetchCount(db) > 0
+        }
+        return result ?? false
+    }
+
     private func handleGroupMessage(
         group: XMTPiOS.Group,
         decodedMessage: DecodedMessage,
@@ -512,6 +530,14 @@ extension MessagingService {
         }
 
         _ = try await messageWriter.store(message: decodedMessage, for: dbConversation)
+
+        // Brainstorm replies persist above (the brainstorm tab reads them
+        // from the shared DB) but never banner - the thread is presented as
+        // not notifying the group. Best effort: recognition depends on the
+        // referenced thinking moment / anchor being in the shared DB already.
+        if await isBrainstormReply(messageId: decodedMessage.id) {
+            return .droppedMessage
+        }
 
         let notificationTitle = (try? await getComputedDisplayName(
             conversationId: conversationId,

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -177,6 +177,10 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         ThinkingSessionRepository(databaseReader: Self.mockDatabase)
     }
 
+    public func brainstormRepository() -> any BrainstormRepositoryProtocol {
+        BrainstormRepository(databaseReader: Self.mockDatabase)
+    }
+
     // MARK: - Notifications
 
     public func notifyChangesInDatabase() {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1304,6 +1304,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                 IdentityShareCodec(),
                 DeviceRemovedCodec(),
                 ThinkingCodec(),
+                BrainstormAnchorCodec(),
                 BuilderBundleManifestCodec()
             ] + ConvosConnectionsXMTP.codecs(),
             dbEncryptionKey: keys.databaseKey,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1407,6 +1407,10 @@ extension SessionManager {
     public func builderBundleHiddenMessagesRepository() -> any BuilderBundleHiddenMessagesRepositoryProtocol {
         BuilderBundleHiddenMessagesRepository(databaseReader: databaseReader)
     }
+
+    public func brainstormRepository() -> any BrainstormRepositoryProtocol {
+        BrainstormRepository(databaseReader: databaseReader)
+    }
 }
 
 // MARK: - Direct-add agent join

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -176,6 +176,7 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     func agentBuilderSummaryRepository() -> any AgentBuilderSummaryRepositoryProtocol
     func builderBundleHiddenMessagesRepository() -> any BuilderBundleHiddenMessagesRepositoryProtocol
     func thinkingSessionRepository() -> any ThinkingSessionRepositoryProtocol
+    func brainstormRepository() -> any BrainstormRepositoryProtocol
 
     /// Resolves a pasted/received agent-share link to the shared template's
     /// public profile (name / emoji / description) for rendering its contact

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBBrainstormAnchor.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBBrainstormAnchor.swift
@@ -1,0 +1,28 @@
+import Foundation
+import GRDB
+
+/// One `convos.org/brainstorm-anchor:1.0` message recorded by the receiver
+/// (or by the sender at publish time). Brainstorm replies reference either a
+/// thinking-moment id or one of these anchor ids; the anchor carries the
+/// agent the thread belongs to so replies can be routed to that agent's
+/// brainstorm tab.
+///
+/// `id` is the XMTP message id of the anchor message, so re-applying the
+/// same event is idempotent (PK conflict on insert).
+struct DBBrainstormAnchor: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName: String = "brainstormAnchor"
+
+    var id: String
+    var conversationId: String
+    var agentInboxId: String
+    var senderInboxId: String
+    var sentAtNs: Int64
+
+    enum Columns {
+        static let id: Column = Column(CodingKeys.id)
+        static let conversationId: Column = Column(CodingKeys.conversationId)
+        static let agentInboxId: Column = Column(CodingKeys.agentInboxId)
+        static let senderInboxId: Column = Column(CodingKeys.senderInboxId)
+        static let sentAtNs: Column = Column(CodingKeys.sentAtNs)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -193,6 +193,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         .filter(DBMessage.Columns.contentType != MessageContentType.connectionInvocation.rawValue)
         .filter(DBMessage.Columns.contentType != MessageContentType.connectionInvocationResult.rawValue)
         .filter(DBMessage.Columns.contentType != MessageContentType.connectionPayload.rawValue)
+        .excludingBrainstormReplies()
         .annotated { max($0.dateNs) }
         .group(\.conversationId)
 
@@ -213,11 +214,19 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
                 FROM message m
                 LEFT JOIN message src ON m.sourceMessageId = src.id
                 WHERE m.contentType NOT IN (?, ?, ?, ?, ?, ?)
+                AND NOT (m.messageType = ? AND m.sourceMessageId IN (
+                    SELECT id FROM thinkingMoment
+                    UNION ALL
+                    SELECT id FROM brainstormAnchor))
                 AND m.dateNs = (
                     SELECT MAX(m2.dateNs)
                     FROM message m2
                     WHERE m2.conversationId = m.conversationId
                     AND m2.contentType NOT IN (?, ?, ?, ?, ?, ?)
+                    AND NOT (m2.messageType = ? AND m2.sourceMessageId IN (
+                        SELECT id FROM thinkingMoment
+                        UNION ALL
+                        SELECT id FROM brainstormAnchor))
                 )
                 """,
             arguments: [
@@ -227,12 +236,14 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
                 MessageContentType.connectionInvocation.rawValue,
                 MessageContentType.connectionInvocationResult.rawValue,
                 MessageContentType.connectionPayload.rawValue,
+                DBMessageType.reply.rawValue,
                 MessageContentType.update.rawValue,
                 MessageContentType.assistantJoinRequest.rawValue,
                 MessageContentType.connectionGrantRequest.rawValue,
                 MessageContentType.connectionInvocation.rawValue,
                 MessageContentType.connectionInvocationResult.rawValue,
                 MessageContentType.connectionPayload.rawValue,
+                DBMessageType.reply.rawValue,
             ]
         )
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderCardContent.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AgentBuilderCardContent.swift
@@ -44,6 +44,14 @@ public struct AgentBuilderCardContent: Sendable, Equatable, Hashable, Identifiab
     /// committed home-flow build (where the card sits at the top and the
     /// composer is on screen); false otherwise.
     public let transitionEligible: Bool
+    /// Replaces the "What needs done?" caption above the quoted text. Empty
+    /// string hides the caption entirely; nil keeps the builder default.
+    /// Lets other surfaces (the brainstorm tab's attached-message card)
+    /// reuse the bordered-quote style without the builder copy.
+    public let promptHeaderOverride: String?
+    /// Replaces the "You made an agent · They'll join soon" footer line.
+    /// Nil keeps the builder default.
+    public let footerTextOverride: String?
 
     public init(
         id: String,
@@ -54,7 +62,9 @@ public struct AgentBuilderCardContent: Sendable, Equatable, Hashable, Identifiab
         creatorProfile: Profile? = nil,
         connectionIdentifiers: [String] = [],
         existingConversation: Bool = false,
-        transitionEligible: Bool = false
+        transitionEligible: Bool = false,
+        promptHeaderOverride: String? = nil,
+        footerTextOverride: String? = nil
     ) {
         self.id = id
         self.prompt = prompt
@@ -65,5 +75,7 @@ public struct AgentBuilderCardContent: Sendable, Equatable, Hashable, Identifiab
         self.connectionIdentifiers = connectionIdentifiers
         self.existingConversation = existingConversation
         self.transitionEligible = transitionEligible
+        self.promptHeaderOverride = promptHeaderOverride
+        self.footerTextOverride = footerTextOverride
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/BrainstormRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/BrainstormRepository.swift
@@ -1,0 +1,117 @@
+import Combine
+import Foundation
+import GRDB
+
+/// One brainstorm message: a standard reply whose reference is a thinking
+/// moment or a brainstorm anchor. `agentInboxId` is the agent whose
+/// brainstorm tab the message belongs to, resolved from the referenced row.
+public struct BrainstormMessageRecord: Equatable, Hashable, Sendable, Identifiable {
+    public let id: String
+    public let clientMessageId: String
+    public let agentInboxId: String
+    public let senderInboxId: String
+    public let text: String
+    public let sentAtNs: Int64
+    public let status: MessageStatus
+    public let referenceId: String
+
+    public var sentAt: Date {
+        Date(timeIntervalSince1970: TimeInterval(sentAtNs) / 1_000_000_000)
+    }
+}
+
+public struct BrainstormAnchorRecord: Equatable, Hashable, Sendable, Identifiable {
+    public let id: String
+    public let agentInboxId: String
+    public let sentAtNs: Int64
+}
+
+public struct BrainstormFeed: Equatable, Sendable {
+    public let anchors: [BrainstormAnchorRecord]
+    public let messages: [BrainstormMessageRecord]
+
+    public static let empty: BrainstormFeed = BrainstormFeed(anchors: [], messages: [])
+
+    public init(anchors: [BrainstormAnchorRecord], messages: [BrainstormMessageRecord]) {
+        self.anchors = anchors
+        self.messages = messages
+    }
+}
+
+public protocol BrainstormRepositoryProtocol: Sendable {
+    /// Live feed of every brainstorm anchor and brainstorm message in the
+    /// conversation, both in ascending sent order. Consumers filter by
+    /// `agentInboxId` for a specific agent's tab.
+    func feedPublisher(for conversationId: String) -> AnyPublisher<BrainstormFeed, Never>
+}
+
+public final class BrainstormRepository: BrainstormRepositoryProtocol, Sendable {
+    private let databaseReader: any DatabaseReader
+
+    public init(databaseReader: any DatabaseReader) {
+        self.databaseReader = databaseReader
+    }
+
+    public func feedPublisher(for conversationId: String) -> AnyPublisher<BrainstormFeed, Never> {
+        ValueObservation
+            .tracking { db in
+                try Self.feed(db: db, conversationId: conversationId)
+            }
+            .publisher(in: databaseReader)
+            .replaceError(with: .empty)
+            .eraseToAnyPublisher()
+    }
+
+    private static func feed(db: Database, conversationId: String) throws -> BrainstormFeed {
+        let anchors = try DBBrainstormAnchor
+            .filter(DBBrainstormAnchor.Columns.conversationId == conversationId)
+            .order(DBBrainstormAnchor.Columns.sentAtNs.asc)
+            .fetchAll(db)
+        let moments = try DBThinkingMoment
+            .filter(DBThinkingMoment.Columns.conversationId == conversationId)
+            .fetchAll(db)
+
+        var agentByReferenceId: [String: String] = [:]
+        for moment in moments {
+            agentByReferenceId[moment.id] = moment.senderInboxId
+        }
+        for anchor in anchors {
+            agentByReferenceId[anchor.id] = anchor.agentInboxId
+        }
+
+        let anchorRecords: [BrainstormAnchorRecord] = anchors.map { anchor in
+            BrainstormAnchorRecord(id: anchor.id, agentInboxId: anchor.agentInboxId, sentAtNs: anchor.sentAtNs)
+        }
+
+        guard !agentByReferenceId.isEmpty else {
+            return BrainstormFeed(anchors: anchorRecords, messages: [])
+        }
+
+        let referenceIds = Array(agentByReferenceId.keys)
+        let rows = try DBMessage
+            .filter(DBMessage.Columns.conversationId == conversationId)
+            .filter(DBMessage.Columns.messageType == DBMessageType.reply.rawValue)
+            .filter(referenceIds.contains(DBMessage.Columns.sourceMessageId))
+            .order(DBMessage.Columns.dateNs.asc)
+            .fetchAll(db)
+
+        let messages: [BrainstormMessageRecord] = rows.compactMap { (row: DBMessage) -> BrainstormMessageRecord? in
+            guard let referenceId = row.sourceMessageId,
+                  let agentInboxId = agentByReferenceId[referenceId] else { return nil }
+            let body: String? = row.text ?? row.emoji
+            guard let body, !body.isEmpty else { return nil }
+            return BrainstormMessageRecord(
+                id: row.id,
+                clientMessageId: row.clientMessageId,
+                agentInboxId: agentInboxId,
+                senderInboxId: row.senderId,
+                text: body,
+                sentAtNs: row.dateNs,
+                status: row.status,
+                referenceId: referenceId
+            )
+        }
+
+        return BrainstormFeed(anchors: anchorRecords, messages: messages)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -306,6 +306,7 @@ class MessagesRepository: MessagesRepositoryProtocol {
             try DBMessage
                 .filter(DBMessage.Columns.conversationId == capturedConversationId)
                 .filter(DBMessage.Columns.messageType != DBMessageType.reaction.rawValue)
+                .excludingBrainstormReplies()
                 .fetchCount(db)
         }
 
@@ -1049,6 +1050,7 @@ fileprivate extension Database {
         var query = DBMessage
             .filter(DBMessage.Columns.conversationId == conversationId)
             .filter(DBMessage.Columns.messageType != DBMessageType.reaction.rawValue)
+            .excludingBrainstormReplies()
             .order(DBMessage.Columns.sortId.desc)
 
         if let limit {
@@ -1184,6 +1186,21 @@ fileprivate extension Database {
             isPaginating: isPaginating
         )
         return result
+    }
+}
+
+extension QueryInterfaceRequest where RowDecoder == DBMessage {
+    /// Excludes brainstorm messages from a chat-list query: standard replies
+    /// whose reference is a thinking moment or a brainstorm anchor - neither
+    /// of which is a chat row. They render only in the brainstorm tab (see
+    /// `BrainstormRepository`), never in the main messages list.
+    func excludingBrainstormReplies() -> QueryInterfaceRequest<DBMessage> {
+        filter(sql: """
+            NOT (messageType = ? AND sourceMessageId IN (
+                SELECT id FROM thinkingMoment
+                UNION ALL
+                SELECT id FROM brainstormAnchor))
+            """, arguments: [DBMessageType.reply.rawValue])
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -195,6 +195,8 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addAgentTemplateGenerationJoinIdempotencyKey",
                                    migrate: Self.addAgentTemplateGenerationJoinIdempotencyKey)
 
+        migrator.registerMigration("createBrainstormAnchor", migrate: Self.createBrainstormAnchor)
+
         return migrator
     }
 
@@ -923,6 +925,26 @@ extension SharedDatabaseMigrator {
             index: "thinkingMoment_sessionKey",
             on: "thinkingMoment",
             columns: ["conversationId", "senderInboxId", "targetMessageId", "sentAtNs"]
+        )
+    }
+
+    /// One row per `convos.org/brainstorm-anchor:1.0` message. Anchors open a
+    /// brainstorm reply chain for an agent when no thinking message exists to
+    /// reply to; replies referencing an anchor id (or a thinkingMoment id) are
+    /// classified as brainstorm messages and hidden from the main chat.
+    private static func createBrainstormAnchor(_ db: Database) throws {
+        try db.create(table: "brainstormAnchor") { t in
+            t.column("id", .text).notNull().primaryKey()
+            t.column("conversationId", .text).notNull()
+                .references("conversation", onDelete: .cascade)
+            t.column("agentInboxId", .text).notNull()
+            t.column("senderInboxId", .text).notNull()
+            t.column("sentAtNs", .integer).notNull()
+        }
+        try db.create(
+            index: "brainstormAnchor_conversationId_agentInboxId",
+            on: "brainstormAnchor",
+            columns: ["conversationId", "agentInboxId"]
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -28,6 +28,12 @@ extension DecodedMessage {
             && contentType.typeID == ContentTypeThinking.typeID
     }
 
+    var isBrainstormAnchor: Bool {
+        guard let contentType = try? encodedContent.type else { return false }
+        return contentType.authorityID == ContentTypeBrainstormAnchor.authorityID
+            && contentType.typeID == ContentTypeBrainstormAnchor.typeID
+    }
+
     var isBuilderBundleManifest: Bool {
         guard let contentType = try? encodedContent.type else { return false }
         return contentType.authorityID == ContentTypeBuilderBundleManifest.authorityID
@@ -659,6 +665,9 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         case .thinking:
             await storeThinking(message, conversationId: conversation.id, currentInboxId: currentInboxId)
             return nil
+        case .brainstormAnchor:
+            await storeBrainstormAnchor(message, conversationId: conversation.id)
+            return nil
         case .builderBundleManifest:
             await storeBuilderBundleManifest(message, conversationId: conversation.id)
             return nil
@@ -1183,6 +1192,30 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             senderInboxId: message.senderInboxId,
             sentAtNs: message.sentAtNs
         )
+    }
+
+    /// Persist a brainstorm anchor so replies referencing its id can be
+    /// classified as brainstorm messages. Own anchors are recorded too:
+    /// the sender writes a row at publish time, but another device of the
+    /// same inbox only learns about the anchor from the wire.
+    private func storeBrainstormAnchor(_ message: DecodedMessage, conversationId: String) async {
+        guard let content = try? BrainstormAnchorCodec().decode(content: message.encodedContent) else {
+            Log.warning("Failed to decode BrainstormAnchor from caught-up message \(message.id)")
+            return
+        }
+        do {
+            try await databaseWriter.write { db in
+                try DBBrainstormAnchor(
+                    id: message.id,
+                    conversationId: conversationId,
+                    agentInboxId: content.agentInboxId,
+                    senderInboxId: message.senderInboxId,
+                    sentAtNs: message.sentAtNs
+                ).save(db, onConflict: .ignore)
+            }
+        } catch {
+            Log.warning("Failed to store brainstorm anchor: \(error.localizedDescription)")
+        }
     }
 
     /// Persist the message ids a `BuilderBundleManifest` flagged as an

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -138,6 +138,19 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     /// Send text after a photo reply (both replying to the same parent).
     func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws
 
+    // MARK: - Brainstorm
+
+    /// Publish a silent `convos.org/brainstorm-anchor:1.0` message for
+    /// `agentInboxId` and return its XMTP message id. Used as the reply-chain
+    /// root of a brainstorm thread when the agent has no thinking message to
+    /// reference yet.
+    func sendBrainstormAnchor(agentInboxId: String) async throws -> String
+
+    /// Send a text reply whose reference is a raw XMTP message id (a thinking
+    /// moment or a brainstorm anchor). Unlike `sendReply`, the referenced
+    /// message has no row in the chat table, so no parent lookup is performed.
+    func sendBrainstormReply(text: String, toReferenceId referenceId: String) async throws
+
     // MARK: - Failed Messages
 
     func retryFailedMessage(id: String) async throws
@@ -150,6 +163,7 @@ enum OutgoingMessageWriterError: Error, CustomStringConvertible {
     case parentMessageNotFound
     case eagerUploadCancelled
     case attachmentEncodingFailed
+    case brainstormUnsupported
 
     var description: String {
         switch self {
@@ -163,7 +177,22 @@ enum OutgoingMessageWriterError: Error, CustomStringConvertible {
             return "Eager upload was cancelled"
         case .attachmentEncodingFailed:
             return "Failed to encode attachment URLs as JSON"
+        case .brainstormUnsupported:
+            return "Brainstorm sends are not supported by this writer"
         }
+    }
+}
+
+public extension OutgoingMessageWriterProtocol {
+    /// Brainstorm sends only make sense in a live conversation with an agent
+    /// member, so draft-conversation writers and mocks fall back to this
+    /// throwing default rather than each stubbing the methods.
+    func sendBrainstormAnchor(agentInboxId: String) async throws -> String {
+        throw OutgoingMessageWriterError.brainstormUnsupported
+    }
+
+    func sendBrainstormReply(text: String, toReferenceId referenceId: String) async throws {
+        throw OutgoingMessageWriterError.brainstormUnsupported
     }
 }
 
@@ -2224,6 +2253,43 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         eagerUploads[trackingKey] = state
 
         try await sendEagerPhoto(trackingKey: trackingKey)
+    }
+
+    // MARK: - Brainstorm
+
+    func sendBrainstormAnchor(agentInboxId: String) async throws -> String {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let client = inboxReady.client
+        guard let conversation = try await client.conversation(with: conversationId) else {
+            throw OutgoingMessageWriterError.conversationNotFound(conversationId: conversationId)
+        }
+
+        let content = BrainstormAnchorContent(agentInboxId: agentInboxId)
+        let messageId = try await conversation.prepareMessage(
+            content: content,
+            options: .init(contentType: ContentTypeBrainstormAnchor)
+        )
+        try await conversation.publishMessages()
+
+        // Record locally right away so the reply that follows can be
+        // classified without waiting for the anchor to round-trip through
+        // the stream (which skips our own messages anyway).
+        let conversationId = self.conversationId
+        let senderInboxId = client.inboxId
+        try await databaseWriter.write { db in
+            try DBBrainstormAnchor(
+                id: messageId,
+                conversationId: conversationId,
+                agentInboxId: agentInboxId,
+                senderInboxId: senderInboxId,
+                sentAtNs: Date().nanosecondsSince1970
+            ).save(db, onConflict: .ignore)
+        }
+        return messageId
+    }
+
+    func sendBrainstormReply(text: String, toReferenceId referenceId: String) async throws {
+        try await sendText(text, afterPhoto: nil, replyContext: ReplyContext(parentDbId: referenceId))
     }
 
     private func resolveReplyContext(parentClientMessageId: String) async throws -> ReplyContext {

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -402,7 +402,7 @@ struct BatchCatchUp {
         // never the batched regular-message transaction. Thinking backs the
         // thinking-detail view and the manifest is a hide-control record --
         // neither is persisted as a chat row.
-        case .readReceipt, .thinking, .builderBundleManifest, .reaction:
+        case .readReceipt, .thinking, .brainstormAnchor, .builderBundleManifest, .reaction:
             return .supplemental
         case .regular:
             return .regular

--- a/ConvosCore/Sources/ConvosCore/Syncing/CaughtUpMessageRouting.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/CaughtUpMessageRouting.swift
@@ -21,6 +21,10 @@ enum CaughtUpMessageKind {
     case ignore
     case readReceipt
     case thinking
+    /// Silent brainstorm-anchor message. Opens a brainstorm reply chain for
+    /// an agent; stored via `storeBrainstormAnchor`, never rendered as a
+    /// chat row.
+    case brainstormAnchor
     /// Silent agent-builder bundle manifest. Lists the prepared XMTP ids of a
     /// builder bundle so every client hides them; stored via
     /// `storeBuilderBundleManifest`, never rendered as a chat row.
@@ -39,6 +43,9 @@ enum CaughtUpMessageKind {
         }
         if message.isThinking {
             return .thinking
+        }
+        if message.isBrainstormAnchor {
+            return .brainstormAnchor
         }
         if message.isBuilderBundleManifest {
             return .builderBundleManifest

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -303,7 +303,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                         return
                     }
 
-                    if await processThinking(message, conversationId: conversation.id, params: params) {
+                    if await processThinkingSideChannels(message, conversationId: conversation.id, params: params) {
                         return
                     }
 
@@ -472,6 +472,50 @@ actor StreamProcessor: StreamProcessorProtocol {
             senderInboxId: message.senderInboxId,
             sentAtNs: message.sentAtNs
         )
+        return true
+    }
+
+    /// Thinking and brainstorm-anchor routing combined so the message loop
+    /// consumes both side-channel types through one branch.
+    private func processThinkingSideChannels(
+        _ message: DecodedMessage,
+        conversationId: String,
+        params: SyncClientParams
+    ) async -> Bool {
+        if await processThinking(message, conversationId: conversationId, params: params) {
+            return true
+        }
+        return await processBrainstormAnchor(message, conversationId: conversationId)
+    }
+
+    /// Persist a brainstorm anchor so replies referencing its id can be
+    /// classified as brainstorm messages. Own anchors are recorded here too:
+    /// the publishing device already wrote a row (same id, `.ignore` on
+    /// conflict), but other devices of the same inbox only learn about the
+    /// anchor from the wire.
+    private func processBrainstormAnchor(_ message: DecodedMessage, conversationId: String) async -> Bool {
+        guard message.isBrainstormAnchor else {
+            return false
+        }
+
+        guard let content = try? BrainstormAnchorCodec().decode(content: message.encodedContent) else {
+            Log.warning("Failed to decode BrainstormAnchor from message \(message.id)")
+            return true
+        }
+
+        do {
+            try await databaseWriter.write { db in
+                try DBBrainstormAnchor(
+                    id: message.id,
+                    conversationId: conversationId,
+                    agentInboxId: content.agentInboxId,
+                    senderInboxId: message.senderInboxId,
+                    sentAtNs: message.sentAtNs
+                ).save(db, onConflict: .ignore)
+            }
+        } catch {
+            Log.warning("Failed to store brainstorm anchor: \(error.localizedDescription)")
+        }
         return true
     }
 


### PR DESCRIPTION
Prototype of **Brainstorm**: a per-agent private side thread, surfaced as a new page in the conversation pager between Chat and Things (Things stays last). Agent-side half: xmtplabs/convos-assistants#2875.

## What it does
- One brainstorm page per agent member (multi-agent groups get one page each), reachable by paging or the dot control.
- The page shows the agent's **entire thinking history** — every session, including abandoned ones the inline footers hide — sorted by sent date (newest at bottom). Above each session, the message it was "attached to" (its `targetMessageId`) renders in the normal chat-bubble style.
- The composer stays visible with placeholder **"Chat with \<agent\>"**. Sends appear as thought bubbles on the right in the outgoing bubble color; the agent's thread replies render as incoming thought bubbles.
- Empty state: **"Brainstorm with \<agent\> / Without notifying the group"** with a CTA that focuses the composer.

## Wire protocol
- A brainstorm message is a **standard XMTP Reply** whose `reference` is one of the agent's `convos.org/thinking:1.0` message ids — so rich content (photos, files, reactions) can ride existing reply plumbing later.
- Cold start (agent has never thought): the client publishes a silent **`convos.org/brainstorm-anchor:1.0`** message (`{agentInboxId}`, no push, no fallback) and replies reference the anchor.

## How filtering works
The referenced ids live outside the chat table (`thinkingMoment` / new `brainstormAnchor`), so classification is a reference-id lookup. Brainstorm replies are excluded from the messages list, the pagination count, and the conversation-list preview, and only surface through `BrainstormRepository`. The NSE still stores them (so the tab is fresh on open) but suppresses the banner.

## Verification
- `swift test --package-path ConvosCore`: **1624 tests in 228 suites pass** (local XMTP stack).
- Dev-scheme simulator build succeeds; no new warnings, no type-check-time (100ms gate) regressions in changed files.
- SwiftLint `--strict` and SwiftFormat clean.
- Note: on Xcode w/ SDK 26.2, `ShareSuggestionDonator.swift` (untouched, identical to dev) trips a new deprecation under warnings-as-errors; verification build used `SWIFT_TREAT_WARNINGS_AS_ERRORS=NO` to get past it.

## Known prototype limits
- Push suppression is best-effort: a recipient whose device never ingested the referenced thinking message will still see a banner for a brainstorm reply.
- Legacy clients render brainstorm replies as ordinary replies (accepted trade-off per design discussion).
- Brainstorm send path is text-only for now; thread pagination loads everything at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252558&installation_model_id=20076&pr_number=1202&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1202&signature=5c514a18ad10363a52f0bd668bf07f40fb3dc626dbec131d015579d3a962fc4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-agent brainstorm side-thread tab to the conversation pager
> - Adds a `brainstorm` case to `ConversationPagerPage` and inserts one brainstorm tab per agent member between the Messages and Things pages in `ConversationView`.
> - Introduces `BrainstormPageView` to render an agent-specific timeline of thinking moments and brainstorm messages, with an empty state CTA and a dedicated composer that routes sends via `sendBrainstormMessage`.
> - Adds a new `brainstorm-anchor` XMTP content type (`BrainstormAnchorCodec`) that silently anchors a per-agent brainstorm thread; anchors are persisted to a new `brainstormAnchor` DB table and classified as supplemental during sync.
> - `BrainstormRepository` publishes a combined GRDB-backed feed of anchors and brainstorm replies for a conversation; `ConversationViewModel` subscribes and exposes items to the UI.
> - Brainstorm replies are excluded from the main chat timeline, conversation last-message computation, and push notifications (messages are still persisted).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8f7b9a3. 25 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->