### PR TITLE
ci: dev TestFlight release on every push to dev (replaces Bitrise)

### DIFF
--- a/.github/workflows/testflight-dev.yml
+++ b/.github/workflows/testflight-dev.yml
@@ -1,0 +1,39 @@
+# Dev TestFlight Release — thin caller. The job lives in convos-releases:
+# https://github.com/xmtplabs/convos-releases/blob/main/.github/workflows/ios-testflight.yml
+#
+# Replaces Bitrise's archive_and_export_dev: every push to dev uploads a
+# Convos (Dev) build to the "Convos Dev" TestFlight app. Rapid merges
+# collapse — a new push cancels the superseded in-flight run (the
+# self-healing build number in the lane tolerates cancelled uploads), which
+# bounds TestFlight's ~100-builds-per-version-train quota on busy days.
+#
+# Required repository secrets (passed via `secrets: inherit`):
+#   CONVOS_CERTIFICATES_TOKEN, MATCH_PASSWORD, APP_STORE_CONNECT_API_KEY_ID,
+#   APP_STORE_CONNECT_ISSUER_ID, APP_STORE_CONNECT_API_PRIVATE_KEY,
+#   CACHIX_AUTH_TOKEN; optional POSTHOG_API_KEY_DEV, SENTRY_DSN_DEV,
+#   SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT.
+name: Dev TestFlight Release
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: testflight-dev
+  cancel-in-progress: true
+
+jobs:
+  testflight_dev:
+    # Callers must grant what the reusable workflow's job declares — a called
+    # workflow can't elevate beyond the caller's grant.
+    permissions:
+      id-token: write
+      contents: read
+    uses: xmtplabs/convos-releases/.github/workflows/ios-testflight.yml@main
+    with:
+      flavor: dev
+      runner: warp-macos-latest-arm64-12x
+      xcode-app-path: /Applications/Xcode_26.3.app
+      xcode-nix-path: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app
+    secrets: inherit


### PR DESCRIPTION
Replaces Bitrise's broken `archive_and_export_dev` with the fastlane/GHA pipeline. Thin caller for the new flavor-parameterized reusable workflow in convos-releases; triggers on every push to dev + manual dispatch, with a cancelling concurrency group so rapid merges collapse into the latest commit.

A follow-up PR migrates the prod callers onto the same reusable workflow.

Do not merge before:
- xmtplabs/convos-releases#27 (the reusable workflow this calls at `@main`)
- One-time match provisioning of `AppStore_org.convos.ios-preview.ShareExtension` (the other two dev profiles already exist in convos-certificates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787262904&installation_model_id=20076&pr_number=1204&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1204&signature=6d584bd373543f7a4b8834baed064588f89aa93a096e414f9b22fe68ee779a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Actions workflow for dev TestFlight releases, replacing Bitrise
> Adds [testflight-dev.yml](https://github.com/xmtplabs/convos-ios/pull/1204/files#diff-d67b9b3c65473a0a40d0f3b6d43e4e6a85729e234867535b50de4b2f7b3e63fb) to trigger a TestFlight build on every push to `dev` (and on manual dispatch). It calls the reusable `ios-testflight.yml` workflow from `xmtplabs/convos-releases` with the `dev` flavor and a specific Xcode version. Concurrent runs in the `testflight-dev` group cancel any in-progress predecessor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7b3b1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->