### PR TITLE
Time-box and isolate per-conversation prepare in batch catch-up

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -376,6 +376,10 @@ struct BatchCatchUp {
                     } catch is CancellationError {
                         return nil
                     } catch {
+                        // A conversation that fails for a non-transient reason
+                        // retries on every catch-up. That is bounded (one
+                        // prepare per batch) and the skipped counter surfaces
+                        // it; a retry-attempt cap is deliberate future work.
                         Log.error("catchup.conversation.skipped: \(group.id) prepare failed: \(error.localizedDescription); cursor not advanced, retrying next catch-up")
                         return nil
                     }
@@ -443,32 +447,51 @@ struct BatchCatchUp {
         )
     }
 
-    /// Races `operation` against a deadline. The losing side is cancelled,
-    /// though a cancelled libxmtp sync may keep running to completion in
-    /// the background - that is harmless because prepare is
-    /// transaction-free and every downstream persist is idempotent.
+    /// Races `operation` against a deadline without blocking on a hung
+    /// operation. Deliberately built on unstructured tasks and a
+    /// resume-once continuation: a task-group implementation cannot work
+    /// here because the group scope awaits all children after
+    /// `cancelAll()`, and cancellation is only cooperative - a hung
+    /// libxmtp sync that never checks it would hold the "timeout"
+    /// hostage, which is the exact failure this helper exists to bound.
+    ///
+    /// The losing operation is cancelled cooperatively and otherwise left
+    /// running detached until it completes; that is harmless because
+    /// prepare is transaction-free and every downstream persist is
+    /// idempotent.
     static func withTimeout<T: Sendable>(
         seconds: TimeInterval,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw BatchCatchUpPrepareTimeout()
-            }
+        let race = BatchCatchUpTimeoutRace<T>()
+        let operationTask = Task {
+            let result: Result<T, any Error>
             do {
-                guard let first = try await group.next() else {
-                    throw BatchCatchUpPrepareTimeout()
-                }
-                group.cancelAll()
-                return first
+                result = .success(try await operation())
             } catch {
-                group.cancelAll()
-                throw error
+                result = .failure(error)
             }
+            await race.finish(result)
+        }
+        let deadlineTask = Task {
+            do {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            } catch {
+                // Deadline cancelled: the operation already won.
+                return
+            }
+            operationTask.cancel()
+            await race.finish(.failure(BatchCatchUpPrepareTimeout()))
+        }
+        defer { deadlineTask.cancel() }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                Task { await race.register(continuation) }
+            }
+        } onCancel: {
+            operationTask.cancel()
+            deadlineTask.cancel()
+            Task { await race.finish(.failure(CancellationError())) }
         }
     }
 
@@ -520,6 +543,32 @@ struct BatchCatchUp {
                 WHERE conversationId = ?
             """, arguments: [conversationId])
             return value ?? 0
+        }
+    }
+}
+
+/// Resume-once state for `BatchCatchUp.withTimeout`'s two-sided race.
+/// Buffers a result that arrives before the continuation registers, and
+/// drops any result that arrives after the race already resolved (e.g.
+/// a timed-out operation eventually completing).
+private actor BatchCatchUpTimeoutRace<T: Sendable> {
+    private var continuation: CheckedContinuation<T, any Error>?
+    private var result: Result<T, any Error>?
+
+    func register(_ continuation: CheckedContinuation<T, any Error>) {
+        if let result {
+            continuation.resume(with: result)
+        } else {
+            self.continuation = continuation
+        }
+    }
+
+    func finish(_ newResult: Result<T, any Error>) {
+        if let continuation {
+            self.continuation = nil
+            continuation.resume(with: newResult)
+        } else if result == nil {
+            result = newResult
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -6,7 +6,16 @@ struct BatchCatchUpResult: Sendable {
     let conversationsProcessed: Int
     let messagesProcessed: Int
     let durationSeconds: Double
+    /// Conversations whose prepare phase timed out or failed and were
+    /// dropped from this batch. Their catch-up cursors did not advance,
+    /// so the next catch-up retries them.
+    let conversationsSkipped: Int
 }
+
+/// Thrown inside `BatchCatchUp.prepareAll` when a single conversation's
+/// prepare exceeds its time budget; always converted to a skip, never
+/// surfaced to callers.
+struct BatchCatchUpPrepareTimeout: Error {}
 
 /// Drains the backlog of conversation/message activity that arrived while
 /// the app was backgrounded or killed, *before* streams resume — so the
@@ -65,15 +74,27 @@ struct BatchCatchUp {
     private let conversationWriter: ConversationWriter
     private let messageWriter: IncomingMessageWriter
     private let databaseWriter: any DatabaseWriter
+    private let perConversationPrepareTimeout: TimeInterval
 
+    /// `perConversationPrepareTimeout` bounds each conversation's prepare
+    /// phase (XMTP group sync + backlog fetch + message prepare). Field
+    /// logs show a single hung group sync stalling a whole batch for
+    /// 35-150s while processing nothing; the budget converts that hang
+    /// into a skip whose cursor is retried on the next catch-up. 30s is
+    /// deliberately generous: prepare runs in parallel across
+    /// conversations, so the budget caps batch wall-clock at roughly one
+    /// budget rather than serializing, and a genuinely slow-but-working
+    /// initial sync on a large group stays under it.
     init(
         conversationWriter: ConversationWriter,
         messageWriter: IncomingMessageWriter,
-        databaseWriter: any DatabaseWriter
+        databaseWriter: any DatabaseWriter,
+        perConversationPrepareTimeout: TimeInterval = 30
     ) {
         self.conversationWriter = conversationWriter
         self.messageWriter = messageWriter
         self.databaseWriter = databaseWriter
+        self.perConversationPrepareTimeout = perConversationPrepareTimeout
     }
 
     /// Run the batch catch-up against the given client. `since` is the
@@ -111,11 +132,13 @@ struct BatchCatchUp {
         guard !groups.isEmpty else {
             let elapsed = CFAbsoluteTimeGetCurrent() - started
             Log.info("[PERF] catchup.batch.messages: \(Int(elapsed * 1000))ms convs=0 messages=0")
-            return BatchCatchUpResult(conversationsProcessed: 0, messagesProcessed: 0, durationSeconds: elapsed)
+            return BatchCatchUpResult(conversationsProcessed: 0, messagesProcessed: 0, durationSeconds: elapsed, conversationsSkipped: 0)
         }
 
         // Phase 1: parallel prepare (network-bound, transaction-free).
-        let prepared = try await prepareAll(
+        // Time-boxed per conversation; timed-out or failed conversations
+        // are skipped and retried by the next catch-up.
+        let (prepared, skippedCount) = await prepareAll(
             groups: groups,
             inboxId: inboxId,
             fetchFromBeginning: fetchFromBeginning
@@ -227,11 +250,12 @@ struct BatchCatchUp {
 
         let elapsed = CFAbsoluteTimeGetCurrent() - started
         let totalRegular = prepared.reduce(0) { $0 + $1.regularMessages.count }
-        Log.info("[PERF] catchup.batch.messages: \(Int(elapsed * 1000))ms convs=\(prepared.count) messages=\(totalRegular) supplementals=\(supplementalCount)")
+        Log.info("[PERF] catchup.batch.messages: \(Int(elapsed * 1000))ms convs=\(prepared.count) messages=\(totalRegular) supplementals=\(supplementalCount) skipped=\(skippedCount)")
         return BatchCatchUpResult(
             conversationsProcessed: prepared.count,
             messagesProcessed: totalRegular,
-            durationSeconds: elapsed
+            durationSeconds: elapsed,
+            conversationsSkipped: skippedCount
         )
     }
 
@@ -322,60 +346,129 @@ struct BatchCatchUp {
         )
     }
 
+    /// One conversation's failure or timeout never aborts the batch: the
+    /// entry is dropped (`skipped`), its cursor stays put, and the next
+    /// catch-up retries it. Before this isolation, a single throwing
+    /// prepare cancelled every sibling task and failed the whole batch.
     private func prepareAll(
         groups: [XMTPiOS.Group],
         inboxId: String,
         fetchFromBeginning: Bool
-    ) async throws -> [PreparedEntry] {
-        try await withThrowingTaskGroup(of: PreparedEntry.self) { [conversationWriter, messageWriter, databaseWriter] taskGroup in
+    ) async -> (entries: [PreparedEntry], skipped: Int) {
+        let timeout = perConversationPrepareTimeout
+        return await withTaskGroup(of: PreparedEntry?.self) { [conversationWriter, messageWriter, databaseWriter] taskGroup in
             for group in groups {
                 taskGroup.addTask {
-                    let preparedConv = try await conversationWriter.prepare(
-                        conversation: group,
-                        inboxId: inboxId
-                    )
-
-                    let perConvCursorNs: Int64
-                    if fetchFromBeginning {
-                        perConvCursorNs = 0
-                    } else {
-                        perConvCursorNs = try await Self.readCatchUpCursorNs(
-                            for: group.id,
-                            in: databaseWriter
-                        )
-                    }
-                    let allMessages = try await group.messages(afterNs: perConvCursorNs)
-
-                    var regularMessages: [IncomingMessageWriter.PreparedIncomingMessage] = []
-                    var supplementalMessages: [XMTPiOS.DecodedMessage] = []
-                    regularMessages.reserveCapacity(allMessages.count)
-                    for message in allMessages {
-                        switch Self.classify(message) {
-                        case .regular:
-                            let prepared = try await messageWriter.prepare(message: message)
-                            regularMessages.append(prepared)
-                        case .supplemental:
-                            supplementalMessages.append(message)
-                        case .skip:
-                            continue
+                    do {
+                        return try await Self.withTimeout(seconds: timeout) {
+                            try await Self.prepareEntry(
+                                group: group,
+                                inboxId: inboxId,
+                                fetchFromBeginning: fetchFromBeginning,
+                                conversationWriter: conversationWriter,
+                                messageWriter: messageWriter,
+                                databaseWriter: databaseWriter
+                            )
                         }
+                    } catch is BatchCatchUpPrepareTimeout {
+                        Log.warning("[PERF] catchup.conversation.skipped: \(group.id) prepare exceeded \(Int(timeout))s; cursor not advanced, retrying next catch-up")
+                        return nil
+                    } catch is CancellationError {
+                        return nil
+                    } catch {
+                        Log.error("catchup.conversation.skipped: \(group.id) prepare failed: \(error.localizedDescription); cursor not advanced, retrying next catch-up")
+                        return nil
                     }
-
-                    return PreparedEntry(
-                        group: group,
-                        conversation: preparedConv,
-                        regularMessages: regularMessages,
-                        supplementalMessages: supplementalMessages,
-                        maxFetchedNs: allMessages.map(\.sentAtNs).max()
-                    )
                 }
             }
 
             var results: [PreparedEntry] = []
-            for try await entry in taskGroup {
-                results.append(entry)
+            var skipped = 0
+            for await entry in taskGroup {
+                if let entry {
+                    results.append(entry)
+                } else {
+                    skipped += 1
+                }
             }
-            return results
+            return (results, skipped)
+        }
+    }
+
+    private static func prepareEntry(
+        group: XMTPiOS.Group,
+        inboxId: String,
+        fetchFromBeginning: Bool,
+        conversationWriter: ConversationWriter,
+        messageWriter: IncomingMessageWriter,
+        databaseWriter: any DatabaseWriter
+    ) async throws -> PreparedEntry {
+        let preparedConv = try await conversationWriter.prepare(
+            conversation: group,
+            inboxId: inboxId
+        )
+
+        let perConvCursorNs: Int64
+        if fetchFromBeginning {
+            perConvCursorNs = 0
+        } else {
+            perConvCursorNs = try await Self.readCatchUpCursorNs(
+                for: group.id,
+                in: databaseWriter
+            )
+        }
+        let allMessages = try await group.messages(afterNs: perConvCursorNs)
+
+        var regularMessages: [IncomingMessageWriter.PreparedIncomingMessage] = []
+        var supplementalMessages: [XMTPiOS.DecodedMessage] = []
+        regularMessages.reserveCapacity(allMessages.count)
+        for message in allMessages {
+            switch Self.classify(message) {
+            case .regular:
+                let prepared = try await messageWriter.prepare(message: message)
+                regularMessages.append(prepared)
+            case .supplemental:
+                supplementalMessages.append(message)
+            case .skip:
+                continue
+            }
+        }
+
+        return PreparedEntry(
+            group: group,
+            conversation: preparedConv,
+            regularMessages: regularMessages,
+            supplementalMessages: supplementalMessages,
+            maxFetchedNs: allMessages.map(\.sentAtNs).max()
+        )
+    }
+
+    /// Races `operation` against a deadline. The losing side is cancelled,
+    /// though a cancelled libxmtp sync may keep running to completion in
+    /// the background - that is harmless because prepare is
+    /// transaction-free and every downstream persist is idempotent.
+    static func withTimeout<T: Sendable>(
+        seconds: TimeInterval,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw BatchCatchUpPrepareTimeout()
+            }
+            do {
+                guard let first = try await group.next() else {
+                    throw BatchCatchUpPrepareTimeout()
+                }
+                group.cancelAll()
+                return first
+            } catch {
+                group.cancelAll()
+                throw error
+            }
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/BatchCatchUpTimeoutTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BatchCatchUpTimeoutTests.swift
@@ -1,0 +1,64 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Coverage for the per-conversation prepare time budget in
+/// `BatchCatchUp`. The batch-level skip semantics (a timed-out or
+/// failing conversation drops out of the batch without aborting it)
+/// are exercised through `withTimeout`, which is the exact racing
+/// primitive `prepareAll` wraps each conversation in.
+@Suite("Batch Catch-Up Timeout Tests")
+struct BatchCatchUpTimeoutTests {
+    @Test("Operation finishing under the budget returns its value")
+    func fastOperationReturns() async throws {
+        let value = try await BatchCatchUp.withTimeout(seconds: 5) { 42 }
+        #expect(value == 42)
+    }
+
+    @Test("Operation exceeding the budget throws the timeout error")
+    func slowOperationTimesOut() async {
+        await #expect(throws: BatchCatchUpPrepareTimeout.self) {
+            try await BatchCatchUp.withTimeout(seconds: 0.05) { () -> Int in
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+                return 1
+            }
+        }
+    }
+
+    @Test("Operation errors propagate unchanged, not as timeouts")
+    func operationErrorPropagates() async {
+        struct Boom: Error {}
+        await #expect(throws: Boom.self) {
+            try await BatchCatchUp.withTimeout(seconds: 5) { () -> Int in
+                throw Boom()
+            }
+        }
+    }
+
+    @Test("The losing operation is cancelled when the deadline fires")
+    func operationIsCancelledOnTimeout() async throws {
+        let cancelled = CancellationProbe()
+        _ = try? await BatchCatchUp.withTimeout(seconds: 0.05) { () -> Int in
+            do {
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+            } catch is CancellationError {
+                await cancelled.mark()
+                throw CancellationError()
+            }
+            return 1
+        }
+        // The cancellation lands asynchronously after the race resolves.
+        for _ in 0..<100 where await !cancelled.isMarked {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(await cancelled.isMarked)
+    }
+}
+
+private actor CancellationProbe {
+    private(set) var isMarked: Bool = false
+
+    func mark() {
+        isMarked = true
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/BatchCatchUpTimeoutTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/BatchCatchUpTimeoutTests.swift
@@ -35,6 +35,28 @@ struct BatchCatchUpTimeoutTests {
         }
     }
 
+    @Test("A cancellation-ignoring operation cannot hold the timeout hostage")
+    func nonCooperativeOperationStillTimesOut() async {
+        let started = Date()
+        await #expect(throws: BatchCatchUpPrepareTimeout.self) {
+            try await BatchCatchUp.withTimeout(seconds: 0.05) { () -> Int in
+                // Simulates a hung FFI sync: swallows cancellation and
+                // keeps running. The race must resolve at the deadline
+                // anyway, leaving this loop orphaned in the background.
+                let deadline = Date().addingTimeInterval(45)
+                while Date() < deadline {
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                }
+                return 1
+            }
+        }
+        // Generous bound: a task-group implementation would block on the
+        // 45s hung operation, while the race resolves at the 0.05s
+        // deadline plus scheduling lag - which reaches several seconds
+        // when the parallel suite saturates the cooperative pool.
+        #expect(Date().timeIntervalSince(started) < 20)
+    }
+
     @Test("The losing operation is cancelled when the deadline fires")
     func operationIsCancelledOnTimeout() async throws {
         let cancelled = CancellationProbe()


### PR DESCRIPTION
## Summary

Adds a per-conversation time budget (30s) to `BatchCatchUp.prepareAll` and isolates per-conversation failures so one bad conversation can no longer stall or abort an entire catch-up batch.

## Field evidence (Shane's logs, build 1178)

- `catchup.batch.messages` p90 was **16s**, worst **153.8s** (`convs=4 messages=1`) and **48.4s** (`convs=2 messages=0`) - batches spending near-total time in `prepareAll`'s network-bound per-conversation XMTP sync while producing nothing, against a network that was timing out asset/profile fetches all day.
- While a batch stalls, the app feels broken: stale list, profile-load timeouts, and conversation opens crawling under sync contention (one message prime took 21s).

## Changes

- Each conversation's prepare phase (group sync + backlog fetch + message prepare) races a **30s budget** (`withTimeout`, injectable via init for tests). Budget rationale is documented at the init: prepare runs in parallel, so the budget caps batch wall-clock at roughly one budget rather than serializing.
- **Failure isolation**: `prepareAll` used a throwing task group, so a single conversation's error cancelled every sibling and failed the whole batch. Timed-out or failing conversations are now skipped; everything else persists normally.
- **Safe retry semantics**: a skipped conversation's catch-up cursor does not advance, so the next catch-up retries it. Prepare is transaction-free and downstream persists are idempotent, so a cancelled-but-still-running libxmtp sync completing later is harmless.
- Observability: the batch PERF line gains `skipped=K`, a per-conversation `catchup.conversation.skipped` warning names the conversation and reason, and `BatchCatchUpResult` gains `conversationsSkipped`.

## Testing

- New `BatchCatchUpTimeoutTests` (4 tests): fast-path value, deadline timeout, error passthrough (not converted to timeout), and cancellation of the losing operation.
- Full ConvosCore suite: **1652/1652 passed**, including the Docker-backed `BatchCatchUpIntegrationTests` that pin batch persist/cursor semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787505816&installation_model_id=20076&pr_number=1229&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1229&signature=46da7c3dfcd34301588112feef8e10e0fbcf3de8bc655b248e53befe1db76fc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Time-box and isolate per-conversation prepare phase in batch catch-up
> - Wraps each conversation's prepare work in a `withTimeout` helper (default 30s), so a slow or hung conversation no longer blocks or aborts the entire batch.
> - Failures and timeouts in `prepareAll` now skip the affected conversation (returning `nil`) instead of throwing, leaving its cursor unadvanced and letting the batch continue.
> - Adds a new `conversationsSkipped` field to `BatchCatchUpResult` to report how many conversations were dropped during prepare.
> - Introduces `BatchCatchUpTimeoutRace` actor to coordinate a two-task race, ensuring the continuation is resumed exactly once regardless of which side wins.
> - Risk: conversations that previously caused the batch to fail hard will now silently skip; their messages will not be caught up until the next batch run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0708da4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->