### PR TITLE
feat: build-time agent-variant pin for prototype builds

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4042,10 +4042,15 @@ extension ConversationViewModel {
     /// The dev-selected agent variant slug to route an agent join, or `nil`.
     /// Gated on the selector flag so a stale persisted selection can't route
     /// joins once the dev toggle is off (mirrors `AgentBuilderViewModel.commit`).
+    /// A selector pick (when the selector is enabled) wins; otherwise fall back to
+    /// a build-time pinned slug from config so a prototype build routes to its
+    /// paired variant with no manual selection. Nil when neither is set.
     private static func selectedAgentVariantSlug() -> String? {
-        FeatureFlags.shared.isAgentVariantSelectorEnabled
-            ? FeatureFlags.shared.selectedAgentVariant?.slug
-            : nil
+        if FeatureFlags.shared.isAgentVariantSelectorEnabled,
+           let selected = FeatureFlags.shared.selectedAgentVariant?.slug {
+            return selected
+        }
+        return ConfigManager.shared.pinnedAgentVariantSlug
     }
 
     private static func performAgentJoinCall(

--- a/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
@@ -213,6 +213,16 @@ public final class ConfigManager: @unchecked Sendable {
         return name
     }
 
+    /// Agent-variant slug pinned at build time via config.json. When set, agent
+    /// joins fall back to this variant, so a build carrying the key routes to its
+    /// paired agent variant without the tester choosing one in the selector. Absent
+    /// or empty in ordinary builds, which leaves routing to the default agent.
+    public var pinnedAgentVariantSlug: String? {
+        guard let slug = config["pinnedAgentVariantSlug"] as? String else { return nil }
+        let trimmed = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// PostHog ingestion host from config.json. Same value across environments today
     public var posthogHost: String? {
         // an absent posthog host simply does not report metrics events


### PR DESCRIPTION
## Summary

Adds a build-time agent-variant pin so a prototype app build routes to its paired agent variant with no manual selection.

- `ConfigManager.pinnedAgentVariantSlug` reads an optional `pinnedAgentVariantSlug` key from `config.json` (trimmed; nil when absent or empty).
- `ConversationViewModel.selectedAgentVariantSlug()` now falls back to that pinned slug when the variant selector isn't providing one. Precedence: an enabled selector's pick wins, otherwise the pinned slug, otherwise nil (default agent).

## Why

The ConvosOS prototype flow opens a paired app + runtime PR. The runtime PR deploys an agent variant; the app PR builds the app. For a tester to experience the prototype, the app has to talk to that variant. The variant selector already exists on `dev`, but it requires enabling a flag and picking the slug by hand — and for prototypes that alter the app UI (e.g. removing the builder, where the selector's own entry point lives), a tester can't reach it at all. This lets the prototype's app PR carry the slug in config so the build auto-routes.

Absent/empty outside prototype builds, so it's a no-op for normal `dev`/prod builds.

Note: `pinnedAgentVariantSlug` reads from the app bundle's `config.json` via the `ConfigManager` singleton, which isn't cleanly unit-testable in isolation; the behavior is exercised end-to-end by the prototype flow. The plumbing is extracted from the shipped no-builder prototype build (#1200).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787413891&installation_model_id=20076&pr_number=1216&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1216&signature=c6fa920db1640f0501a140e7ddb4fa655593a356cdbbc18ad82d71608cd53ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add build-time pinned agent variant slug for prototype builds
> - Adds `ConfigManager.pinnedAgentVariantSlug`, a computed property that reads a `pinnedAgentVariantSlug` key from `config.json`, trimming whitespace and returning nil if absent or empty.
> - Updates `ConversationViewModel.selectedAgentVariantSlug` to fall back to the pinned slug from config when the dev selector is disabled or has no selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 834f347.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->