### PR TITLE
[PROTOTYPE - DO NOT MERGE] Agent-first: new convo starts with an agent present by default

### DIFF
--- a/prototype.yml
+++ b/prototype.yml
@@ -1,0 +1,4 @@
+prototypeId: "agent-first-app"
+side: "app"
+requestedLifetime: "2026-07-30T21:23:34.192Z"
+whatToTest: "Agent-first new-conversation UX: creating a new convo starts it with an agent already present by default (agent joins immediately at creation, not added after); humans get invited into that convo afterward — inverting today's human-first-then-add-agent flow. Validate the create → agent-join → invite-humans sequence experientially."


### PR DESCRIPTION
Shared PR Preview prototype for: Agent-first new-conversation UX: creating a new convo starts it with an agent already present by default (agent joins immediately at creation, not added after); humans get invited into that convo afterward — inverting today's human-first-then-add-agent flow. Validate the create → agent-join → invite-humans sequence experientially.

Proposed by saul@xmtp.com via ConvosOS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787433824&installation_model_id=20076&pr_number=1223&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1223&signature=cf15769ec8038c80a9db0f32fa5ff49cfeb194470b141dc354cf55e1ded8d180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prototype config for agent-first new conversation UX
> Adds [prototype.yml](https://github.com/xmtplabs/convos-ios/pull/1223/files#diff-d96617da6f23e1e14d8bfc6203b17ebb1771fda00d054062b60efff98cf7ce62) defining the `agent-first-app` prototype, which configures the app-side prototype harness to test a UX flow where new conversations start with an agent present by default. This is a prototype branch not intended for merge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd5bd99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->