### PR TITLE
fix: align ShareExtension MARKETING_VERSION to 2.2.0

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -1615,7 +1615,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(SHARE_EXTENSION_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2198,7 +2198,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(SHARE_EXTENSION_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2250,7 +2250,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(SHARE_EXTENSION_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2868,7 +2868,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(SHARE_EXTENSION_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Problem

The scheduled **Release Cut** in `convos-releases` failed with:

```
Train::Versions::Error: inconsistent versions found:
2.2.0
2.0.0
```

([failing run](https://github.com/xmtplabs/convos-releases/actions/runs/30039254203/job/89314854403))

`train cut` reads every `MARKETING_VERSION` in `Convos.xcodeproj/project.pbxproj` and requires them all to agree (`Versions.read`). On `dev`, 32 of 36 entries were `2.2.0`, but the **ShareExtension** target's four build configs (`Local`, `PR Preview`, `Release`, `Dev`) were still at `2.0.0` — so the cut aborted before it could even compare the iOS and Android repos.

## Cause

`train bump` rewrites *all* `MARKETING_VERSION` lines together, so a normal train-driven bump keeps every target in sync. The split came from an out-of-band edit — the ShareExtension target was added/reset in Xcode and picked up the template default `2.0.0`, so it never got swept along.

## Fix

Set the four ShareExtension `MARKETING_VERSION` entries to `2.2.0` so all 36 entries agree. No other targets touched.

```
before:  4 × 2.0.0, 32 × 2.2.0
after:  36 × 2.2.0
```

A CI check to catch this drift going forward (both iOS and Android) is being added separately in `convos-releases`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787428317&installation_model_id=20076&pr_number=1217&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1217&signature=927114c8b37d0915101fb24ee8b54337d379dfe1b873711bebe57eb2d93551d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align ShareExtension MARKETING_VERSION to 2.2.0
> Updates four `MARKETING_VERSION` entries in [project.pbxproj](https://github.com/xmtplabs/convos-ios/pull/1217/files#diff-d58364582ce5ff189bf9f87c20898db7df50a681e6e9df35dca291d7b9373da7) from 2.0.0 to 2.2.0 so the ShareExtension target's `CFBundleShortVersionString` matches the main app version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 975aa6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->