### PR TITLE
fix(dev): honour USE_CONFIG for XMTP_CUSTOM_HOST in Local builds

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -117,6 +117,35 @@ print("🔑 Secrets loaded: \(Secrets.CONVOS_API_BASE_URL.isEmpty ? "No" : "Yes"
 ### Quick Environment Check
 Run `./Scripts/get-version.sh` to see the current app version, or check the build logs for environment information.
 
+## 🚨 Pointing a build at a local backend
+
+Three behaviours here are easy to misread, because each one fails somewhere
+other than the setting that caused it.
+
+**An empty value in `.env` is not an empty value in `Secrets.swift`.** For
+`XMTP_CUSTOM_HOST`, blank means "auto-detect this machine's LAN IP", and the app
+dials any non-empty host it is given — so a blank line silently points XMTP at a
+local node that is probably not running. To genuinely mean "no custom host, use
+the network the config selects", write `USE_CONFIG`. The same applies to
+`CONVOS_API_BASE_URL`, where blank falls back to `http://<LAN-IP>:4000/api`.
+
+**The scheme decides which Firebase app you are.** `Local` builds as
+`org.convos.ios-local`, `Dev` as `org.convos.ios-preview` (see the `.xcconfig`
+files). App Check debug tokens are registered per app, so building a scheme you
+have not used before produces a bundle Firebase does not recognise; the client
+then cannot obtain an App Check token and never issues the auth request at all.
+The symptom is not an auth error — it is silence, with every authenticated call
+401ing and no `/v2/auth/token` reaching the backend.
+
+**A `.env` edit does nothing until you rebuild.** The build phase regenerates
+`Secrets.swift` on every build, so the value the app uses is whatever the last
+build baked in — and the build phase can overwrite what
+`generate-secrets-local.sh` just produced.
+
+When installing to a simulator by hand, `xcrun simctl ... booted` picks an
+arbitrary one if several are running. Target the device by UDID
+(`xcrun simctl list devices booted`) instead.
+
 ## 🚨 Important Notes
 
 - **Secrets are generated from environment variables** → `Secrets.swift` (not tracked in Git)

--- a/Scripts/build-phases/copy-env-config-notification-service.sh
+++ b/Scripts/build-phases/copy-env-config-notification-service.sh
@@ -34,6 +34,15 @@ if [ "$CONFIGURATION" = "Local" ]; then
         AGENT_DEBUG_JWKS=$(grep -v '^#' "${SRCROOT}/.env" | grep '^AGENT_DEBUG_JWKS=' | cut -d'=' -f2- | sed -e "s/^'//" -e "s/'$//" || true)
         POSTHOG_API_KEY=$(grep -v '^#' "${SRCROOT}/.env" | grep '^POSTHOG_API_KEY=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
+    # Resolve the XMTP host the same way Scripts/generate-secrets-local.sh does:
+    # USE_CONFIG means "no custom host, use the network the config selects", and
+    # must stay genuinely empty because the app treats any non-empty value as a
+    # local node to dial. Unset falls back to the auto-detected LAN IP as before.
+    if [ "$XMTP_CUSTOM_HOST" = "USE_CONFIG" ]; then
+        XMTP_HOST_RESOLVED=""
+    else
+        XMTP_HOST_RESOLVED="${XMTP_CUSTOM_HOST:-$LOCAL_IP}"
+    fi
     # Firebase debug token: cached .env first, else 1Password ("Convos" vault); empty in CI.
     FIREBASE_TOKEN="$(resolve_firebase_debug_token "${SRCROOT}/.env")"
 
@@ -45,7 +54,7 @@ import Foundation
 // swiftlint:disable all
 enum Secrets {
     static let CONVOS_API_BASE_URL = "${CONVOS_API_BASE_URL:-http://$LOCAL_IP:4000/api}"
-    static let XMTP_CUSTOM_HOST = "${XMTP_CUSTOM_HOST:-$LOCAL_IP}"
+    static let XMTP_CUSTOM_HOST = "${XMTP_HOST_RESOLVED}"
     static let GATEWAY_URL = ""
     static let SENTRY_DSN = ""
     static let POSTHOG_API_KEY = "$POSTHOG_API_KEY"


### PR DESCRIPTION
Two scripts write `Secrets.swift` and they disagreed about what the `.env` means.

`generate-secrets-local.sh` treats `USE_CONFIG` as "no custom host, use the network the config selects". The build phase did not, and fell through to the auto-detected LAN IP instead. Since the app dials any non-empty host it is given, that points XMTP at a local node that is usually not running — and because the build phase runs on every build, it overwrites whatever the standalone script just produced.

Fixed by resolving the host the same way the standalone script does. An unset value still falls back to the LAN IP, unchanged.

## Docs: shortcuts for aiming a build at a local backend

`ENVIRONMENTS.md` gains a short section covering three behaviours that are easy to misread:

**An empty `.env` value is not an empty `Secrets.swift` value.** For `XMTP_CUSTOM_HOST`, blank means "auto-detect this machine's LAN IP". `USE_CONFIG` is how you say "no custom host". Same story for `CONVOS_API_BASE_URL`.

**The scheme decides which Firebase app you are.** `Local` builds as `org.convos.ios-local`, `Dev` as `org.convos.ios-preview`. App Check debug tokens are registered per app, so an unfamiliar scheme yields a bundle Firebase does not recognise. The symptom is not an auth error but silence: without an App Check token the client never issues the auth request, so you see 401s everywhere and nothing in the backend log explaining them.

**A `.env` edit applies at the next build,** since the build phase regenerates `Secrets.swift` each time.

Plus a note that `xcrun simctl ... booted` picks an arbitrary simulator when several are running, so it is worth targeting by UDID — installing to the wrong one looks exactly like a build that did not take.

## Scope

Independent of the participation work in #1203; branched from `dev`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `USE_CONFIG` handling for `XMTP_CUSTOM_HOST` in local notification service builds
> - Updates [copy-env-config-notification-service.sh](https://github.com/xmtplabs/convos-ios/pull/1211/files#diff-1e0c207a3a3730323155f8961cc14f82400a67570af79ce68f0056588224e15a) to mirror the resolution logic in `generate-secrets-local.sh`: when `XMTP_CUSTOM_HOST=USE_CONFIG`, `Secrets.XMTP_CUSTOM_HOST` is written as empty so the app uses the config-selected network rather than a local node.
> - Unset or empty values still fall back to the auto-detected LAN IP, preserving previous default behavior.
> - Adds documentation in [ENVIRONMENTS.md](https://github.com/xmtplabs/convos-ios/pull/1211/files#diff-4e930685749bfc32fd97a52286f1b91879682f675e383a414794c860e17b3ecd) covering `.env` edge cases, build scheme effects on Firebase/App Check, and the need to rebuild after `.env` edits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67628ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->