### PR TITLE
feat(participation): agent participation control in the contact sheet

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -40,6 +40,21 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- gates the per-conversation agent participation control
+    /// ("Listen"): Speak freely / Mentions only / Paused. Toggle from
+    /// App Settings -> Debug. Hard-locked off in production while the feature is
+    /// still in development.
+    var isListenParticipationEnabled: Bool {
+        get {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+            return UserDefaults.standard.bool(forKey: Constant.listenParticipationEnabledKey)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            UserDefaults.standard.set(newValue, forKey: Constant.listenParticipationEnabledKey)
+        }
+    }
+
     /// Off by default -- opts libxmtp streams onto the shared bidi wire by
     /// exporting `XMTP_BIDI_STREAMS_ENABLED` at launch (see `ConvosApp.init`;
     /// flips take effect on the next launch). Deliberately not prod-locked
@@ -95,6 +110,7 @@ final class FeatureFlags {
         static let mockCreditsPresetKey: String = "featureFlags.mockCreditsPreset"
         static let selectedAgentVariantKey: String = "featureFlags.selectedAgentVariant"
         static let agentVariantSelectorEnabledKey: String = "featureFlags.agentVariantSelectorEnabled"
+        static let listenParticipationEnabledKey: String = "featureFlags.listenParticipationEnabled"
         static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
     }
 }

--- a/Convos/Contacts/AgentParticipationMenu.swift
+++ b/Convos/Contacts/AgentParticipationMenu.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+// MARK: - Agent participation
+
+/// How much an agent talks in a specific conversation. The owner/members pick a
+/// level; the agent keeps *working* at every level short of leaving — only how
+/// much it *speaks* changes.
+///
+/// NOTE (spec, 2026-07-20): product planning trimmed this to three live levels —
+/// `speakFreely`, `mentionsOnly`, `paused`. `listenOnly` (+ its "mute for…"
+/// duration) and `leaveRoom` are rendered here to match the current Figma while
+/// the final set is decided; gate them behind `Self.liveCases` when we lock it.
+enum AgentParticipationLevel: String, CaseIterable, Identifiable {
+    case speakFreely
+    case mentionsOnly
+    case listenOnly
+    case paused
+    case leaveRoom
+
+    var id: String { rawValue }
+
+    /// The subset shipping in v1 per the current spec. Swap the menu's data
+    /// source to this to drop Listen-only + Leave-the-room without touching layout.
+    static let liveCases: [AgentParticipationLevel] = [.speakFreely, .mentionsOnly, .paused]
+
+    var title: String {
+        switch self {
+        case .speakFreely: "Speak freely"
+        case .mentionsOnly: "Mentions only"
+        case .listenOnly: "Listen only"
+        case .paused: "Paused"
+        case .leaveRoom: "Leave the room"
+        }
+    }
+
+    var caption: String {
+        switch self {
+        case .speakFreely: "Chime in any time"
+        case .mentionsOnly: "Speak when you see your name"
+        case .listenOnly: "Mute for …"
+        case .paused: "Offline, uses no credits"
+        case .leaveRoom: "Until invited back"
+        }
+    }
+
+    /// Opens a follow-up step (the duration picker) rather than selecting inline.
+    var hasDisclosure: Bool { self == .listenOnly }
+}
+
+/// The floating "Agent participation" menu: a frosted card of levels with a
+/// leading check on the current one and a disclosure on any level that opens a
+/// follow-up step. Presentation-agnostic — drop it in a popover, a sheet, or a
+/// `.contextMenu`-style overlay from the agent's profile.
+struct AgentParticipationMenu: View {
+    let levels: [AgentParticipationLevel]
+    let selection: AgentParticipationLevel
+    let onSelect: (AgentParticipationLevel) -> Void
+
+    init(
+        levels: [AgentParticipationLevel] = AgentParticipationLevel.allCases,
+        selection: AgentParticipationLevel,
+        onSelect: @escaping (AgentParticipationLevel) -> Void
+    ) {
+        self.levels = levels
+        self.selection = selection
+        self.onSelect = onSelect
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
+            Text("Agent participation")
+                .font(.subheadline)
+                .foregroundStyle(.colorTextSecondary)
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
+                ForEach(levels) { level in
+                    row(for: level)
+                }
+            }
+        }
+        .padding(.vertical, DesignConstants.Spacing.step6x)
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .background(
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLargest, style: .continuous)
+                .fill(.regularMaterial)
+        )
+        // Tight, single-direction lift — reads as a floating menu, not a halo.
+        .shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 6)
+    }
+
+    private func row(for level: AgentParticipationLevel) -> some View {
+        Button {
+            onSelect(level)
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: DesignConstants.Spacing.step3x) {
+                // Fixed check gutter so titles align whether or not selected.
+                Image(systemName: "checkmark")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.colorTextPrimary)
+                    .opacity(level == selection ? 1 : 0)
+                    .frame(width: DesignConstants.Spacing.step6x, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+                    Text(level.title)
+                        .font(.title3.weight(.regular))
+                        .foregroundStyle(.colorTextPrimary)
+                    Text(level.caption)
+                        .font(.subheadline)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+
+                Spacer(minLength: DesignConstants.Spacing.step2x)
+
+                if level.hasDisclosure {
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.colorTextSecondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(level.title)
+        .accessibilityHint(level.caption)
+        .accessibilityAddTraits(level == selection ? .isSelected : [])
+    }
+}
+
+// MARK: - Previews
+
+/// Interactive: tap a level and the check moves. Backed by a mock chat gradient
+/// so the frosted material has something real to refract (glass over a flat
+/// fill reads as a plain blurred box).
+#Preview("Participation menu (interactive)") {
+    struct Harness: View {
+        @State private var selection: AgentParticipationLevel = .speakFreely
+        var body: some View {
+            ZStack {
+                LinearGradient(
+                    colors: [.blue.opacity(0.25), .purple.opacity(0.15), .orange.opacity(0.20)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+
+                AgentParticipationMenu(selection: selection) { selection = $0 }
+                    .frame(maxWidth: 360)
+                    .padding()
+            }
+        }
+    }
+    return Harness()
+}
+
+/// The trimmed three-level set (current spec) — same layout, no Listen-only /
+/// Leave-the-room.
+#Preview("Participation menu (3-level spec)") {
+    struct Harness: View {
+        @State private var selection: AgentParticipationLevel = .mentionsOnly
+        var body: some View {
+            ZStack {
+                Color(.systemGray5).ignoresSafeArea()
+                AgentParticipationMenu(
+                    levels: AgentParticipationLevel.liveCases,
+                    selection: selection
+                ) { selection = $0 }
+                .frame(maxWidth: 360)
+                .padding()
+            }
+        }
+    }
+    return Harness()
+}

--- a/Convos/Contacts/AgentParticipationMenu.swift
+++ b/Convos/Contacts/AgentParticipationMenu.swift
@@ -45,6 +45,17 @@ enum AgentParticipationLevel: String, CaseIterable, Identifiable {
 
     /// Opens a follow-up step (the duration picker) rather than selecting inline.
     var hasDisclosure: Bool { self == .listenOnly }
+
+    /// Wire value sent to the runtime's /convos/participation (speak/mention/paused).
+    var wireMode: String {
+        switch self {
+        case .speakFreely: "speak"
+        case .mentionsOnly: "mention"
+        case .paused: "paused"
+        // Not in the live set; map to speak so a stray value never gates.
+        case .listenOnly, .leaveRoom: "speak"
+        }
+    }
 }
 
 /// The floating "Agent participation" menu: a frosted card of levels with a
@@ -54,15 +65,21 @@ enum AgentParticipationLevel: String, CaseIterable, Identifiable {
 struct AgentParticipationMenu: View {
     let levels: [AgentParticipationLevel]
     let selection: AgentParticipationLevel
+    /// Draws the frosted card + shadow around the rows. Set `false` when the
+    /// host already provides a surface (e.g. inside a sheet) so the panel isn't
+    /// a redundant card-in-a-card.
+    let showsBackground: Bool
     let onSelect: (AgentParticipationLevel) -> Void
 
     init(
         levels: [AgentParticipationLevel] = AgentParticipationLevel.allCases,
         selection: AgentParticipationLevel,
+        showsBackground: Bool = true,
         onSelect: @escaping (AgentParticipationLevel) -> Void
     ) {
         self.levels = levels
         self.selection = selection
+        self.showsBackground = showsBackground
         self.onSelect = onSelect
     }
 
@@ -78,14 +95,21 @@ struct AgentParticipationMenu: View {
                 }
             }
         }
-        .padding(.vertical, DesignConstants.Spacing.step6x)
-        .padding(.horizontal, DesignConstants.Spacing.step6x)
-        .background(
-            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLargest, style: .continuous)
-                .fill(.regularMaterial)
-        )
+        .padding(showsBackground ? DesignConstants.Spacing.step6x : 0)
+        .background {
+            if showsBackground {
+                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLargest, style: .continuous)
+                    .fill(.regularMaterial)
+            }
+        }
         // Tight, single-direction lift — reads as a floating menu, not a halo.
-        .shadow(color: .black.opacity(0.12), radius: 18, x: 0, y: 6)
+        // Only when it's a standalone card; a sheet provides its own elevation.
+        .shadow(
+            color: showsBackground ? .black.opacity(0.12) : .clear,
+            radius: showsBackground ? 18 : 0,
+            x: 0,
+            y: showsBackground ? 6 : 0
+        )
     }
 
     private func row(for level: AgentParticipationLevel) -> some View {

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -82,17 +82,11 @@ struct ContactDetailView: View {
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
-    // Behind the `Listen (agent participation)` debug flag. The selection is
-    // local to this view; postParticipation pushes it to the runtime.
+    // Behind the `Listen (agent participation)` debug flag. The level belongs
+    // to the conversation this card is scoped to, so it is read from there
+    // rather than remembered per device.
     @State private var showingParticipationMenu: Bool = false
-    @State private var participationLevel: AgentParticipationLevel = .speakFreely
-    // Cooldown override (seconds). The runtime default scales by group size;
-    // this lets a member pin the hold explicitly.
-    @State private var cooldownSeconds: Int = 15
-    // The picker updates local state immediately, so a failed write would
-    // otherwise leave the row showing a level the agent never received.
-    @State private var presentingParticipationError: Bool = false
-    @State private var participationErrorMessage: String?
+    @State private var participation: AgentParticipationStore?
     /// Existing conversation pushed onto the host navigation stack when the
     /// user taps a row in the "Convos with you" sections.
     @State private var pushedConversation: NewConversationViewModel?
@@ -162,6 +156,9 @@ struct ContactDetailView: View {
             .task(id: contact.inboxId) { await syncBlockedState() }
             .task(id: contact.agentTemplateId) { await observeAgentTemplateConversations() }
             .task(id: contact.agentTemplateId) { await loadAgentDescription() }
+            // The level lives with the conversation, so it is read per
+            // conversation — not per agent, and not from this device's memory.
+            .task(id: mode.conversationId) { await prepareParticipation() }
             .onAppear {
                 ensureNavigator()
                 navState.markScreenAppeared()
@@ -219,36 +216,27 @@ struct ContactDetailView: View {
             }
             .alert(
                 "Participation not updated",
-                isPresented: $presentingParticipationError
+                isPresented: Binding(
+                    get: { participation?.errorMessage != nil },
+                    set: { if !$0 { participation?.dismissError() } }
+                )
             ) {
-                Button("OK", role: .cancel) {}
+                Button("OK", role: .cancel) { participation?.dismissError() }
             } message: {
-                Text(participationErrorMessage ?? "Please try again.")
+                Text(participation?.errorMessage ?? "Please try again.")
             }
     }
 
     /// The "Agent participation" menu, presented from the Participation row.
-    /// The pick is pushed straight to the runtime; durable per-conversation
-    /// storage lands with the backend work.
+    /// The level belongs to the conversation, so every agent in it moves
+    /// together and one that joins later inherits the choice.
     private var participationMenuSheet: some View {
-        // Three live levels: Speak freely, Mention-only, Paused. Listen-only,
-        // expiration, and Leave-the-room were cut in product planning.
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step8x) {
-            AgentParticipationMenu(
-                levels: AgentParticipationLevel.liveCases,
-                selection: participationLevel,
-                showsBackground: false
-            ) { level in
-                participationLevel = level
-                postParticipation(mode: level.wireMode, cooldownSeconds: nil)
-                showingParticipationMenu = false
-            }
-            // Cooldown only applies to Speak freely: that is the level where the
-            // agent follows the group's flow, so pacing its bursts is meaningful.
-            // Mention-only already speaks only when addressed; Paused is offline.
-            if participationLevel == .speakFreely {
-                cooldownControl
-            }
+        AgentParticipationMenu(
+            selection: participation?.level ?? .default,
+            showsBackground: false
+        ) { level in
+            showingParticipationMenu = false
+            Task { await participation?.set(level) }
         }
         .padding(.horizontal, DesignConstants.Spacing.step6x)
         .padding(.top, DesignConstants.Spacing.step8x)
@@ -256,65 +244,17 @@ struct ContactDetailView: View {
         .presentationDetents([.medium])
     }
 
-    /// Explicit override for the burst-hold the runtime applies before it
-    /// replies once. Left alone, that hold scales with group size (engages at
-    /// 4+ members, +3s each, capped at 30s); picking a value here pins it.
-    /// "Off" means no hold beyond the base coalesce window.
-    private var cooldownControl: some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
-            Text("Cooldown")
-                .font(.subheadline)
-                .foregroundStyle(.colorTextSecondary)
-            Picker("Cooldown", selection: $cooldownSeconds) {
-                Text("Off").tag(0)
-                Text("5s").tag(5)
-                Text("15s").tag(15)
-                Text("30s").tag(30)
-            }
-            .pickerStyle(.segmented)
-            .onChange(of: cooldownSeconds) { _, newValue in
-                postParticipation(mode: nil, cooldownSeconds: newValue)
-            }
-            Text("How long the agent holds a burst of messages before replying once.")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
-                .fixedSize(horizontal: false, vertical: true)
+    /// Builds the store for the conversation this card is scoped to and reads
+    /// the level it is in. Anyone may have set it, so the row has to render
+    /// shared state rather than whatever this device last chose.
+    private func prepareParticipation() async {
+        guard let conversationId = mode.conversationId else {
+            participation = nil
+            return
         }
-    }
-
-    /// Sends the chosen level to the backend, which holds the assistant
-    /// control-plane key and forwards it. Paused needs that hop: the level has
-    /// to reach the control plane to be recorded, otherwise the agent is still
-    /// woken for a message it will only discard.
-    ///
-    /// Fire-and-forget against optimistic local state. The row already shows
-    /// the new level, and a failed write leaves the app claiming a level the
-    /// agent is not honouring, which is why the failure is surfaced rather
-    /// than only logged.
-    private func postParticipation(mode: String?, cooldownSeconds: Int?) {
-        guard let instanceId = contact.agentInstanceId else { return }
-        let apiClient = ConvosAPIClientFactory.client(
-            environment: ConfigManager.shared.currentEnvironment
-        )
-        Task {
-            do {
-                _ = try await apiClient.setAgentParticipation(
-                    instanceId: instanceId,
-                    mode: mode,
-                    cooldownSeconds: cooldownSeconds
-                )
-                Log.info(
-                    "participation set mode=\(mode ?? "-") cooldown=\(cooldownSeconds.map(String.init) ?? "-")"
-                )
-            } catch {
-                Log.error("participation update failed: \(error)")
-                await MainActor.run {
-                    participationErrorMessage =
-                        "Couldn't update participation. The agent is still on its previous setting."
-                    presentingParticipationError = true
-                }
-            }
-        }
+        let store = AgentParticipationStore(conversationId: conversationId)
+        participation = store
+        await store.load()
     }
 
     /// Existing conversation pushed when a "Convos with you" row is tapped.
@@ -484,7 +424,7 @@ struct ContactDetailView: View {
                     showParticipation: FeatureFlags.shared.isListenParticipationEnabled
                         && (isVerifiedAgent || isAgentTemplate)
                         && mode.isScopedToConversation,
-                    participationLevel: participationLevel,
+                    participationLevel: participation?.level ?? .default,
                     onPickParticipation: { showingParticipationMenu = true },
                     showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -89,6 +89,10 @@ struct ContactDetailView: View {
     // Cooldown override (seconds). The runtime default scales by group size;
     // this lets a member pin the hold explicitly.
     @State private var cooldownSeconds: Int = 15
+    // The picker updates local state immediately, so a failed write would
+    // otherwise leave the row showing a level the agent never received.
+    @State private var presentingParticipationError: Bool = false
+    @State private var participationErrorMessage: String?
     /// Existing conversation pushed onto the host navigation stack when the
     /// user taps a row in the "Convos with you" sections.
     @State private var pushedConversation: NewConversationViewModel?
@@ -213,6 +217,14 @@ struct ContactDetailView: View {
                         : "This removes them from the conversation."
                 )
             }
+            .alert(
+                "Participation not updated",
+                isPresented: $presentingParticipationError
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(participationErrorMessage ?? "Please try again.")
+            }
     }
 
     /// The "Agent participation" menu, presented from the Participation row.
@@ -270,33 +282,37 @@ struct ContactDetailView: View {
         }
     }
 
-    /// Local-dev bridge (behind the Listen debug flag): pushes participation
-    /// straight to the local worker's eval container proxy, which forwards to
-    /// the runtime's /convos/participation. No backend and no auth, because the
-    /// eval API is local-only. The shipping path goes through the backend, so
-    /// this whole function is scaffolding and does not survive the feature.
+    /// Sends the chosen level to the backend, which holds the assistant
+    /// control-plane key and forwards it. Paused needs that hop: the level has
+    /// to reach the control plane to be recorded, otherwise the agent is still
+    /// woken for a message it will only discard.
+    ///
+    /// Fire-and-forget against optimistic local state. The row already shows
+    /// the new level, and a failed write leaves the app claiming a level the
+    /// agent is not honouring, which is why the failure is surfaced rather
+    /// than only logged.
     private func postParticipation(mode: String?, cooldownSeconds: Int?) {
         guard let instanceId = contact.agentInstanceId else { return }
-        var payload: [String: Any] = [:]
-        if let mode { payload["mode"] = mode }
-        if let cooldownSeconds { payload["cooldownSeconds"] = cooldownSeconds }
-        guard
-            let url = URL(
-                string:
-                    "http://127.0.0.1:8787/api/eval/assistants/\(instanceId)/container/convos/participation"
-            ),
-            let body = try? JSONSerialization.data(withJSONObject: payload)
-        else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "content-type")
-        request.httpBody = body
+        let apiClient = ConvosAPIClientFactory.client(
+            environment: ConfigManager.shared.currentEnvironment
+        )
         Task {
             do {
-                _ = try await URLSession.shared.data(for: request)
-                Log.info("participation pushed mode=\(mode ?? "-") cooldown=\(cooldownSeconds.map(String.init) ?? "-")")
+                _ = try await apiClient.setAgentParticipation(
+                    instanceId: instanceId,
+                    mode: mode,
+                    cooldownSeconds: cooldownSeconds
+                )
+                Log.info(
+                    "participation set mode=\(mode ?? "-") cooldown=\(cooldownSeconds.map(String.init) ?? "-")"
+                )
             } catch {
-                Log.error("participation push failed: \(error)")
+                Log.error("participation update failed: \(error)")
+                await MainActor.run {
+                    participationErrorMessage =
+                        "Couldn't update participation. The agent is still on its previous setting."
+                    presentingParticipationError = true
+                }
             }
         }
     }

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -77,10 +77,18 @@ struct ContactDetailView: View {
     @State private var isBlocked: Bool
     @State private var isApplyingBlockChange: Bool = false
     @State private var presentingBlockConfirmation: Bool = false
+    @State private var presentingRemoveConfirmation: Bool = false
     @State private var presentingPicker: Bool = false
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
+    // Behind the `Listen (agent participation)` debug flag. The selection is
+    // local to this view; postParticipation pushes it to the runtime.
+    @State private var showingParticipationMenu: Bool = false
+    @State private var participationLevel: AgentParticipationLevel = .speakFreely
+    // Cooldown override (seconds). The runtime default scales by group size;
+    // this lets a member pin the hold explicitly.
+    @State private var cooldownSeconds: Int = 15
     /// Existing conversation pushed onto the host navigation stack when the
     /// user taps a row in the "Convos with you" sections.
     @State private var pushedConversation: NewConversationViewModel?
@@ -189,6 +197,108 @@ struct ContactDetailView: View {
                 pushedConversationView(vm)
             }
             .overlay { agentShareOverlay }
+            .sheet(isPresented: $showingParticipationMenu) {
+                participationMenuSheet
+            }
+            .alert(
+                "Remove \(contact.resolvedDisplayName)?",
+                isPresented: $presentingRemoveConfirmation
+            ) {
+                Button("Remove", role: .destructive) { onRemove?() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(
+                    (isVerifiedAgent || isAgentTemplate)
+                        ? "This removes the agent from the conversation. It stops responding here, and you can add it back later."
+                        : "This removes them from the conversation."
+                )
+            }
+    }
+
+    /// The "Agent participation" menu, presented from the Participation row.
+    /// The pick is pushed straight to the runtime; durable per-conversation
+    /// storage lands with the backend work.
+    private var participationMenuSheet: some View {
+        // Three live levels: Speak freely, Mention-only, Paused. Listen-only,
+        // expiration, and Leave-the-room were cut in product planning.
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step8x) {
+            AgentParticipationMenu(
+                levels: AgentParticipationLevel.liveCases,
+                selection: participationLevel,
+                showsBackground: false
+            ) { level in
+                participationLevel = level
+                postParticipation(mode: level.wireMode, cooldownSeconds: nil)
+                showingParticipationMenu = false
+            }
+            // Cooldown only applies to Speak freely: that is the level where the
+            // agent follows the group's flow, so pacing its bursts is meaningful.
+            // Mention-only already speaks only when addressed; Paused is offline.
+            if participationLevel == .speakFreely {
+                cooldownControl
+            }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.top, DesignConstants.Spacing.step8x)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .presentationDetents([.medium])
+    }
+
+    /// Explicit override for the burst-hold the runtime applies before it
+    /// replies once. Left alone, that hold scales with group size (engages at
+    /// 4+ members, +3s each, capped at 30s); picking a value here pins it.
+    /// "Off" means no hold beyond the base coalesce window.
+    private var cooldownControl: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Cooldown")
+                .font(.subheadline)
+                .foregroundStyle(.colorTextSecondary)
+            Picker("Cooldown", selection: $cooldownSeconds) {
+                Text("Off").tag(0)
+                Text("5s").tag(5)
+                Text("15s").tag(15)
+                Text("30s").tag(30)
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: cooldownSeconds) { _, newValue in
+                postParticipation(mode: nil, cooldownSeconds: newValue)
+            }
+            Text("How long the agent holds a burst of messages before replying once.")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Local-dev bridge (behind the Listen debug flag): pushes participation
+    /// straight to the local worker's eval container proxy, which forwards to
+    /// the runtime's /convos/participation. No backend and no auth, because the
+    /// eval API is local-only. The shipping path goes through the backend, so
+    /// this whole function is scaffolding and does not survive the feature.
+    private func postParticipation(mode: String?, cooldownSeconds: Int?) {
+        guard let instanceId = contact.agentInstanceId else { return }
+        var payload: [String: Any] = [:]
+        if let mode { payload["mode"] = mode }
+        if let cooldownSeconds { payload["cooldownSeconds"] = cooldownSeconds }
+        guard
+            let url = URL(
+                string:
+                    "http://127.0.0.1:8787/api/eval/assistants/\(instanceId)/container/convos/participation"
+            ),
+            let body = try? JSONSerialization.data(withJSONObject: payload)
+        else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = body
+        Task {
+            do {
+                _ = try await URLSession.shared.data(for: request)
+                Log.info("participation pushed mode=\(mode ?? "-") cooldown=\(cooldownSeconds.map(String.init) ?? "-")")
+            } catch {
+                Log.error("participation push failed: \(error)")
+            }
+        }
     }
 
     /// Existing conversation pushed when a "Convos with you" row is tapped.
@@ -353,6 +463,13 @@ struct ContactDetailView: View {
                     showRemove: mode.isScopedToConversation
                         && !mode.isCurrentUser
                         && mode.canRemoveMembers,
+                    // Any member can change participation (not owner-gated); it
+                    // only needs to be an agent scoped to this conversation.
+                    showParticipation: FeatureFlags.shared.isListenParticipationEnabled
+                        && (isVerifiedAgent || isAgentTemplate)
+                        && mode.isScopedToConversation,
+                    participationLevel: participationLevel,
+                    onPickParticipation: { showingParticipationMenu = true },
                     showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
@@ -569,7 +686,8 @@ struct ContactDetailView: View {
     }
 
     private func handleRemoveTap() {
-        onRemove?()
+        // Removing the agent is destructive, so confirm natively before firing.
+        presentingRemoveConfirmation = true
     }
 
     private func applyBlockChange(block: Bool) {
@@ -785,6 +903,11 @@ private struct ContactDetailActions: View {
     let isAgent: Bool
     let showShare: Bool
     let showRemove: Bool
+    /// Gated by the `Listen (agent participation)` debug flag; opens the
+    /// participation menu. Any member (not owner-only) sees it.
+    let showParticipation: Bool
+    let participationLevel: AgentParticipationLevel
+    let onPickParticipation: () -> Void
     let showBlock: Bool
     let contactDisplayName: String
     /// Agent's email address from its profile metadata. Renders the
@@ -823,6 +946,9 @@ private struct ContactDetailActions: View {
             }
             if showChat {
                 chatButton
+            }
+            if showParticipation {
+                participationRow
             }
             if showShare {
                 shareRow
@@ -885,6 +1011,18 @@ private struct ContactDetailActions: View {
             accessibilityLabel: "Share \(contactDisplayName)",
             accessibilityIdentifier: "contact-detail-share-agent-row",
             action: onShare
+        )
+    }
+
+    private var participationRow: some View {
+        ContactDetailActionRow(
+            label: "Participation",
+            footer: "\(participationLevel.title) · In this convo",
+            color: .colorTextPrimary,
+            isDisabled: false,
+            accessibilityLabel: "Agent participation: \(participationLevel.title)",
+            accessibilityIdentifier: "agent-participation-button",
+            action: onPickParticipation
         )
     }
 

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -198,9 +198,6 @@ struct ContactDetailView: View {
                 pushedConversationView(vm)
             }
             .overlay { agentShareOverlay }
-            .sheet(isPresented: $showingParticipationMenu) {
-                participationMenuSheet
-            }
             .alert(
                 "Remove \(contact.resolvedDisplayName)?",
                 isPresented: $presentingRemoveConfirmation
@@ -225,23 +222,17 @@ struct ContactDetailView: View {
             } message: {
                 Text(participation?.errorMessage ?? "Please try again.")
             }
-    }
-
-    /// The "Agent participation" menu, presented from the Participation row.
-    /// The level belongs to the conversation, so every agent in it moves
-    /// together and one that joins later inherits the choice.
-    private var participationMenuSheet: some View {
-        AgentParticipationMenu(
-            selection: participation?.level ?? .default,
-            showsBackground: false
-        ) { level in
-            showingParticipationMenu = false
-            Task { await participation?.set(level) }
-        }
-        .padding(.horizontal, DesignConstants.Spacing.step6x)
-        .padding(.top, DesignConstants.Spacing.step8x)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .presentationDetents([.medium])
+            // Screen-relative floating card — same bubble, same behavior as the
+            // chat composer. Anchored to the screen, not to the row's scroll
+            // position, so it always lands in the same place with free space
+            // below it regardless of where the Participation row is scrolled.
+            .agentParticipationMenu(
+                isPresented: $showingParticipationMenu,
+                selection: participation?.level ?? .default,
+                bottomInset: DesignConstants.Spacing.step4x
+            ) { level in
+                Task { await participation?.set(level) }
+            }
     }
 
     /// Builds the store for the conversation this card is scoped to and reads
@@ -425,7 +416,10 @@ struct ContactDetailView: View {
                         && (isVerifiedAgent || isAgentTemplate)
                         && mode.isScopedToConversation,
                     participationLevel: participation?.level ?? .default,
-                    onPickParticipation: { showingParticipationMenu = true },
+                    showingParticipationMenu: $showingParticipationMenu,
+                    onSelectParticipation: { level in
+                        Task { await participation?.set(level) }
+                    },
                     showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
@@ -863,7 +857,11 @@ private struct ContactDetailActions: View {
     /// participation menu. Any member (not owner-only) sees it.
     let showParticipation: Bool
     let participationLevel: AgentParticipationLevel
-    let onPickParticipation: () -> Void
+    /// Drives the floating menu anchored to the participation row. Held by the
+    /// parent (which owns the participation store); the popover lives here so it
+    /// anchors to the row rather than to the whole card.
+    @Binding var showingParticipationMenu: Bool
+    let onSelectParticipation: (AgentParticipationLevel) -> Void
     let showBlock: Bool
     let contactDisplayName: String
     /// Agent's email address from its profile metadata. Renders the
@@ -978,7 +976,12 @@ private struct ContactDetailActions: View {
             isDisabled: false,
             accessibilityLabel: "Agent participation: \(participationLevel.title)",
             accessibilityIdentifier: "agent-participation-button",
-            action: onPickParticipation
+            leadingSystemImage: participationLevel.iconSystemName,
+            action: {
+                withAnimation(.snappy(duration: 0.2)) {
+                    showingParticipationMenu.toggle()
+                }
+            }
         )
     }
 
@@ -1025,18 +1028,28 @@ private struct ContactDetailActionRow: View {
     let isDisabled: Bool
     let accessibilityLabel: String
     let accessibilityIdentifier: String
+    /// Optional leading glyph inside the capsule, before the label. Used by the
+    /// participation row to show which level is in force at a glance.
+    var leadingSystemImage: String? = nil
     let action: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
             Button(action: action) {
-                Text(label)
-                    .font(.body)
-                    .foregroundStyle(color)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, DesignConstants.Spacing.step4x)
-                    .padding(.horizontal, DesignConstants.Spacing.step4x)
-                    .background(Capsule().fill(.colorFillMinimal))
+                HStack(spacing: DesignConstants.Spacing.step3x) {
+                    if let leadingSystemImage {
+                        Image(systemName: leadingSystemImage)
+                            .font(.body)
+                            .foregroundStyle(color)
+                    }
+                    Text(label)
+                        .font(.body)
+                        .foregroundStyle(color)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, DesignConstants.Spacing.step4x)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+                .background(Capsule().fill(.colorFillMinimal))
             }
             .buttonStyle(.plain)
             .disabled(isDisabled)

--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -82,11 +82,6 @@ struct ContactDetailView: View {
     @State private var presentingSendMessageError: Bool = false
     @State private var sendMessageErrorMessage: String?
     @State private var presentingNewConvo: NewConversationViewModel?
-    // Behind the `Listen (agent participation)` debug flag. The level belongs
-    // to the conversation this card is scoped to, so it is read from there
-    // rather than remembered per device.
-    @State private var showingParticipationMenu: Bool = false
-    @State private var participation: AgentParticipationStore?
     /// Existing conversation pushed onto the host navigation stack when the
     /// user taps a row in the "Convos with you" sections.
     @State private var pushedConversation: NewConversationViewModel?
@@ -156,9 +151,6 @@ struct ContactDetailView: View {
             .task(id: contact.inboxId) { await syncBlockedState() }
             .task(id: contact.agentTemplateId) { await observeAgentTemplateConversations() }
             .task(id: contact.agentTemplateId) { await loadAgentDescription() }
-            // The level lives with the conversation, so it is read per
-            // conversation — not per agent, and not from this device's memory.
-            .task(id: mode.conversationId) { await prepareParticipation() }
             .onAppear {
                 ensureNavigator()
                 navState.markScreenAppeared()
@@ -211,41 +203,6 @@ struct ContactDetailView: View {
                         : "This removes them from the conversation."
                 )
             }
-            .alert(
-                "Participation not updated",
-                isPresented: Binding(
-                    get: { participation?.errorMessage != nil },
-                    set: { if !$0 { participation?.dismissError() } }
-                )
-            ) {
-                Button("OK", role: .cancel) { participation?.dismissError() }
-            } message: {
-                Text(participation?.errorMessage ?? "Please try again.")
-            }
-            // Screen-relative floating card — same bubble, same behavior as the
-            // chat composer. Anchored to the screen, not to the row's scroll
-            // position, so it always lands in the same place with free space
-            // below it regardless of where the Participation row is scrolled.
-            .agentParticipationMenu(
-                isPresented: $showingParticipationMenu,
-                selection: participation?.level ?? .default,
-                bottomInset: DesignConstants.Spacing.step4x
-            ) { level in
-                Task { await participation?.set(level) }
-            }
-    }
-
-    /// Builds the store for the conversation this card is scoped to and reads
-    /// the level it is in. Anyone may have set it, so the row has to render
-    /// shared state rather than whatever this device last chose.
-    private func prepareParticipation() async {
-        guard let conversationId = mode.conversationId else {
-            participation = nil
-            return
-        }
-        let store = AgentParticipationStore(conversationId: conversationId)
-        participation = store
-        await store.load()
     }
 
     /// Existing conversation pushed when a "Convos with you" row is tapped.
@@ -410,16 +367,6 @@ struct ContactDetailView: View {
                     showRemove: mode.isScopedToConversation
                         && !mode.isCurrentUser
                         && mode.canRemoveMembers,
-                    // Any member can change participation (not owner-gated); it
-                    // only needs to be an agent scoped to this conversation.
-                    showParticipation: FeatureFlags.shared.isListenParticipationEnabled
-                        && (isVerifiedAgent || isAgentTemplate)
-                        && mode.isScopedToConversation,
-                    participationLevel: participation?.level ?? .default,
-                    showingParticipationMenu: $showingParticipationMenu,
-                    onSelectParticipation: { level in
-                        Task { await participation?.set(level) }
-                    },
                     showBlock: !mode.isCurrentUser && !contact.isUnsavedAgentPlaceholder,
                     contactDisplayName: contact.resolvedDisplayName,
                     agentEmail: contact.agentEmail,
@@ -853,15 +800,6 @@ private struct ContactDetailActions: View {
     let isAgent: Bool
     let showShare: Bool
     let showRemove: Bool
-    /// Gated by the `Listen (agent participation)` debug flag; opens the
-    /// participation menu. Any member (not owner-only) sees it.
-    let showParticipation: Bool
-    let participationLevel: AgentParticipationLevel
-    /// Drives the floating menu anchored to the participation row. Held by the
-    /// parent (which owns the participation store); the popover lives here so it
-    /// anchors to the row rather than to the whole card.
-    @Binding var showingParticipationMenu: Bool
-    let onSelectParticipation: (AgentParticipationLevel) -> Void
     let showBlock: Bool
     let contactDisplayName: String
     /// Agent's email address from its profile metadata. Renders the
@@ -900,9 +838,6 @@ private struct ContactDetailActions: View {
             }
             if showChat {
                 chatButton
-            }
-            if showParticipation {
-                participationRow
             }
             if showShare {
                 shareRow
@@ -968,23 +903,6 @@ private struct ContactDetailActions: View {
         )
     }
 
-    private var participationRow: some View {
-        ContactDetailActionRow(
-            label: "Participation",
-            footer: "\(participationLevel.title) · In this convo",
-            color: .colorTextPrimary,
-            isDisabled: false,
-            accessibilityLabel: "Agent participation: \(participationLevel.title)",
-            accessibilityIdentifier: "agent-participation-button",
-            leadingSystemImage: participationLevel.iconSystemName,
-            action: {
-                withAnimation(.snappy(duration: 0.2)) {
-                    showingParticipationMenu.toggle()
-                }
-            }
-        )
-    }
-
     private var removeRow: some View {
         ContactDetailActionRow(
             label: "Remove",
@@ -1028,24 +946,14 @@ private struct ContactDetailActionRow: View {
     let isDisabled: Bool
     let accessibilityLabel: String
     let accessibilityIdentifier: String
-    /// Optional leading glyph inside the capsule, before the label. Used by the
-    /// participation row to show which level is in force at a glance.
-    var leadingSystemImage: String? = nil
     let action: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
             Button(action: action) {
-                HStack(spacing: DesignConstants.Spacing.step3x) {
-                    if let leadingSystemImage {
-                        Image(systemName: leadingSystemImage)
-                            .font(.body)
-                            .foregroundStyle(color)
-                    }
-                    Text(label)
-                        .font(.body)
-                        .foregroundStyle(color)
-                }
+                Text(label)
+                    .font(.body)
+                    .foregroundStyle(color)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, DesignConstants.Spacing.step4x)
                 .padding(.horizontal, DesignConstants.Spacing.step4x)

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -51,6 +51,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var showingLockedInfo: Bool = false
     @State private var showingFullInfo: Bool = false
     @State private var showingAgentsInfo: Bool = false
+    /// Agent participation for this conversation, behind the Listen debug flag.
+    /// It lives here rather than in the composer because the level belongs to
+    /// the conversation; the composer only draws the control.
+    @State private var participation: AgentParticipationStore?
+    @State private var showingParticipationMenu: Bool = false
     @State private var pagerSelectedPage: ConversationPagerPage = .messages
     /// Tracks keyboard visibility so the pager dots hide and the pager-dots
     /// inset collapses while the keyboard is up.
@@ -375,6 +380,64 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
             }
         )
+        // Only where there is an agent to govern, and only while the Listen
+        // flag is on. Absent, the composer draws no bubble at all.
+        .environment(\.agentParticipation, participationContext)
+        .task(id: viewModel.conversation.id) { await prepareParticipation() }
+        .sheet(isPresented: $showingParticipationMenu) {
+            participationMenuSheet
+        }
+        .alert(
+            "Participation not updated",
+            isPresented: Binding(
+                get: { participation?.errorMessage != nil },
+                set: { if !$0 { participation?.dismissError() } }
+            )
+        ) {
+            Button("OK", role: .cancel) { participation?.dismissError() }
+        } message: {
+            Text(participation?.errorMessage ?? "Please try again.")
+        }
+    }
+
+    /// What the composer needs to draw the bubble: the level, and the tap.
+    /// `nil` in a conversation with no agent — a control for agents has no
+    /// business in a room without one.
+    private var participationContext: AgentParticipationContext? {
+        guard let participation else { return nil }
+        return AgentParticipationContext(level: participation.level) {
+            showingParticipationMenu = true
+        }
+    }
+
+    private var participationMenuSheet: some View {
+        AgentParticipationMenu(
+            selection: participation?.level ?? .default,
+            showsBackground: false
+        ) { level in
+            showingParticipationMenu = false
+            Task { await participation?.set(level) }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step6x)
+        .padding(.top, DesignConstants.Spacing.step8x)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .presentationDetents([.medium])
+    }
+
+    /// Builds the store for this conversation and reads its current level.
+    /// Skipped where the control would be meaningless, so a conversation
+    /// without agents never spends a request on it.
+    private func prepareParticipation() async {
+        guard FeatureFlags.shared.isListenParticipationEnabled,
+              viewModel.conversation.members.contains(where: \.isAgent) else {
+            participation = nil
+            return
+        }
+        let store = AgentParticipationStore(
+            conversationId: viewModel.conversation.id
+        )
+        participation = store
+        await store.load()
     }
 
     @ToolbarContentBuilder

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -452,43 +452,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
     }
 
-    /// What the composer needs to draw the bubble: the level, and the tap.
-    /// `nil` in a conversation with no agent — a control for agents has no
-    /// business in a room without one.
-    private var participationContext: AgentParticipationContext? {
-        guard let participation else { return nil }
-        return AgentParticipationContext(level: participation.level) {
-            withAnimation(.snappy(duration: 0.2)) {
-                showingParticipationMenu.toggle()
-            }
-        }
-    }
-
-    /// Keys the participation `.task` on the conversation AND on whether it has
-    /// an agent, so an agent that joins an already-open conversation re-runs
-    /// `prepareParticipation` and surfaces the control — keying on the
-    /// conversation id alone would miss that transition.
-    private var participationTaskKey: String {
-        let hasAgent = viewModel.conversation.members.contains(where: \.isAgent)
-        return "\(viewModel.conversation.id)-\(hasAgent)"
-    }
-
-    /// Builds the store for this conversation and reads its current level.
-    /// Skipped where the control would be meaningless, so a conversation
-    /// without agents never spends a request on it.
-    private func prepareParticipation() async {
-        guard FeatureFlags.shared.isListenParticipationEnabled,
-              viewModel.conversation.members.contains(where: \.isAgent) else {
-            participation = nil
-            return
-        }
-        let store = AgentParticipationStore(
-            conversationId: viewModel.conversation.id
-        )
-        participation = store
-        await store.load()
-    }
-
     @ToolbarContentBuilder
     private var topBarTrailing: some ToolbarContent {
         // The embedded Scan/Invite toggle owns scanning, so the lone viewfinder
@@ -987,5 +950,44 @@ extension ConversationView {
             onNewConvoInviteChanged: handleNewConvoInviteChanged(from:to:),
             onAddFromContactsChanged: handleAddFromContactsChanged(from:to:)
         )
+    }
+}
+
+private extension ConversationView {
+    /// What the composer needs to draw the bubble: the level, and the tap.
+    /// `nil` in a conversation with no agent — a control for agents has no
+    /// business in a room without one.
+    var participationContext: AgentParticipationContext? {
+        guard let participation else { return nil }
+        return AgentParticipationContext(level: participation.level) {
+            withAnimation(.snappy(duration: 0.2)) {
+                showingParticipationMenu.toggle()
+            }
+        }
+    }
+
+    /// Keys the participation `.task` on the conversation AND on whether it has
+    /// an agent, so an agent that joins an already-open conversation re-runs
+    /// `prepareParticipation` and surfaces the control — keying on the
+    /// conversation id alone would miss that transition.
+    var participationTaskKey: String {
+        let hasAgent = viewModel.conversation.members.contains(where: \.isAgent)
+        return "\(viewModel.conversation.id)-\(hasAgent)"
+    }
+
+    /// Builds the store for this conversation and reads its current level.
+    /// Skipped where the control would be meaningless, so a conversation
+    /// without agents never spends a request on it.
+    func prepareParticipation() async {
+        guard FeatureFlags.shared.isListenParticipationEnabled,
+              viewModel.conversation.members.contains(where: \.isAgent) else {
+            participation = nil
+            return
+        }
+        let store = AgentParticipationStore(
+            conversationId: viewModel.conversation.id
+        )
+        participation = store
+        await store.load()
     }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -4,6 +4,16 @@ import ConvosCoreiOS
 import ConvosMetrics
 import SwiftUI
 
+/// Publishes the composer's bounds up to the root so the floating participation
+/// card can be placed exactly above it — never reflowing the message list,
+/// never scrolling with it, never covering the input.
+private struct ComposerBoundsKey: PreferenceKey {
+    static let defaultValue: Anchor<CGRect>? = nil
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = nextValue() ?? value
+    }
+}
+
 struct ConversationView<MessagesBottomBar: View>: View {
     @Bindable var viewModel: ConversationViewModel
     @Bindable var profileSettingsViewModel: ProfileSettingsViewModel
@@ -378,14 +388,56 @@ struct ConversationView<MessagesBottomBar: View>: View {
                     .animation(.spring(duration: 0.4, bounce: 0.2), value: viewModel.showsCapabilityApprovedToast)
                 }
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
+                // Publish the bottom bar's bounds so the card can float exactly
+                // above it from the root overlay — never tied to scroll.
+                .anchorPreference(
+                    key: ComposerBoundsKey.self,
+                    value: .bounds
+                ) { $0 }
             }
         )
         // Only where there is an agent to govern, and only while the Listen
         // flag is on. Absent, the composer draws no bubble at all.
         .environment(\.agentParticipation, participationContext)
         .task(id: viewModel.conversation.id) { await prepareParticipation() }
-        .sheet(isPresented: $showingParticipationMenu) {
-            participationMenuSheet
+        // The participation card floats just ABOVE the composer, placed against
+        // the composer's real bounds — so it never reflows the message list,
+        // never scrolls with it, and never covers the input. A full-screen scrim
+        // behind it dismisses on an outside tap without eating the card's taps.
+        .overlayPreferenceValue(ComposerBoundsKey.self) { anchor in
+            GeometryReader { proxy in
+                if showingParticipationMenu, let participation, let anchor {
+                    let composerRect = proxy[anchor]
+                    ZStack(alignment: .bottomLeading) {
+                        Color.black.opacity(0.001)
+                            .ignoresSafeArea()
+                            .contentShape(.rect)
+                            .onTapGesture {
+                                withAnimation(.snappy(duration: 0.2)) {
+                                    showingParticipationMenu = false
+                                }
+                            }
+
+                        AgentParticipationMenu(
+                            selection: participation.level,
+                            showsBackground: true
+                        ) { level in
+                            withAnimation(.snappy(duration: 0.2)) {
+                                showingParticipationMenu = false
+                            }
+                            Task { await participation.set(level) }
+                        }
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, DesignConstants.Spacing.step4x)
+                        .padding(
+                            .bottom,
+                            proxy.size.height - composerRect.minY + DesignConstants.Spacing.step3x
+                        )
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    }
+                }
+            }
         }
         .alert(
             "Participation not updated",
@@ -406,22 +458,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
     private var participationContext: AgentParticipationContext? {
         guard let participation else { return nil }
         return AgentParticipationContext(level: participation.level) {
-            showingParticipationMenu = true
+            withAnimation(.snappy(duration: 0.2)) {
+                showingParticipationMenu.toggle()
+            }
         }
-    }
-
-    private var participationMenuSheet: some View {
-        AgentParticipationMenu(
-            selection: participation?.level ?? .default,
-            showsBackground: false
-        ) { level in
-            showingParticipationMenu = false
-            Task { await participation?.set(level) }
-        }
-        .padding(.horizontal, DesignConstants.Spacing.step6x)
-        .padding(.top, DesignConstants.Spacing.step8x)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .presentationDetents([.medium])
     }
 
     /// Builds the store for this conversation and reads its current level.

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -399,7 +399,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
         // Only where there is an agent to govern, and only while the Listen
         // flag is on. Absent, the composer draws no bubble at all.
         .environment(\.agentParticipation, participationContext)
-        .task(id: viewModel.conversation.id) { await prepareParticipation() }
+        .task(id: participationTaskKey) { await prepareParticipation() }
         // The participation card floats just ABOVE the composer, placed against
         // the composer's real bounds — so it never reflows the message list,
         // never scrolls with it, and never covers the input. A full-screen scrim
@@ -462,6 +462,15 @@ struct ConversationView<MessagesBottomBar: View>: View {
                 showingParticipationMenu.toggle()
             }
         }
+    }
+
+    /// Keys the participation `.task` on the conversation AND on whether it has
+    /// an agent, so an agent that joins an already-open conversation re-runs
+    /// `prepareParticipation` and surfaces the control — keying on the
+    /// conversation id alone would miss that transition.
+    private var participationTaskKey: String {
+        let hasAgent = viewModel.conversation.members.contains(where: \.isAgent)
+        return "\(viewModel.conversation.id)-\(hasAgent)"
     }
 
     /// Builds the store for this conversation and reads its current level.

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -985,7 +985,8 @@ private extension ConversationView {
             return
         }
         let store = AgentParticipationStore(
-            conversationId: viewModel.conversation.id
+            conversationId: viewModel.conversation.id,
+            variantId: FeatureFlags.shared.selectedAgentVariant?.slug
         )
         participation = store
         await store.load()

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -74,6 +74,7 @@ struct DebugViewSection: View {
         Section("Features") {
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
             Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
+            Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
 
             let showInfoAction = { showingAgentsInfoSheet = true }

--- a/Convos/Share Suggestions/ShareSuggestionDonator.swift
+++ b/Convos/Share Suggestions/ShareSuggestionDonator.swift
@@ -40,10 +40,10 @@ enum ShareSuggestionDonator {
 
             let removedIds: [String] = lastDonated.keys.filter { !currentIds.contains($0) }
             if !removedIds.isEmpty {
-                INInteraction.delete(with: removedIds) { error in
-                    if let error {
-                        Log.error("[ShareSuggestions] delete failed: \(error.localizedDescription)")
-                    }
+                do {
+                    try await INInteraction.delete(with: removedIds)
+                } catch {
+                    Log.error("[ShareSuggestions] delete failed: \(error.localizedDescription)")
                 }
             }
 

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -162,57 +162,6 @@ public struct AgentParticipationMenu: View {
     }
 }
 
-// MARK: - Screen-relative floating presentation
-
-public extension View {
-    /// Presents the participation menu as a **screen-relative** floating card,
-    /// anchored to the bottom of the screen — never tied to scroll position and
-    /// never clipped by a composer or a list row. A full-screen scrim behind it
-    /// dismisses on an outside tap; the card floats above the scrim, so the
-    /// scrim never eats the menu's own taps. Applied at the ROOT of a screen so
-    /// the overlay spans the whole viewport.
-    ///
-    /// `bottomInset` is the free space to leave below the card — the composer's
-    /// height on the chat screen, a comfortable margin on the agent profile —
-    /// so the same bubble lands consistently in both places.
-    func agentParticipationMenu(
-        isPresented: Binding<Bool>,
-        selection: AgentParticipationLevel,
-        bottomInset: CGFloat,
-        onSelect: @escaping (AgentParticipationLevel) -> Void
-    ) -> some View {
-        overlay {
-            if isPresented.wrappedValue {
-                ZStack(alignment: .bottom) {
-                    Color.black.opacity(0.001)
-                        .ignoresSafeArea()
-                        .contentShape(.rect)
-                        .onTapGesture {
-                            withAnimation(.snappy(duration: 0.2)) {
-                                isPresented.wrappedValue = false
-                            }
-                        }
-
-                    AgentParticipationMenu(
-                        selection: selection,
-                        showsBackground: true
-                    ) { level in
-                        withAnimation(.snappy(duration: 0.2)) {
-                            isPresented.wrappedValue = false
-                        }
-                        onSelect(level)
-                    }
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, DesignConstants.Spacing.step4x)
-                    .padding(.bottom, bottomInset)
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
-                }
-            }
-        }
-    }
-}
-
 // MARK: - Previews
 
 /// Interactive: tap a level and the check moves. Backed by a mock chat gradient

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -162,6 +162,57 @@ public struct AgentParticipationMenu: View {
     }
 }
 
+// MARK: - Screen-relative floating presentation
+
+public extension View {
+    /// Presents the participation menu as a **screen-relative** floating card,
+    /// anchored to the bottom of the screen — never tied to scroll position and
+    /// never clipped by a composer or a list row. A full-screen scrim behind it
+    /// dismisses on an outside tap; the card floats above the scrim, so the
+    /// scrim never eats the menu's own taps. Applied at the ROOT of a screen so
+    /// the overlay spans the whole viewport.
+    ///
+    /// `bottomInset` is the free space to leave below the card — the composer's
+    /// height on the chat screen, a comfortable margin on the agent profile —
+    /// so the same bubble lands consistently in both places.
+    func agentParticipationMenu(
+        isPresented: Binding<Bool>,
+        selection: AgentParticipationLevel,
+        bottomInset: CGFloat,
+        onSelect: @escaping (AgentParticipationLevel) -> Void
+    ) -> some View {
+        overlay {
+            if isPresented.wrappedValue {
+                ZStack(alignment: .bottom) {
+                    Color.black.opacity(0.001)
+                        .ignoresSafeArea()
+                        .contentShape(.rect)
+                        .onTapGesture {
+                            withAnimation(.snappy(duration: 0.2)) {
+                                isPresented.wrappedValue = false
+                            }
+                        }
+
+                    AgentParticipationMenu(
+                        selection: selection,
+                        showsBackground: true
+                    ) { level in
+                        withAnimation(.snappy(duration: 0.2)) {
+                            isPresented.wrappedValue = false
+                        }
+                        onSelect(level)
+                    }
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, DesignConstants.Spacing.step4x)
+                    .padding(.bottom, bottomInset)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Previews
 
 /// Interactive: tap a level and the check moves. Backed by a mock chat gradient

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -1,69 +1,77 @@
+#if canImport(UIKit)
 import SwiftUI
 
 // MARK: - Agent participation
 
-/// How much an agent talks in a specific conversation. The owner/members pick a
-/// level; the agent keeps *working* at every level short of leaving — only how
-/// much it *speaks* changes.
+/// How much the agents in a conversation talk. Members pick a level; the agents
+/// keep *working* at every level short of Pause — only how much they *speak*
+/// changes.
 ///
-/// NOTE (spec, 2026-07-20): product planning trimmed this to three live levels —
-/// `speakFreely`, `mentionsOnly`, `paused`. `listenOnly` (+ its "mute for…"
-/// duration) and `leaveRoom` are rendered here to match the current Figma while
-/// the final set is decided; gate them behind `Self.liveCases` when we lock it.
-enum AgentParticipationLevel: String, CaseIterable, Identifiable {
+/// The level belongs to the conversation, not to one agent: a room holding
+/// several agents has a single setting that governs all of them, and an agent
+/// that joins later inherits it.
+public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendable {
     case speakFreely
     case mentionsOnly
-    case listenOnly
     case paused
-    case leaveRoom
 
-    var id: String { rawValue }
+    public var id: String { rawValue }
 
-    /// The subset shipping in v1 per the current spec. Swap the menu's data
-    /// source to this to drop Listen-only + Leave-the-room without touching layout.
-    static let liveCases: [AgentParticipationLevel] = [.speakFreely, .mentionsOnly, .paused]
-
-    var title: String {
+    public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
         case .mentionsOnly: "Mentions only"
-        case .listenOnly: "Listen only"
-        case .paused: "Paused"
-        case .leaveRoom: "Leave the room"
+        case .paused: "Pause"
         }
     }
 
-    var caption: String {
+    public var caption: String {
         switch self {
         case .speakFreely: "Chime in any time"
         case .mentionsOnly: "Speak when you see your name"
-        case .listenOnly: "Mute for …"
-        case .paused: "Offline, uses no credits"
-        case .leaveRoom: "Until invited back"
+        case .paused: "Go offline, use no credits"
         }
     }
 
-    /// Opens a follow-up step (the duration picker) rather than selecting inline.
-    var hasDisclosure: Bool { self == .listenOnly }
+    /// The mark for this level. It carries the level on its own in the
+    /// composer, where there is no room for the title — so each one has to read
+    /// as its own idea at a glance: sound, a name, a stop.
+    public var iconSystemName: String {
+        switch self {
+        case .speakFreely: "speaker.wave.2"
+        case .mentionsOnly: "at"
+        case .paused: "pause.circle"
+        }
+    }
 
-    /// Wire value sent to the runtime's /convos/participation (speak/mention/paused).
-    var wireMode: String {
+    /// Wire value for the control plane (speak / mention / paused).
+    public var wireMode: String {
         switch self {
         case .speakFreely: "speak"
         case .mentionsOnly: "mention"
         case .paused: "paused"
-        // Not in the live set; map to speak so a stray value never gates.
-        case .listenOnly, .leaveRoom: "speak"
+        }
+    }
+
+    /// The level a conversation is in until someone sets one. Matches the
+    /// control plane's default, so an unset room and an explicit Speak freely
+    /// render identically — because they behave identically.
+    public static let `default`: AgentParticipationLevel = .speakFreely
+
+    public init?(wireMode: String) {
+        switch wireMode {
+        case "speak": self = .speakFreely
+        case "mention": self = .mentionsOnly
+        case "paused": self = .paused
+        default: return nil
         }
     }
 }
 
 /// The floating "Agent participation" menu: a frosted card of levels with a
-/// leading check on the current one and a disclosure on any level that opens a
-/// follow-up step. Presentation-agnostic — drop it in a popover, a sheet, or a
-/// `.contextMenu`-style overlay from the agent's profile.
-struct AgentParticipationMenu: View {
-    let levels: [AgentParticipationLevel]
+/// leading check on the current one. Presentation-agnostic — drop it in a
+/// popover, a sheet, or an overlay from the composer or the agent's profile.
+public struct AgentParticipationMenu: View {
     let selection: AgentParticipationLevel
     /// Draws the frosted card + shadow around the rows. Set `false` when the
     /// host already provides a surface (e.g. inside a sheet) so the panel isn't
@@ -71,26 +79,24 @@ struct AgentParticipationMenu: View {
     let showsBackground: Bool
     let onSelect: (AgentParticipationLevel) -> Void
 
-    init(
-        levels: [AgentParticipationLevel] = AgentParticipationLevel.allCases,
+    public init(
         selection: AgentParticipationLevel,
         showsBackground: Bool = true,
         onSelect: @escaping (AgentParticipationLevel) -> Void
     ) {
-        self.levels = levels
         self.selection = selection
         self.showsBackground = showsBackground
         self.onSelect = onSelect
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
             Text("Agent participation")
                 .font(.subheadline)
                 .foregroundStyle(.colorTextSecondary)
 
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
-                ForEach(levels) { level in
+                ForEach(AgentParticipationLevel.allCases) { level in
                     row(for: level)
                 }
             }
@@ -98,8 +104,11 @@ struct AgentParticipationMenu: View {
         .padding(showsBackground ? DesignConstants.Spacing.step6x : 0)
         .background {
             if showsBackground {
-                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLargest, style: .continuous)
-                    .fill(.regularMaterial)
+                RoundedRectangle(
+                    cornerRadius: DesignConstants.CornerRadius.mediumLargest,
+                    style: .continuous
+                )
+                .fill(.regularMaterial)
             }
         }
         // Tight, single-direction lift — reads as a floating menu, not a halo.
@@ -116,13 +125,14 @@ struct AgentParticipationMenu: View {
         Button {
             onSelect(level)
         } label: {
-            HStack(alignment: .firstTextBaseline, spacing: DesignConstants.Spacing.step3x) {
-                // Fixed check gutter so titles align whether or not selected.
-                Image(systemName: "checkmark")
-                    .font(.body.weight(.semibold))
+            HStack(alignment: .center, spacing: DesignConstants.Spacing.step3x) {
+                // The icon is the same mark the composer bubble shows, so the
+                // control the member taps and the level they picked are visibly
+                // the same thing.
+                Image(systemName: level.iconSystemName)
+                    .font(.system(size: 18, weight: .regular))
                     .foregroundStyle(.colorTextPrimary)
-                    .opacity(level == selection ? 1 : 0)
-                    .frame(width: DesignConstants.Spacing.step6x, alignment: .leading)
+                    .frame(width: DesignConstants.Spacing.step8x, alignment: .center)
 
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
                     Text(level.title)
@@ -135,11 +145,13 @@ struct AgentParticipationMenu: View {
 
                 Spacer(minLength: DesignConstants.Spacing.step2x)
 
-                if level.hasDisclosure {
-                    Image(systemName: "chevron.right")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.colorTextSecondary)
-                }
+                // Fixed check gutter so every row's text sits on the same axis
+                // whether or not it is the selected one.
+                Image(systemName: "checkmark")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.colorTextPrimary)
+                    .opacity(level == selection ? 1 : 0)
+                    .frame(width: DesignConstants.Spacing.step6x, alignment: .trailing)
             }
             .contentShape(Rectangle())
         }
@@ -175,23 +187,4 @@ struct AgentParticipationMenu: View {
     }
     return Harness()
 }
-
-/// The trimmed three-level set (current spec) — same layout, no Listen-only /
-/// Leave-the-room.
-#Preview("Participation menu (3-level spec)") {
-    struct Harness: View {
-        @State private var selection: AgentParticipationLevel = .mentionsOnly
-        var body: some View {
-            ZStack {
-                Color(.systemGray5).ignoresSafeArea()
-                AgentParticipationMenu(
-                    levels: AgentParticipationLevel.liveCases,
-                    selection: selection
-                ) { selection = $0 }
-                .frame(maxWidth: 360)
-                .padding()
-            }
-        }
-    }
-    return Harness()
-}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
@@ -5,7 +5,9 @@ import SwiftUI
 /// conversation is in, and what to do when someone taps it.
 ///
 /// The composer owns none of this. The host resolves the level for the
-/// conversation and performs the change; the bubble is only the affordance.
+/// conversation and performs the change; the accessory is only the affordance.
+/// The accessory itself lives inside the input field — see
+/// `MessagesInputView.participationAccessory`.
 public struct AgentParticipationContext {
     public let level: AgentParticipationLevel
     public let onTap: () -> Void
@@ -28,43 +30,6 @@ public extension EnvironmentValues {
     var agentParticipation: AgentParticipationContext? {
         get { self[AgentParticipationEnvironmentKey.self] }
         set { self[AgentParticipationEnvironmentKey.self] = newValue }
-    }
-}
-
-/// The participation bubble that sits in the input bar next to the attachment
-/// control, wearing the icon of the level the conversation is in.
-///
-/// It is in the composer, not buried in the agent's profile, because every
-/// member may change the level and the moment they want to is while they are
-/// typing — and because the icon doubles as the answer to "is the agent
-/// listening right now".
-public struct AgentParticipationBubble: View {
-    let level: AgentParticipationLevel
-    let action: () -> Void
-
-    public init(level: AgentParticipationLevel, action: @escaping () -> Void) {
-        self.level = level
-        self.action = action
-    }
-
-    public var body: some View {
-        Button(action: action) {
-            Image(systemName: level.iconSystemName)
-                .font(.system(size: 18.0, weight: .medium))
-                .foregroundStyle(Color.colorTextPrimary)
-                .frame(width: 32, height: 32)
-                .contentShape(.circle)
-        }
-        .buttonStyle(.plain)
-        .frame(
-            width: DesignConstants.Spacing.step12x,
-            height: DesignConstants.Spacing.step12x
-        )
-        .clipShape(.circle)
-        .glassEffect(.regular.interactive(), in: .circle)
-        .accessibilityLabel("Agent participation: \(level.title)")
-        .accessibilityHint("Change how much the agents speak here")
-        .accessibilityIdentifier("agent-participation-button")
     }
 }
 #endif

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
@@ -1,0 +1,70 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// What the composer needs to show the participation control: the level the
+/// conversation is in, and what to do when someone taps it.
+///
+/// The composer owns none of this. The host resolves the level for the
+/// conversation and performs the change; the bubble is only the affordance.
+public struct AgentParticipationContext {
+    public let level: AgentParticipationLevel
+    public let onTap: () -> Void
+
+    public init(level: AgentParticipationLevel, onTap: @escaping () -> Void) {
+        self.level = level
+        self.onTap = onTap
+    }
+}
+
+private struct AgentParticipationEnvironmentKey: EnvironmentKey {
+    static let defaultValue: AgentParticipationContext?
+    = nil
+}
+
+public extension EnvironmentValues {
+    /// Set by the host on conversations that have at least one agent. `nil`
+    /// means there is nothing to govern, and the composer shows no bubble —
+    /// a control for agents has no business in a conversation without one.
+    var agentParticipation: AgentParticipationContext? {
+        get { self[AgentParticipationEnvironmentKey.self] }
+        set { self[AgentParticipationEnvironmentKey.self] = newValue }
+    }
+}
+
+/// The participation bubble that sits in the input bar next to the attachment
+/// control, wearing the icon of the level the conversation is in.
+///
+/// It is in the composer, not buried in the agent's profile, because every
+/// member may change the level and the moment they want to is while they are
+/// typing — and because the icon doubles as the answer to "is the agent
+/// listening right now".
+public struct AgentParticipationBubble: View {
+    let level: AgentParticipationLevel
+    let action: () -> Void
+
+    public init(level: AgentParticipationLevel, action: @escaping () -> Void) {
+        self.level = level
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            Image(systemName: level.iconSystemName)
+                .font(.system(size: 18.0, weight: .medium))
+                .foregroundStyle(Color.colorTextPrimary)
+                .frame(width: 32, height: 32)
+                .contentShape(.circle)
+        }
+        .buttonStyle(.plain)
+        .frame(
+            width: DesignConstants.Spacing.step12x,
+            height: DesignConstants.Spacing.step12x
+        )
+        .clipShape(.circle)
+        .glassEffect(.regular.interactive(), in: .circle)
+        .accessibilityLabel("Agent participation: \(level.title)")
+        .accessibilityHint("Change how much the agents speak here")
+        .accessibilityIdentifier("agent-participation-button")
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -1,0 +1,80 @@
+#if canImport(UIKit)
+import ConvosCore
+import Foundation
+
+/// Owns one conversation's participation level for the views that show it.
+///
+/// Two surfaces render this — the bubble in the composer and the row in an
+/// agent's profile — and both have to agree, load it the same way, and fail the
+/// same way. Keeping the level and its two calls here means neither surface
+/// carries its own copy of the optimistic-write dance.
+@Observable
+@MainActor
+public final class AgentParticipationStore {
+    /// The level to render. Starts at the product default so the control is
+    /// never blank; replaced by the conversation's real level once read.
+    public private(set) var level: AgentParticipationLevel = .default
+
+    /// Set when a write failed and was rolled back, so the host can surface it.
+    /// Cleared by `dismissError()` — the host owns the alert, not this store.
+    public private(set) var errorMessage: String?
+
+    private let conversationId: String
+
+    public init(conversationId: String) {
+        self.conversationId = conversationId
+    }
+
+    public func dismissError() {
+        errorMessage = nil
+    }
+
+    /// Reads the level the conversation is in. Any member may have set it, so
+    /// this is the only honest source — a device-local memory goes stale the
+    /// moment someone else changes it.
+    ///
+    /// Quiet on failure: the default is a safe thing to show, and an error for
+    /// a read the member never asked for is noise.
+    public func load() async {
+        do {
+            let response = try await client().getAgentParticipation(
+                conversationId: conversationId
+            )
+            if let loaded = AgentParticipationLevel(wireMode: response.mode) {
+                level = loaded
+            }
+        } catch {
+            Log.error("participation read failed: \(error)")
+        }
+    }
+
+    /// Applies a level to every agent in the conversation.
+    ///
+    /// Optimistic, and rolled back when the write fails: the control moves
+    /// immediately because that is what a tap should feel like, but if the
+    /// write never lands the agents are still on the old level — leaving the
+    /// check on the new one would tell the member the opposite of the error.
+    public func set(_ newLevel: AgentParticipationLevel) async {
+        let previous = level
+        guard newLevel != previous else { return }
+        level = newLevel
+        do {
+            _ = try await client().setAgentParticipation(
+                conversationId: conversationId,
+                mode: newLevel.wireMode
+            )
+            Log.info("participation set mode=\(newLevel.wireMode)")
+        } catch {
+            Log.error("participation update failed: \(error)")
+            level = previous
+            errorMessage = "Couldn't update participation. The agents are still on their previous setting."
+        }
+    }
+
+    private func client() -> any ConvosAPIClientProtocol {
+        ConvosAPIClientFactory.client(
+            environment: ConfigManager.shared.currentEnvironment
+        )
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -24,7 +24,7 @@ public final class AgentParticipationStore {
     /// Bumped on every local `set()`. `load()` captures it before its network
     /// read and bails if it changed meanwhile, so a tap that lands mid-read is
     /// never clobbered by the older server value the read was already fetching.
-    private var writeGeneration = 0
+    private var writeGeneration: Int = 0
 
     public init(conversationId: String) {
         self.conversationId = conversationId

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -21,6 +21,11 @@ public final class AgentParticipationStore {
 
     private let conversationId: String
 
+    /// Bumped on every local `set()`. `load()` captures it before its network
+    /// read and bails if it changed meanwhile, so a tap that lands mid-read is
+    /// never clobbered by the older server value the read was already fetching.
+    private var writeGeneration = 0
+
     public init(conversationId: String) {
         self.conversationId = conversationId
     }
@@ -36,10 +41,14 @@ public final class AgentParticipationStore {
     /// Quiet on failure: the default is a safe thing to show, and an error for
     /// a read the member never asked for is noise.
     public func load() async {
+        let generationAtStart = writeGeneration
         do {
             let response = try await client().getAgentParticipation(
                 conversationId: conversationId
             )
+            // A set() that landed while this read was in flight is newer than the
+            // value the server just returned; don't overwrite it with stale data.
+            guard writeGeneration == generationAtStart else { return }
             if let loaded = AgentParticipationLevel(wireMode: response.mode) {
                 level = loaded
             }
@@ -58,6 +67,7 @@ public final class AgentParticipationStore {
         let previous = level
         guard newLevel != previous else { return }
         level = newLevel
+        writeGeneration += 1
         do {
             _ = try await client().setAgentParticipation(
                 conversationId: conversationId,

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -21,13 +21,20 @@ public final class AgentParticipationStore {
 
     private let conversationId: String
 
+    /// Dev-only variant routing key. An agent built on a variant worker only
+    /// exists there, so both participation calls must carry this or the backend
+    /// routes them to the default worker and the write fails. Nil (and stripped
+    /// in production) for a normal agent.
+    private let variantId: String?
+
     /// Bumped on every local `set()`. `load()` captures it before its network
     /// read and bails if it changed meanwhile, so a tap that lands mid-read is
     /// never clobbered by the older server value the read was already fetching.
     private var writeGeneration: Int = 0
 
-    public init(conversationId: String) {
+    public init(conversationId: String, variantId: String? = nil) {
         self.conversationId = conversationId
+        self.variantId = variantId
     }
 
     public func dismissError() {
@@ -44,7 +51,8 @@ public final class AgentParticipationStore {
         let generationAtStart = writeGeneration
         do {
             let response = try await client().getAgentParticipation(
-                conversationId: conversationId
+                conversationId: conversationId,
+                variantId: variantId
             )
             // A set() that landed while this read was in flight is newer than the
             // value the server just returned; don't overwrite it with stale data.
@@ -71,7 +79,8 @@ public final class AgentParticipationStore {
         do {
             _ = try await client().setAgentParticipation(
                 conversationId: conversationId,
-                mode: newLevel.wireMode
+                mode: newLevel.wireMode,
+                variantId: variantId
             )
             Log.info("participation set mode=\(newLevel.wireMode)")
         } catch {

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -107,6 +107,9 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
     @State private var didSelectPhotoThisSession: Bool = false
     @Namespace private var namespace: Namespace.ID
+    // Injected by the host on conversations that hold an agent; nil elsewhere,
+    // and the bubble simply isn't drawn.
+    @Environment(\.agentParticipation) private var agentParticipation: AgentParticipationContext?
 
     public init(
         profile: Profile,
@@ -467,6 +470,18 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @ViewBuilder
     private var normalInputView: some View {
         HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
+            // Only where there is an agent to govern. It sits ahead of the
+            // attachment control because it is a property of the room rather
+            // than of the message being written.
+            if let participation = agentParticipation {
+                AgentParticipationBubble(
+                    level: participation.level,
+                    action: participation.onTap
+                )
+                .glassEffectID("participation", in: namespace)
+                .glassEffectTransition(.matchedGeometry)
+            }
+
             if isMessageInputFocused {
                 Button {
                     withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -470,18 +470,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @ViewBuilder
     private var normalInputView: some View {
         HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
-            // Only where there is an agent to govern. It sits ahead of the
-            // attachment control because it is a property of the room rather
-            // than of the message being written.
-            if let participation = agentParticipation {
-                AgentParticipationBubble(
-                    level: participation.level,
-                    action: participation.onTap
-                )
-                .glassEffectID("participation", in: namespace)
-                .glassEffectTransition(.matchedGeometry)
-            }
-
             if isMessageInputFocused {
                 Button {
                     withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -40,6 +40,9 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
     private let attachmentPreviewSize: CGFloat = 80.0
     @State private var poofingAttachmentIds: Set<UUID> = []
     @State private var isPoofingInvite: Bool = false
+    // Set by the host on conversations with an agent; nil elsewhere. Rendered as
+    // a leading accessory inside the input field — see `participationAccessory`.
+    @Environment(\.agentParticipation) private var agentParticipation: AgentParticipationContext?
 
     public init(
         displayName: Binding<String>,
@@ -158,12 +161,38 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
             }
 
             HStack(alignment: .bottom, spacing: 0) {
+                participationAccessory
                 messageTextField
                 sendButton
             }
         }
         .padding(DesignConstants.Spacing.step2x)
         .frame(alignment: .bottom)
+    }
+
+    /// The agent-participation control, living inside the input field as a
+    /// leading accessory just before the placeholder. A property of the
+    /// conversation, so it sits with the field the members type into rather than
+    /// among the attachment buttons. Bare — no glass — because it is already
+    /// inside the input's own capsule; a second glass shape here would read as a
+    /// chip stuck on the field. Bottom-aligned so it stays on the placeholder
+    /// line as the field grows to multiple lines.
+    @ViewBuilder
+    private var participationAccessory: some View {
+        if let participation = agentParticipation {
+            Button(action: participation.onTap) {
+                Image(systemName: participation.level.iconSystemName)
+                    .font(.callout)
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(height: Self.defaultHeight)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .padding(.leading, DesignConstants.Spacing.step2x)
+            .accessibilityLabel("Agent participation: \(participation.level.title)")
+            .accessibilityHint("Change how much the agents speak here")
+            .accessibilityIdentifier("agent-participation-button")
+        }
     }
 
     @ViewBuilder

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -332,41 +332,31 @@ public enum ConvosAPI {
         }
     }
 
-    // MARK: - v2/agents/:instanceId/participation
+    // MARK: - v2/conversations/:conversationId/participation
 
-    /// Partial update: send the level, the cooldown, or both. Omitted fields
-    /// are left as they are, so changing the cooldown does not disturb the
-    /// level and vice versa.
+    /// How much the agents in a conversation may speak. The level belongs to
+    /// the conversation, not to one agent: a room with several agents has one
+    /// setting that governs all of them, and an agent that joins later
+    /// inherits it.
     public struct AgentParticipationRequest: Codable {
         /// "speak", "mention" or "paused".
-        public let mode: String?
-        /// Explicit burst hold in seconds. 0 turns the explicit hold off and
-        /// returns the agent to the automatic, member-scaled window.
-        public let cooldownSeconds: Int?
+        public let mode: String
 
-        public init(mode: String? = nil, cooldownSeconds: Int? = nil) {
+        public init(mode: String) {
             self.mode = mode
-            self.cooldownSeconds = cooldownSeconds
         }
     }
 
     public struct AgentParticipationResponse: Codable {
         public let success: Bool
-        public let instanceId: String
-        /// Echo of what was applied; nil for a field the request left alone.
-        public let mode: String?
-        public let cooldownSeconds: Int?
+        public let conversationId: String
+        /// The level now in force — echoed on a write, read on a fetch.
+        public let mode: String
 
-        public init(
-            success: Bool,
-            instanceId: String,
-            mode: String? = nil,
-            cooldownSeconds: Int? = nil
-        ) {
+        public init(success: Bool, conversationId: String, mode: String) {
             self.success = success
-            self.instanceId = instanceId
+            self.conversationId = conversationId
             self.mode = mode
-            self.cooldownSeconds = cooldownSeconds
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -332,6 +332,44 @@ public enum ConvosAPI {
         }
     }
 
+    // MARK: - v2/agents/:instanceId/participation
+
+    /// Partial update: send the level, the cooldown, or both. Omitted fields
+    /// are left as they are, so changing the cooldown does not disturb the
+    /// level and vice versa.
+    public struct AgentParticipationRequest: Codable {
+        /// "speak", "mention" or "paused".
+        public let mode: String?
+        /// Explicit burst hold in seconds. 0 turns the explicit hold off and
+        /// returns the agent to the automatic, member-scaled window.
+        public let cooldownSeconds: Int?
+
+        public init(mode: String? = nil, cooldownSeconds: Int? = nil) {
+            self.mode = mode
+            self.cooldownSeconds = cooldownSeconds
+        }
+    }
+
+    public struct AgentParticipationResponse: Codable {
+        public let success: Bool
+        public let instanceId: String
+        /// Echo of what was applied; nil for a field the request left alone.
+        public let mode: String?
+        public let cooldownSeconds: Int?
+
+        public init(
+            success: Bool,
+            instanceId: String,
+            mode: String? = nil,
+            cooldownSeconds: Int? = nil
+        ) {
+            self.success = success
+            self.instanceId = instanceId
+            self.mode = mode
+            self.cooldownSeconds = cooldownSeconds
+        }
+    }
+
     // MARK: - v2/agent-templates/:id
 
     // Subset of the agent-template object the backend returns from the

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -105,6 +105,17 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// the poll hit the default worker, which has no record of the instance.
     func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse
 
+    /// Sets how much an agent may speak in its conversation. The backend holds
+    /// the assistant control-plane key and forwards this; the app cannot reach
+    /// that plane directly. Paused depends on the hop: the level has to be
+    /// recorded there for a message to be refused before the agent is woken.
+    /// Both fields are a partial update, but sending neither is rejected.
+    func setAgentParticipation(
+        instanceId: String,
+        mode: String?,
+        cooldownSeconds: Int?
+    ) async throws -> ConvosAPI.AgentParticipationResponse
+
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
     /// template id (UUID) or hashed url slug (e.g. `gandalf.felpl`). Backs the
@@ -875,6 +886,24 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // request. Kept well under the loop's overall deadline so a stuck
         // request fails fast and the next iteration's deadline check fires.
         request.timeoutInterval = 10
+        return try await performRequest(request)
+    }
+
+    func setAgentParticipation(
+        instanceId: String,
+        mode: String?,
+        cooldownSeconds: Int?
+    ) async throws -> ConvosAPI.AgentParticipationResponse {
+        let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
+        var request = try authenticatedRequest(for: "v2/agents/\(encoded)/participation", method: "PATCH")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // One small write that fans out to the control plane and, for the two
+        // speaking levels, on to the container. Bounded so a stuck call cannot
+        // leave the sheet waiting.
+        request.timeoutInterval = 20
+        request.httpBody = try JSONEncoder().encode(
+            ConvosAPI.AgentParticipationRequest(mode: mode, cooldownSeconds: cooldownSeconds)
+        )
         return try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -105,15 +105,24 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// the poll hit the default worker, which has no record of the instance.
     func getAgentJoinStatus(instanceId: String, variantId: String?) async throws -> ConvosAPI.AgentJoinStatusResponse
 
-    /// Sets how much an agent may speak in its conversation. The backend holds
+    /// Sets how much the agents in a conversation may speak. The backend holds
     /// the assistant control-plane key and forwards this; the app cannot reach
     /// that plane directly. Paused depends on the hop: the level has to be
-    /// recorded there for a message to be refused before the agent is woken.
-    /// Both fields are a partial update, but sending neither is rejected.
+    /// recorded there for a message to be refused before an agent is woken.
+    ///
+    /// Keyed by conversation, not by agent: one level governs every agent in
+    /// the room, and an agent that joins later inherits it.
     func setAgentParticipation(
-        instanceId: String,
-        mode: String?,
-        cooldownSeconds: Int?
+        conversationId: String,
+        mode: String
+    ) async throws -> ConvosAPI.AgentParticipationResponse
+
+    /// The level a conversation is currently in. Any member may change it, so
+    /// a device-local guess goes stale the moment someone else does — the
+    /// control has to render from the shared record. Answered upstream without
+    /// waking an agent.
+    func getAgentParticipation(
+        conversationId: String
     ) async throws -> ConvosAPI.AgentParticipationResponse
 
     // Agent templates
@@ -890,21 +899,39 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func setAgentParticipation(
-        instanceId: String,
-        mode: String?,
-        cooldownSeconds: Int?
+        conversationId: String,
+        mode: String
     ) async throws -> ConvosAPI.AgentParticipationResponse {
-        let encoded = instanceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? instanceId
-        var request = try authenticatedRequest(for: "v2/agents/\(encoded)/participation", method: "PATCH")
+        var request = try authenticatedRequest(
+            for: "v2/conversations/\(participationPathComponent(conversationId))/participation",
+            method: "PATCH"
+        )
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        // One small write that fans out to the control plane and, for the two
-        // speaking levels, on to the container. Bounded so a stuck call cannot
-        // leave the sheet waiting.
+        // One small write that fans out to every agent in the conversation and,
+        // for the two speaking levels, on to their containers. Bounded so a
+        // stuck call cannot leave the menu waiting.
         request.timeoutInterval = 20
         request.httpBody = try JSONEncoder().encode(
-            ConvosAPI.AgentParticipationRequest(mode: mode, cooldownSeconds: cooldownSeconds)
+            ConvosAPI.AgentParticipationRequest(mode: mode)
         )
         return try await performRequest(request)
+    }
+
+    func getAgentParticipation(
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentParticipationResponse {
+        var request = try authenticatedRequest(
+            for: "v2/conversations/\(participationPathComponent(conversationId))/participation",
+            method: "GET"
+        )
+        // Read on open; the control falls back to its default if this is slow,
+        // so it must not hold the view.
+        request.timeoutInterval = 10
+        return try await performRequest(request)
+    }
+
+    private func participationPathComponent(_ conversationId: String) -> String {
+        conversationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? conversationId
     }
 
     // MARK: - Agent templates

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -114,7 +114,8 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// the room, and an agent that joins later inherits it.
     func setAgentParticipation(
         conversationId: String,
-        mode: String
+        mode: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse
 
     /// The level a conversation is currently in. Any member may change it, so
@@ -122,7 +123,8 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// control has to render from the shared record. Answered upstream without
     /// waking an agent.
     func getAgentParticipation(
-        conversationId: String
+        conversationId: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse
 
     // Agent templates
@@ -900,11 +902,17 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func setAgentParticipation(
         conversationId: String,
-        mode: String
+        mode: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse {
+        // `variantId` is load-bearing, exactly as on the join poll: an agent
+        // provisioned on a variant worker only exists there, so a write that
+        // omits it lands on the default worker — which has no such conversation
+        // and rejects the update.
         var request = try authenticatedRequest(
             for: "v2/conversations/\(participationPathComponent(conversationId))/participation",
-            method: "PATCH"
+            method: "PATCH",
+            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
         )
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         // One small write that fans out to every agent in the conversation and,
@@ -918,11 +926,15 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func getAgentParticipation(
-        conversationId: String
+        conversationId: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse {
+        // Read and write must resolve to the same worker (see setAgentParticipation),
+        // or the control renders a level that isn't the conversation's.
         var request = try authenticatedRequest(
             for: "v2/conversations/\(participationPathComponent(conversationId))/participation",
-            method: "GET"
+            method: "GET",
+            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
         )
         // Read on open; the control falls back to its default if this is slow,
         // so it must not hold the view.

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -116,18 +116,18 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func setAgentParticipation(
-        instanceId: String,
-        mode: String?,
-        cooldownSeconds: Int?
+        conversationId: String,
+        mode: String
     ) async throws -> ConvosAPI.AgentParticipationResponse {
         // Echo the request back, matching the real endpoint: the caller renders
         // the level it just set.
-        .init(
-            success: true,
-            instanceId: instanceId,
-            mode: mode,
-            cooldownSeconds: cooldownSeconds
-        )
+        .init(success: true, conversationId: conversationId, mode: mode)
+    }
+
+    func getAgentParticipation(
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentParticipationResponse {
+        .init(success: true, conversationId: conversationId, mode: "speak")
     }
 
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -115,6 +115,21 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         )
     }
 
+    func setAgentParticipation(
+        instanceId: String,
+        mode: String?,
+        cooldownSeconds: Int?
+    ) async throws -> ConvosAPI.AgentParticipationResponse {
+        // Echo the request back, matching the real endpoint: the caller renders
+        // the level it just set.
+        .init(
+            success: true,
+            instanceId: instanceId,
+            mode: mode,
+            cooldownSeconds: cooldownSeconds
+        )
+    }
+
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         .init(
             id: UUID().uuidString,

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -117,7 +117,8 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
 
     func setAgentParticipation(
         conversationId: String,
-        mode: String
+        mode: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse {
         // Echo the request back, matching the real endpoint: the caller renders
         // the level it just set.
@@ -125,7 +126,8 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
     }
 
     func getAgentParticipation(
-        conversationId: String
+        conversationId: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse {
         .init(success: true, conversationId: conversationId, mode: "speak")
     }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -47,6 +47,22 @@ extension ConvosAPIClientProtocol {
         )
     }
 
+    /// Default for the participation write so pre-existing stubs don't re-stub
+    /// it. Echoes the request, matching the real endpoint. Tests that exercise
+    /// participation should override this on their fixture.
+    func setAgentParticipation(
+        instanceId: String,
+        mode: String?,
+        cooldownSeconds: Int?
+    ) async throws -> ConvosAPI.AgentParticipationResponse {
+        ConvosAPI.AgentParticipationResponse(
+            success: true,
+            instanceId: instanceId,
+            mode: mode,
+            cooldownSeconds: cooldownSeconds
+        )
+    }
+
     /// Default for the direct-add status poll so pre-existing stubs don't
     /// re-stub it. A coherent terminal state — joined ⇒ inbox present — so
     /// unrelated tests don't iterate the poll loop. Tests that exercise the

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -47,19 +47,28 @@ extension ConvosAPIClientProtocol {
         )
     }
 
-    /// Default for the participation write so pre-existing stubs don't re-stub
-    /// it. Echoes the request, matching the real endpoint. Tests that exercise
-    /// participation should override this on their fixture.
+    /// Defaults for the participation read/write so pre-existing stubs don't
+    /// re-stub them. The write echoes the request, matching the real endpoint;
+    /// the read reports the product default. Tests that exercise participation
+    /// should override these on their fixture.
     func setAgentParticipation(
-        instanceId: String,
-        mode: String?,
-        cooldownSeconds: Int?
+        conversationId: String,
+        mode: String
     ) async throws -> ConvosAPI.AgentParticipationResponse {
         ConvosAPI.AgentParticipationResponse(
             success: true,
-            instanceId: instanceId,
-            mode: mode,
-            cooldownSeconds: cooldownSeconds
+            conversationId: conversationId,
+            mode: mode
+        )
+    }
+
+    func getAgentParticipation(
+        conversationId: String
+    ) async throws -> ConvosAPI.AgentParticipationResponse {
+        ConvosAPI.AgentParticipationResponse(
+            success: true,
+            conversationId: conversationId,
+            mode: "speak"
         )
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -53,7 +53,8 @@ extension ConvosAPIClientProtocol {
     /// should override these on their fixture.
     func setAgentParticipation(
         conversationId: String,
-        mode: String
+        mode: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse {
         ConvosAPI.AgentParticipationResponse(
             success: true,
@@ -63,7 +64,8 @@ extension ConvosAPIClientProtocol {
     }
 
     func getAgentParticipation(
-        conversationId: String
+        conversationId: String,
+        variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse {
         ConvosAPI.AgentParticipationResponse(
             success: true,


### PR DESCRIPTION
App-side control for how much an agent is allowed to talk in a conversation. Three levels: Speak freely, Mentions only, Paused. Behind the `Listen (agent participation)` debug flag, hard-locked off in production.

Runtime and control-plane side: xmtplabs/convos-assistants#2880.

## What it adds

- A **Participation** row in the agent's contact sheet, showing the current level.
- A sheet with the three levels. Picking one pushes it to the runtime, which enforces it.
- A **cooldown override for Speak freely only**. That is the one level where pacing means anything: Mentions only already speaks just when addressed, and Paused is offline. Left alone the hold scales with group size; this pins it.
- A confirmation before removing an agent. It is destructive and was firing straight off the tap.

Any member can change participation. It is not owner-gated, matching the product decision.

## How it reaches the agent

The level goes to the backend (`PATCH /api/v2/agents/:instanceId/participation`), which holds the assistant control-plane key and forwards it. The app cannot hold that key, and Paused depends on the hop: the level has to be recorded on the control plane for a message to be refused before the agent is woken.

This reuses the existing authenticated client, the same one already used for agent provisioning, so there is no new plumbing and the hardcoded `127.0.0.1` endpoint an earlier commit introduced is gone.

Backend side: xmtplabs/convos-backend#385.

A failed write now surfaces an alert. The picker updates local state immediately, so swallowing the error left the row claiming a level the agent never received.

The level is still held in view state rather than read back from a server, so the row reflects what you picked in this session. The read-back endpoint lands with the durable-storage work.

## Two things worth flagging

The level is durable on the server side: the runtime persists it under /data and reloads it on container boot, and the worker keeps its own copy for the Paused wake gate. What is not durable is the app's view of it, which is why the read-back endpoint matters.

Build status: ConvosCore builds. The full test suite has not been run against this branch.

The second commit is unrelated cleanup that rode along: `INInteraction.delete` moved off its completion handler to the async form. Happy to split it out.





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent participation control to the conversation composer and contact sheet
> - Adds an `AgentParticipationMenu` (speak freely / mentions only / paused) as a floating overlay above the composer in conversations that contain an agent, toggled via a new leading button in `MessagesInputView`.
> - Introduces `AgentParticipationStore` with optimistic updates and rollback on failure; errors surface as an in-view alert.
> - Adds `GET`/`PATCH` endpoints for `v2/conversations/:id/participation` in `ConvosAPIClient`, with corresponding mock and test-stub implementations.
> - Tapping Remove in `ContactDetailView` now shows a confirmation alert (with agent- or template-specific messaging) before invoking the removal callback.
> - The feature is gated behind the `isListenParticipationEnabled` debug flag (always `false` in production), togglable from the Debug view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc8e808.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->