### PR TITLE
[DO NOT MERGE - TEST] Prototype: smiley-face-only home screen

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -55,6 +55,22 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- gates the prototype smiley-only home screen (see
+    /// `SmileyPrototypeHomeView`), which replaces the entire tab shell with a
+    /// single giant smiley button that builds and joins a smiley-only agent.
+    /// Toggle from App Settings -> Debug. Hard-locked off in production so the
+    /// prototype surface can never replace the real home screen for end users.
+    var isSmileyPrototypeEnabled: Bool {
+        get {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+            return UserDefaults.standard.bool(forKey: Constant.smileyPrototypeEnabledKey)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            UserDefaults.standard.set(newValue, forKey: Constant.smileyPrototypeEnabledKey)
+        }
+    }
+
     /// Mock credits/subscription state used by the in-app paywall preview surface
     /// in the Debug menu. Non-production only; defaults to `.plusAmple`.
     var mockCreditsPreset: CreditsStatePreset {
@@ -96,5 +112,6 @@ final class FeatureFlags {
         static let selectedAgentVariantKey: String = "featureFlags.selectedAgentVariant"
         static let agentVariantSelectorEnabledKey: String = "featureFlags.agentVariantSelectorEnabled"
         static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
+        static let smileyPrototypeEnabledKey: String = "featureFlags.smileyPrototypeEnabled"
     }
 }

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -74,6 +74,7 @@ struct DebugViewSection: View {
         Section("Features") {
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
             Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
+            Toggle("Smiley prototype home screen", isOn: Bindable(FeatureFlags.shared).isSmileyPrototypeEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
 
             let showInfoAction = { showingAgentsInfoSheet = true }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -269,20 +269,31 @@ struct MainTabView: View {
     }
 
     var body: some View {
-        bodyCore
-            .profilesRepository(conversationsViewModel.session.messagingServiceSync().profilesRepository())
-            .environment(promptHints)
-            .task {
-                await promptHints.loadOnLaunch()
+        Group {
+            if FeatureFlags.shared.isSmileyPrototypeEnabled {
+                // Prototype: replace the entire tab shell with the
+                // smiley-only home screen. See `SmileyPrototypeHomeView`.
+                SmileyPrototypeHomeView(
+                    session: conversationsViewModel.session,
+                    coreActions: coreActions
+                )
+            } else {
+                bodyCore
+                    .profilesRepository(conversationsViewModel.session.messagingServiceSync().profilesRepository())
+                    .environment(promptHints)
+                    .task {
+                        await promptHints.loadOnLaunch()
+                    }
+                    .onAppear {
+                        ensureNavigators()
+                        tabRootNavState.markScreenAppeared()
+                        navStateForTab(activeTab).markScreenAppeared()
+                        conversationsViewModel.bringChatsTabToFront = { activeTab = .chats }
+                        conversationsViewModel.isChatsTabActive = activeTab == .chats
+                    }
+                    .modifier(metricsObserversModifier)
             }
-            .onAppear {
-                ensureNavigators()
-                tabRootNavState.markScreenAppeared()
-                navStateForTab(activeTab).markScreenAppeared()
-                conversationsViewModel.bringChatsTabToFront = { activeTab = .chats }
-                conversationsViewModel.isChatsTabActive = activeTab == .chats
-            }
-            .modifier(metricsObserversModifier)
+        }
     }
 
     @ViewBuilder

--- a/Convos/Smiley Prototype/SmileyPrototypeHomeView.swift
+++ b/Convos/Smiley Prototype/SmileyPrototypeHomeView.swift
@@ -1,0 +1,64 @@
+import ConvosCore
+import SwiftUI
+
+/// Prototype home screen (see `FeatureFlags.isSmileyPrototypeEnabled`): the
+/// entire app surface is a single giant smiley button. Tapping it builds and
+/// joins a fresh agent whose only instruction is to reply with smiley face
+/// emoji, reusing the same direct-build pipeline the real "Make an agent"
+/// composer uses (`AgentBuilderViewModel.commit`), then morphs into the
+/// standard `ConversationView` once the draft group is ready -- identical to
+/// the normal builder flow, just pre-seeded and auto-committed instead of
+/// waiting on typed input.
+struct SmileyPrototypeHomeView: View {
+    let session: any SessionManagerProtocol
+    let coreActions: any CoreActions
+
+    @State private var builderViewModel: AgentBuilderViewModel?
+    @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
+
+    var body: some View {
+        ZStack {
+            Color.colorBackgroundSurfaceless.ignoresSafeArea()
+
+            Button(action: startSmileyConversation) {
+                Text("😀")
+                    .font(.system(size: 220))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Start a conversation with the smiley agent")
+            .accessibilityIdentifier("smiley-prototype-home-button")
+        }
+        .sheet(item: $builderViewModel) { viewModel in
+            AgentBuilderView(viewModel: viewModel, profileSettingsViewModel: .shared)
+                .background(.colorBackgroundSurfaceless)
+                .presentationSizing(.page)
+                .interactiveDismissDisabled(true)
+        }
+    }
+
+    /// Builds a fresh `AgentBuilderViewModel`, seeds its composer with the
+    /// smiley-only instruction, and immediately commits -- mirroring what
+    /// tapping "Make" in the real composer does, minus the user having to
+    /// type anything. `commit()` itself defers the actual generation start
+    /// until the inner conversation has an invite slug, so it is safe to
+    /// call right away; the short sleep just lets the sheet finish mounting
+    /// before the reveal animation kicks off.
+    private func startSmileyConversation() {
+        let viewModel = AgentBuilderViewModel(session: session, coreActions: coreActions)
+        viewModel.composerText = Constant.smileyPrompt
+        builderViewModel = viewModel
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(50))
+            viewModel.commit(focusCoordinator: focusCoordinator)
+        }
+    }
+
+    private enum Constant {
+        static let smileyPrompt: String =
+            "You only ever reply with one or more smiley face emoji (😀 🙂 😄 😆 😊 😁). " +
+            "Never send plain text, words, or any other emoji -- every message you send must " +
+            "be smiley faces only, no matter what the other person says."
+    }
+}

--- a/Convos/Smiley Prototype/SmileyPrototypeHomeView.swift
+++ b/Convos/Smiley Prototype/SmileyPrototypeHomeView.swift
@@ -1,13 +1,14 @@
 import ConvosCore
 import SwiftUI
 
-/// Prototype home screen (see `FeatureFlags.isSmileyPrototypeEnabled`): the
-/// entire app surface is a single giant smiley button. Tapping it builds and
-/// joins a fresh agent whose only instruction is to reply with smiley face
-/// emoji, reusing the same direct-build pipeline the real "Make an agent"
-/// composer uses (`AgentBuilderViewModel.commit`), then morphs into the
-/// standard `ConversationView` once the draft group is ready -- identical to
-/// the normal builder flow, just pre-seeded and auto-committed instead of
+/// Throwaway shared-prototype view -- see `prototype.yml`. Prototype home
+/// screen (see `FeatureFlags.isSmileyPrototypeEnabled`): the entire app
+/// surface is a single giant smiley button. Tapping it builds and joins a
+/// fresh agent whose only instruction is to reply with smiley face emoji,
+/// reusing the same direct-build pipeline the real "Make an agent" composer
+/// uses (`AgentBuilderViewModel.commit`), then morphs into the standard
+/// `ConversationView` once the draft group is ready -- identical to the
+/// normal builder flow, just pre-seeded and auto-committed instead of
 /// waiting on typed input.
 struct SmileyPrototypeHomeView: View {
     let session: any SessionManagerProtocol

--- a/Convos/Smiley Prototype/SmileyPrototypeHomeView.swift
+++ b/Convos/Smiley Prototype/SmileyPrototypeHomeView.swift
@@ -17,10 +17,12 @@ struct SmileyPrototypeHomeView: View {
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
 
     var body: some View {
-        ZStack {
+        let tapAction: () -> Void = { startSmileyConversation() }
+        let exitAction: () -> Void = { FeatureFlags.shared.isSmileyPrototypeEnabled = false }
+        ZStack(alignment: .topTrailing) {
             Color.colorBackgroundSurfaceless.ignoresSafeArea()
 
-            Button(action: startSmileyConversation) {
+            Button(action: tapAction) {
                 Text("😀")
                     .font(.system(size: 220))
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -29,6 +31,22 @@ struct SmileyPrototypeHomeView: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Start a conversation with the smiley agent")
             .accessibilityIdentifier("smiley-prototype-home-button")
+
+            // Escape hatch: without this the prototype has no navigation path
+            // back to Debug settings (this screen replaces the entire tab
+            // shell, including the App Settings sheet that hosts the toggle),
+            // so a tester could only exit by clearing UserDefaults. Flagged in
+            // review -- flip the flag directly instead of requiring that.
+            Button(action: exitAction) {
+                Text("Exit prototype")
+                    .font(.footnote)
+                    .padding(.horizontal, DesignConstants.Spacing.step3x)
+                    .padding(.vertical, DesignConstants.Spacing.step2x)
+            }
+            .buttonStyle(.bordered)
+            .padding(.top, DesignConstants.Spacing.step5x)
+            .padding(.trailing, DesignConstants.Spacing.step3x)
+            .accessibilityIdentifier("smiley-prototype-exit-button")
         }
         .sheet(item: $builderViewModel) { viewModel in
             AgentBuilderView(viewModel: viewModel, profileSettingsViewModel: .shared)
@@ -46,7 +64,7 @@ struct SmileyPrototypeHomeView: View {
     /// call right away; the short sleep just lets the sheet finish mounting
     /// before the reveal animation kicks off.
     private func startSmileyConversation() {
-        let viewModel = AgentBuilderViewModel(session: session, coreActions: coreActions)
+        let viewModel: AgentBuilderViewModel = AgentBuilderViewModel(session: session, coreActions: coreActions)
         viewModel.composerText = Constant.smileyPrompt
         builderViewModel = viewModel
         Task { @MainActor in

--- a/prototype.yml
+++ b/prototype.yml
@@ -1,0 +1,4 @@
+prototypeId: "home-screen-shows-only-a-large-smiley-face-tapping-it-joins-a-co"
+side: "app"
+requestedLifetime: "2026-07-30T05:16:53.621Z"
+whatToTest: "Home screen shows only a large smiley face; tapping it joins a conversation with an agent that responds only with smiley face emojis"


### PR DESCRIPTION
Prototype for testing: `FeatureFlags.isSmileyPrototypeEnabled` (dev-only, hard-locked off in production, toggle in the Debug menu) swaps the entire tab shell for `SmileyPrototypeHomeView` — a full-screen giant 😀 button. Tapping it spins up a fresh agent through the existing "Make an agent" direct-build pipeline (`AgentBuilderViewModel`), pre-seeded with an instruction to reply only with smiley emoji, and auto-commits so the user lands straight in the conversation once the agent joins. No changes to the default app experience — the flag defaults off.

An "Exit prototype" button in the top-trailing corner flips the flag back off directly, since this screen replaces the entire tab shell (including the normal path to Debug settings) — added per Macroscope's review flagging that testers would otherwise have no way back without clearing UserDefaults. Also addressed Claude's review: extracted button actions to lets and added explicit types per CLAUDE.md's SwiftUI type-check conventions.

Pairs with the runtime-side prototype PR xmtplabs/convos-assistants#2925 (ephemeral "smiley-agent" variant, selectable via the existing dev Agent Variant selector once enabled).

Proposed by saul@xmtp.com via ConvosOS.