### PR TITLE
fix: restore agent files and links in Files & Links and Things

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLPageMetadata.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLPageMetadata.swift
@@ -50,15 +50,28 @@ public final class HTMLPageMetadata {
         }.value
     }
 
+    /// Both the decimal and hex numeric forms are decoded, because the two
+    /// producers disagree: HTML written by hand tends to use `&#39;`, while
+    /// Python's `html.escape` — which the runtime runs over every artifact
+    /// title — emits `&#x27;`. Decoding only one leaves titles like
+    /// "Who&#x27;s here" on screen, which is what the group sees for any
+    /// artifact whose title contains an apostrophe.
     private nonisolated static func decodeEntities(_ value: String) -> String {
         value
-            .replacingOccurrences(of: "&amp;", with: "&")
             .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&#x3C;", with: "<", options: .caseInsensitive)
             .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&#x3E;", with: ">", options: .caseInsensitive)
             .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#34;", with: "\"")
+            .replacingOccurrences(of: "&#x22;", with: "\"", options: .caseInsensitive)
             .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&#x27;", with: "'", options: .caseInsensitive)
             .replacingOccurrences(of: "&apos;", with: "'")
             .replacingOccurrences(of: "&nbsp;", with: " ")
+            // Ampersand last: decoding it first would turn an escaped literal
+            // like `&amp;#x27;` into `&#x27;` and then into an apostrophe.
+            .replacingOccurrences(of: "&amp;", with: "&")
     }
 }
 #endif

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentFilesLinksRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/AgentFilesLinksRepository.swift
@@ -78,6 +78,13 @@ public final class AgentFilesLinksRepository: Sendable {
             .eraseToAnyPublisher()
     }
 
+    /// Agent-sent files for a conversation.
+    ///
+    /// The sender check reads `profile`, the unified per-inbox table, because
+    /// that is the only one agent verification writes to. `memberProfile` is
+    /// still populated, but only with the kind that arrived on the wire —
+    /// plain `agent` — and nothing upgrades it to a verified kind, so a check
+    /// against it matches nothing and every agent's files disappear.
     private static func loadFiles(db: Database, conversationId: String) throws -> [AgentFile] {
         let rows = try Row.fetchAll(db, sql: """
             SELECT m.id, m.date, m.attachmentUrls, m.senderId
@@ -86,10 +93,9 @@ public final class AgentFilesLinksRepository: Sendable {
                 AND m.contentType = 'attachments'
                 AND EXISTS (
                     SELECT 1
-                    FROM memberProfile mp
-                    WHERE mp.conversationId = m.conversationId
-                        AND mp.inboxId = m.senderId
-                        AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
+                    FROM profile p
+                    WHERE p.inboxId = m.senderId
+                        AND p.memberKind IN ('agent:convos', 'agent:user-oauth')
                 )
             ORDER BY m.date DESC
             """,
@@ -134,6 +140,8 @@ public final class AgentFilesLinksRepository: Sendable {
         return deduped
     }
 
+    /// Agent-shared links. Same sender check as `loadFiles`, and the same
+    /// reason: verification only ever lands on the unified `profile` row.
     private static func loadLinks(db: Database, conversationId: String) throws -> [AgentLink] {
         let rows = try Row.fetchAll(db, sql: """
             SELECT m.id, m.date, m.linkPreview, m.senderId
@@ -142,10 +150,9 @@ public final class AgentFilesLinksRepository: Sendable {
                 AND m.contentType = 'linkPreview'
                 AND EXISTS (
                     SELECT 1
-                    FROM memberProfile mp
-                    WHERE mp.conversationId = m.conversationId
-                        AND mp.inboxId = m.senderId
-                        AND mp.memberKind IN ('agent:convos', 'agent:user-oauth')
+                    FROM profile p
+                    WHERE p.inboxId = m.senderId
+                        AND p.memberKind IN ('agent:convos', 'agent:user-oauth')
                 )
             ORDER BY m.date DESC
             """,

--- a/ConvosCore/Tests/ConvosCoreTests/AgentFilesLinksRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentFilesLinksRepositoryTests.swift
@@ -1,0 +1,161 @@
+@testable import ConvosCore
+import Combine
+import Foundation
+import GRDB
+import Testing
+
+/// Regression coverage for the sender check behind Files & Links and Things.
+///
+/// The unified-profile cutover moved agent verification to the per-inbox
+/// `profile` table and left `memberProfile` populated with only the kind that
+/// arrives on the wire — plain `agent`. A sender check against the legacy table
+/// therefore matched nothing, and every agent's files and links silently
+/// vanished from both surfaces.
+@Suite("AgentFilesLinksRepository Tests", .serialized)
+@MainActor
+struct AgentFilesLinksRepositoryTests {
+    nonisolated private static let conversationId: String = "convo-1"
+    nonisolated private static let agentInboxId: String = "agent-1"
+
+    nonisolated private static func seedAgentAttachment(
+        db: Database,
+        verifiedKindOnUnifiedProfile: DBMemberKind?,
+        kindOnLegacyMemberProfile: DBMemberKind?
+    ) throws {
+        try DBMember(inboxId: Self.agentInboxId).save(db, onConflict: .ignore)
+        try DBMember(inboxId: "creator").save(db, onConflict: .ignore)
+        try DBConversation(
+            id: Self.conversationId,
+            clientConversationId: "client-\(Self.conversationId)",
+            inviteTag: "tag-\(Self.conversationId)",
+            creatorId: "creator",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(timeIntervalSince1970: 0),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).save(db, onConflict: .ignore)
+        if let verifiedKindOnUnifiedProfile {
+            try DBProfile(
+                inboxId: Self.agentInboxId,
+                name: "Agent",
+                memberKind: verifiedKindOnUnifiedProfile,
+                profileSource: .profileSnapshot,
+                updatedAt: Date(timeIntervalSince1970: 0)
+            ).save(db)
+        }
+        if let kindOnLegacyMemberProfile {
+            try DBMemberProfile(
+                conversationId: Self.conversationId,
+                inboxId: Self.agentInboxId,
+                name: "Agent",
+                avatar: nil
+            )
+            .with(memberKind: kindOnLegacyMemberProfile)
+            .save(db)
+        }
+        try DBMessage(
+            id: "msg-1",
+            clientMessageId: "msg-1",
+            conversationId: Self.conversationId,
+            senderId: Self.agentInboxId,
+            dateNs: 1,
+            date: Date(timeIntervalSince1970: 0),
+            sortId: nil,
+            status: .published,
+            messageType: .original,
+            contentType: .attachments,
+            text: nil,
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            // A row with no attachment key is dropped before the sender
+            // check is reached, which would make this test pass for the wrong reason.
+            attachmentUrls: ["notes.html"],
+            update: nil
+        ).insert(db)
+    }
+
+    private func files(_ fixtures: TestFixtures) async -> [AgentFile] {
+        let repo = AgentFilesLinksRepository(
+            dbReader: fixtures.dbReader,
+            conversationId: Self.conversationId
+        )
+        return await withCheckedContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = repo.filesPublisher()
+                .first()
+                .sink { value in
+                    continuation.resume(returning: value)
+                    cancellable?.cancel()
+                }
+        }
+    }
+
+    @Test("a verified agent's attachment is returned")
+    func verifiedAgentAttachmentIsReturned() async throws {
+        let fixtures = try await makeTestFixtures()
+        try await fixtures.dbWriter.write { db in
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .verifiedConvos,
+                kindOnLegacyMemberProfile: .agent
+            )
+        }
+        // The legacy row deliberately carries the unverified wire kind: this is
+        // the production shape, and reading it instead is what lost the file.
+        #expect(await files(fixtures).count == 1)
+    }
+
+    @Test("verification is read even when the legacy row is missing entirely")
+    func legacyRowAbsent() async throws {
+        let fixtures = try await makeTestFixtures()
+        try await fixtures.dbWriter.write { db in
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .verifiedConvos,
+                kindOnLegacyMemberProfile: nil
+            )
+        }
+        #expect(await files(fixtures).count == 1)
+    }
+
+    @Test("an unverified sender's attachment is still excluded")
+    func unverifiedSenderExcluded() async throws {
+        let fixtures = try await makeTestFixtures()
+        try await fixtures.dbWriter.write { db in
+            try Self.seedAgentAttachment(
+                db: db,
+                verifiedKindOnUnifiedProfile: .agent,
+                kindOnLegacyMemberProfile: .agent
+            )
+        }
+        #expect(await files(fixtures).isEmpty)
+    }
+
+    // MARK: - Test Helpers
+
+    struct TestFixtures {
+        let dbWriter: any DatabaseWriter
+        let dbReader: any DatabaseReader
+    }
+
+    func makeTestFixtures() async throws -> TestFixtures {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        return TestFixtures(dbWriter: dbManager.dbWriter, dbReader: dbManager.dbReader)
+    }
+}


### PR DESCRIPTION
Two independent bugs, both of which make an agent's artifacts unusable. Neither is specific to any feature branch — they affect production today.

## Agent files and links are invisible

Every agent's files **and links** have been missing from Files & Links and the Things tab since the unified-profile cutover (#1126, Jul 6).

Both queries gate on the sender being a verified agent:

```sql
AND EXISTS (SELECT 1 FROM memberProfile mp
    WHERE mp.inboxId = m.senderId
      AND mp.memberKind IN ('agent:convos', 'agent:user-oauth'))
```

That cutover repointed `AgentVerificationWriter` at the per-inbox `profile` table and left `memberProfile` inert — still populated, and only ever with the kind that arrives on the wire, plain `agent`. Its own commit titles describe the transition: *"make the legacy member_profile table inert"*, then *"keep member_profile populated (drop the clear)"*.

Nothing upgrades the legacy row, so the `EXISTS` clause stopped matching anything and both surfaces silently emptied. `ProfileInboundApplier` computes the verified kind on what its own doc comment calls a *"transient, never-saved probe"* and writes the result to the unified row — so `profile` is the only table that carries a verified kind at all.

The queries themselves haven't changed since May, which is why nothing pointed here: the data moved out from under them.

I checked the other readers of the inert table and both are fine — a one-time migration, and `InviteWriter` asking only whether *any* kind is present.

## Artifact titles show raw entities

An artifact titled `Who's here` displayed as `Who&#x27;s here`. `HTMLPageMetadata.decodeEntities` handled `&#39;` and `&apos;` but not the hex form — and hex is what the runtime produces, since Python's `html.escape`, which runs over every artifact title during expansion, emits `&#x27;`.

Escaping on the producer side is correct, so the fix belongs in the consumer. Adds the hex spellings alongside the decimal ones and moves `&amp;` last, so an escaped literal like `&amp;#x27;` isn't double-decoded into an apostrophe.

## Testing

The regression test seeds the production shape — verified on the unified row, plain `agent` on the legacy one — and **fails against the old query** rather than passing either way. Its fixture carries an attachment key because a keyless row is dropped before the sender check is reached, which would have made the test pass for the wrong reason.

The decoder has no unit test: `HTMLPageMetadata` is `#if canImport(UIKit)` and doesn't compile in the package's macOS test run. It would need the iOS test target.

## Follow-up worth considering

`memberProfile` being "kept populated" while carrying data nothing maintains is a trap that will catch the next person. Worth either finishing its removal or documenting that it is never authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7pdgsBZsX8JnemAAdYuck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787282105&installation_model_id=20076&pr_number=1207&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1207&signature=3ea02dc7d2560ea111e0009e886b227321d2e917771e6f6380fcb741bee2b8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent files and links not appearing in Files & Links by querying unified profile table
> - `AgentFilesLinksRepository.loadFiles` and `loadLinks` now verify agent senders against the unified `profile` table (by `inboxId`) instead of the legacy `memberProfile` table (scoped by `conversationId`), fixing cases where agent files and links were missing because verification only existed in the unified profile.
> - Regression tests are added in `AgentFilesLinksRepositoryTests` covering: verified agent in unified profile with unverified legacy row, verified agent with no legacy row, and unverified agent correctly excluded.
> - `HTMLPageMetadata.decodeEntities` is updated to handle decimal and hex numeric HTML entity references (e.g. `'`, `"`) and moves `&` replacement last to avoid double-decoding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73b6e4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->