### PR TITLE
Fix cold-launch flash of empty-state CTA over existing conversations

### DIFF
--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -160,6 +160,11 @@ final class ConversationsViewModel {
     var presentingPinLimitInfo: Bool = false
 
     var conversations: [Conversation] = []
+    /// Whether `conversations` has received its first real value from the
+    /// database (first-frame prime or first publisher emission). Until then
+    /// an empty array means "not loaded yet", not "no conversations", so the
+    /// empty-state CTA must stay hidden.
+    private(set) var hasLoadedInitialConversations: Bool = false
     private(set) var hiddenConversationIds: Set<String> = []
     private var conversationsCount: Int = 0 {
         didSet {
@@ -236,9 +241,13 @@ final class ConversationsViewModel {
     /// `ConversationsListEmptyCTA` ("Pop-up private convos"). Mirrors the
     /// SwiftUI-side gate inside `ConversationsView.sidebarContent` so the
     /// shell can swap the chats tab for an inline agent builder and hide
-    /// the bottom chrome.
+    /// the bottom chrome. Gated on the initial read having landed: on cold
+    /// launch `conversations` starts empty while the first database read is
+    /// still in flight, and rendering the CTA then shows a user with
+    /// conversations a false "no convos yet" screen for seconds.
     var isEmptyCTAActive: Bool {
-        unpinnedConversations.isEmpty
+        hasLoadedInitialConversations
+            && unpinnedConversations.isEmpty
             && pinnedConversations.isEmpty
             && activeFilter == .all
     }
@@ -608,6 +617,7 @@ final class ConversationsViewModel {
             .sink { [weak self] conversations in
                 guard let self else { return }
                 self.conversationsObservationHasEmitted = true
+                self.hasLoadedInitialConversations = true
                 self.conversations = hiddenConversationIds.isEmpty
                     ? conversations
                     : conversations.filter { !hiddenConversationIds.contains($0.id) }
@@ -1391,6 +1401,7 @@ extension ConversationsViewModel {
         let client = ConvosClient.mock()
         let vm = ConversationsViewModel(session: client.session)
         vm.conversations = conversations
+        vm.hasLoadedInitialConversations = true
         return vm
     }
 }
@@ -1445,6 +1456,12 @@ extension ConversationsViewModel {
     }
 
     private func applyInitialPrime(_ prime: InitialPrime, deliveredLate: Bool) {
+        if prime.conversations != nil {
+            // The read succeeded, so the database state is known even when
+            // the snapshot below is discarded in favor of a publisher
+            // emission that arrived first.
+            hasLoadedInitialConversations = true
+        }
         if let fetched = prime.conversations {
             // On the late path the conversations publisher may have emitted
             // already; it is the source of truth, so never replace its


### PR DESCRIPTION
## Problem

Caroline's report (Slack, 7/23): cold-launching the app takes a few seconds to show the conversation list. Her screen recording shows what actually happens: for ~3 seconds the app renders the new-user empty state ("Make little agents for everyday life") as if she had zero conversations, then the full list pops in.

## Root cause

`ConversationsViewModel` has no loading state. `conversations` initializes to `[]`, and `isEmptyCTAActive` shows the empty-state CTA whenever the (pinned + unpinned) lists are empty. On cold launch:

- the first-frame prime (`BoundedInitialRead`, 50ms deadline) misses, because the `composeAllConversations` query is heavy and the reader pool is contended by the XMTP initial sync kicked off from `SessionManager.init` (`[PERF] ... initial conversations read missed the first-frame deadline` fires);
- the GRDB observation's first emission lands seconds later, and until it does the empty array renders as the false "no convos yet" CTA.

## Fix

Add `hasLoadedInitialConversations`, latched when the initial read lands via any path (on-time prime, late prime, or first publisher emission), and require it in `isEmptyCTAActive`. While the read is in flight the view now falls through to the plain (empty) collection view, which matches the eventual list chrome — no more false empty state. Brand-new users are unaffected: an empty database primes well inside the 50ms first-frame deadline, so they still get the CTA on first frame.

This intentionally does not address the underlying read latency (heavy list query vs. cold-launch sync writes) — that's a follow-up; candidates are slimming `composeAllConversations`' last-message hydration or deferring the initial sync burst until after the first list emission.

## Verification

- `Convos (Dev)` simulator build passes with the 100ms type-check-as-error gate
- SwiftLint clean on the changed file
- `swift test --package-path ConvosCore`: 1642 tests in 229 suites passed
- Checked all `isEmptyCTAActive` consumers (`ConversationsView.sidebarContent`, `MainTabView.isEmptyChatsCTAActive`): during load they keep normal list chrome, matching the eventual state for users with conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787432980&installation_model_id=20076&pr_number=1222&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1222&signature=46df6630a5c30261b5cd2857af198bf84a81a32aab35307a5fa75a1e68c0d0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cold-launch flash of empty-state CTA over existing conversations
> Adds a `hasLoadedInitialConversations` flag to `ConversationsViewModel` that gates the `isEmptyCTAActive` computed property. The empty-state CTA now stays hidden until the first real value arrives from the database publisher or the initial prime snapshot, preventing it from briefly appearing over existing conversations on startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67dee08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->