### PR TITLE
ci: bump convos-releases flake input for the testflight_dev lane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784228574,
-        "narHash": "sha256-tAuVvVda+dX0uVipxNZAo9fjZigsVMWarrrCYerxen0=",
+        "lastModified": 1784671855,
+        "narHash": "sha256-J+LsHELIMpsQx/c2tH4HiKiFy3Uj37KxwExpFvYkX+8=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "41eaa61a3ace25541f10a6b1814048b898ea17d3",
+        "rev": "7b77115b25f6b1bf2fb72881b76965c2545dd6dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The first Dev TestFlight Release run failed with "Could not find lane 'ios testflight_dev'": the nix dev shell pins the fastlane lanes to the convos-releases revision in this repo's flake.lock, which predated xmtplabs/convos-releases#27. Bumps the input to current main (7b77115); verified `fastlane lanes` in the pinned shell now lists `testflight_dev`.

Merging this triggers the next dev TestFlight run automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264145&installation_model_id=20076&pr_number=1205&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1205&signature=3f4492ac35cc5763ec3b3f4bf6aa9fd9947dd710c93f3b759a19f07192f1a5c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `convos-releases` flake input for the `testflight_dev` lane
> Updates [flake.lock](https://github.com/xmtplabs/convos-ios/pull/1205/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to pin the `convos-releases` flake input to a newer revision for use in the `testflight_dev` CI lane.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e490e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->