### PR TITLE
ci: add Version Alignment PR check

### DIFF
--- a/.github/workflows/version-alignment.yml
+++ b/.github/workflows/version-alignment.yml
@@ -1,0 +1,27 @@
+# Version Alignment — thin caller. The job lives in convos-releases:
+# https://github.com/xmtplabs/convos-releases/blob/main/.github/workflows/check-versions.yml
+#
+# On every PR to dev, asserts this repo's Convos.xcodeproj MARKETING_VERSION
+# entries are internally consistent (the ShareExtension-stuck-at-2.0.0 drift
+# that aborted a cut) AND match convos-client's current dev VERSION_NAME, so
+# the two apps can't drift apart and abort the next release cut.
+name: Version Alignment
+
+on:
+  pull_request:
+    branches: [dev]
+
+concurrency:
+  group: version-alignment-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_versions:
+    # Match the reusable workflow's declared job permissions explicitly.
+    permissions:
+      contents: read
+    uses: xmtplabs/convos-releases/.github/workflows/check-versions.yml@main
+    with:
+      self-repo: xmtplabs/convos-ios
+      sibling-repo: xmtplabs/convos-client
+    secrets: inherit


### PR DESCRIPTION
## Why

A scheduled Release Cut recently aborted because this repo's `Convos.xcodeproj/project.pbxproj` had drifted — the ShareExtension target was stuck at `2.0.0` while every other target was `2.2.0` — and nothing caught it before the cut read the file ([convos-releases run 30039254203](https://github.com/xmtplabs/convos-releases/actions/runs/30039254203/job/89314854403); fixed in #1217).

## What

Thin caller for the new reusable **Check Versions** workflow in convos-releases. On every PR to `dev`, it asserts:
- every `MARKETING_VERSION` entry in this repo agrees (the intra-repo split that caused the incident), **and**
- this repo's version matches convos-client's current `dev` `VERSION_NAME` (cross-repo agreement).

All logic lives in the tested `train check-versions` CLI; this file is just the `uses:` + inputs.

## Order note

This references `xmtplabs/convos-releases/.github/workflows/check-versions.yml@main`, which lands with **convos-releases#34**. Until that merges, this check will error on "workflow not found" — merge #34 first, then this goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787428979&installation_model_id=20076&pr_number=1220&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1220&signature=66a824b4fc5b2d75701891cdf3f18f87d3113ce0dfbcdde5988b13564b9eaed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Version Alignment CI check for PRs targeting the `dev` branch
> Adds a new GitHub Actions workflow ([version-alignment.yml](.github/workflows/version-alignment.yml)) that runs on pull requests to `dev`. It calls a reusable `check-versions` workflow from `xmtplabs/convos-releases`, passing `xmtplabs/convos-ios` and `xmtplabs/convos-client` as the self and sibling repos. Concurrent runs for the same PR are cancelled automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96fffc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->