### PR TITLE
Slim the conversation-list last-message CTEs to a grouped MAX

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -201,6 +201,19 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         request: lastMessageRequest
     )
 
+    /// Content types that never surface as a conversation-list preview.
+    /// Bound twice into `lastMessageWithSourceCTE` (once for the grouped-MAX
+    /// subquery, once for the join-back filter); each placeholder list in
+    /// the SQL must stay the same length as this array.
+    private static let previewExcludedContentTypes: [String] = [
+        MessageContentType.update.rawValue,
+        MessageContentType.assistantJoinRequest.rawValue,
+        MessageContentType.connectionGrantRequest.rawValue,
+        MessageContentType.connectionInvocation.rawValue,
+        MessageContentType.connectionInvocationResult.rawValue,
+        MessageContentType.connectionPayload.rawValue,
+    ]
+
     /// The text columns are capped with substr so a pathological message
     /// body (XMTP allows just under 1MB, roughly 250 SQLite overflow pages
     /// per row) cannot drag overflow pages for every conversation's last
@@ -239,20 +252,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
                     AND m.contentType NOT IN (?, ?, ?, ?, ?, ?)
                 LEFT JOIN message src ON m.sourceMessageId = src.id
                 """,
-            arguments: [
-                MessageContentType.update.rawValue,
-                MessageContentType.assistantJoinRequest.rawValue,
-                MessageContentType.connectionGrantRequest.rawValue,
-                MessageContentType.connectionInvocation.rawValue,
-                MessageContentType.connectionInvocationResult.rawValue,
-                MessageContentType.connectionPayload.rawValue,
-                MessageContentType.update.rawValue,
-                MessageContentType.assistantJoinRequest.rawValue,
-                MessageContentType.connectionGrantRequest.rawValue,
-                MessageContentType.connectionInvocation.rawValue,
-                MessageContentType.connectionInvocationResult.rawValue,
-                MessageContentType.connectionPayload.rawValue,
-            ]
+            arguments: StatementArguments(previewExcludedContentTypes + previewExcludedContentTypes)
         )
 
     /// Same grouped-MAX shape as `lastMessageWithSourceCTE`, served

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -207,6 +207,16 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
     /// message through the page cache on each list read. 4096 characters
     /// covers the longest preview and the ConnectionEventSummary JSON that
     /// `hydrateMessagePreview` decodes out of `text`.
+    ///
+    /// The winners are found with a grouped MAX over
+    /// `message_on_conversationId_contentType_dateNs` (an index-only scan)
+    /// and then joined back to `message` to load just those rows. The
+    /// earlier per-row correlated subquery re-scanned each conversation's
+    /// index entries once per message, which made materializing this CTE
+    /// scale with messages-per-conversation squared and dominated the
+    /// conversation-list read on message-heavy databases. Ties on dateNs
+    /// keep the same behavior as before: every tied eligible row comes
+    /// through, and the outer query's GROUP BY collapses them.
     nonisolated(unsafe) static let lastMessageWithSourceCTE: CommonTableExpression<DBLastMessageWithSource> =
         CommonTableExpression<DBLastMessageWithSource>(
             named: "conversationLastMessageWithSource",
@@ -217,15 +227,17 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
                     substr(m.text, 1, 4096) as text,
                     m.emoji, m.invite, m.linkPreview, m.sourceMessageId, m.attachmentUrls,
                     substr(src.text, 1, 4096) as sourceMessageText
-                FROM message m
+                FROM (
+                    SELECT conversationId, MAX(dateNs) AS maxDateNs
+                    FROM message
+                    WHERE contentType NOT IN (?, ?, ?, ?, ?, ?)
+                    GROUP BY conversationId
+                ) last
+                JOIN message m
+                    ON m.conversationId = last.conversationId
+                    AND m.dateNs = last.maxDateNs
+                    AND m.contentType NOT IN (?, ?, ?, ?, ?, ?)
                 LEFT JOIN message src ON m.sourceMessageId = src.id
-                WHERE m.contentType NOT IN (?, ?, ?, ?, ?, ?)
-                AND m.dateNs = (
-                    SELECT MAX(m2.dateNs)
-                    FROM message m2
-                    WHERE m2.conversationId = m.conversationId
-                    AND m2.contentType NOT IN (?, ?, ?, ?, ?, ?)
-                )
                 """,
             arguments: [
                 MessageContentType.update.rawValue,
@@ -243,19 +255,24 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
             ]
         )
 
+    /// Same grouped-MAX shape as `lastMessageWithSourceCTE`, served
+    /// index-only by the partial `message_assistantJoinRequest_conversationId`
+    /// index.
     nonisolated(unsafe) static let latestAgentJoinRequestCTE: CommonTableExpression<DBAgentJoinRequest> =
         CommonTableExpression<DBAgentJoinRequest>(
             named: "conversationAgentJoinRequest",
             sql: """
                 SELECT m.conversationId, m.text AS status, m.date
-                FROM message m
-                WHERE m.contentType = ?
-                AND m.dateNs = (
-                    SELECT MAX(m2.dateNs)
-                    FROM message m2
-                    WHERE m2.conversationId = m.conversationId
-                    AND m2.contentType = ?
-                )
+                FROM (
+                    SELECT conversationId, MAX(dateNs) AS maxDateNs
+                    FROM message
+                    WHERE contentType = ?
+                    GROUP BY conversationId
+                ) last
+                JOIN message m
+                    ON m.conversationId = last.conversationId
+                    AND m.dateNs = last.maxDateNs
+                    AND m.contentType = ?
                 """,
             arguments: [
                 MessageContentType.assistantJoinRequest.rawValue,

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLastMessageCTETests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLastMessageCTETests.swift
@@ -1,0 +1,294 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the grouped-MAX form of `lastMessageWithSourceCTE` and
+/// `latestAgentJoinRequestCTE` - the conversation-list previews that used
+/// to be computed with a per-row correlated subquery. These pin the
+/// observable semantics the rewrite must preserve: newest eligible message
+/// wins, excluded content types never surface as previews, reply/reaction
+/// previews carry the source message text, conversations without eligible
+/// messages fall back to `createdAt` ordering, and the newest agent join
+/// request drives `agentJoinStatus`.
+@Suite("Conversation Last Message CTE Tests", .serialized)
+struct ConversationLastMessageCTETests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let otherInboxId: String = "inbox-other"
+
+    private static func seedInbox(db: Database) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+    }
+
+    /// Seeds a two-member conversation (current user + other) with every
+    /// row `detailedConversationQuery` requires. Two members keeps
+    /// `shouldShowSenderName` false so text previews are the raw body.
+    private static func seedConversation(
+        db: Database,
+        id: String,
+        createdAt: Date
+    ) throws {
+        try seedInbox(db: db)
+        try DBMember(inboxId: otherInboxId).save(db, onConflict: .ignore)
+
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: createdAt,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: false,
+            isUnread: false,
+            isUnreadUpdatedAt: createdAt,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            leftHostedInviteSession: false,
+            wasRemoved: false,
+            hasHadOtherMembers: false,
+            hasSharedInvite: false
+        ).insert(db)
+
+        for (index, inboxId) in [currentInboxId, otherInboxId].enumerated() {
+            let role: MemberRole = index == 0 ? .superAdmin : .member
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: role,
+                consent: .allowed,
+                createdAt: createdAt,
+                invitedByInboxId: nil
+            ).insert(db)
+            try DBMemberProfile(
+                conversationId: id,
+                inboxId: inboxId,
+                name: inboxId,
+                avatar: nil
+            ).insert(db, onConflict: .ignore)
+        }
+    }
+
+    @discardableResult
+    private static func seedMessage(
+        db: Database,
+        conversationId: String,
+        id: String,
+        dateNs: Int64,
+        date: Date,
+        messageType: DBMessageType = .original,
+        contentType: MessageContentType = .text,
+        text: String? = nil,
+        emoji: String? = nil,
+        sourceMessageId: String? = nil
+    ) throws -> String {
+        try DBMessage(
+            id: id,
+            clientMessageId: id,
+            conversationId: conversationId,
+            senderId: otherInboxId,
+            dateNs: dateNs,
+            date: date,
+            sortId: dateNs,
+            status: .published,
+            messageType: messageType,
+            contentType: contentType,
+            text: text,
+            emoji: emoji,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: sourceMessageId,
+            attachmentUrls: [],
+            update: nil
+        ).insert(db)
+        return id
+    }
+
+    private static func fetchAll(_ dbManager: any DatabaseManagerProtocol) throws -> [Conversation] {
+        let repo = ConversationsRepository(dbReader: dbManager.dbReader, consent: [.allowed])
+        return try repo.fetchAll()
+    }
+
+    // MARK: - Tests
+
+    @Test("Newest eligible message wins over newer excluded content types")
+    func newestEligibleMessageWins() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let base = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1", createdAt: base)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-old",
+                dateNs: 1_000, date: base, text: "older text"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-latest-eligible",
+                dateNs: 2_000, date: base.addingTimeInterval(1), text: "latest eligible text"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-newer-update",
+                dateNs: 3_000, date: base.addingTimeInterval(2), contentType: .update
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-newer-invocation",
+                dateNs: 4_000, date: base.addingTimeInterval(3),
+                contentType: .connectionInvocation, text: "{}"
+            )
+        }
+
+        let conversations = try Self.fetchAll(dbManager)
+        #expect(conversations.count == 1)
+        #expect(conversations.first?.lastMessage?.text == "latest eligible text")
+    }
+
+    @Test("Each conversation gets its own last message")
+    func lastMessagesDoNotLeakAcrossConversations() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let base = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-a", createdAt: base)
+            try Self.seedConversation(db: db, id: "convo-b", createdAt: base)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-a", id: "m-a",
+                dateNs: 1_000, date: base, text: "message in a"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-b", id: "m-b",
+                dateNs: 2_000, date: base.addingTimeInterval(1), text: "message in b"
+            )
+        }
+
+        let conversations = try Self.fetchAll(dbManager)
+        let byId = Dictionary(uniqueKeysWithValues: conversations.map { ($0.id, $0) })
+        #expect(byId["convo-a"]?.lastMessage?.text == "message in a")
+        #expect(byId["convo-b"]?.lastMessage?.text == "message in b")
+    }
+
+    @Test("Reaction preview joins the source message text")
+    func reactionPreviewCarriesSourceText() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let base = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1", createdAt: base)
+            let sourceId = try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-source",
+                dateNs: 1_000, date: base, text: "the original body"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-reaction",
+                dateNs: 2_000, date: base.addingTimeInterval(1),
+                messageType: .reaction, contentType: .emoji,
+                emoji: "🔥", sourceMessageId: sourceId
+            )
+        }
+
+        let conversations = try Self.fetchAll(dbManager)
+        let previewText = conversations.first?.lastMessage?.text ?? ""
+        #expect(previewText.contains("🔥"))
+        #expect(previewText.contains("the original body"))
+    }
+
+    @Test("Conversations without eligible messages order by createdAt and have no preview")
+    func orderingFallsBackToCreatedAt() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let base = Date()
+        try dbManager.dbWriter.write { db in
+            // Oldest createdAt, but the newest message overall.
+            try Self.seedConversation(db: db, id: "convo-active", createdAt: base)
+            // Newer createdAt than convo-active, older message activity.
+            try Self.seedConversation(
+                db: db, id: "convo-quiet", createdAt: base.addingTimeInterval(10)
+            )
+            // Newest createdAt, no messages at all.
+            try Self.seedConversation(
+                db: db, id: "convo-empty", createdAt: base.addingTimeInterval(20)
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-quiet", id: "m-quiet",
+                dateNs: 1_000, date: base.addingTimeInterval(15), text: "quiet"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-active", id: "m-active",
+                dateNs: 2_000, date: base.addingTimeInterval(30), text: "active"
+            )
+        }
+
+        let conversations = try Self.fetchAll(dbManager)
+        #expect(conversations.map(\.id) == ["convo-active", "convo-empty", "convo-quiet"])
+        #expect(conversations.first { $0.id == "convo-empty" }?.lastMessage == nil)
+    }
+
+    @Test("Tied dateNs still yields a single conversation row")
+    func tiedDateNsCollapsesToOneRow() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let base = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1", createdAt: base)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-tie-1",
+                dateNs: 5_000, date: base, text: "tied one"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-tie-2",
+                dateNs: 5_000, date: base, text: "tied two"
+            )
+        }
+
+        let conversations = try Self.fetchAll(dbManager)
+        #expect(conversations.count == 1)
+        let previewText = conversations.first?.lastMessage?.text
+        #expect(previewText == "tied one" || previewText == "tied two")
+    }
+
+    @Test("Newest agent join request drives agentJoinStatus; requests stay out of previews")
+    func newestAgentJoinRequestWins() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let base = Date()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1", createdAt: base)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-text",
+                dateNs: 1_000, date: base.addingTimeInterval(-5), text: "visible preview"
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-join-failed",
+                dateNs: 2_000, date: base.addingTimeInterval(-4),
+                contentType: .assistantJoinRequest, text: AgentJoinStatus.failed.rawValue
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "m-join-pending",
+                dateNs: 3_000, date: base,
+                contentType: .assistantJoinRequest, text: AgentJoinStatus.pending.rawValue
+            )
+        }
+
+        let conversations = try Self.fetchAll(dbManager)
+        #expect(conversations.first?.agentJoinStatus == .pending)
+        #expect(conversations.first?.lastMessage?.text == "visible preview")
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to #1222 (Caroline's cold-launch report): the conversation list's first read takes seconds on message-heavy databases, and it re-runs on every database write during initial sync.

`lastMessageWithSourceCTE` materialized by scanning **every message row** and running a correlated `MAX(dateNs)` subquery per row. The subquery walks the `(conversationId, dateNs)` index downward from the newest entry until it hits an eligible contentType — fetching the table row for each entry it checks. A burst of excluded `update` messages at the tail of a conversation (exactly what initial-sync membership churn writes) multiplies the entire scan. `latestAgentJoinRequestCTE` had the same correlated shape.

## Fix

Compute the winners with a grouped `MAX(dateNs) ... GROUP BY conversationId` subquery — an index-only scan of the covering `message_on_conversationId_contentType_dateNs` index — then join back to `message` for just those rows. Identical select list, identical tie-on-dateNs semantics (all tied rows emerge; the outer `GROUP BY conversation.id` collapses them, as before). No migration, no GRDB structure change; every `detailedConversationQuery` caller (list, single conversation, drafts, find-1:1) benefits.

Query plans:
```
old: SCAN m
     CORRELATED SCALAR SUBQUERY: SEARCH m2 USING INDEX message_on_conversationId_dateNs (conversationId=?)
new: CO-ROUTINE last: SCAN message USING COVERING INDEX message_on_conversationId_contentType_dateNs
     SEARCH m USING INDEX message_on_conversationId_dateNs (conversationId=? AND dateNs=?)
```

## Benchmarks

In-memory DB, 30 conversations × 1,500 messages (45k rows), CTE materialization alone, median of runs:

| Workload | Old | New |
|---|---|---|
| 10% updates interleaved | 34.7ms | 6.2ms (5.6×) |
| + 60 trailing updates per conversation (sync churn) | 621.8ms | 6.1ms (~100×) |

Full `fetchAll` (CTE + member/invite fan-out + hydration) lands at ~20ms on the same dataset. On-device the old form is worse than these numbers: it touches every message table row (cold page-cache I/O adjacent to giant text bodies), while the new form's working set is one compact index.

## Verification

- 6 new tests in `ConversationLastMessageCTETests` pin the preview semantics: newest eligible wins over newer excluded types, per-conversation isolation, reaction previews join source text, createdAt ordering fallback for message-less conversations, dateNs ties collapse to one row, newest agent join request drives `agentJoinStatus`
- Full ConvosCore suite: 1,648 tests in 230 suites passed
- SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787435421&installation_model_id=20076&pr_number=1224&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1224&signature=196f81f783913e1ebfb06fc25cac673557f05cecde5e2c2a3b6dccb0aed2b210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Slim conversation-list last-message CTEs to a grouped MAX with tests
> - Extracts excluded content types into a shared `previewExcludedContentTypes` constant in [DBConversation.swift](https://github.com/xmtplabs/convos-ios/pull/1224/files#diff-07de778835113866c79aa888797b79ecbcd89aa5ca1aa8aec46d5c3442517ded), replacing duplicated inline argument arrays in `lastMessageWithSourceCTE`.
> - Adds a new test suite in [ConversationLastMessageCTETests.swift](https://github.com/xmtplabs/convos-ios/pull/1224/files#diff-9245af7b76d3d2d8d7c4bf4838dbb998fd03ba6e750e3d4d970cee4d952a2951) covering edge cases: excluded type filtering, per-conversation isolation, reaction preview source text, `createdAt` ordering fallback, tie-breaking, and agent join request status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 739441b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->