### PR TITLE
fix(renovate): actually enable the beta nix manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "labels": ["dependencies"],
-  "enabledManagers": ["custom.regex", "nix"],
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "enabledManagers": [
+    "custom.regex",
+    "nix"
+  ],
+  "nix": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",
       "description": "Match the libxmtp tag in Package.swift `revision:` pins. Recognizes both -dev and -nightly tags as currentValue; allowedVersions in the package rule restricts update candidates to nightly only.",
-      "managerFilePatterns": ["/Package\\.swift$/"],
+      "managerFilePatterns": [
+        "/Package\\.swift$/"
+      ],
       "matchStrings": [
         "url:\\s*\"https://github\\.com/xmtp/libxmtp\\.git\"[\\s\\S]*?revision:\\s*\"(?<currentValue>ios-[^\"]+)\""
       ],
@@ -18,7 +30,9 @@
     {
       "customType": "regex",
       "description": "Match Package.resolved's libxmtp entry. SPM stores the tag under `branch` and the resolved commit SHA under `revision`; both must be updated together, captured here as currentValue + currentDigest.",
-      "managerFilePatterns": ["/Package\\.resolved$/"],
+      "managerFilePatterns": [
+        "/Package\\.resolved$/"
+      ],
       "matchStrings": [
         "\"identity\"\\s*:\\s*\"libxmtp\"[\\s\\S]*?\"branch\"\\s*:\\s*\"(?<currentValue>ios-[^\"]+)\"[\\s\\S]*?\"revision\"\\s*:\\s*\"(?<currentDigest>[a-f0-9]{40})\""
       ],
@@ -29,12 +43,18 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["nix"],
+      "matchManagers": [
+        "nix"
+      ],
       "enabled": false
     },
     {
-      "matchManagers": ["nix"],
-      "matchDepNames": ["convos-releases"],
+      "matchManagers": [
+        "nix"
+      ],
+      "matchDepNames": [
+        "convos-releases"
+      ],
       "enabled": true,
       "groupName": "convos-releases",
       "branchTopic": "convos-releases",
@@ -44,7 +64,9 @@
       "rebaseWhen": "behind-base-branch"
     },
     {
-      "matchPackageNames": ["https://github.com/xmtp/libxmtp"],
+      "matchPackageNames": [
+        "https://github.com/xmtp/libxmtp"
+      ],
       "groupName": "libxmtp",
       "branchTopic": "libxmtp",
       "prConcurrentLimit": 1,
@@ -55,8 +77,13 @@
       "commitMessageExtra": "to {{newValue}}"
     },
     {
-      "matchPackageNames": ["https://github.com/xmtp/libxmtp"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": [
+        "https://github.com/xmtp/libxmtp"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "automerge": true,
       "platformAutomerge": true
     }


### PR DESCRIPTION
## Why Renovate never opened a convos-releases flake bump

The config was right in spirit — `"nix"` in `enabledManagers` plus purpose-built `packageRules` for the `convos-releases` input. But **`enabledManagers` only selects which managers run; it does not override a manager's own default config**, and the nix manager is beta with `enabled: false` by default ([renovate `lib/modules/manager/nix/index.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/nix/index.ts)). Extraction short-circuits with "manager is disabled" ([`manager-files.ts`](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/extract/manager-files.ts)) — which is why the Dependency Dashboard shows **zero nix dependencies** and the rules never had anything to act on.

## Fix

One line: `"nix": { "enabled": true }`. The existing per-dep rules (blanket nix disable + convos-releases-only enable) now take effect as originally intended: Renovate should detect the `convos-releases` flake input (git-refs) and open bump PRs to `dev` when convos-releases main moves.

## Why this matters

Release branches inherit dev's `flake.lock` at cut time, and promote runs the `train` from that pin — the 2.2.0 Android promote ran a 2026-07-16 pin and silently skipped the release back-merge guard (fixed manually in convos-client#156). Fresh dev pins prevent the recurrence.

**Caveat to watch on the first Renovate run:** regenerating `flake.lock` requires Renovate to run `nix` — if the Mend-hosted app lacks nix support, the PR will show an artifact-update error and we'll need the workflow-based fallback instead. Tick the "run again" box on the Dependency Dashboard after merging to test immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787596611&installation_model_id=20076&pr_number=1234&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1234&signature=8547be617ad481b952a0903a4544d0c71589851191e3dc32370b54795f214ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable the beta Nix manager in Renovate config
> Adds `"nix": { "enabled": true }` to [renovate.json](https://github.com/xmtplabs/convos-ios/pull/1234/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) to activate Renovate's beta Nix dependency manager. Also reformats several array fields to multi-line style for readability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c0a9ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->