### PR TITLE
Show the draft agent's name and emoji in the chat header while it activates

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -482,9 +482,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     ///
     /// The agent-template flows ("Chat on a contact" + the
     /// `convos://template/<id>` deep link) take priority and supply the real
-    /// identity (`showsContactCard == true`). The Agent Builder is the
+    /// identity (`showsContactCard == true`). The Agent Builder starts as the
     /// generic "no identity" case (`name`/`emoji` nil, `showsContactCard
-    /// == false`) -- it keeps its own gating in
+    /// == false`) and adopts the direct build's draft preview identity once
+    /// the backend streams one -- it keeps its own gating in
     /// `shouldRenderAsPendingAgentBuilder` and its own summary card. Both
     /// drop the moment a real verified Convos agent joins
     /// `conversation.members`, and both are time-boxed as a backstop.
@@ -501,16 +502,21 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 showsContactCard: hasIdentity
             )
         }
-        // Direct builder: the header intentionally stays generic ("Agent" title
-        // + add-agent glyph + "Making agent..." subtitle) for the whole build.
-        // The draft preview identity is revealed progressively by the dedicated
-        // `.agentActivating` card, not the header; the header only adopts the
-        // real name/emoji once the verified agent actually joins. So fall
-        // through to the generic no-identity pending case below.
+        // Direct builder: the header starts generic ("New Agent" title +
+        // add-agent glyph) and adopts the draft preview identity (name +
+        // emoji) as soon as the build streams one, so the header matches the
+        // `.agentActivating` card instead of staying a placeholder while the
+        // agent's name is already on screen. The card keeps owning the
+        // progressive reveal (`showsContactCard` stays false); the repository
+        // retains the last preview through the terminal poll, so the identity
+        // doesn't regress before the agent joins.
         if shouldRenderAsPendingAgentBuilder {
+            let preview: ConvosAPI.AgentPreview? = directBuildGeneration?.preview
+            let previewName: String? = preview?.agentName.flatMap { $0.isEmpty ? nil : $0 }
+            let previewEmoji: String? = preview?.emoji.flatMap { $0.isEmpty ? nil : $0 }
             return PendingAgentPresentation(
-                name: nil,
-                emoji: nil,
+                name: previewName,
+                emoji: previewEmoji,
                 avatarURL: nil,
                 agentDescription: nil,
                 showsContactCard: false

--- a/ConvosCore/Sources/ConvosComposer/AttachmentShareLink.swift
+++ b/ConvosCore/Sources/ConvosComposer/AttachmentShareLink.swift
@@ -11,7 +11,7 @@ import UIKit
 /// never exposed); the rendered tile image rides along only as the share
 /// sheet preview thumbnail, never as a second shared file. Markdown shares
 /// the underlying file, adding the rendered thumbnail image once it resolves.
-struct AttachmentSharePayload {
+public struct AttachmentSharePayload {
     let items: [URL]
     let title: String
     let previewImage: UIImage?
@@ -138,7 +138,7 @@ struct AttachmentSharePayload {
         return result.image
     }
 
-    static func sanitizeFilename(_ raw: String) -> String {
+    public static func sanitizeFilename(_ raw: String) -> String {
         let allowed: CharacterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_. "))
         var output: String = ""
         for scalar in raw.unicodeScalars {
@@ -211,7 +211,7 @@ struct AttachmentSharePayload {
     /// missing or non-html (e.g. `report.txt`); force `html` unless the source
     /// already carries a valid HTML extension, so recipients never get an HTML
     /// payload that opens as plain text.
-    static func htmlShareExtension(for fileURL: URL) -> String {
+    public static func htmlShareExtension(for fileURL: URL) -> String {
         let htmlExtensions: Set<String> = ["html", "htm"]
         let rawExtension: String = fileURL.pathExtension.lowercased()
         return htmlExtensions.contains(rawExtension) ? rawExtension : "html"

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/MessageBubble.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/MessageBubble.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// keeps CoreText layout bounded on the main thread. Classification is cheap
 /// (character count plus a capped newline scan) and never measures or lays out
 /// the text.
-enum MessageLengthClass {
+public enum MessageLengthClass {
     case short
     case long
     case pathological
@@ -17,17 +17,17 @@ enum MessageLengthClass {
 /// no CoreText, no `NSAttributedString`, no `boundingRect`. Thresholds are
 /// tunable in one place. Exposed (not private) so any caller that builds a
 /// `MessageBubble` preview shares the same classification semantics.
-enum MessageBodyClassifier {
-    static let longCharThreshold: Int = 500 // a few paragraphs; human messages rarely exceed this
-    static let pathologicalCharThreshold: Int = 1_500 // long-form; well past a normal chat message
-    static let shortNewlineThreshold: Int = 20 // many short lines, e.g. code snippets or poems
+public enum MessageBodyClassifier {
+    public static let longCharThreshold: Int = 500 // a few paragraphs; human messages rarely exceed this
+    public static let pathologicalCharThreshold: Int = 1_500 // long-form; well past a normal chat message
+    public static let shortNewlineThreshold: Int = 20 // many short lines, e.g. code snippets or poems
     static let longPreviewLineLimit: Int = 6
     static let pathologicalPreviewLineLimit: Int = 6
     // Short ease so the inline "Read More" expand/collapse reads as a quick
     // reveal, not a slow unfold that the user has to wait through.
     static let readMoreExpandAnimationDuration: Double = 0.18
 
-    static func classify(_ text: String) -> MessageLengthClass {
+    public static func classify(_ text: String) -> MessageLengthClass {
         let count: Int = text.count
         if count > pathologicalCharThreshold { return .pathological }
         let newlines: Int = newlineCount(in: text, cappedAt: shortNewlineThreshold + 1)

--- a/ConvosCore/Sources/ConvosComposer/PendingAgentPresentation.swift
+++ b/ConvosCore/Sources/ConvosComposer/PendingAgentPresentation.swift
@@ -7,10 +7,12 @@ import SwiftUI
 /// Two flows produce one of these and every indicator render site consumes
 /// it (see `ConversationViewModel.pendingAgentPresentation`):
 ///
-/// - Agent Builder: the "no identity" case. The builder has no real agent
-///   identity at Make time, so it emits a generic presentation (`name` /
-///   `emoji` nil -> "New Agent" + the add-agent glyph) and shows its own
-///   summary card rather than a contact card (`showsContactCard == false`).
+/// - Agent Builder: starts as the "no identity" case. The builder has no
+///   real agent identity at Make time, so it emits a generic presentation
+///   (`name` / `emoji` nil -> "New Agent" + the add-agent glyph) until the
+///   build streams a draft preview, whose name/emoji then take over. It shows
+///   its own summary card rather than a contact card
+///   (`showsContactCard == false`).
 /// - Agent template (chat-on-a-contact or `convos://template/<id>` deep
 ///   link): the "with identity" case. The template name + emoji/photo are
 ///   painted immediately with verified styling, and the agent contact card is

--- a/ConvosTests/AttachmentSharePayloadTests.swift
+++ b/ConvosTests/AttachmentSharePayloadTests.swift
@@ -1,4 +1,5 @@
 @testable import Convos
+import ConvosComposer
 import XCTest
 
 final class AttachmentSharePayloadTests: XCTestCase {

--- a/ConvosTests/FocusCoordinatorTests.swift
+++ b/ConvosTests/FocusCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import ConvosComposer
 import SwiftUI
 import XCTest
 @testable import Convos

--- a/ConvosTests/MessageBodyClassifierTests.swift
+++ b/ConvosTests/MessageBodyClassifierTests.swift
@@ -1,4 +1,5 @@
 @testable import Convos
+import ConvosComposer
 import XCTest
 
 final class MessageBodyClassifierTests: XCTestCase {

--- a/ConvosTests/PendingAgentPresentationTests.swift
+++ b/ConvosTests/PendingAgentPresentationTests.swift
@@ -98,7 +98,7 @@ final class PendingAgentPresentationTests: XCTestCase {
 
         XCTAssertEqual(viewModel.conversationName, "Tifoso")
         XCTAssertEqual(viewModel.untitledConversationPlaceholder, "Tifoso")
-        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Joining...")
+        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Activating")
     }
 
     func testNeutralPresentationHidesContactCard() {
@@ -112,8 +112,8 @@ final class PendingAgentPresentationTests: XCTestCase {
                        "No contact card until an identity (name/emoji) exists")
         XCTAssertNil(presentation?.avatarIdentity,
                      "No avatar identity -> falls back to the add-agent glyph")
-        XCTAssertEqual(viewModel.untitledConversationPlaceholder, "Agent")
-        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Joining...")
+        XCTAssertEqual(viewModel.untitledConversationPlaceholder, "New Agent")
+        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Activating")
     }
 
     func testDeepLinkIdentityUpgradesInPlace() {
@@ -153,7 +153,63 @@ final class PendingAgentPresentationTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldRenderAsPendingAgent)
     }
 
+    func testDirectBuildWithoutPreviewStaysGeneric() {
+        let viewModel = makeViewModel()
+        viewModel.directBuildGeneration = makeGeneration(preview: nil)
+
+        let presentation = viewModel.pendingAgentPresentation
+        XCTAssertNotNil(presentation, "An in-flight direct build renders as pending")
+        XCTAssertNil(presentation?.name)
+        XCTAssertNil(presentation?.avatarIdentity,
+                     "No preview yet -> falls back to the add-agent glyph")
+        XCTAssertEqual(presentation?.showsContactCard, false)
+        XCTAssertEqual(viewModel.conversationName, "New Agent")
+    }
+
+    func testDirectBuildPreviewDrivesHeaderIdentity() {
+        let viewModel = makeViewModel()
+        viewModel.directBuildGeneration = makeGeneration(preview: ConvosAPI.AgentPreview(
+            agentName: "Fin Watch",
+            emoji: "🦈",
+            description: "Tracks live shark data"
+        ))
+
+        let presentation = viewModel.pendingAgentPresentation
+        XCTAssertEqual(presentation?.name, "Fin Watch")
+        XCTAssertEqual(presentation?.emoji, "🦈")
+        XCTAssertEqual(presentation?.showsContactCard, false,
+                       "The builder keeps its own activating card, not the contact card")
+        XCTAssertEqual(presentation?.avatarIdentity?.emoji, "🦈")
+        XCTAssertEqual(viewModel.conversationName, "Fin Watch")
+        XCTAssertEqual(viewModel.untitledConversationPlaceholder, "Fin Watch")
+        XCTAssertEqual(viewModel.conversationInfoSubtitle, "Activating")
+    }
+
+    func testDirectBuildEmptyPreviewFieldsStayGeneric() {
+        let viewModel = makeViewModel()
+        viewModel.directBuildGeneration = makeGeneration(preview: ConvosAPI.AgentPreview(
+            agentName: "",
+            emoji: "",
+            description: nil
+        ))
+
+        let presentation = viewModel.pendingAgentPresentation
+        XCTAssertNil(presentation?.name)
+        XCTAssertNil(presentation?.avatarIdentity)
+        XCTAssertEqual(viewModel.conversationName, "New Agent")
+    }
+
     // MARK: - Helpers
+
+    private func makeGeneration(preview: ConvosAPI.AgentPreview?) -> AgentTemplateGeneration {
+        AgentTemplateGeneration(
+            conversationId: "test-convo",
+            status: .running,
+            templateId: nil,
+            errorMessage: nil,
+            preview: preview
+        )
+    }
 
     private func makeAgentMember(metadata: ProfileMetadata?) -> ConversationMember {
         let profile = Profile(


### PR DESCRIPTION
## What

While a direct-builder agent build is in flight, the chat header stayed generic — "New Agent" title + add-agent glyph — even after the build streamed a draft identity that the activating card below was already showing (name, emoji, description, progress bar).

The header now adopts the draft preview identity (name + emoji, rendered with the existing verified pending-agent styling) as soon as the generation's `preview` exists, and falls back to the generic placeholder until then. The `.agentActivating` card keeps owning the progressive reveal — `showsContactCard` stays `false` — and since `AgentTemplateRepository` retains the last non-nil preview fields through the terminal poll, the header identity doesn't regress before the agent joins.

| Before | After |
|---|---|
| "New Agent" + add-agent glyph for the whole build | 🦈 Fin Watch in the header once the preview streams |

## How

- `ConversationViewModel.pendingAgentPresentation`: the `shouldRenderAsPendingAgentBuilder` branch now feeds `directBuildGeneration?.preview` (empty strings treated as absent) instead of a hardcoded nil-identity presentation. Title (`conversationName` / `untitledConversationPlaceholder`) and avatar (`pendingAgentIdentity` environment → `ConversationAvatarView`) pick it up through the existing plumbing; no view changes needed.

## Test-bundle repairs (second commit)

`ConvosTests` did not compile at dev tip — `FocusCoordinator`, `AttachmentSharePayload`, and `MessageBodyClassifier` moved into the `ConvosComposer` package without their app-target tests gaining the import (app-target tests evidently aren't in CI). Fixed the imports, made the tested members of the two internal types public (`@testable` imports of package products don't resolve from the app test bundle), and refreshed stale assertions ("Joining..." → "Activating" from #1079, "Agent" → "New Agent").

## Testing

- New coverage in `PendingAgentPresentationTests`: preview drives header identity, nil preview stays generic, empty-string preview fields stay generic.
- `xcodebuild test … -only-testing:ConvosTests/PendingAgentPresentationTests`: 13/13 pass.
- Full `swift test --package-path ConvosCore` against the local Docker stack: 1,627 tests / 229 suites pass.
- SwiftLint strict clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787333272&installation_model_id=20076&pr_number=1212&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1212&signature=92b71b979a2e44d1985adcd318fabe66a8b682a0100c7cb8da7c8dfee7ec98fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show draft agent name and emoji in chat header while agent activates
> - Updates `ConversationViewModel.pendingAgentPresentation` to read the streamed `directBuildGeneration?.preview` and surface its `agentName` and emoji in the conversation header as soon as they are available, instead of staying generic until the verified agent joins.
> - Makes `AttachmentSharePayload`, `MessageLengthClass`, `MessageBodyClassifier`, and related helpers public so they are accessible from external modules, with test files updated to import `ConvosComposer` accordingly.
> - Updates `PendingAgentPresentationTests` to reflect the new subtitle text (`'Activating'` instead of `'Joining...'`) and adds tests covering streamed preview identity and empty preview fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29cdc13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->