### PR TITLE
ci: migrate prod TestFlight callers to the generic ios-testflight workflow

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -13,8 +13,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: xmtplabs/convos-releases/.github/workflows/ios-testflight-prod.yml@main
+    uses: xmtplabs/convos-releases/.github/workflows/ios-testflight.yml@main
     with:
+      flavor: prod
       runner: warp-macos-latest-arm64-12x
       xcode-app-path: /Applications/Xcode_26.3.app
       xcode-nix-path: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app

--- a/.github/workflows/testflight-prod.yml
+++ b/.github/workflows/testflight-prod.yml
@@ -1,5 +1,5 @@
 # Prod TestFlight Release — thin caller. The job lives in convos-releases:
-# https://github.com/xmtplabs/convos-releases/blob/main/.github/workflows/ios-testflight-prod.yml
+# https://github.com/xmtplabs/convos-releases/blob/main/.github/workflows/ios-testflight.yml
 #
 # Scheduled (not per-merge): Apple limits TestFlight uploads per version —
 # a train closes entirely once that version ships to the App Store
@@ -67,8 +67,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: xmtplabs/convos-releases/.github/workflows/ios-testflight-prod.yml@main
+    uses: xmtplabs/convos-releases/.github/workflows/ios-testflight.yml@main
     with:
+      flavor: prod
       runner: warp-macos-latest-arm64-12x
       xcode-app-path: /Applications/Xcode_26.3.app
       xcode-nix-path: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app


### PR DESCRIPTION
Points testflight-prod.yml and release-rc.yml at convos-releases' flavor-parameterized ios-testflight.yml with `flavor: prod`. Triggers, freshness check, and scheduling are unchanged; the reusable job keeps the exact prod concurrency group shared with appstore-promote.

The dev flavor of the same reusable workflow is already validated green (build 2.2.0 (1161) on the Convos Dev TestFlight app). After this merges I'll validate prod with a manual dispatch, then delete the superseded ios-testflight-prod.yml from convos-releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787325203&installation_model_id=20076&pr_number=1210&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1210&signature=5e2d6e1e7767dffc93a69aa61ce780616d55813d0a47d550bf13d7d3c05d82f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate prod TestFlight callers to the generic `ios-testflight` workflow
> Both [release-rc.yml](https://github.com/xmtplabs/convos-ios/pull/1210/files#diff-a023d86bb9353b6f0abc01e07d82830bff7d5599db32c54b3796ad60fd3db789) and [testflight-prod.yml](https://github.com/xmtplabs/convos-ios/pull/1210/files#diff-6a52e76b9ccf920f24c7080e29c09a487cf354be795fe6ea38f9bf70703520b7) previously called the `ios-testflight-prod.yml` reusable workflow. They now call the generic `ios-testflight.yml` workflow with an explicit `flavor: prod` input instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5035f4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->