### PR TITLE
[SM PROTOTYPE - DO NOT MERGE] Group Desktop

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -129,9 +129,7 @@ struct AppSettingsView: View {
         Section {
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
                 Text("Convos")
-                    .font(.convosTitle)
-                    .tracking(Font.convosTitleTracking)
-                    .foregroundStyle(.colorTextPrimary)
+                    .convosTextStyle(.display)
             }
             .padding(.horizontal, DesignConstants.Spacing.step2x)
             .listRowBackground(Color.clear)

--- a/Convos/App Settings/ConnectionsListView.swift
+++ b/Convos/App Settings/ConnectionsListView.swift
@@ -41,12 +41,9 @@ struct ConnectionsListView: View {
         Section {
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
                 Text("Connections")
-                    .font(.convosTitle)
-                    .tracking(Font.convosTitleTracking)
-                    .foregroundStyle(.colorTextPrimary)
+                    .convosTextStyle(.display)
                 Text("Share services with conversations")
-                    .font(.subheadline)
-                    .foregroundStyle(.colorTextPrimary)
+                    .convosTextStyle(.supportingPrimary)
             }
             .padding(.horizontal, DesignConstants.Spacing.step2x)
             .listRowBackground(Color.clear)

--- a/Convos/App Settings/CustomizeSettingsView.swift
+++ b/Convos/App Settings/CustomizeSettingsView.swift
@@ -20,12 +20,9 @@ struct CustomizeSettingsView: View {
             Section {
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
                     Text("Customize")
-                        .font(.convosTitle)
-                        .tracking(Font.convosTitleTracking)
-                        .foregroundStyle(.colorTextPrimary)
+                        .convosTextStyle(.display)
                     Text("Your new convos")
-                        .font(.subheadline)
-                        .foregroundStyle(.colorTextPrimary)
+                        .convosTextStyle(.supportingPrimary)
                 }
                 .padding(.horizontal, DesignConstants.Spacing.step2x)
                 .listRowBackground(Color.clear)
@@ -74,32 +71,11 @@ struct CustomizeSettingsView: View {
         isOn: Binding<Bool>,
         toggleAccessibilityIdentifier: String
     ) -> some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
-            Image(systemName: symbolName)
-                .font(.headline)
-                .padding(.horizontal, DesignConstants.Spacing.step2x)
-                .padding(.vertical, 10.0)
-                .foregroundStyle(.colorTextPrimary)
-                .frame(width: 40.0, height: 40.0)
-                .background(
-                    RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
-                        .fill(Color.colorFillMinimal)
-                        .aspectRatio(1.0, contentMode: .fit)
-                )
-
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                Text(title)
-                    .font(.body)
-                    .foregroundStyle(.colorTextPrimary)
-
-                Text(subtitle)
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
-                    .lineLimit(3)
-            }
-
-            Spacer()
-
+        ConvosSettingsRow(
+            iconSystemName: symbolName,
+            title: title,
+            subtitle: subtitle
+        ) {
             Toggle("", isOn: isOn)
                 .labelsHidden()
                 .accessibilityIdentifier(toggleAccessibilityIdentifier)

--- a/Convos/Contacts/ContactRowView.swift
+++ b/Convos/Contacts/ContactRowView.swift
@@ -17,20 +17,21 @@ struct ContactRowView: View {
     var body: some View {
         // Dim blocked contacts to distinguish from normal contacts.
         let isBlocked: Bool = contact.isBlocked
-        let rowOpacity: Double = isBlocked ? 0.45 : 1.0
+        let rowOpacity: Double = isBlocked ? DesignConstants.Opacity.subdued : 1.0
         HStack(spacing: DesignConstants.Spacing.step3x) {
             ContactAvatarView(contact: contact)
-                .frame(width: 56.0, height: 56.0)
+                .frame(
+                    width: DesignConstants.ImageSizes.listAvatar,
+                    height: DesignConstants.ImageSizes.listAvatar
+                )
 
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
                 Text(contact.resolvedDisplayName)
-                    .font(.body)
-                    .foregroundStyle(.colorTextPrimary)
+                    .convosTextStyle(.body)
                     .lineLimit(1)
                 if !subtitle.isEmpty {
                     Text(subtitle)
-                        .font(.subheadline)
-                        .foregroundStyle(.colorTextSecondary)
+                        .convosTextStyle(.supporting)
                         .lineLimit(1)
                 }
             }
@@ -45,7 +46,7 @@ struct ContactRowView: View {
         .contentShape(Rectangle())
         .opacity(rowOpacity)
         .accessibilityIdentifier("contact-row-\(contact.inboxId)")
-        // VoiceOver doesn't surface the 0.45 opacity dim or the "blocked"
+        // VoiceOver does not surface the subdued opacity or the "blocked"
         // pill on its own; the hint ensures users with VoiceOver enabled
         // know the contact is blocked before activating the row.
         .accessibilityHint(isBlocked ? "This contact is blocked" : "")
@@ -54,14 +55,7 @@ struct ContactRowView: View {
     /// "blocked" pill -- same `.colorFillMinimal` capsule + caption2 style
     /// as the picker's "blocked" badge so both surfaces read identically.
     private var blockedBadge: some View {
-        Text("blocked")
-            .font(.caption2)
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .padding(.vertical, 4.0)
-            .background(
-                Capsule().fill(.colorFillMinimal)
-            )
+        ConvosBadge(label: "blocked", tone: .subtle, size: .compact)
     }
 }
 

--- a/Convos/Contacts/ContactsPickerRow.swift
+++ b/Convos/Contacts/ContactsPickerRow.swift
@@ -10,11 +10,14 @@ struct ContactsPickerRow: View {
 
     var body: some View {
         let isDisabled: Bool = row.isAlreadyInChat
-        let opacity: Double = isDisabled ? 0.45 : 1.0
+        let opacity: Double = isDisabled ? DesignConstants.Opacity.subdued : 1.0
         Button(action: onTap) {
             HStack(spacing: DesignConstants.Spacing.step3x) {
                 ContactAvatarView(contact: row.contact)
-                    .frame(width: 56.0, height: 56.0)
+                    .frame(
+                        width: DesignConstants.ImageSizes.listAvatar,
+                        height: DesignConstants.ImageSizes.listAvatar
+                    )
 
                 ContactsPickerRowText(contact: row.contact, subtitle: row.subtitle)
 
@@ -48,13 +51,11 @@ private struct ContactsPickerRowText: View {
     var body: some View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
             Text(contact.resolvedDisplayName)
-                .font(.body)
-                .foregroundStyle(.colorTextPrimary)
+                .convosTextStyle(.body)
                 .lineLimit(1)
             if !subtitle.isEmpty {
                 Text(subtitle)
-                    .font(.subheadline)
-                    .foregroundStyle(.colorTextSecondary)
+                    .convosTextStyle(.supporting)
                     .lineLimit(1)
             }
         }
@@ -78,14 +79,7 @@ private struct ContactsPickerRowAccessory: View {
     }
 
     private var inChatBadge: some View {
-        Text("in chat")
-            .font(.caption2)
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .padding(.vertical, 4.0)
-            .background(
-                Capsule().fill(.colorFillMinimal)
-            )
+        ConvosBadge(label: "in chat", tone: .subtle, size: .compact)
     }
 
     private var selectedIndicator: some View {
@@ -113,7 +107,7 @@ private struct ContactsPickerRowAccessory: View {
         displayName: "Convo Agent",
         agentVerification: .verified(.convos)
     )
-    return VStack(alignment: .leading, spacing: 12.0) {
+    return VStack(alignment: .leading, spacing: DesignConstants.Spacing.step3x) {
         ContactsPickerRow(
             row: .init(id: alice.inboxId, contact: alice, isAlreadyInChat: false, subtitle: "Bike Trip 2026"),
             isSelected: false,

--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -29,7 +29,11 @@ struct NewConversationView: View {
     /// indicator out of the status bar (mirrors the Chats tab's pushed
     /// conversation, which sets this on its own `ConversationPresenter`).
     var insetsTopSafeArea: Bool = false
+    /// Optional draft used when a message on a group chat opens a private
+    /// side conversation with that group's agent.
+    var initialMessageText: String?
     @State private var hasShownScannerOnAppear: Bool = false
+    @State private var didApplyInitialMessage: Bool = false
     @State private var sidebarWidth: CGFloat = 0.0
     @State private var focusCoordinator: FocusCoordinator = FocusCoordinator(horizontalSizeClass: nil)
     @State private var navState: NewConversationNavigatorImpl = .init()
@@ -86,6 +90,14 @@ struct NewConversationView: View {
                             onInviteShared: viewModel.markInviteShared
                         ) {
                             EmptyView()
+                        }
+                        .onAppear {
+                            guard !didApplyInitialMessage,
+                                  let initialMessageText,
+                                  conversationViewModel.messageText.isEmpty else { return }
+                            didApplyInitialMessage = true
+                            conversationViewModel.messageText = initialMessageText
+                            coordinator.moveFocus(to: .message)
                         }
                     } else {
                         EmptyView()

--- a/Convos/Conversation Detail/AddToConversationMenu.swift
+++ b/Convos/Conversation Detail/AddToConversationMenu.swift
@@ -18,7 +18,7 @@ struct AddToConversationMenu: View {
 
     private var agentSubtitle: String {
         if isAgentJoinPending { return "Joining…" }
-        return "Made for this group"
+        return "Bring your own power"
     }
 
     private var labelColor: Color {
@@ -38,7 +38,7 @@ struct AddToConversationMenu: View {
             .accessibilityIdentifier("context-menu-add-from-contacts")
 
             Button(action: onInviteAgent) {
-                Text("New agent")
+                Text("Invite your agent")
                 Text(agentSubtitle)
                 Image("addAgentIcon")
                     .renderingMode(.template)

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -12,47 +12,29 @@ struct FeatureRowItem<AccessoryView: View>: View {
     var iconForegroundColor: Color = .white
     @ViewBuilder let accessoryView: () -> AccessoryView
 
-    private var hasIcon: Bool {
-        imageName != nil || symbolName != nil
-    }
-
-    var image: Image? {
-        if let imageName {
-            Image(imageName)
-        } else if let symbolName {
-            Image(systemName: symbolName)
-        } else {
-            nil
-        }
-    }
-
     var body: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
-            if let image {
-                Group {
-                    image
-                        .font(.headline)
-                        .padding(.horizontal, DesignConstants.Spacing.step2x)
-                        .padding(.vertical, DesignConstants.Spacing.step3x)
-                        .foregroundStyle(iconForegroundColor)
-                }
-                .frame(width: DesignConstants.Spacing.step10x, height: DesignConstants.Spacing.step10x)
-                .background(
-                    RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
-                        .fill(iconBackgroundColor)
-                        .aspectRatio(1.0, contentMode: .fit)
+            if let imageName {
+                ConvosIconTile(
+                    imageName: imageName,
+                    foregroundColor: iconForegroundColor,
+                    backgroundColor: iconBackgroundColor
+                )
+            } else if let symbolName {
+                ConvosIconTile(
+                    systemName: symbolName,
+                    foregroundColor: iconForegroundColor,
+                    backgroundColor: iconBackgroundColor
                 )
             }
 
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
                 Text(title)
-                    .font(.body)
-                    .foregroundStyle(.colorTextPrimary)
+                    .convosTextStyle(.body)
 
                 if let subtitle {
                     Text(subtitle)
-                        .font(.footnote)
-                        .foregroundStyle(.colorTextSecondary)
+                        .convosTextStyle(.detail)
                         .lineLimit(1)
                 }
             }

--- a/Convos/Conversation Detail/ConversationPager.swift
+++ b/Convos/Conversation Detail/ConversationPager.swift
@@ -5,11 +5,12 @@ import SwiftUIIntrospect
 enum ConversationPagerPage: Int, CaseIterable, Identifiable {
     case messages
     case things
+    case agent
 
     var id: Int { rawValue }
 }
 
-struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
+struct ConversationPager<MessagesPage: View, ThingsPage: View, AgentPage: View>: View {
     @Binding var selectedPage: ConversationPagerPage
     /// Whether the dots are mounted at all. Drives the `safeAreaInset`
     /// itself, so flipping this resizes the pager content — only set it
@@ -30,6 +31,7 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
     var scrollingDisabled: Bool = false
     @ViewBuilder let messagesPage: () -> MessagesPage
     @ViewBuilder let thingsPage: () -> ThingsPage
+    @ViewBuilder let agentPage: () -> AgentPage
 
     var body: some View {
         GeometryReader { proxy in
@@ -42,6 +44,10 @@ struct ConversationPager<MessagesPage: View, ThingsPage: View>: View {
                     thingsPage()
                         .frame(width: proxy.size.width, height: proxy.size.height)
                         .id(ConversationPagerPage.things)
+
+                    agentPage()
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .id(ConversationPagerPage.agent)
                 }
                 .scrollTargetLayout()
             }
@@ -113,6 +119,13 @@ private struct ConversationPagerDots: View {
                 bottomTrailing: 2.0,
                 topTrailing: 2.0
             ))
+        case .agent:
+            return UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 8.0,
+                bottomLeading: 8.0,
+                bottomTrailing: 8.0,
+                topTrailing: 2.0
+            ))
         }
     }
 
@@ -120,6 +133,7 @@ private struct ConversationPagerDots: View {
         switch page {
         case .messages: return "Messages"
         case .things: return "Things"
+        case .agent: return "Agent"
         }
     }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -79,8 +79,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var navState: ConversationNavigatorImpl = .init()
     @State private var navigator: ConversationCollector?
     @State private var showingGroupOutputs: Bool = false
-    @State private var agentSideChatViewModel: NewConversationViewModel?
-    @State private var agentSideChatDraft: String?
+    @State private var agentSideChatDraft: String = ""
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     private func ensureNavigator() {
@@ -577,7 +576,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
             dotsHidden: contextMenuState.isPresented,
             scrollingDisabled: contextMenuState.isPresented,
             messagesPage: { messagesView },
-            thingsPage: { thingsPage }
+            thingsPage: { thingsPage },
+            agentPage: { agentPage }
         )
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
             isKeyboardVisible = true
@@ -588,6 +588,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .onChange(of: pagerSelectedPage) { _, newPage in
             if newPage != .things {
                 focusCoordinator.dismissThingsSearchIfNeeded()
+            }
+            if newPage == .messages {
+                seedAgentMentionIfNeeded()
             }
         }
         .onChange(of: viewModel.messageText) { _, _ in
@@ -646,19 +649,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
             newConversationSheet(viewModel)
         }
-        .sheet(
-            item: $agentSideChatViewModel,
-            onDismiss: {
-                agentSideChatDraft = nil
-            },
-            content: { sideChatViewModel in
-                NewConversationView(
-                    viewModel: sideChatViewModel,
-                    profileSettingsViewModel: profileSettingsViewModel,
-                    initialMessageText: agentSideChatDraft
-                )
-            }
-        )
         .sheet(isPresented: $showingGroupOutputs) {
             NavigationStack {
                 AgentFilesLinksView(
@@ -995,6 +985,14 @@ private extension ConversationView {
         )
     }
 
+    var agentPage: some View {
+        GroupAgentSideChatView(
+            agentName: groupAgent?.profile.displayName ?? "Mountain Guide",
+            groupName: groupDisplayName,
+            draft: $agentSideChatDraft
+        )
+    }
+
     var isGroupConversation: Bool {
         let humanCount = viewModel.conversation.members.filter { !$0.isAgent }.count
         return humanCount >= 2 && viewModel.conversation.members.count >= 3
@@ -1012,6 +1010,7 @@ private extension ConversationView {
 
     func configureMessageWorkMenu() {
         contextMenuState.isWorkMenuEnabled = isGroupConversation
+        contextMenuState.workAgentName = groupAgent?.profile.displayName ?? "Mountain Guide"
         contextMenuState.onWorkAction = { [weak viewModel] action, message in
             guard viewModel != nil else { return }
             handleMessageWorkAction(action, message: message)
@@ -1184,26 +1183,27 @@ private extension ConversationView {
         withAnimation(.easeInOut(duration: 0.25)) {
             pagerSelectedPage = .messages
         }
-        viewModel.messageText = draft
+        let mention = "@\(groupAgent?.profile.displayName ?? "Mountain Guide")"
+        viewModel.messageText = draft.hasPrefix(mention) ? draft : "\(mention) \(draft)"
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
             focusCoordinator.moveFocus(to: .message)
         }
     }
 
     func openAgentSideChat(draft: String) {
-        guard let groupAgent else {
+        guard groupAgent != nil else {
             viewModel.presentAgentBuilder()
             return
         }
-
         agentSideChatDraft = draft
-        agentSideChatViewModel = NewConversationViewModel(
-            session: viewModel.session,
-            mode: .newConversationWithMembers(
-                initialMemberInboxIds: [groupAgent.profile.inboxId]
-            ),
-            coreActions: viewModel.coreActions
-        )
+        withAnimation(.easeInOut(duration: 0.25)) {
+            pagerSelectedPage = .agent
+        }
+    }
+
+    func seedAgentMentionIfNeeded() {
+        guard let groupAgent, viewModel.messageText.isEmpty else { return }
+        viewModel.messageText = "@\(groupAgent.profile.displayName) "
     }
 
     /// What the composer needs to draw the bubble: the level, and the tap.

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -78,6 +78,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var presentingAddFromContactsPicker: Bool = false
     @State private var navState: ConversationNavigatorImpl = .init()
     @State private var navigator: ConversationCollector?
+    @State private var showingGroupOutputs: Bool = false
+    @State private var agentSideChatViewModel: NewConversationViewModel?
+    @State private var agentSideChatDraft: String?
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     private func ensureNavigator() {
@@ -528,31 +531,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .accessibilityIdentifier("scan-invite-button")
     }
 
-    private var debugAttachmentTapHandler: (() -> Void)? {
-        guard FeatureFlags.shared.isDebugInjectorEnabled else { return nil }
-        return { showingDebugInjector = true }
-    }
-
-    private var debugInjectorBinding: Binding<Bool> {
-        guard FeatureFlags.shared.isDebugInjectorEnabled else { return .constant(false) }
-        return $showingDebugInjector
-    }
-
-    private var thingsPage: some View {
-        AgentFilesLinksView(
-            conversationId: viewModel.conversation.id,
-            repository: viewModel.makeAgentFilesLinksRepository(),
-            members: viewModel.conversation.members,
-            usesInlineHeader: true,
-            profileSheetContent: profileSheetForMember,
-            focusBinding: $focusState
-        )
-    }
-
-    private func profileSheetForMember(_ member: ConversationMember) -> AnyView {
-        AnyView(MemberContactDetailSheetContent(viewModel: viewModel, member: member, profileSettingsViewModel: profileSettingsViewModel))
-    }
-
     /// Approval sheet for the pending capability request, opened from the
     /// transcript's connect pill. Extracted to keep `body`'s type-check time
     /// in budget. The layout can clear while the sheet is up (another device
@@ -622,10 +600,12 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .onAppear {
             ensureNavigator()
             navState.markScreenAppeared()
+            configureMessageWorkMenu()
             viewModel.onConversationAppeared()
         }
         .onDisappear {
             focusCoordinator.dismissThingsSearchIfNeeded()
+            contextMenuState.onWorkAction = nil
             viewModel.onConversationDisappeared()
             navigator?.closed(context: navState.closeContext())
         }
@@ -666,6 +646,38 @@ struct ConversationView<MessagesBottomBar: View>: View {
         .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
             newConversationSheet(viewModel)
         }
+        .sheet(
+            item: $agentSideChatViewModel,
+            onDismiss: {
+                agentSideChatDraft = nil
+            },
+            content: { sideChatViewModel in
+                NewConversationView(
+                    viewModel: sideChatViewModel,
+                    profileSettingsViewModel: profileSettingsViewModel,
+                    initialMessageText: agentSideChatDraft
+                )
+            }
+        )
+        .sheet(isPresented: $showingGroupOutputs) {
+            NavigationStack {
+                AgentFilesLinksView(
+                    conversationId: viewModel.conversation.id,
+                    repository: viewModel.makeAgentFilesLinksRepository(),
+                    members: viewModel.conversation.members,
+                    usesInlineHeader: false,
+                    profileSheetContent: profileSheetForMember
+                )
+                .navigationTitle("Files & links")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            showingGroupOutputs = false
+                        }
+                    }
+                }
+            }
+        }
         .sheet(item: $viewModel.presentingContactForAgentShare) { contact in
             agentShareContactDetailSheet(for: contact)
         }
@@ -698,9 +710,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
             )
             PaywallView(viewModel: paywallViewModel)
         }
-        .selfSizingSheet(isPresented: $showingAgentsInfo) {
-            AgentsInfoView()
-                .padding(.top, 20)
+        .sheet(isPresented: $showingAgentsInfo) {
+            GroupAgentsView(
+                conversation: viewModel.conversation,
+                onAction: handleGroupAgentsAction
+            )
         }
         .sheet(item: $viewModel.presentingProfileForMember) { member in
             memberContactDetailSheet(for: member)
@@ -954,6 +968,244 @@ extension ConversationView {
 }
 
 private extension ConversationView {
+    var debugAttachmentTapHandler: (() -> Void)? {
+        guard FeatureFlags.shared.isDebugInjectorEnabled else { return nil }
+        return { showingDebugInjector = true }
+    }
+
+    var debugInjectorBinding: Binding<Bool> {
+        guard FeatureFlags.shared.isDebugInjectorEnabled else { return .constant(false) }
+        return $showingDebugInjector
+    }
+
+    func profileSheetForMember(_ member: ConversationMember) -> AnyView {
+        AnyView(
+            MemberContactDetailSheetContent(
+                viewModel: viewModel,
+                member: member,
+                profileSettingsViewModel: profileSettingsViewModel
+            )
+        )
+    }
+
+    var thingsPage: some View {
+        GroupDesktopView(
+            conversation: viewModel.conversation,
+            onAction: handleGroupDesktopAction
+        )
+    }
+
+    var isGroupConversation: Bool {
+        let humanCount = viewModel.conversation.members.filter { !$0.isAgent }.count
+        return humanCount >= 2 && viewModel.conversation.members.count >= 3
+    }
+
+    var groupAgent: ConversationMember? {
+        viewModel.conversation.members.first(where: \.isAgent)
+    }
+
+    var groupDisplayName: String {
+        let name = viewModel.conversation.name?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return name.isEmpty ? "this group" : name
+    }
+
+    func configureMessageWorkMenu() {
+        contextMenuState.isWorkMenuEnabled = isGroupConversation
+        contextMenuState.onWorkAction = { [weak viewModel] action, message in
+            guard viewModel != nil else { return }
+            handleMessageWorkAction(action, message: message)
+        }
+    }
+
+    func messageContext(_ message: AnyMessage) -> String {
+        switch message.content {
+        case .text(let text), .emoji(let text):
+            return text
+        case .linkPreview(let preview):
+            return preview.url
+        case .attachment(let attachment):
+            return attachment.filename ?? "an attachment"
+        case .attachments(let attachments):
+            return attachments.compactMap(\.filename).joined(separator: ", ")
+        default:
+            return "the selected message"
+        }
+    }
+
+    func quotedContext(_ message: AnyMessage) -> String {
+        let context = messageContext(message)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let limited = String(context.prefix(500))
+        return limited.isEmpty ? "the selected message" : "“\(limited)”"
+    }
+
+    func handleMessageWorkAction(_ action: MessageWorkAction, message: AnyMessage) {
+        let sender = message.sender.profile.displayName
+        let context = quotedContext(message)
+
+        switch action {
+        case .research:
+            draftInGroupChat(
+                "Research this from \(sender): \(context)\n\n"
+                    + "Compare the best options and keep the useful result in Things."
+            )
+        case .doSomething:
+            draftInGroupChat(
+                "Do something useful with this from \(sender): \(context)\n\n"
+                    + "Use the group context, connected apps, and the right skills. Show what changed."
+            )
+        case .remind:
+            draftInGroupChat(
+                "Turn this message from \(sender) into a reminder for the right people: \(context)\n\n"
+                    + "Ask only for any missing timing."
+            )
+        case .addToThings:
+            draftInGroupChat(
+                "Add this message from \(sender) to Things and put it in the right place: \(context)"
+            )
+        case .connectService:
+            draftInGroupChat(
+                "Connect this group to the service needed for this message from \(sender): \(context)\n\n"
+                    + "Explain why the connection helps and ask for the minimum access needed."
+            )
+        case .askAgentPrivately:
+            openAgentSideChat(
+                draft: "From \(groupDisplayName), \(sender) shared: \(context)\n\n"
+                    + "Work this out quietly using the group context. "
+                    + "Make the result easy to bring back to everyone."
+            )
+        }
+    }
+
+    func handleGroupDesktopAction(_ action: GroupDesktopView.Action) {
+        switch action {
+        case .describeGroup:
+            draftInGroupChat("This group is about ")
+        case .addUsefulThing:
+            draftInGroupChat("Add this to the group and put it in the right place: ")
+        case .connectAnything, .openConnections:
+            draftInGroupChat("Connect this group to ")
+        case .askEveryone:
+            openAgentSideChat(draft: "Ask everyone in \(groupDisplayName) privately for ")
+        case .researchOptions:
+            openAgentSideChat(
+                draft: "Research the best options for the group. "
+                    + "Use what everyone has already shared, then show the comparison in Things."
+            )
+        case .addThoughts:
+            openAgentSideChat(
+                draft: "Add these thoughts to the group’s shared work and improve what is already there: "
+            )
+        case .leaveVoiceNote:
+            withAnimation(.easeInOut(duration: 0.25)) {
+                pagerSelectedPage = .messages
+            }
+            viewModel.onVoiceMemoTapped()
+        case .openOutputs:
+            showingGroupOutputs = true
+        case .openAgents:
+            if viewModel.conversation.hasAgent {
+                showingAgentsInfo = true
+            } else {
+                viewModel.presentAgentBuilder()
+            }
+        case .openSkills:
+            openAgentSideChat(
+                draft: "Show useful skills for this group and explain what each one could do."
+            )
+        case .openMembers:
+            viewModel.onConversationSettings(focusCoordinator: focusCoordinator)
+        case .openNotes:
+            openAgentSideChat(
+                draft: "Open the group notes. Help add, edit, or organize anything that belongs there."
+            )
+        case .openTodos:
+            openAgentSideChat(
+                draft: "Open the group todos. Show what is unfinished, who can help, "
+                    + "and what each item came from."
+            )
+        case .openReminders:
+            openAgentSideChat(
+                draft: "Open the group reminders. Show who set each one, who will be reminded, and when."
+            )
+        case .setUpInboundEmail:
+            openAgentSideChat(
+                draft: "Set up an email address for this group so anyone can forward or CC emails "
+                    + "to the desktop. Show the address here when it is ready."
+            )
+        case .setUpInboundText:
+            openAgentSideChat(
+                draft: "Set up a text number for this group so anyone can send links, screenshots, "
+                    + "reminders, or add it to another group chat. "
+                    + "Keep listening off until the group allows it."
+            )
+        }
+    }
+
+    func handleGroupAgentsAction(_ action: GroupAgentsView.Action) {
+        switch action {
+        case .openAgent(let member):
+            dismissGroupAgents {
+                viewModel.presentingProfileForMember = member
+            }
+        case .addCredits:
+            dismissGroupAgents {
+                viewModel.presentingPaywall = true
+            }
+        case .setGroupLimit:
+            dismissGroupAgents {
+                openAgentSideChat(
+                    draft: "Set a $10 total spending limit for \(groupDisplayName). "
+                        + "Everyone can use the shared agent until the limit is reached. "
+                        + "Ask before changing who can spend."
+                )
+            }
+        case .bringOwnAI(let provider):
+            dismissGroupAgents {
+                openAgentSideChat(
+                    draft: "Connect \(provider) as another way to help power \(groupDisplayName). "
+                        + "Give it a visible Convos identity and start in Listen only mode."
+                )
+            }
+        case .addConvosAgent:
+            dismissGroupAgents {
+                viewModel.presentAgentBuilder()
+            }
+        }
+    }
+
+    func dismissGroupAgents(then action: @escaping @MainActor @Sendable () -> Void) {
+        showingAgentsInfo = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: action)
+    }
+
+    func draftInGroupChat(_ draft: String) {
+        withAnimation(.easeInOut(duration: 0.25)) {
+            pagerSelectedPage = .messages
+        }
+        viewModel.messageText = draft
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            focusCoordinator.moveFocus(to: .message)
+        }
+    }
+
+    func openAgentSideChat(draft: String) {
+        guard let groupAgent else {
+            viewModel.presentAgentBuilder()
+            return
+        }
+
+        agentSideChatDraft = draft
+        agentSideChatViewModel = NewConversationViewModel(
+            session: viewModel.session,
+            mode: .newConversationWithMembers(
+                initialMemberInboxIds: [groupAgent.profile.inboxId]
+            ),
+            coreActions: viewModel.coreActions
+        )
+    }
+
     /// What the composer needs to draw the bubble: the level, and the tap.
     /// `nil` in a conversation with no agent — a control for agents has no
     /// business in a room without one.

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1163,16 +1163,17 @@ private extension ConversationView {
         case .setGroupLimit:
             dismissGroupAgents {
                 openAgentSideChat(
-                    draft: "Set a $10 total spending limit for \(groupDisplayName). "
-                        + "Everyone can use the shared agent until the limit is reached. "
-                        + "Ask before changing who can spend."
+                    draft: "Set a $10 limit on what my agent can contribute to \(groupDisplayName). "
+                        + "Let everyone use it until my limit is reached, but ask me before changing "
+                        + "its group access or using more of my power."
                 )
             }
         case .bringOwnAI(let provider):
             dismissGroupAgents {
                 openAgentSideChat(
-                    draft: "Connect \(provider) as another way to help power \(groupDisplayName). "
-                        + "Give it a visible Convos identity and start in Listen only mode."
+                    draft: "Invite \(provider) as my agent in \(groupDisplayName). "
+                        + "Give it a visible Convos identity and keep its power private by default. "
+                        + "Let me choose listening, speaking, memory, actions, and group access separately."
                 )
             }
         case .addConvosAgent:

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1045,27 +1045,28 @@ private extension ConversationView {
 
         switch action {
         case .research:
-            draftInGroupChat(
-                "Research this from \(sender): \(context)\n\n"
-                    + "Compare the best options and keep the useful result in Things."
+            openAgentSideChat(
+                draft: "From \(groupDisplayName), \(sender) shared: \(context)\n\n"
+                    + "Research this quietly. Compare the best options and keep the useful result in Things."
             )
         case .doSomething:
-            draftInGroupChat(
-                "Do something useful with this from \(sender): \(context)\n\n"
-                    + "Use the group context, connected apps, and the right skills. Show what changed."
+            openAgentSideChat(
+                draft: "From \(groupDisplayName), \(sender) shared: \(context)\n\n"
+                    + "Do something useful with this. Use the group context, connected apps, "
+                    + "and the right skills. Show what changed in Things."
             )
         case .remind:
-            draftInGroupChat(
-                "Turn this message from \(sender) into a reminder for the right people: \(context)\n\n"
+            openAgentSideChat(
+                draft: "Turn this message from \(sender) into a reminder for the right people: \(context)\n\n"
                     + "Ask only for any missing timing."
             )
         case .addToThings:
-            draftInGroupChat(
-                "Add this message from \(sender) to Things and put it in the right place: \(context)"
+            openAgentSideChat(
+                draft: "Add this message from \(sender) to Things and put it in the right place: \(context)"
             )
         case .connectService:
-            draftInGroupChat(
-                "Connect this group to the service needed for this message from \(sender): \(context)\n\n"
+            openAgentSideChat(
+                draft: "Connect this group to the service needed for this message from \(sender): \(context)\n\n"
                     + "Explain why the connection helps and ask for the minimum access needed."
             )
         case .askAgentPrivately:
@@ -1080,11 +1081,18 @@ private extension ConversationView {
     func handleGroupDesktopAction(_ action: GroupDesktopView.Action) {
         switch action {
         case .describeGroup:
-            draftInGroupChat("This group is about ")
+            openAgentSideChat(
+                draft: "Help shape the desktop around what this group is for: "
+            )
         case .addUsefulThing:
-            draftInGroupChat("Add this to the group and put it in the right place: ")
+            openAgentSideChat(
+                draft: "Add this to Things and put it in the right place for everyone: "
+            )
         case .connectAnything, .openConnections:
-            draftInGroupChat("Connect this group to ")
+            openAgentSideChat(
+                draft: "Connect this group to an app, service, file, calendar, account, or agent. "
+                    + "Explain why it helps and ask for the minimum access needed: "
+            )
         case .askEveryone:
             openAgentSideChat(draft: "Ask everyone in \(groupDisplayName) privately for ")
         case .researchOptions:

--- a/Convos/Conversation Detail/GroupAgentSideChatView.swift
+++ b/Convos/Conversation Detail/GroupAgentSideChatView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// A deliberately static first pass of the private group-agent side chat.
+/// It proves the three-space loop before a durable one-to-one conversation
+/// model is wired in.
+struct GroupAgentSideChatView: View {
+    let agentName: String
+    let groupName: String
+    @Binding var draft: String
+
+    @State private var sentPrompts: [String] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            transcript
+            composer
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "sparkles")
+                .foregroundStyle(.white)
+                .frame(width: 42, height: 42)
+                .background(.black)
+                .clipShape(.rect(cornerRadius: 14))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(agentName)
+                    .font(.headline)
+                Text("Private side chat · working for \(groupName)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text("LISTEN ONLY")
+                .font(.caption2.weight(.bold))
+                .tracking(0.8)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                agentBubble(
+                    "Anything from \(groupName) can become work here. "
+                        + "Drop context, request an edit, ask for research, or say what should happen next."
+                )
+
+                promptGrid
+
+                ForEach(Array(sentPrompts.enumerated()), id: \.offset) { _, prompt in
+                    userBubble(prompt)
+                    agentBubble(
+                        "Working on it quietly. The useful result, sources, and changes will come back to Things "
+                            + "so everyone can keep improving it."
+                    )
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 20)
+        }
+    }
+
+    private var promptGrid: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("TRY ASKING")
+                .font(.caption2.weight(.bold))
+                .tracking(1.4)
+                .foregroundStyle(.secondary)
+
+            prompt("Research this with everything the group shared")
+            prompt("Update the plan and show everyone what changed")
+            prompt("Ask each person privately for their thoughts")
+            prompt("Connect the app or file needed to finish this")
+            prompt("Leave a voice note and sort it all out")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func prompt(_ text: String) -> some View {
+        Button {
+            draft = text
+        } label: {
+            HStack {
+                Image(systemName: "plus")
+                    .font(.caption.bold())
+                Text(text)
+                    .font(.subheadline.weight(.semibold))
+                    .multilineTextAlignment(.leading)
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.bold())
+            }
+            .foregroundStyle(.primary)
+            .padding(13)
+            .background(Color.primary.opacity(0.05))
+            .clipShape(.rect(cornerRadius: 16))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func agentBubble(_ text: String) -> some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.caption)
+                .foregroundStyle(.white)
+                .frame(width: 28, height: 28)
+                .background(.black)
+                .clipShape(Circle())
+
+            Text(text)
+                .font(.callout)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 11)
+                .background(Color.primary.opacity(0.065))
+                .clipShape(.rect(cornerRadius: 18))
+
+            Spacer(minLength: 52)
+        }
+    }
+
+    private func userBubble(_ text: String) -> some View {
+        HStack {
+            Spacer(minLength: 52)
+            Text(text)
+                .font(.callout)
+                .foregroundStyle(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 11)
+                .background(.black)
+                .clipShape(.rect(cornerRadius: 18))
+        }
+    }
+
+    private var composer: some View {
+        HStack(spacing: 10) {
+            Button {
+                draft = "Here’s more context: "
+            } label: {
+                Image(systemName: "plus")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 38, height: 38)
+            }
+
+            TextField("Tell \(agentName) what to do", text: $draft, axis: .vertical)
+                .lineLimit(1 ... 4)
+                .foregroundStyle(.white)
+
+            Button {
+                send()
+            } label: {
+                Image(systemName: "arrow.up")
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(.black)
+                    .frame(width: 38, height: 38)
+                    .background(.white)
+                    .clipShape(Circle())
+            }
+            .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color(white: 0.12))
+        .clipShape(.capsule)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+
+    private func send() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { return }
+        sentPrompts.append(prompt)
+        draft = ""
+    }
+}

--- a/Convos/Conversation Detail/GroupAgentSideChatView.swift
+++ b/Convos/Conversation Detail/GroupAgentSideChatView.swift
@@ -30,7 +30,7 @@ struct GroupAgentSideChatView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(agentName)
                     .font(.headline)
-                Text("Private side chat · working for \(groupName)")
+                Text("Your agent · private side chat · working for \(groupName)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -61,7 +61,7 @@ struct GroupAgentSideChatView: View {
                     userBubble(prompt)
                     agentBubble(
                         "Working on it quietly. The useful result, sources, and changes will come back to Things "
-                            + "so everyone can keep improving it."
+                            + "so everyone can keep improving it. You get the credit for moving the group forward."
                     )
                 }
             }

--- a/Convos/Conversation Detail/GroupAgentsView.swift
+++ b/Convos/Conversation Detail/GroupAgentsView.swift
@@ -3,9 +3,8 @@ import SwiftUI
 
 /// The group-scoped Agents directory.
 ///
-/// Consumer language stays focused on who can help and how the group keeps
-/// that help powered. Provider and harness details remain available deeper in
-/// each profile, but are not required to understand the shared model.
+/// Consumer language stays focused on who can help, who owns each agent, and
+/// whether that member has chosen to let the rest of the group use it.
 struct GroupAgentsView: View {
     enum Action {
         case openAgent(ConversationMember)
@@ -34,7 +33,8 @@ struct GroupAgentsView: View {
                 LazyVStack(alignment: .leading, spacing: 24) {
                     introduction
                     agentDirectory
-                    sharedPower
+                    memberOwnedPower
+                    taskInvitation
                     bringYourOwnAI
                 }
                 .padding(.horizontal, 20)
@@ -59,11 +59,11 @@ struct GroupAgentsView: View {
 
     private var introduction: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Who can help this group")
+            Text("Every member can bring their own agent")
                 .font(.largeTitle.bold())
                 .foregroundStyle(.colorTextPrimary)
 
-            Text("Agents join as visible members. Everyone can see who added them, what they can access, and whether they can listen or speak.")
+            Text("Members invite agents to become visible members in the group chat. Each person owns their agent and decides whether its power is private, approval-only, or available to everyone.")
                 .font(.body)
                 .foregroundStyle(.colorTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -90,8 +90,8 @@ struct GroupAgentsView: View {
                                 .foregroundStyle(.colorTextPrimary)
 
                             Text(index == 0
-                                 ? "Available to everyone · Shared group credits"
-                                 : "Added to this group · Listen only")
+                                 ? "Shane’s Convos agent · Group use allowed"
+                                 : "Shane’s agent · Private power")
                                 .font(.caption)
                                 .foregroundStyle(.colorTextSecondary)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -135,26 +135,29 @@ struct GroupAgentsView: View {
             }
     }
 
-    private var sharedPower: some View {
+    private var memberOwnedPower: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("SHARED POWER")
+            Text("MEMBER-OWNED POWER")
                 .font(.caption2.weight(.bold))
                 .foregroundStyle(.colorTextTertiary)
 
-            Text("Everyone can use \(groupAgentName)")
+            Text("Your agent. Your power. Your choice.")
                 .font(.title2.bold())
                 .foregroundStyle(.colorTextPrimary)
 
-            Text("One shared balance powers the agent for the whole group. Anyone can add credits. Change who can use them or set a group limit anytime.")
+            Text("\(groupAgentName) belongs to Shane. He currently lets the group use it, but he can require approval or keep it private without removing it from the Convo.")
                 .font(.body)
                 .foregroundStyle(.colorTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
             VStack(spacing: 0) {
-                powerSettingRow(title: "Who can use it", value: "Everyone", icon: "person.2.fill")
+                powerSettingRow(title: "Owner", value: "Shane", icon: "person.crop.circle")
                 Divider()
                     .padding(.leading, 44)
-                powerSettingRow(title: "Group spending limit", value: "No limit set", icon: "gauge.with.dots.needle.33percent")
+                powerSettingRow(title: "Group access", value: "Allowed", icon: "person.2.fill")
+                Divider()
+                    .padding(.leading, 44)
+                powerSettingRow(title: "Shane’s group limit", value: "$10", icon: "gauge.with.dots.needle.33percent")
             }
             .padding(.horizontal, 14)
             .background(
@@ -166,7 +169,7 @@ struct GroupAgentsView: View {
                 Button {
                     onAction(.addCredits)
                 } label: {
-                    Label("Add credits", systemImage: "plus")
+                    Label("Power my agent", systemImage: "plus")
                         .font(.subheadline.weight(.semibold))
                         .frame(maxWidth: .infinity)
                 }
@@ -176,7 +179,7 @@ struct GroupAgentsView: View {
                 Button {
                     onAction(.setGroupLimit)
                 } label: {
-                    Text("Set a $10 limit")
+                    Text("Who can use mine")
                         .font(.subheadline.weight(.semibold))
                         .frame(maxWidth: .infinity)
                 }
@@ -184,7 +187,7 @@ struct GroupAgentsView: View {
                 .tint(.colorTextPrimary)
             }
 
-            Text("If power runs out, paid work pauses and the group can decide who wants to help.")
+            Text("Every member can bring their own Convos agent or connect the AI service they already use. No one has to depend on someone else’s power.")
                 .font(.footnote)
                 .foregroundStyle(.colorTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -194,6 +197,40 @@ struct GroupAgentsView: View {
             RoundedRectangle(cornerRadius: 24, style: .continuous)
                 .fill(.colorFillMinimal)
         )
+    }
+
+    private var taskInvitation: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("THE TASK BECOMES THE INVITATION")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.colorLava)
+
+            Text("Brent taps “Find 15 more places.”")
+                .font(.title3.bold())
+                .foregroundStyle(.colorTextPrimaryInverted)
+
+            Text("If Brent cannot use Shane’s agent, Convos asks Brent to add his own or request access. "
+                + "His contribution brings new power into the group—and Brent gets the credit for improving the work.")
+                .font(.body)
+                .foregroundStyle(.colorTextPrimaryInverted.opacity(0.72))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                onAction(.addConvosAgent)
+            } label: {
+                Label("Add my agent to do this task", systemImage: "plus")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.colorTextPrimary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 13)
+                    .background(.colorBackgroundSurfaceless)
+                    .clipShape(.rect(cornerRadius: 14))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(18)
+        .background(.colorTextPrimary)
+        .clipShape(.rect(cornerRadius: 24))
     }
 
     private func powerSettingRow(title: String, value: String, icon: String) -> some View {
@@ -216,15 +253,15 @@ struct GroupAgentsView: View {
 
     private var bringYourOwnAI: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("BRING YOUR OWN AI")
+            Text("INVITE YOUR AGENT")
                 .font(.caption2.weight(.bold))
                 .foregroundStyle(.colorTextTertiary)
 
-            Text("Already use an AI service? Bring its powers to the group.")
+            Text("Already use an AI service? Bring it into the Convo.")
                 .font(.title3.bold())
                 .foregroundStyle(.colorTextPrimary)
 
-            Text("Connect the AI you already pay for as another way to help. It gets a Convos identity, stays visible to everyone, and starts in Listen only mode.")
+            Text("It becomes your visible agent in this group. Its power is private by default. You decide separately whether it can listen, speak, remember, act, or help other members.")
                 .font(.body)
                 .foregroundStyle(.colorTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -246,7 +283,7 @@ struct GroupAgentsView: View {
             Button {
                 onAction(.addConvosAgent)
             } label: {
-                Label("Add another Convos agent", systemImage: "plus")
+                Label("Create my Convos agent", systemImage: "plus")
                     .font(.subheadline.weight(.semibold))
                     .frame(maxWidth: .infinity)
             }

--- a/Convos/Conversation Detail/GroupAgentsView.swift
+++ b/Convos/Conversation Detail/GroupAgentsView.swift
@@ -1,0 +1,275 @@
+import ConvosCore
+import SwiftUI
+
+/// The group-scoped Agents directory.
+///
+/// Consumer language stays focused on who can help and how the group keeps
+/// that help powered. Provider and harness details remain available deeper in
+/// each profile, but are not required to understand the shared model.
+struct GroupAgentsView: View {
+    enum Action {
+        case openAgent(ConversationMember)
+        case addCredits
+        case setGroupLimit
+        case bringOwnAI(String)
+        case addConvosAgent
+    }
+
+    let conversation: Conversation
+    let onAction: (Action) -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    private var agents: [ConversationMember] {
+        conversation.members.filter(\.isAgent)
+    }
+
+    private var groupAgentName: String {
+        agents.first?.profile.displayName ?? "Group Agent"
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    introduction
+                    agentDirectory
+                    sharedPower
+                    bringYourOwnAI
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+            }
+            .background(.colorBackgroundSurfaceless)
+            .navigationTitle("Agents")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+        .presentationBackground(.colorBackgroundSurfaceless)
+    }
+
+    private var introduction: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Who can help this group")
+                .font(.largeTitle.bold())
+                .foregroundStyle(.colorTextPrimary)
+
+            Text("Agents join as visible members. Everyone can see who added them, what they can access, and whether they can listen or speak.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var agentDirectory: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(agents.enumerated()), id: \.element.profile.inboxId) { index, agent in
+                if index > 0 {
+                    Divider()
+                        .padding(.leading, 58)
+                }
+
+                Button {
+                    onAction(.openAgent(agent))
+                } label: {
+                    HStack(spacing: 12) {
+                        agentAvatar(agent, isGroupAgent: index == 0)
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(agent.profile.displayName)
+                                .font(.headline)
+                                .foregroundStyle(.colorTextPrimary)
+
+                            Text(index == 0
+                                 ? "Available to everyone · Shared group credits"
+                                 : "Added to this group · Listen only")
+                                .font(.caption)
+                                .foregroundStyle(.colorTextSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer(minLength: 8)
+
+                        Text("Open")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.colorLava)
+                    }
+                    .padding(.vertical, 14)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(Color.colorBorderSubtle, lineWidth: 1)
+        )
+    }
+
+    private func agentAvatar(_ agent: ConversationMember, isGroupAgent: Bool) -> some View {
+        let initial = agent.profile.displayName.first.map(String.init) ?? "A"
+
+        return Circle()
+            .fill(.colorTextPrimary)
+            .frame(width: 46, height: 46)
+            .overlay {
+                if isGroupAgent {
+                    Image(systemName: "sparkles")
+                        .font(.body.weight(.bold))
+                        .foregroundStyle(.colorTextPrimaryInverted)
+                } else {
+                    Text(initial)
+                        .font(.headline)
+                        .foregroundStyle(.colorTextPrimaryInverted)
+                }
+            }
+    }
+
+    private var sharedPower: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("SHARED POWER")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.colorTextTertiary)
+
+            Text("Everyone can use \(groupAgentName)")
+                .font(.title2.bold())
+                .foregroundStyle(.colorTextPrimary)
+
+            Text("One shared balance powers the agent for the whole group. Anyone can add credits. Change who can use them or set a group limit anytime.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 0) {
+                powerSettingRow(title: "Who can use it", value: "Everyone", icon: "person.2.fill")
+                Divider()
+                    .padding(.leading, 44)
+                powerSettingRow(title: "Group spending limit", value: "No limit set", icon: "gauge.with.dots.needle.33percent")
+            }
+            .padding(.horizontal, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(.colorBackgroundSurfaceless)
+            )
+
+            HStack(spacing: 10) {
+                Button {
+                    onAction(.addCredits)
+                } label: {
+                    Label("Add credits", systemImage: "plus")
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.colorTextPrimary)
+
+                Button {
+                    onAction(.setGroupLimit)
+                } label: {
+                    Text("Set a $10 limit")
+                        .font(.subheadline.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(.colorTextPrimary)
+            }
+
+            Text("If power runs out, paid work pauses and the group can decide who wants to help.")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.colorFillMinimal)
+        )
+    }
+
+    private func powerSettingRow(title: String, value: String, icon: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.body.weight(.semibold))
+                .frame(width: 32)
+
+            Text(title)
+                .font(.subheadline)
+
+            Spacer()
+
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+        }
+        .foregroundStyle(.colorTextPrimary)
+        .padding(.vertical, 13)
+    }
+
+    private var bringYourOwnAI: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("BRING YOUR OWN AI")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.colorTextTertiary)
+
+            Text("Already use an AI service? Bring its powers to the group.")
+                .font(.title3.bold())
+                .foregroundStyle(.colorTextPrimary)
+
+            Text("Connect the AI you already pay for as another way to help. It gets a Convos identity, stays visible to everyone, and starts in Listen only mode.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 10),
+                    GridItem(.flexible(), spacing: 10)
+                ],
+                spacing: 10
+            ) {
+                providerButton("ChatGPT")
+                providerButton("Claude")
+                providerButton("Hermes")
+                providerButton("OpenClaw")
+                providerButton("Custom")
+            }
+
+            Button {
+                onAction(.addConvosAgent)
+            } label: {
+                Label("Add another Convos agent", systemImage: "plus")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .tint(.colorLava)
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.colorFillMinimal)
+        )
+    }
+
+    private func providerButton(_ name: String) -> some View {
+        Button {
+            onAction(.bringOwnAI(name))
+        } label: {
+            Text(name)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.colorTextPrimary)
+                .frame(maxWidth: .infinity, minHeight: 48)
+        }
+        .buttonStyle(.bordered)
+        .tint(.colorBorderSubtle)
+    }
+}

--- a/Convos/Conversation Detail/GroupDesktopView.swift
+++ b/Convos/Conversation Detail/GroupDesktopView.swift
@@ -31,8 +31,6 @@ struct GroupDesktopView: View {
 
     @State private var copiedAddress: String?
 
-    private let accent: Color = Color(red: 1, green: 0.32, blue: 0.22)
-
     private var people: [ConversationMember] {
         conversation.members.filter { !$0.isAgent }
     }
@@ -140,7 +138,11 @@ struct GroupDesktopView: View {
 
     private var start: some View {
         VStack(alignment: .leading, spacing: 16) {
-            kicker("THE THINGS YOUR GROUP IS DOING")
+            HStack {
+                kicker("THE THINGS YOUR GROUP IS DOING")
+                Spacer()
+                DesktopAddButton { onAction(.addUsefulThing) }
+            }
 
             Text("Let’s get this Convo started.")
                 .font(.system(size: 37, weight: .bold, design: .rounded))
@@ -694,5 +696,27 @@ struct GroupDesktopView: View {
             .font(.caption2.weight(.bold))
             .tracking(1.6)
             .foregroundStyle(.secondary)
+    }
+}
+
+private extension GroupDesktopView {
+    var accent: Color { Color(red: 1, green: 0.32, blue: 0.22) }
+}
+
+private struct DesktopAddButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label("Add", systemImage: "plus")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 13)
+                .padding(.vertical, 9)
+                .background(.black)
+                .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add something to Things")
     }
 }

--- a/Convos/Conversation Detail/GroupDesktopView.swift
+++ b/Convos/Conversation Detail/GroupDesktopView.swift
@@ -4,7 +4,7 @@ import UIKit
 
 /// The living home for a group: inputs at the top, work in the middle,
 /// and durable group memory below.
-struct GroupDesktopView: View {
+struct GroupDesktopView: View { // swiftlint:disable:this type_body_length
     enum Action {
         case describeGroup
         case addUsefulThing
@@ -151,6 +151,11 @@ struct GroupDesktopView: View {
             Text("Start with one useful thing. Everyone can help make it better.")
                 .font(.body)
                 .foregroundStyle(.secondary)
+
+            Text("Every person can bring an agent of their own. People add the direction and get the credit; their agents handle the research, updates, and feedback behind the scenes.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
             startCard(
                 number: "1",
@@ -382,7 +387,7 @@ struct GroupDesktopView: View {
 
                     HStack {
                         avatarStack
-                        Text("3 people made this better")
+                        Text("3 people made this better · their agents handled the work")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -452,10 +457,10 @@ struct GroupDesktopView: View {
             Text("Who did what")
                 .font(.title2.bold())
 
-            activityRow("Shane compared 17 cabins", detail: "The research and sources are saved.", actionTitle: "Open research", action: .openOutputs)
-            activityRow("Brent started the restaurant list", detail: "Last updated with Tahoe City favorites.", actionTitle: "Add yours", action: .addThoughts)
+            activityRow("Shane improved the cabin research", detail: "His agent compared 17 places and saved the sources.", actionTitle: "Open research", action: .openOutputs)
+            activityRow("Brent started the restaurant list", detail: "His agent keeps everyone’s Tahoe City favorites current.", actionTitle: "Add yours", action: .addThoughts)
             activityRow("Julie set a booking reminder", detail: "Everyone will be nudged Friday.", actionTitle: "See reminder", action: .openReminders)
-            activityRow("Shane added agent Kai", detail: "Kai added food and workout plans to Notes.", actionTitle: "Open notes", action: .openNotes)
+            activityRow("Shane invited his agent Kai", detail: "Shane used Kai to add food and workout plans to Notes.", actionTitle: "Open notes", action: .openNotes)
         }
     }
 
@@ -502,7 +507,7 @@ struct GroupDesktopView: View {
                 directoryTile("Notes", "Shared context", "note.text", .openNotes)
                 directoryTile("Todos", "What happens next", "checkmark.circle", .openTodos)
                 directoryTile("Reminders", "Who · what · when", "bell", .openReminders)
-                directoryTile("Agents", "\(agents.count) can help", "sparkles", .openAgents)
+                directoryTile("Agents", "Everyone can bring one", "sparkles", .openAgents)
                 directoryTile("Skills", "Give agents powers", "bolt", .openSkills)
                 directoryTile("Connections", "Apps from your life", "link", .openConnections)
                 directoryTile("Files", "Outputs + sources", "folder", .openOutputs)
@@ -633,7 +638,7 @@ struct GroupDesktopView: View {
             Text(
                 "Anything on this desktop—or in an app the group connected—can be improved in the agent side chat. "
                     + "Add what you know, request an edit, or ask for more research. "
-                    + "The update comes back to everyone. And we can see who’s doing what."
+                    + "The update comes back to everyone. People get the credit, and agents manage the feedback and chaos."
             )
             .font(.subheadline)
             .foregroundStyle(.secondary)
@@ -641,6 +646,7 @@ struct GroupDesktopView: View {
             Divider().padding(.vertical, 4)
 
             Text("Convos is made in the open. You are in control. The desktop is your space. "
+                + "Every member can bring an agent and decide whether its power stays private or helps the group. "
                 + "Your secure chat has forward secrecy. If you don’t want an agent to listen, tap pause. Connect anything.")
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Convos/Conversation Detail/GroupDesktopView.swift
+++ b/Convos/Conversation Detail/GroupDesktopView.swift
@@ -2,11 +2,8 @@ import ConvosCore
 import SwiftUI
 import UIKit
 
-/// The group-scoped home behind a conversation.
-///
-/// This is deliberately a native, action-first surface. Chat remains the
-/// source of input; this page makes the group's shared context, work, and
-/// next-best actions visible without introducing a second document model.
+/// The living home for a group: inputs at the top, work in the middle,
+/// and durable group memory below.
 struct GroupDesktopView: View {
     enum Action {
         case describeGroup
@@ -28,22 +25,13 @@ struct GroupDesktopView: View {
         case setUpInboundText
     }
 
-    private struct InboundAddress {
-        let title: String
-        let address: String?
-        let placeholder: String
-        let detail: String
-        let icon: String
-        let setupAction: Action
-        let obscuresPlaceholder: Bool
-    }
-
     let conversation: Conversation
     let onAction: (Action) -> Void
     var onScrollOffsetChange: ((CGFloat) -> Void)?
 
-    @Environment(\.openURL) private var openURL: OpenURLAction
-    @State private var copiedInboundAddress: String?
+    @State private var copiedAddress: String?
+
+    private let accent: Color = Color(red: 1, green: 0.32, blue: 0.22)
 
     private var people: [ConversationMember] {
         conversation.members.filter { !$0.isAgent }
@@ -54,39 +42,32 @@ struct GroupDesktopView: View {
     }
 
     private var agentName: String {
-        agents.first?.profile.displayName ?? "Group Agent"
-    }
-
-    private var agentEmail: String? {
-        agents.first?.profile.agentEmail
-    }
-
-    private var agentPhone: String? {
-        agents.first?.profile.agentPhone
+        agents.first?.profile.displayName ?? "Mountain Guide"
     }
 
     private var groupName: String {
         let name = conversation.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return name.isEmpty ? "this group" : name
+        return name.isEmpty ? "Tahoe Weekend" : name
     }
 
     var body: some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 28) {
+            LazyVStack(alignment: .leading, spacing: 30) {
                 peopleHeader
-                gettingStarted
-                sendAnything
-                agentExplainer
+                start
+                dropItAllIn
+                conversationStartsWork
                 sharedWork
-                everythingHasAPlace
+                activity
                 directory
+                inbound
                 principles
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 12)
-            .padding(.bottom, 48)
+            .padding(.horizontal, 18)
+            .padding(.top, 10)
+            .padding(.bottom, 54)
         }
-        .background(.colorBackgroundSurfaceless)
+        .background(Color(uiColor: .systemBackground))
         .onScrollGeometryChange(for: CGFloat.self) { geometry in
             geometry.contentOffset.y + geometry.contentInsets.top
         } action: { _, offset in
@@ -98,51 +79,48 @@ struct GroupDesktopView: View {
         Button {
             onAction(.openMembers)
         } label: {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
+            HStack(spacing: 12) {
+                avatarStack
+
+                VStack(alignment: .leading, spacing: 2) {
                     Text(groupName)
-                        .font(.title2.bold())
-                        .foregroundStyle(.colorTextPrimary)
-
-                    Spacer()
-
-                    Label("Invite", systemImage: "person.badge.plus")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.colorTextPrimary)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text("\(people.count) people · Tap to open the group")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: -6) {
-                        ForEach(Array(people.prefix(8)), id: \.profile.inboxId) { member in
-                            memberAvatar(member)
-                        }
+                Spacer()
 
-                        Circle()
-                            .fill(.colorFillMinimal)
-                            .frame(width: 44, height: 44)
-                            .overlay {
-                                Image(systemName: "plus")
-                                    .font(.body.weight(.semibold))
-                                    .foregroundStyle(.colorTextPrimary)
-                            }
-                            .overlay {
-                                Circle().stroke(.colorBackgroundSurfaceless, lineWidth: 2)
-                            }
-                            .accessibilityLabel("Invite more people")
-                    }
-                }
-
-                Text("\(people.count) people are making this better together")
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
+                Image(systemName: "person.badge.plus")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 42, height: 42)
+                    .background(Color.primary.opacity(0.055))
+                    .clipShape(Circle())
             }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
 
-    private func memberAvatar(_ member: ConversationMember) -> some View {
-        let name = member.profile.displayName
-        let initials = name
+    private var avatarStack: some View {
+        HStack(spacing: -9) {
+            ForEach(Array(people.prefix(4)), id: \.profile.inboxId) { member in
+                avatar(member)
+            }
+            if people.isEmpty {
+                Circle()
+                    .fill(Color.primary.opacity(0.08))
+                    .frame(width: 38, height: 38)
+                    .overlay { Image(systemName: "person.fill") }
+            }
+        }
+    }
+
+    private func avatar(_ member: ConversationMember) -> some View {
+        let initials = member.profile.displayName
             .split(separator: " ")
             .prefix(2)
             .compactMap(\.first)
@@ -151,303 +129,210 @@ struct GroupDesktopView: View {
             .uppercased()
 
         return Circle()
-            .fill(Color.colorFillMinimal)
-            .frame(width: 44, height: 44)
+            .fill(Color.primary.opacity(0.08))
+            .frame(width: 38, height: 38)
             .overlay {
                 Text(initials.isEmpty ? "?" : initials)
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(.colorTextPrimary)
+                    .font(.caption2.weight(.bold))
             }
-            .overlay {
-                Circle().stroke(.colorBackgroundSurfaceless, lineWidth: 2)
-            }
-            .accessibilityLabel(name)
+            .overlay { Circle().stroke(Color(uiColor: .systemBackground), lineWidth: 2) }
     }
 
-    private var gettingStarted: some View {
+    private var start: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Let’s get this Convo started")
-                .font(.largeTitle.bold())
-                .foregroundStyle(.colorTextPrimary)
+            kicker("THE THINGS YOUR GROUP IS DOING")
 
-            Text("A few quick inputs give \(agentName) enough context to start doing useful work for everyone.")
+            Text("Let’s get this Convo started.")
+                .font(.system(size: 37, weight: .bold, design: .rounded))
+                .tracking(-1.2)
+
+            Text("Start with one useful thing. Everyone can help make it better.")
                 .font(.body)
-                .foregroundStyle(.colorTextSecondary)
+                .foregroundStyle(.secondary)
 
-            numberedAction(
-                number: 1,
+            startCard(
+                number: "1",
                 title: "What’s this group for?",
-                detail: "Family, fantasy crew, book club, girls trip, golf crew—or tell anything.",
-                action: .describeGroup
-            )
+                detail: "Pick a starting point—or just tell \(agentName) anything."
+            ) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        startChip("A trip")
+                        startChip("My family")
+                        startChip("Fantasy")
+                    }
+                    HStack(spacing: 8) {
+                        startChip("Book club")
+                        startChip("Something else…")
+                    }
+                }
+            }
 
-            numberedAction(
-                number: 2,
+            startCard(
+                number: "2",
                 title: "Add the first useful thing",
-                detail: "Drop a link, file, note, screenshot, or voice memo. Connect anything and the group can learn from what already exists.",
-                action: .addUsefulThing
+                detail: "A message, link, screenshot, file, or voice note all work."
+            ) {
+                actionRow(
+                    icon: "plus",
+                    title: "Connect anything",
+                    detail: "\(agentName) learns from what you already have—files, calendars, email, places, and more.",
+                    action: .connectAnything
+                )
+            }
+
+            startCard(
+                number: "3",
+                title: "Bring in your people",
+                detail: "Friends join something already moving—not another empty chat."
+            ) {
+                Button {
+                    onAction(.openMembers)
+                } label: {
+                    Label("Invite people", systemImage: "person.badge.plus")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(accent)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func startCard<Content: View>(
+        number: String,
+        title: String,
+        detail: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                Text(number)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 28, height: 28)
+                    .background(.black)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            content()
+                .padding(.leading, 40)
+        }
+        .padding(18)
+        .background(Color.primary.opacity(0.045))
+        .clipShape(.rect(cornerRadius: 22))
+    }
+
+    private func startChip(_ title: String) -> some View {
+        Button(title) {
+            onAction(.describeGroup)
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.primary)
+        .buttonStyle(.bordered)
+        .buttonBorderShape(.capsule)
+    }
+
+    private var dropItAllIn: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 9) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(accent)
+                kicker("DROP IT ALL IN")
+            }
+
+            Text("The work happens behind the scenes.")
+                .font(.title2.bold())
+
+            Text(
+                "No more manual research or keeping track of endless apps, files, lists, and notes. "
+                    + "Give the group context once. The agents can organize it, research it, and act on it."
+            )
+            .font(.body)
+            .foregroundStyle(.secondary)
+
+            VStack(spacing: 0) {
+                actionRow(
+                    icon: "magnifyingglass",
+                    title: "Research it",
+                    detail: "Compare options across the web and connected apps.",
+                    action: .researchOptions
+                )
+                Divider().padding(.leading, 54)
+                actionRow(
+                    icon: "checklist",
+                    title: "Keep track of it",
+                    detail: "Turn talk into notes, todos, reminders, and living plans.",
+                    action: .addUsefulThing
+                )
+                Divider().padding(.leading, 54)
+                actionRow(
+                    icon: "arrow.up.right",
+                    title: "Go do it",
+                    detail: "Update a doc, send something, make a plan, or use a skill.",
+                    action: .addThoughts
+                )
+            }
+            .background(Color.primary.opacity(0.04))
+            .clipShape(.rect(cornerRadius: 20))
+        }
+    }
+
+    private var conversationStartsWork: some View {
+        VStack(spacing: 12) {
+            actionBanner(
+                eyebrow: "EVERY CONVERSATION CAN START WORK",
+                title: "Tap + beside any message.",
+                detail: "Research it, connect it, remember it, or ask \(agentName) privately. The message comes along as context.",
+                button: "Try it",
+                action: .researchOptions
             )
 
-            numberedAction(
-                number: 3,
-                title: "Connect this group to your life",
-                detail: "Docs, calendars, email, Drive, Spotify, and more—only with the access each person chooses.",
-                action: .connectAnything
-            )
-
-            numberedAction(
-                number: 4,
-                title: "Ask everyone for something",
-                detail: "Collect answers privately without blowing up the group chat.",
+            actionBanner(
+                eyebrow: "ASK EVERYONE FOR SOMETHING",
+                title: "Collect answers without blowing up the chat.",
+                detail: "\(agentName) can privately ask each person, combine the answers, and bring the useful result back.",
+                button: "Ask everyone",
                 action: .askEveryone
             )
         }
     }
 
-    private func numberedAction(number: Int, title: String, detail: String, action: Action) -> some View {
-        Button {
-            onAction(action)
-        } label: {
-            HStack(alignment: .top, spacing: 14) {
-                Text("\(number)")
-                    .font(.subheadline.bold())
-                    .foregroundStyle(.colorTextPrimaryInverted)
-                    .frame(width: 30, height: 30)
-                    .background(Circle().fill(.colorTextPrimary))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(.headline)
-                        .foregroundStyle(.colorTextPrimary)
-                    Text(detail)
-                        .font(.subheadline)
-                        .foregroundStyle(.colorTextSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 8)
-
-                Image(systemName: "chevron.right")
-                    .font(.footnote.weight(.bold))
-                    .foregroundStyle(.colorTextTertiary)
-                    .padding(.top, 4)
-            }
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 22, style: .continuous)
-                    .fill(.colorFillMinimal)
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var sendAnything: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Label("Email or text anything to this desktop", systemImage: "tray.and.arrow.down.fill")
-                .font(.title2.bold())
-                .foregroundStyle(.colorTextPrimary)
-
-            Text(
-                "Forward or CC emails. Text links, screenshots, reminders, or anything the group should remember. "
-                    + "Ask \(agentName) to send emails, or add the text number to another group chat "
-                    + "so it can listen when you allow it."
-            )
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Text("TRY IT NOW")
-                .font(.caption2.weight(.bold))
-                .foregroundStyle(.colorTextTertiary)
-
-            inboundAddressRow(
-                InboundAddress(
-                    title: "Email",
-                    address: agentEmail,
-                    placeholder: "Set up the group email",
-                    detail: "Forward or CC anything",
-                    icon: "envelope.fill",
-                    setupAction: .setUpInboundEmail,
-                    obscuresPlaceholder: false
-                ),
-                open: openEmail
-            )
-
-            inboundAddressRow(
-                InboundAddress(
-                    title: "Text",
-                    address: agentPhone,
-                    placeholder: "+1 (415) 555-0142",
-                    detail: "Send links, photos, or reminders",
-                    icon: "message.fill",
-                    setupAction: .setUpInboundText,
-                    obscuresPlaceholder: true
-                ),
-                open: openText
-            )
-
-            Text("Anything sent here becomes shared group context. The agent only listens and acts with the group’s permission.")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(.colorFillMinimal)
-        )
-    }
-
-    private func inboundAddressRow(
-        _ content: InboundAddress,
-        open: @escaping (String) -> Void
+    private func actionBanner(
+        eyebrow: String,
+        title: String,
+        detail: String,
+        button: String,
+        action: Action
     ) -> some View {
-        HStack(spacing: 10) {
-            Button {
-                if let address = content.address {
-                    open(address)
-                } else {
-                    onAction(content.setupAction)
-                }
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: content.icon)
-                        .font(.body.weight(.semibold))
-                        .frame(width: 34, height: 34)
-                        .background(Circle().fill(.colorBackgroundSurfaceless))
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(content.title)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.colorTextSecondary)
-
-                        Text(content.address ?? content.placeholder)
-                            .font(.callout.weight(.semibold))
-                            .foregroundStyle(.colorTextPrimary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                            .blur(radius: content.address == nil && content.obscuresPlaceholder ? 4 : 0)
-                            .accessibilityHidden(content.address == nil && content.obscuresPlaceholder)
-
-                        Text(inboundAddressDetail(content))
-                            .font(.caption2)
-                            .foregroundStyle(.colorTextSecondary)
-                    }
-
-                    Spacer(minLength: 6)
-
-                    Image(systemName: content.address == nil ? "chevron.right" : "arrow.up.right")
-                        .font(.caption.bold())
-                        .foregroundStyle(.colorTextTertiary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if let address = content.address {
-                Button {
-                    copyInboundAddress(address)
-                } label: {
-                    Image(systemName: copiedInboundAddress == address ? "checkmark" : "square.on.square")
-                        .font(.body.weight(.semibold))
-                        .foregroundStyle(.colorTextPrimary)
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(
-                    copiedInboundAddress == address
-                        ? "Copied"
-                        : "Copy \(content.title.lowercased()) address"
-                )
-            }
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(.colorBackgroundSurfaceless)
-        )
-    }
-
-    private func inboundAddressDetail(_ content: InboundAddress) -> String {
-        guard content.address == nil else { return content.detail }
-        return content.obscuresPlaceholder ? "Tap to activate" : "Tap to finish setup"
-    }
-
-    private func openEmail(_ email: String) {
-        var components = URLComponents()
-        components.scheme = "mailto"
-        components.path = email
-        components.queryItems = [
-            URLQueryItem(name: "subject", value: "Add to \(groupName)")
-        ]
-        guard let url = components.url else { return }
-        openURL(url)
-    }
-
-    private func openText(_ phone: String) {
-        let dialable = phone.filter { $0.isNumber || $0 == "+" }
-        guard !dialable.isEmpty, let url = URL(string: "sms:\(dialable)") else { return }
-        openURL(url)
-    }
-
-    private func copyInboundAddress(_ address: String) {
-        UIPasteboard.general.string = address
-        copiedInboundAddress = address
-        Task {
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
-            if copiedInboundAddress == address {
-                copiedInboundAddress = nil
-            }
-        }
-    }
-
-    private var agentExplainer: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Label("Talking is doing the work", systemImage: "sparkles")
-                .font(.title3.bold())
-                .foregroundStyle(.colorTextPrimary)
-
-            Text(
-                "Anything on this desktop—or in an app the group connected—can be improved "
-                    + "in the agent side chat. Add what you know, request an edit, or ask for more research. "
-                    + "The update comes back to everyone. And we can see who’s doing what."
-            )
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack(spacing: 8) {
-                compactAction("Research options", icon: "magnifyingglass", action: .researchOptions)
-                compactAction("Add thoughts", icon: "square.and.pencil", action: .addThoughts)
-                compactAction("Voice note", icon: "waveform", action: .leaveVoiceNote)
-            }
-        }
-        .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(Color.colorFillMinimal)
-        )
-    }
-
-    private func compactAction(_ title: String, icon: String, action: Action) -> some View {
         Button {
             onAction(action)
         } label: {
-            VStack(spacing: 7) {
-                Image(systemName: icon)
-                    .font(.body.weight(.semibold))
+            VStack(alignment: .leading, spacing: 8) {
+                kicker(eyebrow)
                 Text(title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("\(button)  ↗")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(accent)
+                    .padding(.top, 3)
             }
-            .foregroundStyle(.colorTextPrimary)
-            .frame(maxWidth: .infinity, minHeight: 70)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.colorBackgroundSurfaceless)
-            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(18)
+            .background(Color.primary.opacity(0.04))
+            .clipShape(.rect(cornerRadius: 20))
         }
         .buttonStyle(.plain)
     }
@@ -455,203 +340,359 @@ struct GroupDesktopView: View {
     private var sharedWork: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 3) {
+                    kicker("HAPPENING NOW")
                     Text("One place to keep going")
                         .font(.title2.bold())
-                    Text("The useful output and its full work log stay together.")
-                        .font(.subheadline)
-                        .foregroundStyle(.colorTextSecondary)
                 }
-
                 Spacer()
-
-                Button("See all") {
-                    onAction(.openOutputs)
-                }
-                .font(.subheadline.weight(.semibold))
+                Button("Work log") { onAction(.openOutputs) }
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(accent)
             }
 
             Button {
                 onAction(.openOutputs)
             } label: {
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 14) {
                     HStack {
-                        Image(systemName: "doc.text.fill")
-                            .font(.title2)
-                            .foregroundStyle(.colorTextPrimary)
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Shared group plan")
-                                .font(.headline)
-                                .foregroundStyle(.colorTextPrimary)
-                            Text("Living output · updated as the group works")
-                                .font(.footnote)
-                                .foregroundStyle(.colorTextSecondary)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("Cabins under $250")
+                                .font(.title3.bold())
+                                .foregroundStyle(.primary)
+                            Label("Work lives in Google Docs", systemImage: "doc.text")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
-
                         Spacer()
-
                         Image(systemName: "arrow.up.right")
-                            .foregroundStyle(.colorTextSecondary)
+                            .foregroundStyle(accent)
                     }
 
                     Divider()
 
-                    Label("Open the output, edits, research, and who requested each change", systemImage: "clock.arrow.circlepath")
+                    Text("Tahoe cabin comparison")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text("Four options match the dates, budget, and what everyone has shared so far.")
                         .font(.subheadline)
-                        .foregroundStyle(.colorTextSecondary)
-                        .multilineTextAlignment(.leading)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        avatarStack
+                        Text("3 people made this better")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("Zoe hasn’t weighed in")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("Ask Zoe")
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(accent)
+                    }
                 }
                 .padding(18)
-                .background(
-                    RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .stroke(Color.colorBorderSubtle, lineWidth: 1)
-                )
+                .background(Color(red: 0.94, green: 0.98, blue: 0.94))
+                .clipShape(.rect(cornerRadius: 22))
             }
             .buttonStyle(.plain)
 
-            VStack(spacing: 10) {
-                suggestionRow("Add your links to the research", icon: "link", action: .addThoughts)
-                suggestionRow("Compare the best options", icon: "arrow.left.arrow.right", action: .researchOptions)
-                suggestionRow("Leave a voice note—\(agentName) can sort it out", icon: "waveform", action: .leaveVoiceNote)
+            Text("Keep improving this")
+                .font(.headline)
+
+            suggestion("Add your cabin links", detail: "Drop what you found. The comparison updates.", action: .addThoughts)
+            suggestion("Ask Jimmy for his picks", detail: "Collect his answer privately.", action: .askEveryone)
+            suggestion("Keep this in Google Drive", detail: "Connect Google and the living doc stays current.", action: .openConnections)
+
+            Button("See every change  ↗") {
+                onAction(.openOutputs)
             }
+            .font(.subheadline.weight(.bold))
+            .foregroundStyle(accent)
         }
     }
 
-    private func suggestionRow(_ title: String, icon: String, action: Action) -> some View {
+    private func suggestion(_ title: String, detail: String, action: Action) -> some View {
         Button {
             onAction(action)
         } label: {
             HStack(spacing: 12) {
-                Image(systemName: icon)
-                    .frame(width: 24)
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                    .multilineTextAlignment(.leading)
+                Image(systemName: "plus")
+                    .font(.caption.bold())
+                    .frame(width: 30, height: 30)
+                    .background(Color.primary.opacity(0.06))
+                    .clipShape(Circle())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.primary)
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                }
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(.caption.bold())
+                    .foregroundStyle(.tertiary)
             }
-            .foregroundStyle(.colorTextPrimary)
-            .padding(.vertical, 4)
         }
         .buttonStyle(.plain)
     }
 
-    private var everythingHasAPlace: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Everything has a place")
+    private var activity: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            kicker("GROUP MEMORY")
+            Text("Who did what")
                 .font(.title2.bold())
 
-            Text("Chat is the input. \(agentName) can organize what matters here and keep connected apps up to date.")
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-
-            Button {
-                onAction(.connectAnything)
-            } label: {
-                Label("Connect any service to this group", systemImage: "plus.circle.fill")
-                    .font(.headline)
-                    .foregroundStyle(.colorTextPrimaryInverted)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
-                    .background(
-                        Capsule().fill(.colorTextPrimary)
-                    )
-            }
-            .buttonStyle(.plain)
-
-            HStack(spacing: 18) {
-                serviceIcon("doc.text.fill", label: "Docs")
-                serviceIcon("envelope.fill", label: "Email")
-                serviceIcon("calendar", label: "Calendar")
-                serviceIcon("airplane", label: "Travel")
-                serviceIcon("music.note", label: "Music")
-            }
+            activityRow("Shane compared 17 cabins", detail: "The research and sources are saved.", actionTitle: "Open research", action: .openOutputs)
+            activityRow("Brent started the restaurant list", detail: "Last updated with Tahoe City favorites.", actionTitle: "Add yours", action: .addThoughts)
+            activityRow("Julie set a booking reminder", detail: "Everyone will be nudged Friday.", actionTitle: "See reminder", action: .openReminders)
+            activityRow("Shane added agent Kai", detail: "Kai added food and workout plans to Notes.", actionTitle: "Open notes", action: .openNotes)
         }
     }
 
-    private func serviceIcon(_ icon: String, label: String) -> some View {
-        VStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.body.weight(.semibold))
-                .frame(width: 42, height: 42)
-                .background(Circle().fill(.colorFillMinimal))
-            Text(label)
-                .font(.caption2)
-                .foregroundStyle(.colorTextSecondary)
+    private func activityRow(
+        _ title: String,
+        detail: String,
+        actionTitle: String,
+        action: Action
+    ) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(.primary)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("\(actionTitle)  ↗")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(accent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 5)
         }
-        .frame(maxWidth: .infinity)
+        .buttonStyle(.plain)
     }
 
     private var directory: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Group memory")
+            kicker("EVERYTHING THIS GROUP REMEMBERS")
+            Text("The group directory")
                 .font(.title2.bold())
+            Text("Every useful thing has a place—and every place can become the next input.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
 
-            Text("The shared directory gets richer as people and agents contribute.")
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
-
-            LazyVGrid(columns: [
-                GridItem(.flexible(), spacing: 12),
-                GridItem(.flexible(), spacing: 12)
-            ], spacing: 12) {
-                directoryButton("Members", value: "\(people.count)", icon: "person.2.fill", action: .openMembers)
-                directoryButton("Notes", value: "Shared context", icon: "note.text", action: .openNotes)
-                directoryButton("Todos", value: "Ready to act", icon: "checkmark.circle", action: .openTodos)
-                directoryButton("Reminders", value: "For the right people", icon: "bell.fill", action: .openReminders)
-                directoryButton("Agents", value: agents.isEmpty ? "Add one" : "\(agents.count) listening", icon: "sparkles", action: .openAgents)
-                directoryButton("Skills", value: "Give superpowers", icon: "wand.and.stars", action: .openSkills)
-                directoryButton("Connections", value: "Your apps", icon: "link.circle.fill", action: .openConnections)
-                directoryButton("Files & links", value: "All outputs", icon: "folder.fill", action: .openOutputs)
+            LazyVGrid(
+                columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)],
+                spacing: 10
+            ) {
+                directoryTile("Members", "People + profiles", "person.2", .openMembers)
+                directoryTile("Notes", "Shared context", "note.text", .openNotes)
+                directoryTile("Todos", "What happens next", "checkmark.circle", .openTodos)
+                directoryTile("Reminders", "Who · what · when", "bell", .openReminders)
+                directoryTile("Agents", "\(agents.count) can help", "sparkles", .openAgents)
+                directoryTile("Skills", "Give agents powers", "bolt", .openSkills)
+                directoryTile("Connections", "Apps from your life", "link", .openConnections)
+                directoryTile("Files", "Outputs + sources", "folder", .openOutputs)
             }
+
+            Button {
+                onAction(.addUsefulThing)
+            } label: {
+                Label("Add anything to group memory", systemImage: "plus")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 15)
+                    .background(.black)
+                    .clipShape(.capsule)
+            }
+            .buttonStyle(.plain)
         }
     }
 
-    private func directoryButton(_ title: String, value: String, icon: String, action: Action) -> some View {
+    private func directoryTile(_ title: String, _ detail: String, _ icon: String, _ action: Action) -> some View {
         Button {
             onAction(action)
         } label: {
-            VStack(alignment: .leading, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.title3.weight(.semibold))
-                Spacer(minLength: 8)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Image(systemName: icon)
+                    Spacer()
+                    Image(systemName: "plus")
+                        .font(.caption.bold())
+                }
                 Text(title)
                     .font(.headline)
-                Text(value)
+                Text(detail)
                     .font(.caption)
-                    .foregroundStyle(.colorTextSecondary)
+                    .foregroundStyle(.secondary)
             }
-            .foregroundStyle(.colorTextPrimary)
-            .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(.colorFillMinimal)
+            .foregroundStyle(.primary)
+            .frame(maxWidth: .infinity, minHeight: 105, alignment: .leading)
+            .padding(15)
+            .background(Color.primary.opacity(0.045))
+            .clipShape(.rect(cornerRadius: 18))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var inbound: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            kicker("SEND CONTEXT FROM ANYWHERE")
+            Text("Email or text anything to this desktop.")
+                .font(.title2.bold())
+            Text(
+                "Forward emails, CC the group, text links or screenshots, ask \(agentName) to send something, "
+                    + "or add the number to another chat. Everything useful can become context."
             )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+
+            inboundRow(
+                title: "Group email",
+                value: agents.first?.profile.agentEmail,
+                placeholder: "group@convos.email",
+                icon: "envelope",
+                setup: .setUpInboundEmail
+            )
+            inboundRow(
+                title: "Group text",
+                value: agents.first?.profile.agentPhone,
+                placeholder: "+1 (415) 555-0142",
+                icon: "message",
+                setup: .setUpInboundText,
+                blurred: true
+            )
+        }
+        .padding(18)
+        .background(Color.primary.opacity(0.045))
+        .clipShape(.rect(cornerRadius: 22))
+    }
+
+    private func inboundRow(
+        title: String,
+        value: String?,
+        placeholder: String,
+        icon: String,
+        setup: Action,
+        blurred: Bool = false
+    ) -> some View {
+        Button {
+            guard let value else {
+                onAction(setup)
+                return
+            }
+            UIPasteboard.general.string = value
+            copiedAddress = value
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .frame(width: 36, height: 36)
+                    .background(Color(uiColor: .systemBackground))
+                    .clipShape(Circle())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(value ?? placeholder)
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.primary)
+                        .blur(radius: value == nil && blurred ? 4 : 0)
+                    Text(value == nil ? "Tap to activate" : (copiedAddress == value ? "Copied" : "Tap to copy"))
+                        .font(.caption2)
+                        .foregroundStyle(accent)
+                }
+                Spacer()
+                Image(systemName: value == nil ? "chevron.right" : "square.on.square")
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+            .background(Color(uiColor: .systemBackground))
+            .clipShape(.rect(cornerRadius: 16))
         }
         .buttonStyle(.plain)
     }
 
     private var principles: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Made in the open. You are in control.")
-                .font(.headline)
+            Text("Talking is doing.")
+                .font(.title2.bold())
+            Text(
+                "Anything on this desktop—or in an app the group connected—can be improved in the agent side chat. "
+                    + "Add what you know, request an edit, or ask for more research. "
+                    + "The update comes back to everyone. And we can see who’s doing what."
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
 
-            Text("The desktop is your space. Secure chat has forward secrecy. If an agent shouldn’t listen, tap pause. Connect anything only when it helps the group.")
-                .font(.subheadline)
-                .foregroundStyle(.colorTextSecondary)
+            Divider().padding(.vertical, 4)
+
+            Text("Convos is made in the open. You are in control. The desktop is your space. "
+                + "Your secure chat has forward secrecy. If you don’t want an agent to listen, tap pause. Connect anything.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
 
             Text("Groups change the world.")
                 .font(.title3.bold())
-                .padding(.top, 8)
+                .padding(.top, 4)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(.colorFillMinimal)
-        )
+        .background(.black)
+        .foregroundStyle(.white)
+        .clipShape(.rect(cornerRadius: 24))
+    }
+
+    private func actionRow(
+        icon: String,
+        title: String,
+        detail: String,
+        action: Action
+    ) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.subheadline.weight(.semibold))
+                    .frame(width: 38, height: 38)
+                    .background(Color(uiColor: .systemBackground))
+                    .clipShape(.rect(cornerRadius: 12))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.primary)
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                }
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.right")
+                    .font(.caption.bold())
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func kicker(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.bold))
+            .tracking(1.6)
+            .foregroundStyle(.secondary)
     }
 }

--- a/Convos/Conversation Detail/GroupDesktopView.swift
+++ b/Convos/Conversation Detail/GroupDesktopView.swift
@@ -1,0 +1,657 @@
+import ConvosCore
+import SwiftUI
+import UIKit
+
+/// The group-scoped home behind a conversation.
+///
+/// This is deliberately a native, action-first surface. Chat remains the
+/// source of input; this page makes the group's shared context, work, and
+/// next-best actions visible without introducing a second document model.
+struct GroupDesktopView: View {
+    enum Action {
+        case describeGroup
+        case addUsefulThing
+        case connectAnything
+        case askEveryone
+        case researchOptions
+        case addThoughts
+        case leaveVoiceNote
+        case openOutputs
+        case openConnections
+        case openAgents
+        case openSkills
+        case openMembers
+        case openNotes
+        case openTodos
+        case openReminders
+        case setUpInboundEmail
+        case setUpInboundText
+    }
+
+    private struct InboundAddress {
+        let title: String
+        let address: String?
+        let placeholder: String
+        let detail: String
+        let icon: String
+        let setupAction: Action
+        let obscuresPlaceholder: Bool
+    }
+
+    let conversation: Conversation
+    let onAction: (Action) -> Void
+    var onScrollOffsetChange: ((CGFloat) -> Void)?
+
+    @Environment(\.openURL) private var openURL: OpenURLAction
+    @State private var copiedInboundAddress: String?
+
+    private var people: [ConversationMember] {
+        conversation.members.filter { !$0.isAgent }
+    }
+
+    private var agents: [ConversationMember] {
+        conversation.members.filter(\.isAgent)
+    }
+
+    private var agentName: String {
+        agents.first?.profile.displayName ?? "Group Agent"
+    }
+
+    private var agentEmail: String? {
+        agents.first?.profile.agentEmail
+    }
+
+    private var agentPhone: String? {
+        agents.first?.profile.agentPhone
+    }
+
+    private var groupName: String {
+        let name = conversation.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return name.isEmpty ? "this group" : name
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 28) {
+                peopleHeader
+                gettingStarted
+                sendAnything
+                agentExplainer
+                sharedWork
+                everythingHasAPlace
+                directory
+                principles
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 48)
+        }
+        .background(.colorBackgroundSurfaceless)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentOffset.y + geometry.contentInsets.top
+        } action: { _, offset in
+            onScrollOffsetChange?(offset)
+        }
+    }
+
+    private var peopleHeader: some View {
+        Button {
+            onAction(.openMembers)
+        } label: {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text(groupName)
+                        .font(.title2.bold())
+                        .foregroundStyle(.colorTextPrimary)
+
+                    Spacer()
+
+                    Label("Invite", systemImage: "person.badge.plus")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.colorTextPrimary)
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: -6) {
+                        ForEach(Array(people.prefix(8)), id: \.profile.inboxId) { member in
+                            memberAvatar(member)
+                        }
+
+                        Circle()
+                            .fill(.colorFillMinimal)
+                            .frame(width: 44, height: 44)
+                            .overlay {
+                                Image(systemName: "plus")
+                                    .font(.body.weight(.semibold))
+                                    .foregroundStyle(.colorTextPrimary)
+                            }
+                            .overlay {
+                                Circle().stroke(.colorBackgroundSurfaceless, lineWidth: 2)
+                            }
+                            .accessibilityLabel("Invite more people")
+                    }
+                }
+
+                Text("\(people.count) people are making this better together")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func memberAvatar(_ member: ConversationMember) -> some View {
+        let name = member.profile.displayName
+        let initials = name
+            .split(separator: " ")
+            .prefix(2)
+            .compactMap(\.first)
+            .map(String.init)
+            .joined()
+            .uppercased()
+
+        return Circle()
+            .fill(Color.colorFillMinimal)
+            .frame(width: 44, height: 44)
+            .overlay {
+                Text(initials.isEmpty ? "?" : initials)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.colorTextPrimary)
+            }
+            .overlay {
+                Circle().stroke(.colorBackgroundSurfaceless, lineWidth: 2)
+            }
+            .accessibilityLabel(name)
+    }
+
+    private var gettingStarted: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Let’s get this Convo started")
+                .font(.largeTitle.bold())
+                .foregroundStyle(.colorTextPrimary)
+
+            Text("A few quick inputs give \(agentName) enough context to start doing useful work for everyone.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+
+            numberedAction(
+                number: 1,
+                title: "What’s this group for?",
+                detail: "Family, fantasy crew, book club, girls trip, golf crew—or tell anything.",
+                action: .describeGroup
+            )
+
+            numberedAction(
+                number: 2,
+                title: "Add the first useful thing",
+                detail: "Drop a link, file, note, screenshot, or voice memo. Connect anything and the group can learn from what already exists.",
+                action: .addUsefulThing
+            )
+
+            numberedAction(
+                number: 3,
+                title: "Connect this group to your life",
+                detail: "Docs, calendars, email, Drive, Spotify, and more—only with the access each person chooses.",
+                action: .connectAnything
+            )
+
+            numberedAction(
+                number: 4,
+                title: "Ask everyone for something",
+                detail: "Collect answers privately without blowing up the group chat.",
+                action: .askEveryone
+            )
+        }
+    }
+
+    private func numberedAction(number: Int, title: String, detail: String, action: Action) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            HStack(alignment: .top, spacing: 14) {
+                Text("\(number)")
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.colorTextPrimaryInverted)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(.colorTextPrimary))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(.colorTextPrimary)
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.colorTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(.colorTextTertiary)
+                    .padding(.top, 4)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(.colorFillMinimal)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var sendAnything: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Email or text anything to this desktop", systemImage: "tray.and.arrow.down.fill")
+                .font(.title2.bold())
+                .foregroundStyle(.colorTextPrimary)
+
+            Text(
+                "Forward or CC emails. Text links, screenshots, reminders, or anything the group should remember. "
+                    + "Ask \(agentName) to send emails, or add the text number to another group chat "
+                    + "so it can listen when you allow it."
+            )
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("TRY IT NOW")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.colorTextTertiary)
+
+            inboundAddressRow(
+                InboundAddress(
+                    title: "Email",
+                    address: agentEmail,
+                    placeholder: "Set up the group email",
+                    detail: "Forward or CC anything",
+                    icon: "envelope.fill",
+                    setupAction: .setUpInboundEmail,
+                    obscuresPlaceholder: false
+                ),
+                open: openEmail
+            )
+
+            inboundAddressRow(
+                InboundAddress(
+                    title: "Text",
+                    address: agentPhone,
+                    placeholder: "+1 (415) 555-0142",
+                    detail: "Send links, photos, or reminders",
+                    icon: "message.fill",
+                    setupAction: .setUpInboundText,
+                    obscuresPlaceholder: true
+                ),
+                open: openText
+            )
+
+            Text("Anything sent here becomes shared group context. The agent only listens and acts with the group’s permission.")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.colorFillMinimal)
+        )
+    }
+
+    private func inboundAddressRow(
+        _ content: InboundAddress,
+        open: @escaping (String) -> Void
+    ) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                if let address = content.address {
+                    open(address)
+                } else {
+                    onAction(content.setupAction)
+                }
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: content.icon)
+                        .font(.body.weight(.semibold))
+                        .frame(width: 34, height: 34)
+                        .background(Circle().fill(.colorBackgroundSurfaceless))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(content.title)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.colorTextSecondary)
+
+                        Text(content.address ?? content.placeholder)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(.colorTextPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .blur(radius: content.address == nil && content.obscuresPlaceholder ? 4 : 0)
+                            .accessibilityHidden(content.address == nil && content.obscuresPlaceholder)
+
+                        Text(inboundAddressDetail(content))
+                            .font(.caption2)
+                            .foregroundStyle(.colorTextSecondary)
+                    }
+
+                    Spacer(minLength: 6)
+
+                    Image(systemName: content.address == nil ? "chevron.right" : "arrow.up.right")
+                        .font(.caption.bold())
+                        .foregroundStyle(.colorTextTertiary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if let address = content.address {
+                Button {
+                    copyInboundAddress(address)
+                } label: {
+                    Image(systemName: copiedInboundAddress == address ? "checkmark" : "square.on.square")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(.colorTextPrimary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    copiedInboundAddress == address
+                        ? "Copied"
+                        : "Copy \(content.title.lowercased()) address"
+                )
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(.colorBackgroundSurfaceless)
+        )
+    }
+
+    private func inboundAddressDetail(_ content: InboundAddress) -> String {
+        guard content.address == nil else { return content.detail }
+        return content.obscuresPlaceholder ? "Tap to activate" : "Tap to finish setup"
+    }
+
+    private func openEmail(_ email: String) {
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = email
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: "Add to \(groupName)")
+        ]
+        guard let url = components.url else { return }
+        openURL(url)
+    }
+
+    private func openText(_ phone: String) {
+        let dialable = phone.filter { $0.isNumber || $0 == "+" }
+        guard !dialable.isEmpty, let url = URL(string: "sms:\(dialable)") else { return }
+        openURL(url)
+    }
+
+    private func copyInboundAddress(_ address: String) {
+        UIPasteboard.general.string = address
+        copiedInboundAddress = address
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            if copiedInboundAddress == address {
+                copiedInboundAddress = nil
+            }
+        }
+    }
+
+    private var agentExplainer: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Talking is doing the work", systemImage: "sparkles")
+                .font(.title3.bold())
+                .foregroundStyle(.colorTextPrimary)
+
+            Text(
+                "Anything on this desktop—or in an app the group connected—can be improved "
+                    + "in the agent side chat. Add what you know, request an edit, or ask for more research. "
+                    + "The update comes back to everyone. And we can see who’s doing what."
+            )
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                compactAction("Research options", icon: "magnifyingglass", action: .researchOptions)
+                compactAction("Add thoughts", icon: "square.and.pencil", action: .addThoughts)
+                compactAction("Voice note", icon: "waveform", action: .leaveVoiceNote)
+            }
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.colorFillMinimal)
+        )
+    }
+
+    private func compactAction(_ title: String, icon: String, action: Action) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            VStack(spacing: 7) {
+                Image(systemName: icon)
+                    .font(.body.weight(.semibold))
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+            }
+            .foregroundStyle(.colorTextPrimary)
+            .frame(maxWidth: .infinity, minHeight: 70)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.colorBackgroundSurfaceless)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var sharedWork: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("One place to keep going")
+                        .font(.title2.bold())
+                    Text("The useful output and its full work log stay together.")
+                        .font(.subheadline)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+
+                Spacer()
+
+                Button("See all") {
+                    onAction(.openOutputs)
+                }
+                .font(.subheadline.weight(.semibold))
+            }
+
+            Button {
+                onAction(.openOutputs)
+            } label: {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Image(systemName: "doc.text.fill")
+                            .font(.title2)
+                            .foregroundStyle(.colorTextPrimary)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Shared group plan")
+                                .font(.headline)
+                                .foregroundStyle(.colorTextPrimary)
+                            Text("Living output · updated as the group works")
+                                .font(.footnote)
+                                .foregroundStyle(.colorTextSecondary)
+                        }
+
+                        Spacer()
+
+                        Image(systemName: "arrow.up.right")
+                            .foregroundStyle(.colorTextSecondary)
+                    }
+
+                    Divider()
+
+                    Label("Open the output, edits, research, and who requested each change", systemImage: "clock.arrow.circlepath")
+                        .font(.subheadline)
+                        .foregroundStyle(.colorTextSecondary)
+                        .multilineTextAlignment(.leading)
+                }
+                .padding(18)
+                .background(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(Color.colorBorderSubtle, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+
+            VStack(spacing: 10) {
+                suggestionRow("Add your links to the research", icon: "link", action: .addThoughts)
+                suggestionRow("Compare the best options", icon: "arrow.left.arrow.right", action: .researchOptions)
+                suggestionRow("Leave a voice note—\(agentName) can sort it out", icon: "waveform", action: .leaveVoiceNote)
+            }
+        }
+    }
+
+    private func suggestionRow(_ title: String, icon: String, action: Action) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .frame(width: 24)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .multilineTextAlignment(.leading)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.bold())
+            }
+            .foregroundStyle(.colorTextPrimary)
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var everythingHasAPlace: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Everything has a place")
+                .font(.title2.bold())
+
+            Text("Chat is the input. \(agentName) can organize what matters here and keep connected apps up to date.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+
+            Button {
+                onAction(.connectAnything)
+            } label: {
+                Label("Connect any service to this group", systemImage: "plus.circle.fill")
+                    .font(.headline)
+                    .foregroundStyle(.colorTextPrimaryInverted)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(
+                        Capsule().fill(.colorTextPrimary)
+                    )
+            }
+            .buttonStyle(.plain)
+
+            HStack(spacing: 18) {
+                serviceIcon("doc.text.fill", label: "Docs")
+                serviceIcon("envelope.fill", label: "Email")
+                serviceIcon("calendar", label: "Calendar")
+                serviceIcon("airplane", label: "Travel")
+                serviceIcon("music.note", label: "Music")
+            }
+        }
+    }
+
+    private func serviceIcon(_ icon: String, label: String) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.body.weight(.semibold))
+                .frame(width: 42, height: 42)
+                .background(Circle().fill(.colorFillMinimal))
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var directory: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Group memory")
+                .font(.title2.bold())
+
+            Text("The shared directory gets richer as people and agents contribute.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 12),
+                GridItem(.flexible(), spacing: 12)
+            ], spacing: 12) {
+                directoryButton("Members", value: "\(people.count)", icon: "person.2.fill", action: .openMembers)
+                directoryButton("Notes", value: "Shared context", icon: "note.text", action: .openNotes)
+                directoryButton("Todos", value: "Ready to act", icon: "checkmark.circle", action: .openTodos)
+                directoryButton("Reminders", value: "For the right people", icon: "bell.fill", action: .openReminders)
+                directoryButton("Agents", value: agents.isEmpty ? "Add one" : "\(agents.count) listening", icon: "sparkles", action: .openAgents)
+                directoryButton("Skills", value: "Give superpowers", icon: "wand.and.stars", action: .openSkills)
+                directoryButton("Connections", value: "Your apps", icon: "link.circle.fill", action: .openConnections)
+                directoryButton("Files & links", value: "All outputs", icon: "folder.fill", action: .openOutputs)
+            }
+        }
+    }
+
+    private func directoryButton(_ title: String, value: String, icon: String, action: Action) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            VStack(alignment: .leading, spacing: 12) {
+                Image(systemName: icon)
+                    .font(.title3.weight(.semibold))
+                Spacer(minLength: 8)
+                Text(title)
+                    .font(.headline)
+                Text(value)
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            .foregroundStyle(.colorTextPrimary)
+            .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(.colorFillMinimal)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var principles: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Made in the open. You are in control.")
+                .font(.headline)
+
+            Text("The desktop is your space. Secure chat has forward secrecy. If an agent shouldn’t listen, tap pause. Connect anything only when it helps the group.")
+                .font(.subheadline)
+                .foregroundStyle(.colorTextSecondary)
+
+            Text("Groups change the world.")
+                .font(.title3.bold())
+                .padding(.top, 8)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.colorFillMinimal)
+        )
+    }
+}

--- a/Convos/Conversations List/FilteredEmptyStateView.swift
+++ b/Convos/Conversations List/FilteredEmptyStateView.swift
@@ -9,23 +9,13 @@ struct FilteredEmptyStateView: View {
     let onShowAll: () -> Void
 
     var body: some View {
-        VStack(spacing: DesignConstants.Spacing.step3x) {
-            Text(message)
-                .font(.callout)
-                .foregroundStyle(.colorTextSecondary)
-
-            let showAllAction = { onShowAll() }
-            Button(action: showAllAction) {
-                Text("Show all")
-            }
-            .convosButtonStyle(.rounded(fullWidth: false))
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityIdentifier("show-all-button")
-        }
-        .frame(maxWidth: .infinity)
-        .padding(DesignConstants.Spacing.step6x)
-        .background(.colorFillMinimal)
-        .cornerRadius(DesignConstants.Spacing.step6x)
+        ConvosEmptyStateCard(
+            message: message,
+            actionTitle: "Show all",
+            actionAccessibilityLabel: accessibilityLabel,
+            actionAccessibilityIdentifier: "show-all-button",
+            action: onShowAll
+        )
     }
 }
 

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -72,6 +72,12 @@ struct DebugViewSection: View {
     @ViewBuilder
     private var featuresSection: some View {
         Section("Features") {
+            NavigationLink {
+                DesignSystemCatalogView()
+            } label: {
+                Text("Design system catalog")
+            }
+
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
             Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)

--- a/Convos/Design System/Components/ConvosBadge.swift
+++ b/Convos/Design System/Components/ConvosBadge.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct ConvosBadge: View {
+    let label: String
+    var tone: Tone = .neutral
+    var size: Size = .regular
+
+    var body: some View {
+        Text(label)
+            .font(size.font)
+            .foregroundStyle(tone.foregroundColor)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepX)
+            .background(tone.backgroundColor, in: .capsule)
+            .accessibilityLabel(label)
+    }
+
+    enum Tone {
+        case neutral
+        case subtle
+        case accent
+        case warning
+        case danger
+
+        var foregroundColor: Color {
+            switch self {
+            case .neutral, .subtle:
+                .colorTextSecondary
+            case .accent:
+                .colorTextPrimaryInverted
+            case .warning:
+                .colorTextPrimary
+            case .danger:
+                .colorCaution
+            }
+        }
+
+        var backgroundColor: Color {
+            switch self {
+            case .neutral:
+                .colorTextSecondary.opacity(0.1)
+            case .subtle:
+                .colorFillMinimal
+            case .accent:
+                .colorFillPrimary
+            case .warning:
+                .colorWarning.opacity(0.18)
+            case .danger:
+                .colorCaution.opacity(0.08)
+            }
+        }
+    }
+
+    enum Size {
+        case regular
+        case compact
+
+        var font: Font {
+            switch self {
+            case .regular:
+                DesignConstants.Typography.label
+            case .compact:
+                .caption2
+            }
+        }
+    }
+}
+
+#Preview {
+    HStack(spacing: DesignConstants.Spacing.step2x) {
+        ConvosBadge(label: "Agent")
+        ConvosBadge(label: "quiet", tone: .subtle, size: .compact)
+        ConvosBadge(label: "New", tone: .accent)
+        ConvosBadge(label: "Pending", tone: .warning)
+        ConvosBadge(label: "Blocked", tone: .danger)
+    }
+    .padding()
+}

--- a/Convos/Design System/Components/ConvosEmptyStateCard.swift
+++ b/Convos/Design System/Components/ConvosEmptyStateCard.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ConvosEmptyStateCard: View {
+    let message: String
+    let actionTitle: String
+    var actionAccessibilityLabel: String?
+    var actionAccessibilityIdentifier: String?
+    let action: () -> Void
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            Text(message)
+                .convosTextStyle(.callout)
+                .multilineTextAlignment(.center)
+
+            let buttonAction = { action() }
+            Button(action: buttonAction) {
+                Text(actionTitle)
+            }
+            .convosButtonStyle(.rounded(fullWidth: false))
+            .accessibilityLabel(actionAccessibilityLabel ?? actionTitle)
+            .accessibilityIdentifier(actionAccessibilityIdentifier ?? "")
+        }
+        .frame(maxWidth: .infinity)
+        .convosSurface(.emptyState, padding: DesignConstants.Spacing.step6x)
+    }
+}
+
+#Preview {
+    ConvosEmptyStateCard(
+        message: "No unread convos",
+        actionTitle: "Show all"
+    ) {}
+    .padding()
+}

--- a/Convos/Design System/Components/ConvosIconTile.swift
+++ b/Convos/Design System/Components/ConvosIconTile.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct ConvosIconTile: View {
+    private let image: Image
+    private let foregroundColor: Color
+    private let backgroundColor: Color
+    private let size: CGFloat
+
+    init(
+        systemName: String,
+        foregroundColor: Color = .colorTextPrimary,
+        backgroundColor: Color = .colorFillMinimal,
+        size: CGFloat = DesignConstants.Layout.iconTile
+    ) {
+        self.image = Image(systemName: systemName)
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+        self.size = size
+    }
+
+    init(
+        imageName: String,
+        foregroundColor: Color = .colorTextPrimary,
+        backgroundColor: Color = .colorFillMinimal,
+        size: CGFloat = DesignConstants.Layout.iconTile
+    ) {
+        self.image = Image(imageName)
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+        self.size = size
+    }
+
+    var body: some View {
+        image
+            .font(.headline)
+            .foregroundStyle(foregroundColor)
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+                    .fill(backgroundColor)
+            )
+            .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    HStack {
+        ConvosIconTile(systemName: "qrcode")
+        ConvosIconTile(
+            systemName: "exclamationmark.triangle",
+            foregroundColor: .colorCaution,
+            backgroundColor: .colorCaution.opacity(0.08)
+        )
+    }
+    .padding()
+}

--- a/Convos/Design System/Components/ConvosSettingsRow.swift
+++ b/Convos/Design System/Components/ConvosSettingsRow.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct ConvosSettingsRow<Accessory: View>: View {
+    let iconSystemName: String
+    let title: String
+    let subtitle: String?
+    private let accessory: Accessory
+
+    init(
+        iconSystemName: String,
+        title: String,
+        subtitle: String? = nil,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
+        self.iconSystemName = iconSystemName
+        self.title = title
+        self.subtitle = subtitle
+        self.accessory = accessory()
+    }
+
+    var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            ConvosIconTile(systemName: iconSystemName)
+
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                Text(title)
+                    .convosTextStyle(.body)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .convosTextStyle(.detail)
+                        .lineLimit(3)
+                }
+            }
+
+            Spacer(minLength: DesignConstants.Spacing.step2x)
+            accessory
+        }
+        .frame(minHeight: DesignConstants.Layout.minimumTapTarget)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .contain)
+    }
+}
+
+#Preview {
+    @Previewable @State var isOn: Bool = true
+    VStack {
+        ConvosSettingsRow(
+            iconSystemName: "eye",
+            title: "Read receipts",
+            subtitle: "Let others know when you have read their messages"
+        ) {
+            Toggle("", isOn: $isOn)
+                .labelsHidden()
+        }
+
+        ConvosSettingsRow(
+            iconSystemName: "person.2",
+            title: "Members"
+        ) {
+            Image(systemName: "chevron.right")
+                .foregroundStyle(.colorTextTertiary)
+        }
+    }
+    .padding()
+}

--- a/Convos/Design System/DesignSystemCatalogView.swift
+++ b/Convos/Design System/DesignSystemCatalogView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+struct DesignSystemCatalogView: View {
+    @State private var sampleToggle: Bool = true
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step10x) {
+                catalogHeader
+                CatalogColorSection()
+                CatalogTypographySection()
+                catalogComponents
+            }
+            .frame(maxWidth: DesignConstants.Layout.readableContentWidth, alignment: .leading)
+            .padding(.horizontal, DesignConstants.Layout.screenHorizontalInset)
+            .padding(.vertical, DesignConstants.Spacing.step10x)
+        }
+        .convosSurface(.screen)
+    }
+
+    private var catalogHeader: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Convos")
+                .convosTextStyle(.display)
+            Text("Design system")
+                .convosTextStyle(.title)
+            Text("A living catalog of the visual language already used throughout the app.")
+                .convosTextStyle(.supporting)
+        }
+    }
+
+    private var catalogComponents: some View {
+        CatalogSection(title: "Components") {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
+                HStack(spacing: DesignConstants.Spacing.step2x) {
+                    ConvosBadge(label: "Agent")
+                    ConvosBadge(label: "New", tone: .accent)
+                    ConvosBadge(label: "Pending", tone: .warning)
+                    ConvosBadge(label: "Blocked", tone: .danger)
+                }
+
+                HStack(spacing: DesignConstants.Spacing.step2x) {
+                    ConvosIconTile(systemName: "qrcode")
+                    ConvosIconTile(systemName: "eye")
+                    ConvosIconTile(systemName: "lock")
+                }
+
+                VStack(spacing: DesignConstants.Spacing.step2x) {
+                    Button("Primary") {}
+                        .convosButtonStyle(.rounded(fullWidth: true))
+                    Button("Secondary") {}
+                        .convosButtonStyle(.outline(fullWidth: true))
+                    Button("Text action") {}
+                        .convosButtonStyle(.text)
+                }
+
+                ConvosSettingsRow(
+                    iconSystemName: "eye",
+                    title: "Read receipts",
+                    subtitle: "Let others know when you have read their messages"
+                ) {
+                    Toggle("", isOn: $sampleToggle)
+                        .labelsHidden()
+                }
+
+                ConvosEmptyStateCard(
+                    message: "Nothing here yet",
+                    actionTitle: "Start a convo"
+                ) {}
+            }
+        }
+    }
+}
+
+private struct CatalogColorSection: View {
+    private let colors: [CatalogColor] = [
+        CatalogColor(name: "Background", color: .colorBackgroundSurfaceless),
+        CatalogColor(name: "Raised", color: .colorBackgroundRaised),
+        CatalogColor(name: "Raised secondary", color: .colorBackgroundRaisedSecondary),
+        CatalogColor(name: "Primary text", color: .colorTextPrimary),
+        CatalogColor(name: "Secondary text", color: .colorTextSecondary),
+        CatalogColor(name: "Primary fill", color: .colorFillPrimary),
+        CatalogColor(name: "Minimal fill", color: .colorFillMinimal),
+        CatalogColor(name: "Warning", color: .colorWarning),
+        CatalogColor(name: "Caution", color: .colorCaution),
+    ]
+
+    var body: some View {
+        CatalogSection(title: "Semantic colors") {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 140.0), spacing: DesignConstants.Spacing.step3x)],
+                spacing: DesignConstants.Spacing.step3x
+            ) {
+                ForEach(colors) { color in
+                    VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+                        RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+                            .fill(color.color)
+                            .frame(height: 72.0)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
+                                    .stroke(.colorBorderSubtle, lineWidth: DesignConstants.Layout.hairline)
+                            }
+                        Text(color.name)
+                            .convosTextStyle(.label)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct CatalogTypographySection: View {
+    var body: some View {
+        CatalogSection(title: "Typography") {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+                typographySample("Private by design", style: .display, role: "Display")
+                typographySample("A conversation worth keeping", style: .title, role: "Title")
+                typographySample("Section heading", style: .headline, role: "Headline")
+                typographySample("Messages, settings, and primary content", style: .body, role: "Body")
+                typographySample("Secondary body copy", style: .bodySecondary, role: "Body secondary")
+                typographySample("Compact empty-state guidance", style: .callout, role: "Callout")
+                typographySample("Supporting context and metadata", style: .supporting, role: "Supporting")
+                typographySample("Small explanatory copy", style: .detail, role: "Detail")
+                typographySample("CONTROL LABEL", style: .label, role: "Label")
+                typographySample("Timestamp and quiet detail", style: .caption, role: "Caption")
+            }
+        }
+    }
+
+    private func typographySample(
+        _ text: String,
+        style: ConvosTextStyle,
+        role: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+            Text(role)
+                .convosTextStyle(.caption)
+            Text(text)
+                .convosTextStyle(style)
+        }
+    }
+}
+
+private struct CatalogSection<Content: View>: View {
+    let title: String
+    private let content: Content
+
+    init(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text(title)
+                .convosTextStyle(.headline)
+            content
+        }
+    }
+}
+
+private struct CatalogColor: Identifiable {
+    let id: String
+    let name: String
+    let color: Color
+
+    init(name: String, color: Color) {
+        self.id = name
+        self.name = name
+        self.color = color
+    }
+}
+
+#Preview("Light") {
+    DesignSystemCatalogView()
+        .preferredColorScheme(.light)
+}
+
+#Preview("Dark") {
+    DesignSystemCatalogView()
+        .preferredColorScheme(.dark)
+}

--- a/Convos/Design System/Styles/ButtonStyles.swift
+++ b/Convos/Design System/Styles/ButtonStyles.swift
@@ -31,11 +31,11 @@ struct ActionButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.body)
-            .padding()
-            .background(Color(.systemGray6))
-            .cornerRadius(10)
-            .opacity(configuration.isPressed ? 0.6 : 1.0)
+            .font(DesignConstants.Typography.body)
+            .padding(DesignConstants.Spacing.step4x)
+            .background(.colorFillMinimal)
+            .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular))
+            .opacity(configuration.isPressed ? DesignConstants.Opacity.pressed : 1.0)
     }
 }
 
@@ -48,15 +48,15 @@ struct RoundedButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: fullWidth ? .infinity : nil)
-            .font(.subheadline)
+            .font(DesignConstants.Typography.button)
             .lineLimit(1)
             .truncationMode(.middle)
             .padding(.vertical, DesignConstants.Spacing.step4x)
             .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .opacity(configuration.isPressed ? 0.6 : 1.0)
+            .opacity(configuration.isPressed ? DesignConstants.Opacity.pressed : 1.0)
             .background(backgroundColor)
             .clipShape(Capsule())
-            .foregroundColor(isEnabled ? .colorTextPrimaryInverted : .colorTextTertiary)
+            .foregroundStyle(isEnabled ? .colorTextPrimaryInverted : .colorTextTertiary)
     }
 }
 
@@ -68,15 +68,15 @@ struct RoundedDestructiveButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: fullWidth ? .infinity : nil)
-            .font(.subheadline)
+            .font(DesignConstants.Typography.button)
             .lineLimit(1)
             .truncationMode(.middle)
             .padding(.vertical, DesignConstants.Spacing.step4x)
             .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .opacity(configuration.isPressed ? 0.6 : 1.0)
+            .opacity(configuration.isPressed ? DesignConstants.Opacity.pressed : 1.0)
             .background(.colorCaution.opacity(0.08))
             .clipShape(Capsule())
-            .foregroundColor(isEnabled ? .colorCaution : .colorCaution.opacity(0.75))
+            .foregroundStyle(isEnabled ? .colorCaution : .colorCaution.opacity(0.75))
     }
 }
 
@@ -85,13 +85,17 @@ struct TextButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.subheadline)
+            .font(DesignConstants.Typography.button)
             .lineLimit(1)
             .truncationMode(.middle)
             .foregroundStyle(.colorTextSecondary)
             .padding(.vertical, DesignConstants.Spacing.step4x)
             .padding(.horizontal, DesignConstants.Spacing.step4x)
-            .opacity(isEnabled ? configuration.isPressed ? 0.6 : 1.0 : 0.3)
+            .opacity(
+                isEnabled
+                    ? configuration.isPressed ? DesignConstants.Opacity.pressed : 1.0
+                    : DesignConstants.Opacity.disabled
+            )
     }
 }
 
@@ -103,7 +107,7 @@ struct OutlineButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: fullWidth ? .infinity : nil)
-            .font(.subheadline)
+            .font(DesignConstants.Typography.button)
             .lineLimit(1)
             .truncationMode(.middle)
             .padding(.vertical, DesignConstants.Spacing.step4x)
@@ -111,10 +115,10 @@ struct OutlineButtonStyle: ButtonStyle {
             .background(Color.clear)
             .overlay(
                 RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.medium)
-                    .stroke(.colorBorderSubtle2, lineWidth: 1.0)
+                    .stroke(.colorBorderSubtle2, lineWidth: DesignConstants.Layout.hairline)
             )
-            .foregroundColor(isEnabled ? .colorTextPrimary : .colorTextTertiary)
-            .opacity(configuration.isPressed ? 0.6 : 1.0)
+            .foregroundStyle(isEnabled ? .colorTextPrimary : .colorTextTertiary)
+            .opacity(configuration.isPressed ? DesignConstants.Opacity.pressed : 1.0)
     }
 }
 
@@ -126,7 +130,7 @@ struct OutlineCapsuleButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: fullWidth ? .infinity : nil)
-            .font(.subheadline)
+            .font(DesignConstants.Typography.button)
             .lineLimit(1)
             .truncationMode(.middle)
             .padding(.vertical, DesignConstants.Spacing.step3x)
@@ -134,10 +138,10 @@ struct OutlineCapsuleButtonStyle: ButtonStyle {
             .background(Color.clear)
             .overlay(
                 Capsule()
-                    .stroke(.colorBorderSubtle2, lineWidth: 1.0)
+                    .stroke(.colorBorderSubtle2, lineWidth: DesignConstants.Layout.hairline)
             )
-            .foregroundColor(isEnabled ? .colorTextPrimary : .colorTextTertiary)
-            .opacity(configuration.isPressed ? 0.6 : 1.0)
+            .foregroundStyle(isEnabled ? .colorTextPrimary : .colorTextTertiary)
+            .opacity(configuration.isPressed ? DesignConstants.Opacity.pressed : 1.0)
     }
 }
 

--- a/Convos/Design System/Styles/SurfaceStyles.swift
+++ b/Convos/Design System/Styles/SurfaceStyles.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+enum ConvosSurfaceStyle {
+    case screen
+    case raised
+    case raisedSecondary
+    case card
+    case subtle
+    case emptyState
+    case inverted
+
+    var backgroundColor: Color {
+        switch self {
+        case .screen:
+            .colorBackgroundSurfaceless
+        case .raised, .card:
+            .colorBackgroundRaised
+        case .raisedSecondary:
+            .colorBackgroundRaisedSecondary
+        case .subtle, .emptyState:
+            .colorFillMinimal
+        case .inverted:
+            .colorBackgroundInverted
+        }
+    }
+
+    var cornerRadius: CGFloat {
+        switch self {
+        case .screen:
+            0.0
+        case .raised, .raisedSecondary:
+            DesignConstants.CornerRadius.medium
+        case .card:
+            DesignConstants.CornerRadius.mediumLarge
+        case .subtle:
+            DesignConstants.CornerRadius.regular
+        case .emptyState:
+            DesignConstants.CornerRadius.mediumLarge
+        case .inverted:
+            DesignConstants.CornerRadius.medium
+        }
+    }
+
+    var borderColor: Color? {
+        switch self {
+        case .card:
+            .colorBorderSubtle
+        case .screen, .raised, .raisedSecondary, .subtle, .emptyState, .inverted:
+            nil
+        }
+    }
+}
+
+private struct ConvosSurfaceModifier: ViewModifier {
+    let style: ConvosSurfaceStyle
+    let padding: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .padding(padding)
+            .background(style.backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
+            .overlay {
+                if let borderColor = style.borderColor {
+                    RoundedRectangle(cornerRadius: style.cornerRadius)
+                        .stroke(borderColor, lineWidth: DesignConstants.Layout.hairline)
+                }
+            }
+    }
+}
+
+extension View {
+    func convosSurface(
+        _ style: ConvosSurfaceStyle,
+        padding: CGFloat = 0.0
+    ) -> some View {
+        modifier(ConvosSurfaceModifier(style: style, padding: padding))
+    }
+}

--- a/Convos/Design System/Styles/TextStyles.swift
+++ b/Convos/Design System/Styles/TextStyles.swift
@@ -1,0 +1,74 @@
+import ConvosComposer
+import SwiftUI
+
+enum ConvosTextStyle {
+    case display
+    case title
+    case headline
+    case body
+    case bodySecondary
+    case callout
+    case supportingPrimary
+    case supporting
+    case detail
+    case label
+    case caption
+
+    var font: Font {
+        switch self {
+        case .display:
+            DesignConstants.Typography.display
+        case .title:
+            DesignConstants.Typography.title
+        case .headline:
+            DesignConstants.Typography.headline
+        case .body, .bodySecondary:
+            DesignConstants.Typography.body
+        case .callout:
+            DesignConstants.Typography.callout
+        case .supportingPrimary, .supporting:
+            DesignConstants.Typography.supporting
+        case .detail:
+            DesignConstants.Typography.detail
+        case .label:
+            DesignConstants.Typography.label
+        case .caption:
+            DesignConstants.Typography.caption
+        }
+    }
+
+    var foregroundColor: Color {
+        switch self {
+        case .display, .title, .headline, .body, .supportingPrimary:
+            .colorTextPrimary
+        case .bodySecondary, .callout, .supporting, .detail, .label, .caption:
+            .colorTextSecondary
+        }
+    }
+
+    var tracking: CGFloat {
+        switch self {
+        case .display:
+            Font.convosTitleTracking
+        case .title, .headline, .body, .bodySecondary, .callout, .supportingPrimary, .supporting, .detail, .label, .caption:
+            0.0
+        }
+    }
+}
+
+private struct ConvosTextStyleModifier: ViewModifier {
+    let style: ConvosTextStyle
+
+    func body(content: Content) -> some View {
+        content
+            .font(style.font)
+            .tracking(style.tracking)
+            .foregroundStyle(style.foregroundColor)
+    }
+}
+
+extension View {
+    func convosTextStyle(_ style: ConvosTextStyle) -> some View {
+        modifier(ConvosTextStyleModifier(style: style))
+    }
+}

--- a/Convos/Shared Views/ErrorView.swift
+++ b/Convos/Shared Views/ErrorView.swift
@@ -7,8 +7,7 @@ struct ErrorView: View {
     var body: some View {
         VStack(alignment: .center, spacing: DesignConstants.Spacing.step4x) {
             Text(error.localizedDescription)
-                .font(.body)
-                .foregroundStyle(.colorTextSecondary)
+                .convosTextStyle(.bodySecondary)
                 .multilineTextAlignment(.center)
 
             if let onRetry {

--- a/Convos/Shared Views/FeatureInfoSheet.swift
+++ b/Convos/Shared Views/FeatureInfoSheet.swift
@@ -52,16 +52,14 @@ struct FeatureInfoSheet: View {
         VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             if let tagline {
                 Text(tagline)
-                    .font(.caption)
-                    .foregroundStyle(.colorTextSecondary)
+                    .convosTextStyle(.caption)
             }
 
             TightLineHeightText(text: title, fontSize: 40, lineHeight: 40)
 
             if let subtitle {
                 Text(subtitle)
-                    .font(.body)
-                    .foregroundStyle(.colorTextPrimary)
+                    .convosTextStyle(.body)
             }
 
             ForEach(paragraphs) { paragraph in
@@ -99,7 +97,7 @@ struct FeatureInfoSheet: View {
             }
             .padding(.top, DesignConstants.Spacing.step4x)
         }
-        .padding([.leading, .trailing], DesignConstants.Spacing.step10x)
+        .padding([.leading, .trailing], DesignConstants.Layout.sheetHorizontalInset)
         .padding(.top, DesignConstants.Spacing.step8x)
         .padding(.bottom, horizontalSizeClass == .regular ? DesignConstants.Spacing.step10x : DesignConstants.Spacing.step6x)
         .sheetDragIndicator(showDragIndicator ? .visible : .hidden)

--- a/Convos/Shared Views/RoleLabelPill.swift
+++ b/Convos/Shared Views/RoleLabelPill.swift
@@ -10,12 +10,7 @@ struct RoleLabelPill: View {
     var accessibilityIdentifier: String?
 
     var body: some View {
-        Text(label)
-            .font(.footnote)
-            .foregroundStyle(.colorTextSecondary)
-            .padding(.horizontal, DesignConstants.Spacing.step2x)
-            .padding(.vertical, DesignConstants.Spacing.stepX)
-            .background(.colorTextSecondary.opacity(0.1), in: .capsule)
+        ConvosBadge(label: label)
             .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 }

--- a/ConvosCore/Sources/ConvosComposer/DesignConstants.swift
+++ b/ConvosCore/Sources/ConvosComposer/DesignConstants.swift
@@ -12,6 +12,7 @@ public enum DesignConstants {
         public static let extraSmallAvatar: CGFloat = 16.0
         public static let smallAvatar: CGFloat = 24.0
         public static let mediumAvatar: CGFloat = 40.0
+        public static let listAvatar: CGFloat = 56.0
         public static let largeAvatar: CGFloat = 80.0
     }
 
@@ -47,6 +48,28 @@ public enum DesignConstants {
         public static let small: CGFloat = 8.0
     }
 
+    public enum Layout {
+        public static let hairline: CGFloat = 1.0
+        public static let minimumTapTarget: CGFloat = 44.0
+        public static let iconTile: CGFloat = 40.0
+        public static let searchFieldHeight: CGFloat = 48.0
+        public static let sheetHorizontalInset: CGFloat = Spacing.step10x
+        public static let screenHorizontalInset: CGFloat = Spacing.step6x
+        public static let readableContentWidth: CGFloat = 680.0
+    }
+
+    public enum Opacity {
+        public static let pressed: Double = 0.6
+        public static let disabled: Double = 0.3
+        public static let subdued: Double = 0.45
+    }
+
+    public enum Motion {
+        public static let quick: Double = 0.15
+        public static let standard: Double = 0.25
+        public static let deliberate: Double = 0.4
+    }
+
     public enum Colors {
         public static let light: Color = .white
         /// Subtle neutral fill (Figma `color/fill/subtle`): #F5F5F5 in light,
@@ -72,6 +95,19 @@ public enum DesignConstants {
         public static let small: Font = .system(size: 12.0)
         public static let buttonText: Font = .system(size: 14.0)
         public static let caption3: Font = .system(size: 8.0)
+    }
+
+    public enum Typography {
+        public static let display: Font = .system(size: 40.0, weight: .bold)
+        public static let title: Font = .title2.weight(.bold)
+        public static let headline: Font = .headline
+        public static let body: Font = .body
+        public static let callout: Font = .callout
+        public static let supporting: Font = .subheadline
+        public static let detail: Font = .footnote
+        public static let button: Font = .subheadline
+        public static let label: Font = .footnote
+        public static let caption: Font = .caption
     }
 }
 #endif

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -4,6 +4,9 @@ import LinkPresentation
 import Photos
 import SwiftUI
 
+// The standard reaction menu and the contextual work menu intentionally share
+// one animated bubble-preview state machine.
+// swiftlint:disable type_body_length
 public struct MessageContextMenuOverlay: View {
     @Bindable var state: MessageContextMenuState
     var isReadOnly: Bool = false
@@ -133,9 +136,11 @@ public struct MessageContextMenuOverlay: View {
             // the text-bubble path where the tile holds its size and place.
             let isHTMLTile: Bool = photoAttachment?.isHTMLFile == true
             let usesPhotoLayout: Bool = isPhoto && !isHTMLTile && !state.isReplyParent
-            let menuEstimatedHeight: CGFloat = isPhoto && !state.isReplyParent
-                ? C.photoMenuEstimatedHeight
-                : C.textMenuEstimatedHeight
+            let menuEstimatedHeight: CGFloat = state.presentation == .work
+                ? C.workMenuEstimatedHeight
+                : (isPhoto && !state.isReplyParent
+                    ? C.photoMenuEstimatedHeight
+                    : C.textMenuEstimatedHeight)
             let endBubble = endBubbleRect(
                 source: localBubble,
                 screenSize: screenSize,
@@ -152,7 +157,7 @@ public struct MessageContextMenuOverlay: View {
             ZStack(alignment: .topLeading) {
                 backgroundDimming
 
-                if !isReadOnly {
+                if !isReadOnly, state.presentation == .standard {
                     reactionsBar(
                         messageId: message.messageId,
                         bubbleRect: activeBubble,
@@ -165,7 +170,8 @@ public struct MessageContextMenuOverlay: View {
 
                 actionMenu(
                     message: message,
-                    bubbleRect: activeBubble
+                    bubbleRect: activeBubble,
+                    screenSize: screenSize
                 )
                 .zIndex(2)
 
@@ -489,7 +495,16 @@ public struct MessageContextMenuOverlay: View {
 
     // MARK: - Action Menu
 
-    private func actionMenu(message: AnyMessage, bubbleRect: CGRect) -> some View {
+    @ViewBuilder
+    private func actionMenu(message: AnyMessage, bubbleRect: CGRect, screenSize: CGSize) -> some View {
+        if state.presentation == .work {
+            workActionMenu(message: message, bubbleRect: bubbleRect, screenSize: screenSize)
+        } else {
+            standardActionMenu(message: message, bubbleRect: bubbleRect)
+        }
+    }
+
+    private func standardActionMenu(message: AnyMessage, bubbleRect: CGRect) -> some View {
         let finalY = bubbleRect.maxY + C.sectionSpacing
         let anchorX = state.isOutgoing ? bubbleRect.maxX : bubbleRect.minX
 
@@ -568,6 +583,109 @@ public struct MessageContextMenuOverlay: View {
         .animation(.interactiveSpring(response: 0.35, dampingFraction: 0.7), value: dragOffset)
     }
 
+    private func workActionMenu(
+        message: AnyMessage,
+        bubbleRect: CGRect,
+        screenSize: CGSize
+    ) -> some View {
+        let width = min(C.workMenuWidth, screenSize.width - C.workMenuHorizontalInset * 2)
+        let preferredX = state.isOutgoing ? bubbleRect.maxX - width : bubbleRect.minX
+        let menuX = min(
+            max(preferredX, C.workMenuHorizontalInset),
+            screenSize.width - width - C.workMenuHorizontalInset
+        )
+        let finalY = bubbleRect.maxY + C.sectionSpacing
+
+        return VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Turn this conversation into work")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(.primary)
+
+                Text(
+                    "\(state.workAgentName) already knows where it came from "
+                        + "and can act beyond the chat."
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 18)
+
+            Divider()
+
+            ForEach(Array(MessageWorkAction.allCases.enumerated()), id: \.element.rawValue) { index, action in
+                workActionRow(action, message: message)
+                if index < MessageWorkAction.allCases.count - 1 {
+                    Divider()
+                        .padding(.leading, 72)
+                }
+            }
+        }
+        .frame(width: width)
+        .background(Color(uiColor: .systemBackground))
+        .clipShape(.rect(cornerRadius: C.workMenuCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: C.workMenuCornerRadius)
+                .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.18), radius: 24, y: 12)
+        .scaleEffect(
+            appeared ? 1 : 0.96,
+            anchor: state.isOutgoing ? .topTrailing : .topLeading
+        )
+        .offset(
+            x: menuX,
+            y: (appeared ? finalY : bubbleRect.midY) + dragOffset * C.menuDragFollowRatio
+        )
+        .opacity(isDragDismissing ? 0 : (appeared ? 1 : 0))
+        .animation(.spring(response: 0.28, dampingFraction: 0.84), value: appeared)
+        .animation(.interactiveSpring(response: 0.35, dampingFraction: 0.7), value: dragOffset)
+    }
+
+    private func workActionRow(_ action: MessageWorkAction, message: AnyMessage) -> some View {
+        Button {
+            let selectedMessage = message
+            dismissMenu()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                state.onWorkAction?(action, selectedMessage)
+            }
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: action.systemImage)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 40, height: 40)
+                    .background(Color.primary.opacity(0.055))
+                    .clipShape(.rect(cornerRadius: 12))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(action.title(agentName: state.workAgentName))
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.leading)
+
+                    Text(action.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: 4)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
     private func dismissMenu(afterStateChange: Bool = false) {
         showingEmojiPicker = false
         if state.sourceFrameMoved {
@@ -625,6 +743,10 @@ public struct MessageContextMenuOverlay: View {
         static let photoCornerRadius: CGFloat = DesignConstants.CornerRadius.photo
         static let textMenuEstimatedHeight: CGFloat = 80
         static let photoMenuEstimatedHeight: CGFloat = 160
+        static let workMenuEstimatedHeight: CGFloat = 510
+        static let workMenuWidth: CGFloat = 350
+        static let workMenuHorizontalInset: CGFloat = 14
+        static let workMenuCornerRadius: CGFloat = 22
         static let verticalBreathingRoom: CGFloat = 80
 
         static let dragDismissThreshold: CGFloat = 150
@@ -682,6 +804,7 @@ public struct MessageContextMenuOverlay: View {
         }
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Reactions Bar Subviews
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
@@ -22,19 +22,36 @@ public enum MessageBubbleSegment: Equatable {
 public enum MessageWorkAction: String, CaseIterable, Sendable {
     case research
     case doSomething
+    case connectService
     case remind
     case addToThings
-    case connectService
     case askAgentPrivately
 
-    public var title: String {
+    public func title(agentName: String) -> String {
         switch self {
         case .research: "Research this"
         case .doSomething: "Do something with this"
+        case .connectService: "Connect this to any service"
         case .remind: "Make a reminder"
         case .addToThings: "Add to Things"
-        case .connectService: "Connect this to any service"
-        case .askAgentPrivately: "Ask the group agent privately"
+        case .askAgentPrivately: "Ask \(agentName) privately"
+        }
+    }
+
+    public var subtitle: String {
+        switch self {
+        case .research:
+            "Search the web and connected apps using the context already here."
+        case .doSomething:
+            "Let an agent update a file, app, list, booking, or shared plan."
+        case .connectService:
+            "Bring this into any app, file, calendar, account, or agent the group uses."
+        case .remind:
+            "Turn the message into a reminder for the right people."
+        case .addToThings:
+            "Keep the useful part where everyone can find and improve it."
+        case .askAgentPrivately:
+            "Work it out quietly, then bring the useful result back."
         }
     }
 
@@ -48,6 +65,11 @@ public enum MessageWorkAction: String, CaseIterable, Sendable {
         case .askAgentPrivately: "sparkles"
         }
     }
+}
+
+public enum MessageContextMenuPresentation: Sendable {
+    case standard
+    case work
 }
 
 @Observable
@@ -67,10 +89,12 @@ public class MessageContextMenuState: @unchecked Sendable {
     /// `isExpanded`.
     public var isExpanded: Bool = false
     public var sourceID: UUID?
+    public var presentation: MessageContextMenuPresentation = .standard
     /// Set by the conversation host for group chats. Cells share this state
     /// instance through their UIKit-hosted SwiftUI environment, making it a
     /// lightweight bridge that does not fork the message model.
     public var isWorkMenuEnabled: Bool = false
+    public var workAgentName: String = "Group Agent"
     public var onWorkAction: ((MessageWorkAction, AnyMessage) -> Void)?
 
     public var currentSourceFrame: CGRect = .zero
@@ -86,13 +110,21 @@ public class MessageContextMenuState: @unchecked Sendable {
         return dx > 2 || dy > 2
     }
 
-    public func present(message: AnyMessage, bubbleFrame: CGRect, bubbleStyle: MessageBubbleType, isExpanded: Bool, segment: MessageBubbleSegment = .whole) {
+    public func present(
+        message: AnyMessage,
+        bubbleFrame: CGRect,
+        bubbleStyle: MessageBubbleType,
+        isExpanded: Bool,
+        segment: MessageBubbleSegment = .whole,
+        presentation: MessageContextMenuPresentation = .standard
+    ) {
         self.isOutgoing = message.sender.isCurrentUser
         self.bubbleFrame = bubbleFrame
         self.bubbleStyle = bubbleStyle
         self.isReplyParent = false
         self.presentedSegment = segment
         self.isExpanded = isExpanded
+        self.presentation = presentation
         self.presentedMessage = message
     }
 
@@ -104,6 +136,7 @@ public class MessageContextMenuState: @unchecked Sendable {
         self.isExpanded = false
         self.sourceID = sourceID
         self.presentedSegment = .whole
+        self.presentation = .standard
         self.presentedMessage = message
     }
 
@@ -113,6 +146,7 @@ public class MessageContextMenuState: @unchecked Sendable {
         isReplyParent = false
         isExpanded = false
         sourceID = nil
+        presentation = .standard
     }
 }
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
@@ -16,6 +16,40 @@ public enum MessageBubbleSegment: Equatable {
     case splitLink(LinkPreview, Edge)
 }
 
+/// The native actions exposed by the small `+` control on a message bubble.
+/// The composer package owns the menu presentation; the app host decides how
+/// each intent should route into group chat, Things, connections, or a side DM.
+public enum MessageWorkAction: String, CaseIterable, Sendable {
+    case research
+    case doSomething
+    case remind
+    case addToThings
+    case connectService
+    case askAgentPrivately
+
+    public var title: String {
+        switch self {
+        case .research: "Research this"
+        case .doSomething: "Do something with this"
+        case .remind: "Make a reminder"
+        case .addToThings: "Add to Things"
+        case .connectService: "Connect this to any service"
+        case .askAgentPrivately: "Ask the group agent privately"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .research: "magnifyingglass"
+        case .doSomething: "arrow.up.right"
+        case .remind: "clock"
+        case .addToThings: "square.grid.2x2"
+        case .connectService: "link.badge.plus"
+        case .askAgentPrivately: "sparkles"
+        }
+    }
+}
+
 @Observable
 public class MessageContextMenuState: @unchecked Sendable {
     public init() {}
@@ -33,6 +67,11 @@ public class MessageContextMenuState: @unchecked Sendable {
     /// `isExpanded`.
     public var isExpanded: Bool = false
     public var sourceID: UUID?
+    /// Set by the conversation host for group chats. Cells share this state
+    /// instance through their UIKit-hosted SwiftUI environment, making it a
+    /// lightweight bridge that does not fork the message model.
+    public var isWorkMenuEnabled: Bool = false
+    public var onWorkAction: ((MessageWorkAction, AnyMessage) -> Void)?
 
     public var currentSourceFrame: CGRect = .zero
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenuWrapper.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenuWrapper.swift
@@ -77,6 +77,9 @@ struct MessageGestureModifier: ViewModifier {
             .offset(x: swipeOffset)
             .background(alignment: .leading) { swipeReplyIndicator }
             .overlay { gestureOverlay }
+            .overlay(alignment: message.sender.isCurrentUser ? .leading : .trailing) {
+                workMenu
+            }
             .accessibilityActions {
                 if !isReadOnly {
                     Button("React") {
@@ -87,6 +90,38 @@ struct MessageGestureModifier: ViewModifier {
                     }
                 }
             }
+    }
+
+    @ViewBuilder
+    private var workMenu: some View {
+        if contextMenuState.isWorkMenuEnabled,
+           !isReadOnly,
+           !message.content.isUpdate {
+            Menu {
+                ForEach(MessageWorkAction.allCases, id: \.rawValue) { action in
+                    Button {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        contextMenuState.onWorkAction?(action, message)
+                    } label: {
+                        Label(action.title, systemImage: action.systemImage)
+                    }
+                }
+            } label: {
+                Image(systemName: "plus")
+                    .font(.caption.bold())
+                    .foregroundStyle(.white)
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(.black))
+                    .overlay {
+                        Circle().stroke(Color.white.opacity(0.9), lineWidth: 2)
+                    }
+                    .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+            }
+            .buttonStyle(.plain)
+            .background(GesturePassthroughBackground())
+            .offset(x: message.sender.isCurrentUser ? -18 : 18)
+            .accessibilityLabel("Turn this message into work")
+        }
     }
 
     @ViewBuilder

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenuWrapper.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenuWrapper.swift
@@ -37,6 +37,8 @@ struct MessageGestureModifier: ViewModifier {
     @State private var hasAppeared: Bool = false
     @State private var interactiveExclusionFrames: [CGRect] = []
     @State private var mediaContentFrame: CGRect?
+    @State private var currentBubbleFrame: CGRect = .zero
+    @State private var reportedBubbleFrame: CGRect?
     @Environment(\.messageContextMenuState) private var contextMenuState: MessageContextMenuState
     @Environment(\.isConversationReadOnly) private var isReadOnly: Bool
 
@@ -63,9 +65,16 @@ struct MessageGestureModifier: ViewModifier {
             .onAppear { hasAppeared = true }
             .background { sourceBubbleFrameTracker }
             .onPreferenceChange(SourceFrameKey.self) { frame in
-                if isSourceBubble, let frame {
-                    contextMenuState.currentSourceFrame = bubbleFrame(within: frame)
-                }
+                guard let frame else { return }
+                let resolvedFrame = reportedBubbleFrame ?? bubbleFrame(within: frame)
+                currentBubbleFrame = resolvedFrame
+                if isSourceBubble { contextMenuState.currentSourceFrame = resolvedFrame }
+            }
+            .onPreferenceChange(MessageBubbleFrameKey.self) { frame in
+                reportedBubbleFrame = frame
+                guard let frame else { return }
+                currentBubbleFrame = frame
+                if isSourceBubble { contextMenuState.currentSourceFrame = frame }
             }
             .onPreferenceChange(MessageMediaContentFrameKey.self) { frame in
                 mediaContentFrame = frame
@@ -77,9 +86,7 @@ struct MessageGestureModifier: ViewModifier {
             .offset(x: swipeOffset)
             .background(alignment: .leading) { swipeReplyIndicator }
             .overlay { gestureOverlay }
-            .overlay(alignment: message.sender.isCurrentUser ? .leading : .trailing) {
-                workMenu
-            }
+            .overlay { workButtonOverlay }
             .accessibilityActions {
                 if !isReadOnly {
                     Button("React") {
@@ -93,44 +100,50 @@ struct MessageGestureModifier: ViewModifier {
     }
 
     @ViewBuilder
-    private var workMenu: some View {
-        if contextMenuState.isWorkMenuEnabled,
-           !isReadOnly,
-           !message.content.isUpdate {
-            Menu {
-                ForEach(MessageWorkAction.allCases, id: \.rawValue) { action in
-                    Button {
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        contextMenuState.onWorkAction?(action, message)
-                    } label: {
-                        Label(action.title, systemImage: action.systemImage)
-                    }
+    private var workButtonOverlay: some View {
+        GeometryReader { geometry in
+            if contextMenuState.isWorkMenuEnabled,
+               !isReadOnly,
+               !message.content.isUpdate,
+               currentBubbleFrame != .zero {
+                let origin = geometry.frame(in: .global).origin
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    contextMenuState.present(
+                        message: message,
+                        bubbleFrame: currentBubbleFrame,
+                        bubbleStyle: bubbleStyle,
+                        isExpanded: isExpanded,
+                        segment: segment,
+                        presentation: .work
+                    )
+                } label: {
+                    Image(systemName: isSourceBubble ? "xmark" : "plus")
+                        .font(.caption.bold())
+                        .foregroundStyle(.white)
+                        .frame(width: 28, height: 28)
+                        .background(Circle().fill(.black))
+                        .overlay {
+                            Circle().stroke(Color.white.opacity(0.9), lineWidth: 2)
+                        }
+                        .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
                 }
-            } label: {
-                Image(systemName: "plus")
-                    .font(.caption.bold())
-                    .foregroundStyle(.white)
-                    .frame(width: 28, height: 28)
-                    .background(Circle().fill(.black))
-                    .overlay {
-                        Circle().stroke(Color.white.opacity(0.9), lineWidth: 2)
-                    }
-                    .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+                .buttonStyle(.plain)
+                .background(GesturePassthroughBackground())
+                .position(
+                    x: currentBubbleFrame.maxX - origin.x - 2,
+                    y: currentBubbleFrame.minY - origin.y + 2
+                )
+                .accessibilityLabel("Turn this message into work")
             }
-            .buttonStyle(.plain)
-            .background(GesturePassthroughBackground())
-            .offset(x: message.sender.isCurrentUser ? -18 : 18)
-            .accessibilityLabel("Turn this message into work")
         }
     }
 
     @ViewBuilder
     private var sourceBubbleFrameTracker: some View {
-        if isSourceBubble {
-            GeometryReader { geo in
-                Color.clear
-                    .preference(key: SourceFrameKey.self, value: geo.frame(in: .global))
-            }
+        GeometryReader { geo in
+            Color.clear
+                .preference(key: SourceFrameKey.self, value: geo.frame(in: .global))
         }
     }
 
@@ -177,13 +190,14 @@ struct MessageGestureModifier: ViewModifier {
 
     private func handleLongPress(geometry: GeometryProxy) {
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        let frame = bubbleFrame(within: geometry.frame(in: .global))
+        let frame = reportedBubbleFrame ?? bubbleFrame(within: geometry.frame(in: .global))
         contextMenuState.present(
             message: message,
             bubbleFrame: frame,
             bubbleStyle: bubbleStyle,
             isExpanded: isExpanded,
-            segment: segment
+            segment: segment,
+            presentation: contextMenuState.isWorkMenuEnabled ? .work : .standard
         )
     }
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/MessageContainer.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/MessageContainer.swift
@@ -60,12 +60,14 @@ struct MessageContainer<Content: View>: View {
             case .none:
                 content()
                     .foregroundColor(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
+                    .reportMessageBubbleFrame()
             default:
                 content()
                     .background(isOutgoing ? Color.colorBubble : Color.colorBubbleIncoming)
                     .foregroundColor(isOutgoing ? .colorTextPrimaryInverted : .colorTextPrimary)
                     .compositingGroup()
                     .mask(mask)
+                    .reportMessageBubbleFrame()
             }
 
             if !isOutgoing {
@@ -76,7 +78,26 @@ struct MessageContainer<Content: View>: View {
     }
 }
 
+struct MessageBubbleFrameKey: PreferenceKey {
+    static let defaultValue: CGRect? = nil
+
+    static func reduce(value: inout CGRect?, nextValue: () -> CGRect?) {
+        value = nextValue() ?? value
+    }
+}
+
 extension View {
+    func reportMessageBubbleFrame() -> some View {
+        background {
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: MessageBubbleFrameKey.self,
+                    value: geometry.frame(in: .global)
+                )
+            }
+        }
+    }
+
     /// Caps a bubble row at `Constant.maxBubbleRowWidth`, pinning it to the
     /// sender's edge when the container offers more width (regular-width
     /// layouts like iPad), then re-expands so the row still spans the list.

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -210,6 +210,8 @@ public struct Profile: Codable, Identifiable, Hashable, Sendable {
         static let publishedURLKey: String = "publishedUrl"
         static let instanceIdKey: String = "instanceId"
         static let emailKey: String = "email"
+        static let phoneKey: String = "phone"
+        static let phoneNumberKey: String = "phone_number"
         static let variantKey: String = "variant"
     }
 }
@@ -264,6 +266,18 @@ extension Profile {
     public var agentEmail: String? {
         metadata?[Constant.emailKey]?.stringValue.flatMap { value in
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /// The agent's inbound SMS number. Newer runtimes may publish either
+    /// `phone` or `phone_number`; accepting both lets the desktop expose the
+    /// real address without coupling the client to a rollout order.
+    public var agentPhone: String? {
+        let value = metadata?[Constant.phoneKey]?.stringValue
+            ?? metadata?[Constant.phoneNumberKey]?.stringValue
+        return value.flatMap { rawValue in
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ docs/
 ├── README.md           # This file
 ├── TEMPLATE_PRD.md     # Template for new feature PRDs
 ├── TEMPLATE_ADR.md     # Template for Architecture Decision Records
+├── design-system.md    # Design foundations, components, and adoption guidance
+├── design-system-audit.md # Baseline UI inventory and migration priorities
 ├── plans/              # Feature PRDs and implementation plans
 └── adr/                # Architecture Decision Records (ADRs)
 ```
@@ -86,6 +88,11 @@ Create an ADR when:
 | 008 | Asset Lifecycle and Renewal Strategy | `docs/adr/008-asset-lifecycle-and-renewal.md` |
 | 009 | Encrypted Conversation Images | `docs/adr/009-encrypted-conversation-images.md` |
 | 010 | Public Preview Image Toggle for Invite Links | `docs/adr/010-public-preview-image-toggle.md` |
+| 011 | Single-Inbox Identity Model | `docs/adr/011-single-inbox-identity-model.md` |
+| 012 | Connections Architecture (Device + Cloud) | `docs/adr/012-connections-architecture.md` |
+| 013 | Connections - Resolution and Picker | `docs/adr/013-connections-resolution.md` |
+| 014 | Idempotent Agent Join | `docs/adr/014-idempotent-agent-join.md` |
+| 015 | Design System Foundation | `docs/adr/015-design-system-foundation.md` |
 
 ### Using ADRs with Claude Code
 

--- a/docs/adr/015-design-system-foundation.md
+++ b/docs/adr/015-design-system-foundation.md
@@ -1,0 +1,131 @@
+# ADR 015: Design System Foundation
+
+> **Status**: Proposed
+> **Author**: Convos team
+> **Created**: 2026-07-27
+> **Updated**: 2026-07-27
+
+## Context
+
+Convos already uses semantic color assets, a four-point spacing scale, shared
+corner radii, button styles, and a small set of reusable views. Those pieces are
+split between the main app and `ConvosComposer`, and many feature screens still
+combine them with one-off font, spacing, surface, and interaction values.
+
+The app needs a framework that makes the existing visual language easier to
+reuse without forcing a broad rewrite or creating a second source of truth.
+
+## Decision Drivers
+
+- Maintain the current product character
+- Improve consistency across independently developed features
+- Keep shared composer UI visually aligned with the app
+- Support light mode, dark mode, Dynamic Type, and VoiceOver by default
+- Allow gradual adoption without blocking feature work
+- Avoid a new package or third-party dependency until module boundaries require it
+
+## Considered Options
+
+### Keep informal conventions
+
+Continue using existing assets and `DesignConstants` without a documented
+component framework.
+
+**Pros**:
+
+- No migration cost
+- Maximum local flexibility
+
+**Cons**:
+
+- Repeated patterns continue to drift
+- Designers and engineers lack a shared vocabulary
+- Accessibility behavior must be solved repeatedly
+
+### Add a dedicated design-system Swift package
+
+Move colors, tokens, styles, and components into a standalone package.
+
+**Pros**:
+
+- Strong module boundary
+- Potential reuse by every target
+
+**Cons**:
+
+- Requires disruptive asset and target migration
+- Duplicates or moves composer resources before the ownership boundary is clear
+- Adds package complexity without a second independent consumer
+
+### Layer a framework onto the current modules
+
+Keep shared foundations in `ConvosComposer`, keep app-facing styles and
+components in `Convos/Design System`, and document the ownership boundary.
+
+**Pros**:
+
+- Builds directly on current architecture
+- Supports incremental migration
+- Keeps shared values available to the composer
+- Requires no new dependency
+
+**Cons**:
+
+- The framework spans two modules
+- App components are not automatically reusable by extensions
+
+## Decision
+
+Adopt the layered framework.
+
+Shared, value-only foundations live in `ConvosComposer.DesignConstants`.
+Semantic colors remain asset-backed. App-facing typography, surface, and button
+styles live in `Convos/Design System/Styles`. Reusable view patterns live in
+`Convos/Design System/Components`.
+
+Feature views remain responsible for copy, state, navigation, and business
+behavior. The design system owns reusable appearance, layout, and interaction
+states.
+
+## Consequences
+
+### Positive
+
+- New work has a clear default path for typography, spacing, surfaces, and controls.
+- Existing screens can migrate gradually.
+- Common accessibility behavior is centralized.
+- The visual catalog provides a review surface for light and dark mode.
+
+### Negative
+
+- Contributors must decide whether a primitive belongs in the shared composer or app layer.
+- Some existing one-off styling remains until nearby feature work touches it.
+
+### Neutral
+
+- A standalone package can be reconsidered if another app or extension needs the
+  full component layer.
+- Exact branded typography may continue to use specialized views where native
+  SwiftUI text cannot reproduce the intended line height.
+
+## Implementation Notes
+
+- Foundations: `ConvosCore/Sources/ConvosComposer/DesignConstants.swift`
+- Styles and components: `Convos/Design System`
+- Visual inventory: `Convos/Design System/DesignSystemCatalogView.swift`
+- Usage guide: `docs/design-system.md`
+- Representative migrations begin with settings rows, contact rows, badges,
+  empty states, and informational sheets.
+
+Every shared component should include previews for meaningful states. Changes to
+foundations should be reviewed in light and dark mode and at large accessibility
+text sizes.
+
+## Related Decisions
+
+- [ADR 012](./012-connections-architecture.md): Connections architecture
+- [ADR 013](./013-connections-resolution.md): Connections resolution and picker
+
+## References
+
+- [Convos design system guide](../design-system.md)

--- a/docs/design-system-audit.md
+++ b/docs/design-system-audit.md
@@ -1,0 +1,163 @@
+# Convos UI Audit
+
+> Audited: 2026-07-27
+> Scope: main `Convos` app target and the shared `ConvosComposer` UI
+
+## Inventory
+
+The app currently contains:
+
+- 239 Swift files in the main app target
+- 145 SwiftUI previews
+- 50 semantic color assets
+- 534 uses of the shared spacing scale across 87 files
+- 49 uses of shared corner-radius tokens
+- 52 uses of `convosButtonStyle(_:)` across 22 files
+- 297 numeric padding or corner-radius expressions
+- 27 fixed-size system-font expressions
+
+Numeric values are not automatically defects. Avatar sizes, QR geometry, media
+frames, and animation coordinates often need explicit dimensions. The count is a
+map of places to review when nearby feature work changes a surface.
+
+## Screen families reviewed
+
+### Conversations
+
+The conversations list combines UIKit collection-view cells with SwiftUI empty,
+pinned, filter, and agent-builder surfaces. Its strongest reusable patterns are
+avatar rendering, semantic text colors, spacing tokens, and button styles.
+
+The main opportunity is to standardize empty states, card surfaces, and screen
+insets while preserving the list's performance-sensitive UIKit implementation.
+
+### Conversation detail and composer
+
+This is the deepest component family and already shares many primitives through
+`ConvosComposer`: messages, reactions, attachments, indicators, reply references,
+agent state, avatars, and composer controls.
+
+The composer package is the correct owner for foundations used by both UIKit and
+SwiftUI message surfaces. App-only navigation and sheets should remain outside
+the package.
+
+### Contacts and people
+
+Contact browse, picker, and detail surfaces intentionally share avatars, row
+geometry, and identity badges. They are a strong candidate for shared row,
+badge, and icon-tile components because the product already treats these as one
+family in multiple modes.
+
+### Conversation creation and invites
+
+Creation, joining, QR, and sharing surfaces use the same generous sheet spacing,
+rounded cards, and high-contrast primary actions. The existing
+`FeatureInfoSheet` and QR components should remain the composition anchors.
+
+### Settings, devices, and subscriptions
+
+These surfaces repeatedly use a 40-point icon tile, title/subtitle stacks,
+trailing controls, raised backgrounds, and large branded titles. The first
+framework migration extracts that row pattern as `ConvosSettingsRow`.
+
+Subscription screens intentionally have richer card geometry and should consume
+foundations without being flattened into generic settings components.
+
+### Agents and capabilities
+
+Agent builder, connection, and capability surfaces share status labels, icon
+tiles, explanatory copy, and primary/secondary actions. Semantic badge tones and
+standard surfaces reduce one-off status treatments without hiding feature state.
+
+## Existing strengths
+
+- Colors are already semantic and light/dark aware.
+- The four-point spacing scale is widely adopted.
+- The app has unusually strong preview coverage.
+- Shared composer UI has a clear package home.
+- Buttons already expose a small semantic API.
+- Feature plans frequently call out component reuse and mode-based composition.
+
+## Main consistency gaps
+
+### Typography is expressed as implementation
+
+Most views combine a direct SwiftUI font with a semantic text color. A named
+role such as `body` or `supporting` better captures intent and lets type ramp
+changes happen centrally.
+
+### Surfaces are rebuilt locally
+
+Cards and raised areas often repeat background, radius, border, padding, and
+clip-shape modifiers. A semantic surface modifier keeps those decisions together.
+
+### Repeated row anatomy has no shared owner
+
+Several settings and permission surfaces repeat icon tile, text stack, spacer,
+and trailing accessory layout. This is now represented by `ConvosSettingsRow`.
+
+### Status labels drift
+
+Role, blocked, pending, and warning labels use similar capsules with subtly
+different font, padding, fill, and capitalization. `ConvosBadge` provides a
+shared base with semantic tones.
+
+### Raw values mix layout and content geometry
+
+Some numeric values are meaningful content dimensions; others duplicate spacing,
+tap target, icon tile, or inset decisions. `DesignConstants.Layout` names the
+high-frequency shared geometry so future reviews can distinguish them.
+
+## Framework introduced
+
+- Shared layout, image-size, opacity, motion, and typography foundations
+- Semantic `convosTextStyle(_:)`
+- Semantic `convosSurface(_:padding:)`
+- Token-backed button interaction states
+- `ConvosBadge`
+- `ConvosIconTile`
+- `ConvosSettingsRow`
+- `ConvosEmptyStateCard`
+- Light and dark design-system catalog
+- Development-build debug route for reviewing the catalog on Firebase devices
+
+Representative migrations cover settings, contacts, role labels, filtered empty
+states, and informational sheets.
+
+## Migration order
+
+### Adopt during normal feature work
+
+1. Typography roles and standard screen/sheet insets
+2. Status badges and repeated icon tiles
+3. Settings, permission, and connection rows
+4. Empty, loading, and error states
+5. Repeated card and raised-surface treatments
+
+### Preserve specialized components
+
+- Message bubbles and transcript layout
+- Composer controls
+- QR rendering geometry
+- Media and avatar crops
+- Subscription tier selection
+- Destructive hold and explode interactions
+
+These components can use shared foundations without becoming generic.
+
+### Add later when build tooling is available
+
+- Preview snapshots for the catalog in light/dark and accessibility sizes
+- A lint rule that flags new raw RGB colors and arbitrary layout values
+- Accessibility UI checks for tap targets and clipped text
+- A debug-only route to the catalog for device review, if the team wants it
+
+## Success criteria
+
+The system is working when:
+
+- New screens start with semantic roles instead of copied modifier stacks.
+- Existing screens can migrate locally without broad rewrites.
+- Light/dark and accessibility behavior improve when a shared primitive changes.
+- Designers and engineers use the same names for text, surfaces, spacing, and components.
+- The app still feels recognizably Convos rather than like a generic component library.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,164 @@
+# Convos Design System
+
+The Convos design system turns the app's existing visual language into a small,
+repeatable framework. It does not introduce a new brand direction. The current
+app remains the source of truth.
+
+## Product principles
+
+The interface should feel:
+
+- **Private**: calm, direct, and free of attention-seeking chrome.
+- **Human**: conversational language, generous spacing, and soft geometry.
+- **Impermanent**: lightweight surfaces that do not feel like permanent records.
+- **Self-evident**: actions explain themselves without requiring product knowledge.
+- **Native**: Dynamic Type, VoiceOver, system controls, and platform behavior come first.
+
+## Architecture
+
+The system has four layers:
+
+1. **Foundations** in
+   `ConvosCore/Sources/ConvosComposer/DesignConstants.swift`: spacing, radii,
+   typography, layout metrics, opacity, motion, and image sizes shared with the
+   message composer.
+2. **Semantic color assets** in `Convos/Assets.xcassets`: color names describe
+   their role instead of a literal value and include light/dark appearances.
+3. **Styles** in `Convos/Design System/Styles`: typography, surfaces, and buttons.
+4. **Components** in `Convos/Design System/Components`: reusable interface
+   patterns built only from foundations and styles.
+
+The catalog in `Convos/Design System/DesignSystemCatalogView.swift` is the
+visual inventory. Its light and dark previews should be reviewed whenever a
+foundation or shared component changes.
+
+Development builds also expose the catalog from **Settings -> Debug -> Features
+-> Design system catalog**, which makes it available in Firebase builds without
+Xcode.
+
+The baseline inventory and migration priorities are documented in
+[`design-system-audit.md`](./design-system-audit.md).
+
+## Foundations
+
+### Spacing
+
+Use the existing four-point scale under `DesignConstants.Spacing`.
+
+| Token | Value | Typical use |
+| --- | ---: | --- |
+| `stepHalf` | 2 | Tight text pairs |
+| `stepX` | 4 | Badge and inline detail |
+| `step2x` | 8 | Related controls |
+| `step3x` | 12 | Row content |
+| `step4x` | 16 | Component padding |
+| `step6x` | 24 | Sections and screen margins |
+| `step10x` | 40 | Sheets and large separation |
+
+Use a raw number only when it represents content geometry rather than layout,
+such as a generated QR code size.
+
+### Typography
+
+Apply `convosTextStyle(_:)` to app text:
+
+| Role | Use |
+| --- | --- |
+| `.display` | Branded screen and sheet titles |
+| `.title` | Page and major section titles |
+| `.headline` | Section and card headings |
+| `.body` | Primary content |
+| `.bodySecondary` | Full-size explanatory and error copy |
+| `.callout` | Compact empty-state and inline guidance |
+| `.supportingPrimary` | Secondary-size text that still needs primary emphasis |
+| `.supporting` | Explanations, metadata, and secondary content |
+| `.detail` | Small explanatory copy |
+| `.label` | Badges and compact controls |
+| `.caption` | Timestamps and quiet detail |
+
+Prefer these roles to fixed point sizes. `TightLineHeightText` remains available
+for the few branded 40-point sheet titles that require exact line-height control.
+
+### Color
+
+Use semantic assets rather than system colors or RGB values:
+
+- Backgrounds: `colorBackgroundSurfaceless`, `colorBackgroundRaised`,
+  `colorBackgroundRaisedSecondary`, `colorBackgroundInverted`
+- Text: `colorTextPrimary`, `colorTextSecondary`, `colorTextTertiary`,
+  `colorTextPrimaryInverted`
+- Fills: `colorFillPrimary`, `colorFillMinimal`, `colorFillSubtle`
+- Borders: `colorBorderSubtle`, `colorBorderSubtle2`
+- Feedback: `colorWarning`, `colorCaution`
+
+Do not add a new color asset until an existing semantic role has been ruled out
+in both light and dark mode.
+
+### Layout and interaction
+
+`DesignConstants.Layout` contains shared geometry:
+
+- Minimum tap target: 44 points
+- Icon tile: 40 points
+- Search field: 48 points
+- Screen horizontal inset: 24 points
+- Sheet horizontal inset: 40 points
+- Readable content width: 680 points
+
+Pressed, disabled, and subdued states come from `DesignConstants.Opacity`.
+Animation durations come from `DesignConstants.Motion` and must respect Reduce
+Motion when movement communicates more than a simple state transition.
+
+## Shared styles and components
+
+| API | Purpose |
+| --- | --- |
+| `convosTextStyle(_:)` | Semantic font and foreground color |
+| `convosSurface(_:padding:)` | Background, radius, and optional border |
+| `convosButtonStyle(_:)` | Primary, secondary, text, capsule, and action buttons |
+| `ConvosBadge` | Neutral, subtle, accent, warning, and danger labels |
+| `ConvosIconTile` | Standard symbol tile used by settings and action rows |
+| `ConvosSettingsRow` | Icon, title, optional subtitle, and caller-supplied accessory |
+| `ConvosEmptyStateCard` | Compact empty state with one recovery action |
+| `FeatureInfoSheet` | Full explanatory sheet with primary and optional secondary actions |
+
+Components own appearance and layout. Feature views own copy, state, navigation,
+and business behavior.
+
+## Accessibility
+
+Every shared component should:
+
+- Support Dynamic Type without clipping essential text.
+- Keep interactive targets at least 44 by 44 points.
+- Use semantic colors that work in light and dark mode.
+- Preserve a useful VoiceOver reading order.
+- Add a spoken label when appearance alone communicates state.
+- Avoid relying on color as the only status indicator.
+- Respect Reduce Motion for decorative or spatial animation.
+
+Review the catalog at large accessibility text sizes in light and dark mode.
+
+## Adoption
+
+Migrate incrementally when a screen is already being changed:
+
+1. Replace raw layout values with an existing foundation token.
+2. Replace direct font/color pairs with `convosTextStyle(_:)`.
+3. Replace repeated surface styling with `convosSurface(_:padding:)`.
+4. Reuse a shared component when structure and behavior match.
+5. Add or update a preview for every new component state.
+
+Do not rewrite stable screens solely to reach complete design-system adoption.
+Repeated patterns should become components only after their shared shape is clear.
+
+## Review checklist
+
+- Uses semantic colors and typography roles
+- Uses spacing, radius, and layout tokens where applicable
+- Covers loading, empty, error, disabled, and pressed states
+- Works in light and dark mode
+- Works with large Dynamic Type and VoiceOver
+- Preserves a minimum 44-point tap target
+- Includes previews for shared components
+- Does not move feature state or business logic into the design system


### PR DESCRIPTION
## Summary

Builds the new Group Desktop vision on top of a reusable Convos design-system foundation.

- adds the action-first Group Desktop as the native Things experience
- keeps people, shared context, work, and next actions visible behind group chat
- routes desktop actions into group chat or a private side chat with the group agent
- adds native message actions for research, reminders, Things, connected services, and private agent work
- adds the group Agents directory, shared credits/limits, and bring-your-own-AI entry points
- exposes inbound group email and SMS when an agent publishes them
- retains the broader typography, spacing, surface, component, accessibility, and design-catalog foundation already on this branch

## Why

The first experience should make a Convo feel useful before anyone understands agents. Messages become work, the work returns to a shared place, and every result invites the group to add context, edit, research, or keep improving it. Agents remain visible and attributable without turning the product into an agent-management interface.

## User impact

A group now has three connected spaces:

1. group chat for natural conversation
2. Things as the shared group desktop and memory
3. a private side chat for doing work quietly with the group agent

The desktop is action-oriented, shows who and what can help, and makes connected services part of the group rather than a separate settings concept.

## Validation

- native signed iPhone build succeeded
- corrected preview launched and remained running on a physical iPhone
- SwiftFormat passed on all changed Swift files
- SwiftLint pre-commit and pre-push checks passed
- `git diff --check` passed
- Firebase PR distribution workflow runs on this branch update

## Review notes

This remains a draft product exploration. The new screens intentionally use the existing iOS visual language and shared design tokens while rethinking the product model around the Group Desktop.