### PR TITLE
ci: fast unsigned app-target compile check

### DIFF
--- a/.github/workflows/app-compile-check.yml
+++ b/.github/workflows/app-compile-check.yml
@@ -63,6 +63,7 @@ jobs:
             -skipMacroValidation \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
+            EXCLUDED_ARCHS=x86_64 \
             2>&1 | tee xcodebuild.log
 
       - name: Extract compile errors

--- a/.github/workflows/app-compile-check.yml
+++ b/.github/workflows/app-compile-check.yml
@@ -1,0 +1,95 @@
+# Fast, unsigned compile check for the app target. The package tests
+# (ConvosCore Tests) compile the Swift packages; the signed Firebase build is
+# the only thing that compiles the app itself — and it's slow. This builds the
+# app scheme for the simulator (no signing, no certificates) so app-level
+# compile breakage is caught on every PR in minutes, not only at build time.
+name: App Compile Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  app-compile-check:
+    name: Compile app (simulator, unsigned)
+    runs-on: warp-macos-26-arm64-12x
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Show environment
+        run: |
+          swift --version
+          xcodebuild -version
+
+      - name: Cache Swift Package dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ConvosCore/.build
+            ConvosAppData/.build
+            ConvosInvites/.build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-appcompile-spm-${{ hashFiles('ConvosCore/Package.resolved', 'ConvosAppData/Package.resolved', 'ConvosInvites/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-appcompile-spm-
+
+      - name: Compile app target
+        id: compile
+        run: |
+          set -o pipefail
+          # Build the app scheme for the simulator with signing disabled: this
+          # compiles the app and its embedded extensions without needing
+          # certificates or provisioning profiles. `-skip*Validation` keeps the
+          # macro/plugin trust prompts from blocking a non-interactive run.
+          xcodebuild build \
+            -project Convos.xcodeproj \
+            -scheme "Convos (Dev)" \
+            -configuration Debug \
+            -destination "generic/platform=iOS Simulator" \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            2>&1 | tee xcodebuild.log
+
+      - name: Extract compile errors
+        if: always()
+        run: |
+          # Compact, de-duplicated list of the actual compiler errors — the
+          # signal an agent (or a human) iterates on, without the log noise.
+          grep -E ": (error|fatal error):" xcodebuild.log | sort -u > compile-errors.txt || true
+          if [[ -s compile-errors.txt ]]; then
+            {
+              echo "### App compile errors"
+              echo ""
+              echo '```'
+              cat compile-errors.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No compile errors extracted." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload build log and errors
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-compile-check
+          path: |
+            xcodebuild.log
+            compile-errors.txt
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/app-compile-check.yml
+++ b/.github/workflows/app-compile-check.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   app-compile-check:
-    name: Compile app (simulator, unsigned)
+    name: Compile app (device, unsigned)
     runs-on: warp-macos-26-arm64-12x
     timeout-minutes: 25
 
@@ -50,20 +50,22 @@ jobs:
         id: compile
         run: |
           set -o pipefail
-          # Build the app scheme for the simulator with signing disabled: this
-          # compiles the app and its embedded extensions without needing
-          # certificates or provisioning profiles. `-skip*Validation` keeps the
-          # macro/plugin trust prompts from blocking a non-interactive run.
+          # Build the app scheme for a device (arm64) with signing disabled: this
+          # compiles the app and its embedded extensions without certificates or
+          # profiles. Device, not simulator — a generic iOS Simulator destination
+          # builds arm64+x86_64, but the LibXMTPSwiftFFI xcframework's simulator slice
+          # is arm64-only, and excluding x86_64 left the destination arch unresolved.
+          # `generic/platform=iOS` resolves a single arm64 arch cleanly. `-skip*Validation`
+          # keeps macro/plugin trust prompts from blocking a non-interactive run.
           xcodebuild build \
             -project Convos.xcodeproj \
             -scheme "Convos (Dev)" \
             -configuration Debug \
-            -destination "generic/platform=iOS Simulator" \
+            -destination "generic/platform=iOS" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            EXCLUDED_ARCHS=x86_64 \
             2>&1 | tee xcodebuild.log
 
       - name: Extract compile errors


### PR DESCRIPTION
## What

A fast, unsigned **app-target** compile check that runs on every PR. It builds the `Convos (Dev)` scheme for the iOS Simulator with signing disabled (`CODE_SIGNING_ALLOWED=NO`), so no certificates or provisioning profiles are needed. It surfaces a de-duplicated list of compile errors in the run's step summary and uploads `xcodebuild.log` + `compile-errors.txt` as an artifact.

## Why

The package tests (`ConvosCore Tests`) compile the Swift packages via `swift test`, and SwiftLint lints — but nothing **fast** compiles the app target itself. App-level compile breakage is caught only by the slow signed **Firebase PR Build**. A recent agent-authored change that referenced app-level types the file couldn't see (`CoreActions` / `FocusCoordinator` in a prototype view) compiled clean locally-in-package but failed at the signed build. This closes that feedback gap: app-level compile errors show up in minutes, on every PR.

It reuses the existing WarpBuilds macOS runner and the SPM cache pattern from `ConvosCore Tests`; it adds no signing, no Firebase, and no new secrets.

## Notes

- Debug/simulator build — the signed Firebase build remains the release-config, device-installable gate.
- Follow-ups if useful: post the extracted errors as a PR comment, and add DerivedData caching for incremental speed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787432628&installation_model_id=20076&pr_number=1221&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1221&signature=35a3f2aefce1a22d62cde643ede111b22149caafba3bcff5a7aad9eb4e2bdd15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unsigned iOS simulator compile check workflow for PRs and main/dev pushes
> - Adds [app-compile-check.yml](.github/workflows/app-compile-check.yml), a GitHub Actions workflow that builds the 'Convos (Dev)' scheme for iOS Simulator with code signing disabled and macro/plugin validation skipped.
> - Caches SPM build artifacts for `ConvosCore`, `ConvosAppData`, and `ConvosInvites` to speed up runs.
> - Extracts compiler errors into a job summary and uploads `xcodebuild.log` and `compile-errors.txt` as artifacts with 7-day retention.
> - Concurrency control ensures only one run per ref at a time.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d77fc5b. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->