### PR TITLE
feat(participation): move the bubble out of the input, hold it until loaded

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -959,7 +959,10 @@ private extension ConversationView {
     /// business in a room without one.
     var participationContext: AgentParticipationContext? {
         guard let participation else { return nil }
-        return AgentParticipationContext(level: participation.level) {
+        return AgentParticipationContext(
+            level: participation.level,
+            isLoading: !participation.hasLoaded
+        ) {
             withAnimation(.snappy(duration: 0.2)) {
                 showingParticipationMenu.toggle()
             }

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
@@ -5,15 +5,20 @@ import SwiftUI
 /// conversation is in, and what to do when someone taps it.
 ///
 /// The composer owns none of this. The host resolves the level for the
-/// conversation and performs the change; the accessory is only the affordance.
-/// The accessory itself lives inside the input field — see
-/// `MessagesInputView.participationAccessory`.
+/// conversation and performs the change; the bubble is only the affordance.
+/// The bubble itself leads the composer row, outside the input field — see
+/// `MessagesBottomBar.participationBubble`.
 public struct AgentParticipationContext {
     public let level: AgentParticipationLevel
+    /// True while the conversation's real level is still being read. `level` is
+    /// only a placeholder until then, so the bubble shows a resting dot instead
+    /// of an icon that might be about to change under the member's eyes.
+    public let isLoading: Bool
     public let onTap: () -> Void
 
-    public init(level: AgentParticipationLevel, onTap: @escaping () -> Void) {
+    public init(level: AgentParticipationLevel, isLoading: Bool = false, onTap: @escaping () -> Void) {
         self.level = level
+        self.isLoading = isLoading
         self.onTap = onTap
     }
 }

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -15,6 +15,13 @@ public final class AgentParticipationStore {
     /// never blank; replaced by the conversation's real level once read.
     public private(set) var level: AgentParticipationLevel = .default
 
+    /// False until the first read resolves. Surfaces that `level` is still the
+    /// placeholder default rather than this conversation's real setting, so a
+    /// control can hold its place without claiming a level it doesn't know yet.
+    /// Set once the read finishes either way: a failed read leaves the default,
+    /// and the default is the honest thing to show.
+    public private(set) var hasLoaded: Bool = false
+
     /// Set when a write failed and was rolled back, so the host can surface it.
     /// Cleared by `dismissError()` — the host owns the alert, not this store.
     public private(set) var errorMessage: String?
@@ -49,6 +56,7 @@ public final class AgentParticipationStore {
     /// a read the member never asked for is noise.
     public func load() async {
         let generationAtStart = writeGeneration
+        defer { hasLoaded = true }
         do {
             let response = try await client().getAgentParticipation(
                 conversationId: conversationId,

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -34,6 +34,23 @@ private struct FilePickerModifier: ViewModifier {
     }
 }
 
+/// A single dot breathing in place, holding the participation bubble while the
+/// conversation's level is read. It rests at a visible opacity, so if the
+/// animation never runs the bubble still reads as occupied rather than empty.
+private struct ParticipationLoadingDot: View {
+    @State private var isBright: Bool = false
+
+    var body: some View {
+        let opacity: Double = isBright ? 0.55 : 0.2
+        Circle()
+            .fill(Color.colorTextSecondary)
+            .frame(width: 6.0, height: 6.0)
+            .opacity(opacity)
+            .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: isBright)
+            .onAppear { isBright = true }
+    }
+}
+
 public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePreview: View, AgentChip: View>: View {
     let profile: Profile
     @Binding var displayName: String
@@ -106,6 +123,11 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @State private var previousFocus: MessagesViewInputFocus?
     @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
     @State private var didSelectPhotoThisSession: Bool = false
+    /// Hides the participation bubble while the member is actually typing, so
+    /// the composer belongs to them in that moment. Kept as state rather than
+    /// read from the coordinator directly so it changes inside the same
+    /// animation as the rest of the bar.
+    @State private var showsParticipationBubble: Bool = true
     @Namespace private var namespace: Namespace.ID
     // Injected by the host on conversations that hold an agent; nil elsewhere,
     // and the bubble simply isn't drawn.
@@ -296,6 +318,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
                 || newValue == .message
                 || newValue == .voiceMemoRecording
                 || newValue == .sideConvoName
+            showsParticipationBubble = newValue == nil
         }
     }
 
@@ -467,9 +490,61 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         }
     }
 
+    /// The agent-participation control: how much the agents speak in this
+    /// conversation. It leads the composer row, outside the input field, since
+    /// it governs the room rather than the message being written — and it steps
+    /// aside entirely once someone starts typing.
+    @ViewBuilder
+    private var participationBubble: some View {
+        if let participation = agentParticipation, showsParticipationBubble {
+            let bubbleSize: CGFloat = DesignConstants.Spacing.step12x
+            let isLoading: Bool = participation.isLoading
+            let label: String = isLoading
+                ? "Agent participation, loading"
+                : "Agent participation: \(participation.level.title)"
+            Button(action: participation.onTap) {
+                participationGlyph(for: participation)
+            }
+            .buttonStyle(.plain)
+            .disabled(isLoading)
+            .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
+            .frame(width: bubbleSize, height: bubbleSize)
+            .clipShape(.circle)
+            .glassEffect(.regular.interactive(), in: .circle)
+            .glassEffectID("participation", in: namespace)
+            .glassEffectTransition(.matchedGeometry)
+            .transition(.scale.combined(with: .opacity))
+            .animation(.easeInOut(duration: 0.2), value: isLoading)
+            .accessibilityLabel(label)
+            .accessibilityHint("Change how much the agents speak here")
+            .accessibilityIdentifier("agent-participation-button")
+        }
+    }
+
+    /// The icon, or the resting dot that stands in for it. The level starts at a
+    /// product default the conversation may not actually be in, so showing an
+    /// icon before the read lands would state something that can change a moment
+    /// later — the dot says "not known yet" instead.
+    @ViewBuilder
+    private func participationGlyph(for participation: AgentParticipationContext) -> some View {
+        if participation.isLoading {
+            ParticipationLoadingDot()
+                .frame(width: 32, height: 32)
+        } else {
+            Image(systemName: participation.level.iconSystemName)
+                .font(.system(size: 16.0, weight: .medium))
+                .foregroundStyle(Color.colorTextPrimary)
+                .frame(width: 32, height: 32)
+                .contentShape(.circle)
+                .transition(.opacity)
+        }
+    }
+
     @ViewBuilder
     private var normalInputView: some View {
         HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
+            participationBubble
+
             if isMessageInputFocused {
                 Button {
                     withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -40,9 +40,6 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
     private let attachmentPreviewSize: CGFloat = 80.0
     @State private var poofingAttachmentIds: Set<UUID> = []
     @State private var isPoofingInvite: Bool = false
-    // Set by the host on conversations with an agent; nil elsewhere. Rendered as
-    // a leading accessory inside the input field — see `participationAccessory`.
-    @Environment(\.agentParticipation) private var agentParticipation: AgentParticipationContext?
 
     public init(
         displayName: Binding<String>,
@@ -161,38 +158,12 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
             }
 
             HStack(alignment: .bottom, spacing: 0) {
-                participationAccessory
                 messageTextField
                 sendButton
             }
         }
         .padding(DesignConstants.Spacing.step2x)
         .frame(alignment: .bottom)
-    }
-
-    /// The agent-participation control, living inside the input field as a
-    /// leading accessory just before the placeholder. A property of the
-    /// conversation, so it sits with the field the members type into rather than
-    /// among the attachment buttons. Bare — no glass — because it is already
-    /// inside the input's own capsule; a second glass shape here would read as a
-    /// chip stuck on the field. Bottom-aligned so it stays on the placeholder
-    /// line as the field grows to multiple lines.
-    @ViewBuilder
-    private var participationAccessory: some View {
-        if let participation = agentParticipation {
-            Button(action: participation.onTap) {
-                Image(systemName: participation.level.iconSystemName)
-                    .font(.callout)
-                    .foregroundStyle(.colorTextSecondary)
-                    .frame(height: Self.defaultHeight)
-                    .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
-            .padding(.leading, DesignConstants.Spacing.step2x)
-            .accessibilityLabel("Agent participation: \(participation.level.title)")
-            .accessibilityHint("Change how much the agents speak here")
-            .accessibilityIdentifier("agent-participation-button")
-        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
Two changes to the per-conversation agent participation control, both in the composer.

## The bubble left the input field

It governs the room, not the message being written, so it no longer sits inside the input capsule as a leading accessory. It now leads the composer row, to the left of the `+`, wearing the same treatment as that button: 32pt glyph in a 48pt interactive glass circle, same matched-geometry namespace and bouncy timing.

It also steps aside while any composer field holds focus, so the input takes that width back at the moment the member is actually using it. The rule lives in `handleFocusChanged`, inside the animation the rest of the bar already runs.

## It stopped claiming a level it doesn't know

`AgentParticipationStore.level` starts at the product default, so the old accessory drew an icon immediately and could swap it once the read landed — telling the member something that changed under their eyes.

The store now publishes `hasLoaded`, and until the first read resolves the bubble holds its place with a single breathing dot instead of an icon. It's marked loaded either way: a failed read leaves the default, which is the honest thing to show, and a spinner that never ends is worse. The dot rests at a visible opacity, so if the animation never runs the bubble still reads as occupied rather than empty.

## Scope

Still behind `isListenParticipationEnabled`, which is off by default and hard-locked off in production. `AgentParticipationContext.isLoading` defaults to `false`, so the new field doesn't disturb other call sites.

## Testing

- `swift test --package-path ConvosCore` — 1648 tests in 230 suites passed
- Built and exercised on the convos-dev simulator: bubble in its new position, hidden while typing, dot held until the level arrived

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787851524&installation_model_id=20076&pr_number=1239&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1239&signature=030f34d0b4e429b75414b3dcb9b9f03347fd509e45b49d2eb0805049e0263831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move agent participation bubble outside the input field and hold it until participation data loads
> - Extracts the participation control from [MessagesInputView.swift](https://github.com/xmtplabs/convos-ios/pull/1239/files#diff-e2c931c31bf3ac1ef06979d38abec03cc340be1ee940323e452cf21bd07d74b4) into a new `participationBubble` view in [MessagesBottomBar.swift](https://github.com/xmtplabs/convos-ios/pull/1239/files#diff-15ef93166cd135cbcb601be8008789f84343afa5434a110b42fc9d4369870cd5), placed leading the input row.
> - Adds `hasLoaded` to `AgentParticipationStore` (false until the first `load()` completes) and surfaces it as `isLoading` on `AgentParticipationContext`.
> - While loading, the bubble shows an animated breathing dot instead of the level icon, and the button is disabled with an updated accessibility label.
> - The bubble hides automatically when any input element is focused and reappears when focus clears.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b66228a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->