### PR TITLE
Denormalize last-message pointers onto conversation, maintained by triggers

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -186,33 +186,20 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         using: ForeignKey([Columns.id], to: [DBMessage.Columns.conversationId])
     ).order(DBMessage.Columns.dateNs.desc)
 
-    static let lastMessageRequest: QueryInterfaceRequest<DBMessage> = DBMessage
-        .filter(DBMessage.Columns.contentType != MessageContentType.update.rawValue)
-        .filter(DBMessage.Columns.contentType != MessageContentType.assistantJoinRequest.rawValue)
-        .filter(DBMessage.Columns.contentType != MessageContentType.connectionGrantRequest.rawValue)
-        .filter(DBMessage.Columns.contentType != MessageContentType.connectionInvocation.rawValue)
-        .filter(DBMessage.Columns.contentType != MessageContentType.connectionInvocationResult.rawValue)
-        .filter(DBMessage.Columns.contentType != MessageContentType.connectionPayload.rawValue)
-        .annotated { max($0.dateNs) }
-        .group(\.conversationId)
-
+    /// Newest preview-eligible message per conversation, resolved through the
+    /// denormalized `conversation.lastMessageId` pointer. The pointer is
+    /// maintained by the `conversation_pointer_*` database triggers (see
+    /// `SharedDatabaseMigrator.addConversationLastMessagePointers`), which
+    /// also own the excluded-content-type list, so this read needs no
+    /// filtering and costs one primary-key lookup per conversation.
     nonisolated(unsafe) static let lastMessageCTE: CommonTableExpression<DBMessage> = CommonTableExpression<DBMessage>(
         named: "conversationLastMessage",
-        request: lastMessageRequest
-    )
-
-    /// Content types that never surface as a conversation-list preview.
-    /// Bound twice into `lastMessageWithSourceCTE` (once for the grouped-MAX
-    /// subquery, once for the join-back filter); each placeholder list in
-    /// the SQL must stay the same length as this array.
-    private static let previewExcludedContentTypes: [String] = [
-        MessageContentType.update.rawValue,
-        MessageContentType.assistantJoinRequest.rawValue,
-        MessageContentType.connectionGrantRequest.rawValue,
-        MessageContentType.connectionInvocation.rawValue,
-        MessageContentType.connectionInvocationResult.rawValue,
-        MessageContentType.connectionPayload.rawValue,
-    ]
+        sql: """
+            SELECT m.*
+            FROM conversation c
+            JOIN message m ON m.id = c.lastMessageId
+            """
+        )
 
     /// The text columns are capped with substr so a pathological message
     /// body (XMTP allows just under 1MB, roughly 250 SQLite overflow pages
@@ -221,15 +208,10 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
     /// covers the longest preview and the ConnectionEventSummary JSON that
     /// `hydrateMessagePreview` decodes out of `text`.
     ///
-    /// The winners are found with a grouped MAX over
-    /// `message_on_conversationId_contentType_dateNs` (an index-only scan)
-    /// and then joined back to `message` to load just those rows. The
-    /// earlier per-row correlated subquery re-scanned each conversation's
-    /// index entries once per message, which made materializing this CTE
-    /// scale with messages-per-conversation squared and dominated the
-    /// conversation-list read on message-heavy databases. Ties on dateNs
-    /// keep the same behavior as before: every tied eligible row comes
-    /// through, and the outer query's GROUP BY collapses them.
+    /// Rows come from the `conversation.lastMessageId` pointer (see
+    /// `lastMessageCTE`), so materializing this CTE is one primary-key
+    /// lookup per conversation regardless of message volume, and eligibility
+    /// filtering already happened at write time in the pointer triggers.
     nonisolated(unsafe) static let lastMessageWithSourceCTE: CommonTableExpression<DBLastMessageWithSource> =
         CommonTableExpression<DBLastMessageWithSource>(
             named: "conversationLastMessageWithSource",
@@ -240,44 +222,23 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
                     substr(m.text, 1, 4096) as text,
                     m.emoji, m.invite, m.linkPreview, m.sourceMessageId, m.attachmentUrls,
                     substr(src.text, 1, 4096) as sourceMessageText
-                FROM (
-                    SELECT conversationId, MAX(dateNs) AS maxDateNs
-                    FROM message
-                    WHERE contentType NOT IN (?, ?, ?, ?, ?, ?)
-                    GROUP BY conversationId
-                ) last
-                JOIN message m
-                    ON m.conversationId = last.conversationId
-                    AND m.dateNs = last.maxDateNs
-                    AND m.contentType NOT IN (?, ?, ?, ?, ?, ?)
+                FROM conversation c
+                JOIN message m ON m.id = c.lastMessageId
                 LEFT JOIN message src ON m.sourceMessageId = src.id
-                """,
-            arguments: StatementArguments(previewExcludedContentTypes + previewExcludedContentTypes)
+                """
         )
 
-    /// Same grouped-MAX shape as `lastMessageWithSourceCTE`, served
-    /// index-only by the partial `message_assistantJoinRequest_conversationId`
-    /// index.
+    /// Newest agent join request per conversation, resolved through the
+    /// denormalized `conversation.lastAgentJoinRequestId` pointer maintained
+    /// by the same trigger set as `lastMessageCTE`.
     nonisolated(unsafe) static let latestAgentJoinRequestCTE: CommonTableExpression<DBAgentJoinRequest> =
         CommonTableExpression<DBAgentJoinRequest>(
             named: "conversationAgentJoinRequest",
             sql: """
                 SELECT m.conversationId, m.text AS status, m.date
-                FROM (
-                    SELECT conversationId, MAX(dateNs) AS maxDateNs
-                    FROM message
-                    WHERE contentType = ?
-                    GROUP BY conversationId
-                ) last
-                JOIN message m
-                    ON m.conversationId = last.conversationId
-                    AND m.dateNs = last.maxDateNs
-                    AND m.contentType = ?
-                """,
-            arguments: [
-                MessageContentType.assistantJoinRequest.rawValue,
-                MessageContentType.assistantJoinRequest.rawValue,
-            ]
+                FROM conversation c
+                JOIN message m ON m.id = c.lastAgentJoinRequestId
+                """
         )
 
     static let localState: HasOneAssociation<DBConversation, ConversationLocalState> = hasOne(

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -10,6 +10,13 @@ final class SharedDatabaseMigrator: Sendable {
         let migrator = createMigrator()
         try migrator.migrate(database)
     }
+
+    /// Migrates only up to and including the named migration. Test hook for
+    /// exercising a later migration's backfill against pre-existing rows.
+    func migrate(database: any DatabaseWriter, upTo targetIdentifier: String) throws {
+        let migrator = createMigrator()
+        try migrator.migrate(database, upTo: targetIdentifier)
+    }
 }
 
 extension SharedDatabaseMigrator {
@@ -201,6 +208,7 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addAgentTemplateGenerationJoinIdempotencyKey",
                                    migrate: Self.addAgentTemplateGenerationJoinIdempotencyKey)
         migrator.registerMigration("addProfilePublishJobProfileUpdatedAt", migrate: Self.addProfilePublishJobProfileUpdatedAt)
+        migrator.registerMigration("addConversationLastMessagePointers", migrate: Self.addConversationLastMessagePointers)
 
         return migrator
     }
@@ -329,6 +337,197 @@ extension SharedDatabaseMigrator {
         try db.alter(table: "profilePublishJob") { t in
             t.add(column: "profileUpdatedAt", .datetime)
         }
+    }
+
+    /// Denormalized "newest message" pointers on `conversation`, maintained by
+    /// database triggers so the conversation-list read never derives them from
+    /// the message table. `lastMessageId` points at the newest preview-eligible
+    /// message (content types that surface in the list preview);
+    /// `lastAgentJoinRequestId` points at the newest assistantJoinRequest
+    /// message, which drives `agentJoinStatus`.
+    ///
+    /// Triggers rather than writer code because the database has multiple
+    /// writing processes (app and notification service extension) plus raw-SQL
+    /// paths that bypass record types: publish-time `UPDATE message SET id`
+    /// rewrites, and `ConversationWriter`'s replace-by-inviteTag
+    /// `save(onConflict: .replace)` which re-inserts the conversation row with
+    /// NULL pointers. Each of those cases has a dedicated trigger, so any
+    /// future write path keeps the pointers correct without knowing they exist.
+    ///
+    /// REPLACE conflict resolution deletes rows without firing delete triggers
+    /// (SQLite's default `recursive_triggers` is off). For conversation rows
+    /// that is fine: the messages themselves are cascade-deleted with the old
+    /// row, so NULL pointers on the replacement are correct until its next
+    /// write. For message rows (`id` and `clientMessageId` are both
+    /// unique-on-conflict-replace) the silent delete can leave a pointer at a
+    /// vanished id; `conversation_pointer_dangling_repair` recomputes on the
+    /// very insert that replaced the row, so a dangle never survives the
+    /// transaction that created it.
+    ///
+    /// The excluded content-type list is a frozen snapshot: changing which
+    /// types are preview-eligible requires a new migration that re-creates the
+    /// insert/delete/meta triggers and re-runs the backfill.
+    static func addConversationLastMessagePointers(_ db: Database) throws {
+        try db.alter(table: "conversation") { t in
+            t.add(column: "lastMessageId", .text)
+            t.add(column: "lastAgentJoinRequestId", .text)
+        }
+
+        try createConversationPointerBumpTriggers(db)
+        try createConversationPointerRepairTriggers(db)
+
+        try db.execute(sql: """
+            UPDATE conversation SET lastMessageId = (
+                SELECT id FROM message
+                WHERE conversationId = conversation.id
+                    AND contentType NOT IN \(conversationPointerExcludedContentTypes)
+                ORDER BY dateNs DESC LIMIT 1
+            ),
+            lastAgentJoinRequestId = (
+                SELECT id FROM message
+                WHERE conversationId = conversation.id AND contentType = 'assistantJoinRequest'
+                ORDER BY dateNs DESC LIMIT 1
+            )
+            """)
+    }
+
+    private static let conversationPointerExcludedContentTypes: String = """
+        ('update', 'assistantJoinRequest', 'connectionGrantRequest', \
+        'connectionInvocation', 'connectionInvocationResult', 'connectionPayload')
+        """
+
+    /// Appends are the overwhelmingly common case, so these insert triggers
+    /// are a single conditional pointer bump per insert.
+    private static func createConversationPointerBumpTriggers(_ db: Database) throws {
+        let excludedContentTypes = conversationPointerExcludedContentTypes
+        try db.execute(sql: """
+            CREATE TRIGGER conversation_pointer_message_insert
+            AFTER INSERT ON message
+            WHEN new.contentType NOT IN \(excludedContentTypes)
+            BEGIN
+                UPDATE conversation
+                SET lastMessageId = new.id
+                WHERE id = new.conversationId
+                    AND (lastMessageId IS NULL
+                         OR new.dateNs >= COALESCE((SELECT dateNs FROM message WHERE id = lastMessageId), -1));
+            END;
+
+            CREATE TRIGGER conversation_pointer_join_request_insert
+            AFTER INSERT ON message
+            WHEN new.contentType = 'assistantJoinRequest'
+            BEGIN
+                UPDATE conversation
+                SET lastAgentJoinRequestId = new.id
+                WHERE id = new.conversationId
+                    AND (lastAgentJoinRequestId IS NULL
+                         OR new.dateNs >= COALESCE((SELECT dateNs FROM message WHERE id = lastAgentJoinRequestId), -1));
+            END;
+            """)
+    }
+
+    /// The recompute subquery walks one conversation's (conversationId,
+    /// dateNs) index newest-first and only runs for the rare cases: deletes,
+    /// metadata rewrites, silent REPLACE deletions, and conversation row
+    /// re-insertion.
+    private static func createConversationPointerRepairTriggers(_ db: Database) throws {
+        let excludedContentTypes = conversationPointerExcludedContentTypes
+        try db.execute(sql: """
+            CREATE TRIGGER conversation_pointer_message_delete
+            AFTER DELETE ON message
+            BEGIN
+                UPDATE conversation
+                SET lastMessageId = (
+                    SELECT id FROM message
+                    WHERE conversationId = old.conversationId
+                        AND contentType NOT IN \(excludedContentTypes)
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                WHERE id = old.conversationId AND lastMessageId = old.id;
+                UPDATE conversation
+                SET lastAgentJoinRequestId = (
+                    SELECT id FROM message
+                    WHERE conversationId = old.conversationId AND contentType = 'assistantJoinRequest'
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                WHERE id = old.conversationId AND lastAgentJoinRequestId = old.id;
+            END;
+
+            CREATE TRIGGER conversation_pointer_message_id_update
+            AFTER UPDATE OF id ON message
+            WHEN new.id <> old.id
+            BEGIN
+                UPDATE conversation SET lastMessageId = new.id
+                WHERE id = new.conversationId AND lastMessageId = old.id;
+                UPDATE conversation SET lastAgentJoinRequestId = new.id
+                WHERE id = new.conversationId AND lastAgentJoinRequestId = old.id;
+            END;
+
+            CREATE TRIGGER conversation_pointer_message_meta_update
+            AFTER UPDATE OF dateNs, contentType ON message
+            WHEN new.dateNs <> old.dateNs OR new.contentType <> old.contentType
+            BEGIN
+                UPDATE conversation
+                SET lastMessageId = (
+                    SELECT id FROM message
+                    WHERE conversationId = new.conversationId
+                        AND contentType NOT IN \(excludedContentTypes)
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                WHERE id = new.conversationId;
+                UPDATE conversation
+                SET lastAgentJoinRequestId = (
+                    SELECT id FROM message
+                    WHERE conversationId = new.conversationId AND contentType = 'assistantJoinRequest'
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                WHERE id = new.conversationId;
+            END;
+
+            CREATE TRIGGER conversation_pointer_dangling_repair
+            AFTER INSERT ON message
+            WHEN EXISTS (
+                SELECT 1 FROM conversation c
+                WHERE c.id = new.conversationId
+                    AND ((c.lastMessageId IS NOT NULL
+                          AND NOT EXISTS (SELECT 1 FROM message m2 WHERE m2.id = c.lastMessageId))
+                      OR (c.lastAgentJoinRequestId IS NOT NULL
+                          AND NOT EXISTS (SELECT 1 FROM message m3 WHERE m3.id = c.lastAgentJoinRequestId)))
+            )
+            BEGIN
+                UPDATE conversation
+                SET lastMessageId = (
+                    SELECT id FROM message
+                    WHERE conversationId = new.conversationId
+                        AND contentType NOT IN \(excludedContentTypes)
+                    ORDER BY dateNs DESC LIMIT 1
+                ),
+                lastAgentJoinRequestId = (
+                    SELECT id FROM message
+                    WHERE conversationId = new.conversationId AND contentType = 'assistantJoinRequest'
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                WHERE id = new.conversationId;
+            END;
+
+            CREATE TRIGGER conversation_pointer_conversation_insert
+            AFTER INSERT ON conversation
+            WHEN new.lastMessageId IS NULL OR new.lastAgentJoinRequestId IS NULL
+            BEGIN
+                UPDATE conversation
+                SET lastMessageId = (
+                    SELECT id FROM message
+                    WHERE conversationId = new.id
+                        AND contentType NOT IN \(excludedContentTypes)
+                    ORDER BY dateNs DESC LIMIT 1
+                ),
+                lastAgentJoinRequestId = (
+                    SELECT id FROM message
+                    WHERE conversationId = new.id AND contentType = 'assistantJoinRequest'
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                WHERE id = new.id;
+            END;
+            """)
     }
 
     /// Additive, nullable column recording the `myProfile.updatedAt` of the self

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLastMessageCTETests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLastMessageCTETests.swift
@@ -3,14 +3,15 @@ import Foundation
 import GRDB
 import Testing
 
-/// Coverage for the grouped-MAX form of `lastMessageWithSourceCTE` and
-/// `latestAgentJoinRequestCTE` - the conversation-list previews that used
-/// to be computed with a per-row correlated subquery. These pin the
-/// observable semantics the rewrite must preserve: newest eligible message
-/// wins, excluded content types never surface as previews, reply/reaction
+/// Coverage for `lastMessageWithSourceCTE` and `latestAgentJoinRequestCTE`,
+/// now resolved through the denormalized `conversation.lastMessageId` /
+/// `lastAgentJoinRequestId` pointers. These pin the observable semantics
+/// every implementation must preserve: newest eligible message wins,
+/// excluded content types never surface as previews, reply/reaction
 /// previews carry the source message text, conversations without eligible
 /// messages fall back to `createdAt` ordering, and the newest agent join
-/// request drives `agentJoinStatus`.
+/// request drives `agentJoinStatus`. Trigger-level behavior is covered in
+/// `ConversationLastMessagePointerTests`.
 @Suite("Conversation Last Message CTE Tests", .serialized)
 struct ConversationLastMessageCTETests {
     private static let currentInboxId: String = "inbox-current"

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationLastMessagePointerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationLastMessagePointerTests.swift
@@ -1,0 +1,367 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for the denormalized `conversation.lastMessageId` /
+/// `lastAgentJoinRequestId` pointers and the `conversation_pointer_*`
+/// triggers that maintain them (see
+/// `SharedDatabaseMigrator.addConversationLastMessagePointers`). These pin
+/// the write-time invariant the conversation-list CTEs now rely on: after
+/// any sequence of message writes - inserts, deletes, publish-time id
+/// rewrites, metadata rewrites, and conversation row replacement - each
+/// pointer equals a fresh recompute of "newest eligible message".
+@Suite("Conversation Last Message Pointer Tests", .serialized)
+struct ConversationLastMessagePointerTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let otherInboxId: String = "inbox-other"
+
+    private static let excludedContentTypesSQL: String = """
+        ('update', 'assistantJoinRequest', 'connectionGrantRequest', \
+        'connectionInvocation', 'connectionInvocationResult', 'connectionPayload')
+        """
+
+    private static func seedInbox(db: Database) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBMember(inboxId: otherInboxId).save(db, onConflict: .ignore)
+        try DBInbox(
+            inboxId: currentInboxId,
+            clientId: "client-current",
+            createdAt: Date()
+        ).save(db, onConflict: .ignore)
+    }
+
+    private static func makeConversation(id: String, createdAt: Date) -> DBConversation {
+        DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: createdAt,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        )
+    }
+
+    private static func seedConversation(db: Database, id: String, createdAt: Date = Date()) throws {
+        try seedInbox(db: db)
+        try makeConversation(id: id, createdAt: createdAt).insert(db)
+    }
+
+    @discardableResult
+    private static func seedMessage(
+        db: Database,
+        conversationId: String,
+        id: String,
+        dateNs: Int64,
+        contentType: MessageContentType = .text,
+        text: String? = "body"
+    ) throws -> String {
+        try DBMessage(
+            id: id,
+            clientMessageId: id,
+            conversationId: conversationId,
+            senderId: otherInboxId,
+            dateNs: dateNs,
+            date: Date(timeIntervalSince1970: TimeInterval(dateNs) / 1_000_000_000),
+            sortId: dateNs,
+            status: .published,
+            messageType: .original,
+            contentType: contentType,
+            text: text,
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            attachmentUrls: [],
+            update: nil
+        ).insert(db)
+        return id
+    }
+
+    private static func pointers(_ db: Database, conversationId: String) throws -> (last: String?, joinRequest: String?) {
+        let row = try Row.fetchOne(
+            db,
+            sql: "SELECT lastMessageId, lastAgentJoinRequestId FROM conversation WHERE id = ?",
+            arguments: [conversationId]
+        )
+        return (row?["lastMessageId"], row?["lastAgentJoinRequestId"])
+    }
+
+    /// Recomputes both pointers from scratch and compares against the stored
+    /// columns for every conversation - the invariant the triggers maintain.
+    private static func expectPointersMatchRecompute(_ db: Database) throws {
+        let mismatches = try Row.fetchAll(
+            db,
+            sql: """
+                SELECT c.id FROM conversation c
+                WHERE c.lastMessageId IS NOT (
+                    SELECT id FROM message
+                    WHERE conversationId = c.id
+                        AND contentType NOT IN \(excludedContentTypesSQL)
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                OR c.lastAgentJoinRequestId IS NOT (
+                    SELECT id FROM message
+                    WHERE conversationId = c.id AND contentType = 'assistantJoinRequest'
+                    ORDER BY dateNs DESC LIMIT 1
+                )
+                """
+        )
+        #expect(mismatches.isEmpty)
+    }
+
+    // MARK: - Tests
+
+    @Test("Inserts move the pointer only for newer eligible messages")
+    func insertsMaintainPointer() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m2", dateNs: 200)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m-update", dateNs: 300, contentType: .update, text: nil)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m-old", dateNs: 50)
+            let pointers = try Self.pointers(db, conversationId: "convo-1")
+            #expect(pointers.last == "m2")
+            #expect(pointers.joinRequest == nil)
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Tied dateNs goes to the latest insert")
+    func tieGoesToLatestInsert() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m-tie-1", dateNs: 500)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m-tie-2", dateNs: 500)
+            let pointers = try Self.pointers(db, conversationId: "convo-1")
+            #expect(pointers.last == "m-tie-2")
+        }
+    }
+
+    @Test("Deleting the pointed message recomputes; deleting the rest clears")
+    func deleteRecomputes() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m2", dateNs: 200)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m-update", dateNs: 300, contentType: .update, text: nil)
+
+            try db.execute(sql: "DELETE FROM message WHERE id = 'm2'")
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == "m1")
+
+            try db.execute(sql: "DELETE FROM message WHERE id = 'm1'")
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == nil)
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Publish-time id rewrite carries both pointers along")
+    func publishIdRewriteFollowsPointer() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "client-m1", dateNs: 100)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "client-j1", dateNs: 200,
+                contentType: .assistantJoinRequest, text: AgentJoinStatus.pending.rawValue
+            )
+
+            // The same raw-SQL shape OutgoingMessageWriter uses after publish.
+            try db.execute(sql: "UPDATE message SET id = ? WHERE id = ?", arguments: ["xmtp-m1", "client-m1"])
+            try db.execute(sql: "UPDATE message SET id = ? WHERE id = ?", arguments: ["xmtp-j1", "client-j1"])
+
+            let pointers = try Self.pointers(db, conversationId: "convo-1")
+            #expect(pointers.last == "xmtp-m1")
+            #expect(pointers.joinRequest == "xmtp-j1")
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("contentType and dateNs rewrites recompute the pointer")
+    func metaRewriteRecomputes() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m2", dateNs: 200)
+
+            // The pointed message stops being preview-eligible.
+            try db.execute(sql: "UPDATE message SET contentType = 'update' WHERE id = 'm2'")
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == "m1")
+
+            // It becomes eligible again and is still the newest.
+            try db.execute(sql: "UPDATE message SET contentType = 'text' WHERE id = 'm2'")
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == "m2")
+
+            // An older message is re-stamped past the pointed one.
+            try db.execute(sql: "UPDATE message SET dateNs = 300 WHERE id = 'm1'")
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == "m1")
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Replacing the conversation row cascades its messages and clears pointers")
+    func conversationReplaceCascades() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+
+            // The same shape as ConversationWriter's replace-by-inviteTag save:
+            // REPLACE deletes the old row, the message cascade goes with it,
+            // and the re-inserted row correctly starts with NULL pointers.
+            try Self.makeConversation(id: "convo-1", createdAt: Date()).insert(db, onConflict: .replace)
+
+            let remaining = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM message WHERE conversationId = 'convo-1'")
+            #expect(remaining == 0)
+            let pointers = try Self.pointers(db, conversationId: "convo-1")
+            #expect(pointers.last == nil)
+            #expect(pointers.joinRequest == nil)
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Message REPLACE by clientMessageId repoints or repairs the pointer")
+    func messageReplaceHealsPointer() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m2", dateNs: 200)
+
+            // A stream echo replacing the optimistic row via the
+            // clientMessageId unique-on-conflict-replace: the old row is
+            // deleted without firing delete triggers, and the insert trigger
+            // repoints to the replacement.
+            try DBMessage(
+                id: "m2-real", clientMessageId: "m2", conversationId: "convo-1",
+                senderId: Self.otherInboxId, dateNs: 200, date: Date(),
+                sortId: 200, status: .published, messageType: .original,
+                contentType: .text, text: "body", emoji: nil, invite: nil,
+                linkPreview: nil, sourceMessageId: nil, attachmentUrls: [], update: nil
+            ).insert(db)
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == "m2-real")
+
+            // A replacement that is not preview-eligible cannot take the
+            // pointer itself; the dangling-repair trigger recomputes instead.
+            try DBMessage(
+                id: "m2-morphed", clientMessageId: "m2", conversationId: "convo-1",
+                senderId: Self.otherInboxId, dateNs: 200, date: Date(),
+                sortId: 200, status: .published, messageType: .original,
+                contentType: .update, text: nil, emoji: nil, invite: nil,
+                linkPreview: nil, sourceMessageId: nil, attachmentUrls: [], update: nil
+            ).insert(db)
+            #expect(try Self.pointers(db, conversationId: "convo-1").last == "m1")
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Join-request pointer recomputes independently on delete")
+    func joinRequestPointerRecomputesOnDelete() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "j1", dateNs: 200,
+                contentType: .assistantJoinRequest, text: AgentJoinStatus.failed.rawValue
+            )
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "j2", dateNs: 300,
+                contentType: .assistantJoinRequest, text: AgentJoinStatus.pending.rawValue
+            )
+
+            try db.execute(sql: "DELETE FROM message WHERE id = 'j2'")
+            let pointers = try Self.pointers(db, conversationId: "convo-1")
+            #expect(pointers.joinRequest == "j1")
+            #expect(pointers.last == "m1")
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Migration backfills pointers for rows that predate it")
+    func backfillPopulatesPreMigrationRows() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(
+            database: database,
+            upTo: "addProfilePublishJobProfileUpdatedAt"
+        )
+
+        try database.write { db in
+            try Self.seedConversation(db: db, id: "convo-1")
+            try Self.seedConversation(db: db, id: "convo-empty")
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m1", dateNs: 100)
+            try Self.seedMessage(db: db, conversationId: "convo-1", id: "m-update", dateNs: 300, contentType: .update, text: nil)
+            try Self.seedMessage(
+                db: db, conversationId: "convo-1", id: "j1", dateNs: 200,
+                contentType: .assistantJoinRequest, text: AgentJoinStatus.pending.rawValue
+            )
+        }
+
+        try SharedDatabaseMigrator.shared.migrate(database: database)
+
+        try database.read { db in
+            let pointers = try Self.pointers(db, conversationId: "convo-1")
+            #expect(pointers.last == "m1")
+            #expect(pointers.joinRequest == "j1")
+            let empty = try Self.pointers(db, conversationId: "convo-empty")
+            #expect(empty.last == nil)
+            #expect(empty.joinRequest == nil)
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+
+    @Test("Pointer matches recompute across a mixed write sequence")
+    func pointerMatchesRecomputeInvariant() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(db: db, id: "convo-a")
+            try Self.seedConversation(db: db, id: "convo-b")
+
+            for step in 0..<40 {
+                let conversationId = step.isMultiple(of: 2) ? "convo-a" : "convo-b"
+                let contentType: MessageContentType = switch step % 5 {
+                case 0: .update
+                case 1: .assistantJoinRequest
+                default: .text
+                }
+                let text: String? = contentType == .assistantJoinRequest ? AgentJoinStatus.pending.rawValue : "body"
+                try Self.seedMessage(
+                    db: db,
+                    conversationId: conversationId,
+                    id: "m\(step)",
+                    dateNs: Int64((step * 37) % 900),
+                    contentType: contentType,
+                    text: text
+                )
+                if step.isMultiple(of: 7) {
+                    try db.execute(sql: "DELETE FROM message WHERE id = ?", arguments: ["m\(max(0, step - 3))"])
+                }
+                if step.isMultiple(of: 11) {
+                    try db.execute(sql: "UPDATE message SET id = ? WHERE id = ?", arguments: ["m\(step)-published", "m\(step)"])
+                }
+            }
+
+            try Self.expectPointersMatchRecompute(db)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Makes "last message" a stored fact instead of a derived one. `conversation` gains denormalized `lastMessageId` / `lastAgentJoinRequestId` columns, backfilled by migration and maintained by `conversation_pointer_*` SQLite triggers; the conversation-list CTEs (`lastMessageCTE`, `lastMessageWithSourceCTE`, `latestAgentJoinRequestCTE`) become pointer joins - one primary-key lookup per conversation regardless of message volume.

This is the "denormalized split on last message <-> messages" follow-up to #1224 (which made the derived query fast but left it derived). Deliberately targeting `dev` for the next train, not 2.2.0.

## Why triggers, not writer code

The shared database has multiple writing processes (app + notification service extension) and raw-SQL paths that bypass the record layer. Every one of these keeps the pointers correct without knowing they exist:

- **Appends** (99% case): one conditional pointer bump - `~6us` per insert measured in sqlite, vs millisecond-scale XMTP decrypt/persist work.
- **Publish-time id rewrites** (`UPDATE message SET id = ?` in OutgoingMessageWriter): an `AFTER UPDATE OF id` trigger carries the pointer along.
- **dateNs/contentType rewrites**: recompute for that conversation.
- **Deletes** (incl. explosion sweeps and FK cascades): recompute only when the pointed row was deleted.
- **Silent REPLACE deletions**: `message.id` and `clientMessageId` are unique-on-conflict-replace, and REPLACE's internal delete does not fire delete triggers (`recursive_triggers` defaults off). A dangling-repair trigger recomputes on the very insert that replaced the row, so a dangle never survives its transaction.
- **Conversation row re-insertion** (replace-by-inviteTag in ConversationWriter): an `AFTER INSERT ON conversation` trigger recomputes; messages cascade-delete with the old row, so NULL pointers on the replacement are correct.

The excluded-content-type list is frozen inside the migration; changing preview eligibility later means a new migration that re-creates the triggers and re-runs the backfill.

## Effects on the sync-storm behavior

- List read cost is now O(conversations) with no dependence on message history depth (no grouped MAX, no index walk, no eligibility filter at read time).
- A historical append that is not a conversation's newest eligible message no longer changes what the list query returns - the pointer only moves when a preview actually changes. (The GRDB observation still refires on message-table writes; each refetch is now near-free. Delivery throttling remains available as a separate, purely-UI follow-up if profiling asks for it.)

## Testing

- New `ConversationLastMessagePointerTests` (10 tests): insert/tie/delete/id-rewrite/meta-rewrite semantics, REPLACE cascade + dangling-repair healing, migration backfill against pre-migration rows (via a partial-migrate test hook), and a pointer-equals-recompute invariant swept across a 40-step mixed write sequence.
- Existing `ConversationLastMessageCTETests` (6 tests) pass unchanged - same observable list semantics through the repository.
- Full ConvosCore suite: 1658 tests, green (one unrelated known flake, `VoiceMemoTranscriptionService` happy-path timeout, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787503607&installation_model_id=20076&pr_number=1228&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1228&signature=a6b6a4970d909e072ecc952c1ed08dd7e4eadc54fe07c415a6e491922c880ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Denormalize last-message pointers onto conversation rows, maintained by triggers
> - Adds a migration (`addConversationLastMessagePointers`) that introduces `lastMessageId` and `lastAgentJoinRequestId` columns to the `conversation` table and backfills them for existing rows.
> - Installs two trigger sets: bump triggers advance pointers on insert in constant time; repair triggers recompute pointers on deletes, metadata rewrites, and REPLACE operations.
> - Updates `DBConversation.lastMessageCTE` and `lastMessageWithSourceCTE` to resolve the newest preview-eligible message via the denormalized `lastMessageId` pointer instead of computing it with per-read filters and `MAX(dateNs)` aggregation.
> - Adds a new test suite in [ConversationLastMessagePointerTests.swift](https://github.com/xmtplabs/convos-ios/pull/1228/files#diff-a70b912249307dd1d4caac7ecb31274c1fb4b54731741f7ce6da5d028241b2ef) covering trigger invariants across inserts, deletes, tie-breaking, metadata rewrites, and REPLACE scenarios.
> - Behavioral Change: preview-eligible message resolution is now driven by trigger-maintained pointers; correctness depends on triggers firing correctly on all write paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebb10df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->