### PR TITLE
chore: bump convos-releases flake input (Version Alignment needs check-versions)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784671855,
-        "narHash": "sha256-J+LsHELIMpsQx/c2tH4HiKiFy3Uj37KxwExpFvYkX+8=",
+        "lastModified": 1784988777,
+        "narHash": "sha256-dcF61u/iHQYnetqddHC6L78lELIBOaTdEB6LdY6jwEw=",
         "owner": "xmtplabs",
         "repo": "convos-releases",
-        "rev": "7b77115b25f6b1bf2fb72881b76965c2545dd6dd",
+        "rev": "5cfa214ae04ddac73f483f9589a52bb46bee49bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Why

The Version Alignment check has two version axes ([memory'd gotcha](https://github.com/xmtplabs/convos-releases#): `@main` pins workflow orchestration; **flake.lock pins the `train` CLI**). The sibling-checkout 404 was fixed in [convos-releases#37](https://github.com/xmtplabs/convos-releases/pull/37) (workflow axis), but this repo's flake pin `7b77115` (2026-07-21) **predates the `train check-versions` subcommand** (landed 2026-07-23 in [convos-releases#34](https://github.com/xmtplabs/convos-releases/pull/34)) — so the check's next failure would be `unknown command 'check-versions'` from the dev shell's stale `train`.

## What

`nix flake update convos-releases`: `7b77115` (2026-07-21) → `5cfa214` (current main). Brings in the `check-versions` and `notify` CLI additions. Verified the `train` binary at the new pin has `check-versions`.

(convos-client's pin from 2026-07-24 already includes it — no bump needed there.)

## After merge

Re-run the Version Alignment check on open PRs (e.g. #1231) — the check's self-checkout uses the PR **merge ref**, so they pick up dev's flake.lock without rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787581304&installation_model_id=20076&pr_number=1232&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1232&signature=0bcea25882d8aa92cf3b5c4fd03be858271e7deeaece31d80ab1f214a70d3eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `convos-releases` flake input to align versions for `check-versions`
> Updates [flake.lock](https://github.com/xmtplabs/convos-ios/pull/1232/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to pull in the latest `convos-releases` flake input. This is required for version alignment with the `check-versions` tooling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b438e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->