### PR TITLE
Stop retrying encrypted images that fail deterministically

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Crypto/EncryptedImagePrefetcher.swift
+++ b/ConvosCore/Sources/ConvosCore/Crypto/EncryptedImagePrefetcher.swift
@@ -125,7 +125,17 @@ actor EncryptedImagePrefetcher: EncryptedImagePrefetcherProtocol {
                 ImageCacheContainer.shared.cacheAfterUpload(decryptedData, for: hydratedProfile.imageCacheIdentifier, url: urlString)
                 Log.info("Prefetched encrypted profile image for: \(profile.inboxId)")
                 return
+            } catch is EncryptedImageKnownBadURL {
+                // Already discovered and logged on a previous fetch; the sync
+                // pass re-selects the profile every time because a failed
+                // image never lands in the cache, so keep this quiet.
+                Log.debug("Skipping prefetch for known-bad profile image: \(profile.inboxId)")
+                return
             } catch {
+                if EncryptedImageLoader.isPermanentFailure(error) {
+                    Log.error("Not retrying profile image for \(profile.inboxId); failure is permanent: \(error)")
+                    return
+                }
                 lastError = error
                 if attempt < Self.maxRetryAttempts - 1 {
                     try? await Task.sleep(nanoseconds: Self.retryDelaySeconds * 1_000_000_000)

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -486,27 +486,59 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
             Log.debug("Cannot inline decrypt - missing encryption params for: \(urlKey)")
             return nil
         }
-        do {
-            let decryptedData = try await EncryptedImageLoader.loadAndDecrypt(
-                url: url,
-                salt: salt,
-                nonce: nonce,
-                groupKey: key,
-                priority: priority
-            )
-            guard let image = BoundedImageDecode.image(from: decryptedData) else {
-                Log.error("Failed to create UIImage from decrypted data: \(urlKey)")
+
+        // Share one in-flight fetch per URL, like the plaintext path: the
+        // same avatar visible in several rows used to fire that many
+        // concurrent downloads. The unstructured task also survives the
+        // caller's cancellation (cell reuse), so a scrolled-past avatar
+        // finishes downloading once instead of restarting on every render.
+        let existingTask = loadingTasksLock.withLock { tasks in tasks[url] }
+        if let existingTask {
+            let image = await existingTask.value
+            if let image {
+                rememberLastShown(image, for: identifier, persist: true)
+                cacheUpdateSubject.send(identifier)
+            }
+            return image
+        }
+
+        let loadingTask = Task<UIImage?, Never> {
+            defer {
+                _ = loadingTasksLock.withLock { tasks in tasks.removeValue(forKey: url) }
+            }
+            do {
+                let decryptedData = try await EncryptedImageLoader.loadAndDecrypt(
+                    url: url,
+                    salt: salt,
+                    nonce: nonce,
+                    groupKey: key,
+                    priority: priority
+                )
+                guard let image = BoundedImageDecode.image(from: decryptedData) else {
+                    // The decrypted bytes are immutable for this URL, so
+                    // undecodable now means undecodable on every retry.
+                    EncryptedImageLoader.markKnownBadURL(urlKey)
+                    Log.error("Failed to create UIImage from decrypted data: \(urlKey)")
+                    return nil
+                }
+                cacheImage(image, key: urlKey, cache: cache, logContext: "inline encrypted fetch", imageFormat: .jpg)
+                rememberLastShown(image, for: identifier, persist: true)
+                Task { await saveDataToDisk(decryptedData, key: urlKey, imageFormat: .jpg, forceOverwrite: true) }
+                publishCacheUpdate(urlKey: urlKey, identifier: identifier)
+                return image
+            } catch is EncryptedImageKnownBadURL {
+                // Already discovered and logged; every render of this avatar
+                // lands here, so keep it quiet.
+                Log.debug("Skipping known-bad encrypted image: \(urlKey)")
+                return nil
+            } catch {
+                Log.error("Failed to inline decrypt image for \(urlKey): \(error)")
                 return nil
             }
-            cacheImage(image, key: urlKey, cache: cache, logContext: "inline encrypted fetch", imageFormat: .jpg)
-            rememberLastShown(image, for: identifier, persist: true)
-            Task { await saveDataToDisk(decryptedData, key: urlKey, imageFormat: .jpg, forceOverwrite: true) }
-            publishCacheUpdate(urlKey: urlKey, identifier: identifier)
-            return image
-        } catch {
-            Log.error("Failed to inline decrypt image for \(urlKey): \(error)")
-            return nil
         }
+
+        loadingTasksLock.withLock { tasks in tasks[url] = loadingTask }
+        return await loadingTask.value
     }
 
     // MARK: - Identifier-based Methods (QR codes, generated images)

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -426,24 +426,41 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
 
     // MARK: - Network / decrypt fetch (URL-keyed)
 
-    private func fetchImageFromNetwork(url: URL, urlKey: String, identifier: String) async -> UIImage? {
-        let existingTask = loadingTasksLock.withLock { tasks in tasks[url] }
-        if let existingTask {
-            let image = await existingTask.value
-            if let image {
-                // The shared task only recorded the continuity hint for the first
-                // caller's identity; record it for this caller too so its own
-                // placeholder bridge survives the next render/relaunch.
-                rememberLastShown(image, for: identifier, persist: true)
-                cacheUpdateSubject.send(identifier)
+    /// Resolves the URL through its single in-flight loading task, creating
+    /// one running `operation` if none exists. Check-and-insert happens under
+    /// one lock acquisition so concurrent callers for the same URL always
+    /// converge on one task instead of racing to create duplicates. Callers
+    /// that joined an existing task re-record the continuity hint for their
+    /// own identity, since the task only recorded the creator's.
+    private func withSharedLoadingTask(
+        for url: URL,
+        identifier: String,
+        operation: @escaping @Sendable () async -> UIImage?
+    ) async -> UIImage? {
+        let (loadingTask, didCreateTask): (Task<UIImage?, Never>, Bool) = loadingTasksLock.withLock { tasks in
+            if let existingTask = tasks[url] {
+                return (existingTask, false)
             }
-            return image
+            let task = Task<UIImage?, Never> {
+                defer {
+                    _ = self.loadingTasksLock.withLock { tasks in tasks.removeValue(forKey: url) }
+                }
+                return await operation()
+            }
+            tasks[url] = task
+            return (task, true)
         }
 
-        let loadingTask = Task<UIImage?, Never> {
-            defer {
-                _ = loadingTasksLock.withLock { tasks in tasks.removeValue(forKey: url) }
-            }
+        let image = await loadingTask.value
+        if !didCreateTask, let image {
+            rememberLastShown(image, for: identifier, persist: true)
+            cacheUpdateSubject.send(identifier)
+        }
+        return image
+    }
+
+    private func fetchImageFromNetwork(url: URL, urlKey: String, identifier: String) async -> UIImage? {
+        await withSharedLoadingTask(for: url, identifier: identifier) {
             do {
                 let (tempFileURL, response) = try await URLSession.shared.download(from: url)
                 defer { try? FileManager.default.removeItem(at: tempFileURL) }
@@ -458,19 +475,16 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                     return nil
                 }
 
-                cacheImage(image, key: urlKey, cache: cache, logContext: "loadImage (from network)", imageFormat: .jpg)
-                rememberLastShown(image, for: identifier, persist: true)
-                Task { await saveImageToDisk(image, key: urlKey, imageFormat: .jpg) }
-                publishCacheUpdate(urlKey: urlKey, identifier: identifier)
+                self.cacheImage(image, key: urlKey, cache: self.cache, logContext: "loadImage (from network)", imageFormat: .jpg)
+                self.rememberLastShown(image, for: identifier, persist: true)
+                Task { await self.saveImageToDisk(image, key: urlKey, imageFormat: .jpg) }
+                self.publishCacheUpdate(urlKey: urlKey, identifier: identifier)
                 return image
             } catch {
                 Log.error("Failed to load image from URL: \(url) - \(error)")
                 return nil
             }
         }
-
-        loadingTasksLock.withLock { tasks in tasks[url] = loadingTask }
-        return await loadingTask.value
     }
 
     private func fetchEncryptedImageInline(
@@ -492,20 +506,7 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
         // concurrent downloads. The unstructured task also survives the
         // caller's cancellation (cell reuse), so a scrolled-past avatar
         // finishes downloading once instead of restarting on every render.
-        let existingTask = loadingTasksLock.withLock { tasks in tasks[url] }
-        if let existingTask {
-            let image = await existingTask.value
-            if let image {
-                rememberLastShown(image, for: identifier, persist: true)
-                cacheUpdateSubject.send(identifier)
-            }
-            return image
-        }
-
-        let loadingTask = Task<UIImage?, Never> {
-            defer {
-                _ = loadingTasksLock.withLock { tasks in tasks.removeValue(forKey: url) }
-            }
+        return await withSharedLoadingTask(for: url, identifier: identifier) {
             do {
                 let decryptedData = try await EncryptedImageLoader.loadAndDecrypt(
                     url: url,
@@ -521,10 +522,10 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                     Log.error("Failed to create UIImage from decrypted data: \(urlKey)")
                     return nil
                 }
-                cacheImage(image, key: urlKey, cache: cache, logContext: "inline encrypted fetch", imageFormat: .jpg)
-                rememberLastShown(image, for: identifier, persist: true)
-                Task { await saveDataToDisk(decryptedData, key: urlKey, imageFormat: .jpg, forceOverwrite: true) }
-                publishCacheUpdate(urlKey: urlKey, identifier: identifier)
+                self.cacheImage(image, key: urlKey, cache: self.cache, logContext: "inline encrypted fetch", imageFormat: .jpg)
+                self.rememberLastShown(image, for: identifier, persist: true)
+                Task { await self.saveDataToDisk(decryptedData, key: urlKey, imageFormat: .jpg, forceOverwrite: true) }
+                self.publishCacheUpdate(urlKey: urlKey, identifier: identifier)
                 return image
             } catch is EncryptedImageKnownBadURL {
                 // Already discovered and logged; every render of this avatar
@@ -536,9 +537,6 @@ public final class ImageCache: ImageCacheProtocol, @unchecked Sendable {
                 return nil
             }
         }
-
-        loadingTasksLock.withLock { tasks in tasks[url] = loadingTask }
-        return await loadingTask.value
     }
 
     // MARK: - Identifier-based Methods (QR codes, generated images)

--- a/ConvosCore/Sources/ConvosCore/Profiles/Crypto/EncryptedImageLoader.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Crypto/EncryptedImageLoader.swift
@@ -1,5 +1,7 @@
 import ConvosAppData
+import CryptoKit
 import Foundation
+import os
 
 /// Parameters needed to download and decrypt an encrypted image
 public struct EncryptedImageParams: Sendable {
@@ -48,6 +50,13 @@ public enum EncryptedImageFetchPriority: Sendable {
     case background
 }
 
+/// Thrown when a fetch is refused because the URL previously failed
+/// deterministically (oversized payload, decryption failure, undecodable
+/// bytes). Encrypted assets are immutable blobs - a re-uploaded image gets a
+/// new URL - so a deterministic failure for a URL can never heal and
+/// refetching it only wastes bandwidth.
+public struct EncryptedImageKnownBadURL: Error {}
+
 /// Utility for downloading and decrypting encrypted images
 public enum EncryptedImageLoader {
     /// Per-priority caps on concurrent encrypted-image downloads. Sync can
@@ -58,10 +67,26 @@ public enum EncryptedImageLoader {
     private static let interactiveGate: AsyncSemaphore = AsyncSemaphore(width: 4)
     private static let backgroundGate: AsyncSemaphore = AsyncSemaphore(width: 4)
 
+    /// URLs whose fetch failed deterministically this process lifetime. The
+    /// same URL always yields the same ciphertext and the same key material,
+    /// so retrying cannot change the outcome; without this memory every
+    /// avatar render and sync pass refires the download.
+    private static let knownBadURLs: OSAllocatedUnfairLock<Set<String>> = OSAllocatedUnfairLock(initialState: [])
+
     /// The production transport: streams the payload to a temporary file so
     /// the encoded bytes are never fully buffered in memory.
     private static let urlSessionTransport: DownloadTransport = { url in
         try await URLSession.shared.download(from: url)
+    }
+
+    /// The production size probe: a HEAD request, so an oversized asset is
+    /// rejected for the cost of one header round trip instead of a full
+    /// download. Returns -1 when the server does not report a length.
+    private static let urlSessionSizeProbe: SizeProbe = { url in
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        let (_, response) = try await URLSession.shared.data(for: request)
+        return response.expectedContentLength
     }
 
     /// Downloads a URL to a temporary file and returns its location plus the
@@ -69,29 +94,80 @@ public enum EncryptedImageLoader {
     /// without a live network.
     typealias DownloadTransport = @Sendable (URL) async throws -> (URL, URLResponse)
 
+    /// Reports the expected payload size for a URL (-1 when unknown).
+    /// Injectable so tests can drive the preflight without a live network.
+    typealias SizeProbe = @Sendable (URL) async throws -> Int64
+
     /// Download ciphertext from URL and decrypt using provided parameters
     /// - Parameters:
     ///   - params: Encryption parameters including URL and crypto values
     ///   - priority: Which concurrency budget the fetch belongs to
     /// - Returns: Decrypted image data
-    /// - Throws: Network errors or `ImageEncryptionError` on decryption failure
+    /// - Throws: `EncryptedImageKnownBadURL` without touching the network when
+    ///   the URL previously failed deterministically; otherwise network errors
+    ///   or `ImageEncryptionError` on decryption failure
     public static func loadAndDecrypt(
         params: EncryptedImageParams,
         priority: EncryptedImageFetchPriority = .background
     ) async throws -> Data {
-        try await loadAndDecrypt(params: params, priority: priority, transport: urlSessionTransport)
+        try await loadAndDecrypt(
+            params: params,
+            priority: priority,
+            transport: urlSessionTransport,
+            sizeProbe: urlSessionSizeProbe
+        )
     }
 
     static func loadAndDecrypt(
         params: EncryptedImageParams,
         priority: EncryptedImageFetchPriority,
-        transport: @escaping DownloadTransport
+        transport: @escaping DownloadTransport,
+        sizeProbe: @escaping SizeProbe = { _ in -1 }
     ) async throws -> Data {
-        try await gate(for: priority).withSlot {
-            let (fileURL, response) = try await transport(params.url)
-            defer { try? FileManager.default.removeItem(at: fileURL) }
-            return try decryptDownloadedFile(at: fileURL, response: response, params: params)
+        let urlKey = params.url.absoluteString
+        guard !isKnownBadURL(urlKey) else {
+            throw EncryptedImageKnownBadURL()
         }
+        do {
+            return try await gate(for: priority).withSlot {
+                // Best-effort preflight: a failed probe falls through to the
+                // download, where the post-download size check still guards.
+                let expectedBytes: Int64 = (try? await sizeProbe(params.url)) ?? -1
+                guard expectedBytes <= Int64(Constant.maxCiphertextBytes) else {
+                    throw URLError(.dataLengthExceedsMaximum)
+                }
+                let (fileURL, response) = try await transport(params.url)
+                defer { try? FileManager.default.removeItem(at: fileURL) }
+                return try decryptDownloadedFile(at: fileURL, response: response, params: params)
+            }
+        } catch {
+            if isPermanentFailure(error) {
+                markKnownBadURL(urlKey)
+            }
+            throw error
+        }
+    }
+
+    /// Whether an error can never succeed on retry for the same URL:
+    /// oversized payloads and cryptographic failures are functions of the
+    /// immutable ciphertext and key material, unlike network errors.
+    public static func isPermanentFailure(_ error: any Error) -> Bool {
+        if error is EncryptedImageKnownBadURL { return true }
+        if error is ImageEncryptionError { return true }
+        if error is CryptoKitError { return true }
+        if let urlError = error as? URLError, urlError.code == .dataLengthExceedsMaximum { return true }
+        return false
+    }
+
+    /// Records a URL whose payload proved deterministically unusable (e.g.
+    /// decrypted bytes that are not a decodable image). Subsequent fetches
+    /// fail fast with `EncryptedImageKnownBadURL`.
+    static func markKnownBadURL(_ urlKey: String) {
+        knownBadURLs.withLock { _ = $0.insert(urlKey) }
+    }
+
+    static func isKnownBadURL(_ urlKey: String) -> Bool {
+        knownBadURLs.withLock { $0.contains(urlKey) }
     }
 
     /// Validates the response and ciphertext size, then decrypts from a

--- a/ConvosCore/Tests/ConvosCoreTests/EncryptedImageLoaderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/EncryptedImageLoaderTests.swift
@@ -74,6 +74,122 @@ struct EncryptedImageLoaderDecryptTests {
     }
 }
 
+/// Coverage for the deterministic-failure negative cache: a URL whose fetch
+/// can never succeed (oversized payload, failed decryption) is remembered for
+/// the process lifetime and refused without network work, while transient
+/// network errors stay retriable. Every test uses a unique URL because the
+/// negative cache is process-wide state.
+struct EncryptedImageLoaderNegativeCacheTests {
+    private func makeUniqueParams(groupKey: Data = Data(count: 32)) throws -> EncryptedImageParams {
+        let url = try #require(URL(string: "https://example.com/\(UUID().uuidString).bin"))
+        return EncryptedImageParams(url: url, salt: Data(count: 32), nonce: Data(count: 12), groupKey: groupKey)
+    }
+
+    @Test func oversizedProbeRejectsBeforeDownloading() async throws {
+        let counter = TransportCounter()
+        let params = try makeUniqueParams()
+        let transport: EncryptedImageLoader.DownloadTransport = { _ in
+            await counter.enter()
+            await counter.exit()
+            throw URLError(.cancelled)
+        }
+        let probe: EncryptedImageLoader.SizeProbe = { _ in Int64(20 * 1024 * 1024 + 1) }
+
+        await #expect(throws: URLError(.dataLengthExceedsMaximum)) {
+            try await EncryptedImageLoader.loadAndDecrypt(
+                params: params, priority: .background, transport: transport, sizeProbe: probe
+            )
+        }
+        #expect(await counter.completed == 0)
+
+        // The oversize verdict is deterministic: the next fetch is refused
+        // without probing or downloading anything.
+        await #expect(throws: EncryptedImageKnownBadURL.self) {
+            try await EncryptedImageLoader.loadAndDecrypt(
+                params: params, priority: .background, transport: transport, sizeProbe: probe
+            )
+        }
+        #expect(await counter.completed == 0)
+    }
+
+    @Test func unknownProbeLengthStillDownloadsAndDecrypts() async throws {
+        let original = Data("probe-unknown plaintext".utf8)
+        let groupKey = try ImageEncryption.generateGroupKey()
+        let payload = try ImageEncryption.encrypt(imageData: original, groupKey: groupKey)
+        let url = try #require(URL(string: "https://example.com/\(UUID().uuidString).bin"))
+        let params = EncryptedImageParams(url: url, salt: payload.salt, nonce: payload.nonce, groupKey: groupKey)
+        let ciphertext = payload.ciphertext
+        let transport: EncryptedImageLoader.DownloadTransport = { _ in
+            (try makeTempFile(ciphertext), try makeHTTPResponse(statusCode: 200))
+        }
+
+        let plaintext = try await EncryptedImageLoader.loadAndDecrypt(
+            params: params, priority: .background, transport: transport, sizeProbe: { _ in -1 }
+        )
+        #expect(plaintext == original)
+    }
+
+    @Test func decryptionFailureMarksURLBad() async throws {
+        let counter = TransportCounter()
+        let groupKey = try ImageEncryption.generateGroupKey()
+        let payload = try ImageEncryption.encrypt(imageData: Data("secret".utf8), groupKey: groupKey)
+        // Correct salt and nonce, wrong group key: AES-GCM authentication fails.
+        let params = try makeUniqueParams()
+        let ciphertext = payload.ciphertext
+        let transport: EncryptedImageLoader.DownloadTransport = { _ in
+            await counter.enter()
+            await counter.exit()
+            return (try makeTempFile(ciphertext), try makeHTTPResponse(statusCode: 200))
+        }
+
+        do {
+            _ = try await EncryptedImageLoader.loadAndDecrypt(
+                params: params, priority: .background, transport: transport
+            )
+            Issue.record("Expected decryption to fail")
+        } catch {
+            #expect(EncryptedImageLoader.isPermanentFailure(error))
+        }
+        #expect(await counter.completed == 1)
+
+        await #expect(throws: EncryptedImageKnownBadURL.self) {
+            try await EncryptedImageLoader.loadAndDecrypt(
+                params: params, priority: .background, transport: transport
+            )
+        }
+        #expect(await counter.completed == 1)
+    }
+
+    @Test func transientNetworkFailureStaysRetriable() async throws {
+        let counter = TransportCounter()
+        let params = try makeUniqueParams()
+        let transport: EncryptedImageLoader.DownloadTransport = { _ in
+            await counter.enter()
+            await counter.exit()
+            throw URLError(.timedOut)
+        }
+
+        for _ in 0..<2 {
+            await #expect(throws: URLError(.timedOut)) {
+                try await EncryptedImageLoader.loadAndDecrypt(
+                    params: params, priority: .background, transport: transport
+                )
+            }
+        }
+        // Both attempts reached the transport: no negative-cache entry.
+        #expect(await counter.completed == 2)
+    }
+
+    @Test func classifiesPermanentVersusTransientErrors() {
+        #expect(EncryptedImageLoader.isPermanentFailure(EncryptedImageKnownBadURL()))
+        #expect(EncryptedImageLoader.isPermanentFailure(ImageEncryptionError.decryptionFailed))
+        #expect(EncryptedImageLoader.isPermanentFailure(URLError(.dataLengthExceedsMaximum)))
+        #expect(!EncryptedImageLoader.isPermanentFailure(URLError(.timedOut)))
+        #expect(!EncryptedImageLoader.isPermanentFailure(URLError(.cancelled)))
+        #expect(!EncryptedImageLoader.isPermanentFailure(URLError(.badServerResponse)))
+    }
+}
+
 /// Tracks how many transports are in flight at once.
 private actor TransportCounter {
     private(set) var current: Int = 0

--- a/ConvosCore/Tests/ConvosCoreTests/EncryptedImagePrefetcherTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/EncryptedImagePrefetcherTests.swift
@@ -1,0 +1,66 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Loader stub that always throws a fixed error and counts invocations.
+private actor ThrowingLoader: EncryptedImageLoaderProtocol {
+    private(set) var callCount: Int = 0
+    private let error: any Error
+
+    init(throwing error: any Error) {
+        self.error = error
+    }
+
+    func loadAndDecrypt(params: EncryptedImageParams) async throws -> Data {
+        callCount += 1
+        throw error
+    }
+}
+
+private func makeProfile() -> DBMemberProfile {
+    DBMemberProfile(
+        conversationId: "conversation-\(UUID().uuidString)",
+        inboxId: "inbox-\(UUID().uuidString)",
+        name: nil,
+        avatar: "https://example.com/\(UUID().uuidString).bin",
+        avatarSalt: Data(count: 32),
+        avatarNonce: Data(count: 12),
+        avatarKey: Data(count: 32)
+    )
+}
+
+/// Coverage for the prefetcher's retry policy: transient errors get the
+/// bounded retry, deterministic failures (decryption cannot heal - the
+/// ciphertext and key material are immutable for a URL) get exactly one
+/// attempt and no retry.
+struct EncryptedImagePrefetcherTests {
+    @Test("Permanent decryption failure is not retried")
+    func permanentFailureGetsSingleAttempt() async {
+        let loader = ThrowingLoader(throwing: ImageEncryptionError.decryptionFailed)
+        let prefetcher = EncryptedImagePrefetcher(loader: loader)
+
+        await prefetcher.prefetchProfileImages(profiles: [makeProfile()], groupKey: Data(count: 32))
+
+        #expect(await loader.callCount == 1)
+    }
+
+    @Test("Known-bad URL short-circuits without retry")
+    func knownBadURLGetsSingleAttempt() async {
+        let loader = ThrowingLoader(throwing: EncryptedImageKnownBadURL())
+        let prefetcher = EncryptedImagePrefetcher(loader: loader)
+
+        await prefetcher.prefetchProfileImages(profiles: [makeProfile()], groupKey: Data(count: 32))
+
+        #expect(await loader.callCount == 1)
+    }
+
+    @Test("Transient network failure keeps the bounded retry")
+    func transientFailureIsRetried() async {
+        let loader = ThrowingLoader(throwing: URLError(.timedOut))
+        let prefetcher = EncryptedImagePrefetcher(loader: loader)
+
+        await prefetcher.prefetchProfileImages(profiles: [makeProfile()], groupKey: Data(count: 32))
+
+        #expect(await loader.callCount == 2)
+    }
+}


### PR DESCRIPTION
## Problem

Shane's logs (build 1178) contain 245 `Failed to inline decrypt image` errors, 181 of them for a single URL. That asset is 45,665,835 bytes (43.5 MB) - more than double the loader's 20 MB `maxCiphertextBytes` cap - so every fetch is doomed: the app downloads the full payload, the size guard throws `URLError(.dataLengthExceedsMaximum)`, and nothing remembers the failure. The 245 errors break down as:

- **112 x `-1103` (dataLengthExceedsMaximum)** - each one a completed ~43.5 MB download thrown away (~4.9 GB of wasted bandwidth over the log window)
- **128 x `-999` (cancelled)** - the SwiftUI `.task` cancelling the in-flight download on cell reuse, restarting it from scratch on the next render

Three structural gaps compound this:

1. **No failure memory anywhere.** A deterministic failure (oversized payload, failed decryption, undecodable bytes) returns nil and the next avatar render or sync pass fires a brand-new download. The math doesn't change - the assets are immutable S3 blobs and a re-uploaded image gets a new URL, so a deterministic failure for a URL can never heal.
2. **No in-flight dedupe on the encrypted path.** `fetchImageFromNetwork` (plaintext) shares one task per URL via `loadingTasks`; `fetchEncryptedImageInline` did not, so the same avatar visible in 3 rows fired 3 concurrent 43 MB downloads (visible in the logs as 3 identical failures in the same second).
3. **The size guard runs after the download.** `URLSession.download(from:)` pulls the entire payload before we stat the file, so rejecting an oversized asset costs the full transfer.

All of this competed with catch-up sync traffic on Shane's already-flaky network.

## Fix

**`EncryptedImageLoader`**
- Process-wide negative cache of known-bad URLs. Deterministic failures (`ImageEncryptionError`, `CryptoKitError`, `dataLengthExceedsMaximum`) register the URL; subsequent fetches throw `EncryptedImageKnownBadURL` immediately without touching the network. Transient errors (timeouts, cancels, 5xx) never register.
- HEAD-request size preflight: an oversized asset is now rejected for one header round trip instead of a full download. Best-effort - a failed probe falls through to the download, where the existing post-download check still guards.
- `isPermanentFailure(_:)` exposes the classification for callers.

**`ImageCache.fetchEncryptedImageInline`**
- In-flight dedupe via the same `loadingTasks` map the plaintext path uses: one download per URL no matter how many rows show the avatar. The shared unstructured task also survives cell-reuse cancellation, so a scrolled-past avatar finishes downloading once instead of restarting on every render (eliminates the `-999` churn).
- Undecodable decrypted bytes mark the URL known-bad (the plaintext is immutable too).
- Known-bad hits log at debug, not error - every render of a bad avatar lands there.

**`EncryptedImagePrefetcher`**
- Permanent failures get exactly one attempt: the retry loop (2 attempts, 1s apart, previously error-blind) now returns immediately on a permanent classification. Known-bad short-circuits log at debug, since the sync pass re-selects uncached profiles every time.

The negative cache is in-memory (per launch). With the HEAD preflight, a relaunch re-discovers an oversized asset for the cost of one header round trip; a genuine decryption failure costs one download per launch. Persisting the negative cache wasn't worth the added state for that residual.

## Tests

- `EncryptedImageLoaderNegativeCacheTests` (5 new): oversize probe rejects before downloading and registers the URL; unknown probe length still downloads and decrypts; decryption failure marks the URL bad with no refetch; transient network failure stays retriable; permanent-vs-transient classification.
- `EncryptedImagePrefetcherTests` (3 new): permanent decryption failure gets a single attempt; `EncryptedImageKnownBadURL` short-circuits; transient failure keeps the bounded retry.
- Full ConvosCore suite green; ConvosCore also builds for iOS Simulator (the `ImageCache` changes are UIKit-gated and invisible to the macOS build).

## Follow-up (not in this PR)

How a 43.5 MB avatar got past the upload pipeline's compression in the first place - worth a separate look at the upload path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787856551&installation_model_id=20076&pr_number=1240&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1240&signature=85ce3d936d34e7ec62c8a07ad9689a98a250007901f0485e5b2bf449f827f87d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop retrying encrypted image loads that fail deterministically
> - Introduces a negative cache in [`EncryptedImageLoader`](https://github.com/xmtplabs/convos-ios/pull/1240/files#diff-7b33fc0530e99a3e9a50f447631666ada9ade550b718395a93709803597b28bd) that records permanently failing URLs (decryption errors, oversized payloads, known-bad URLs) for the process lifetime, fast-failing all subsequent attempts without network work.
> - Adds `isPermanentFailure` to classify errors as permanent vs. transient, and `EncryptedImageKnownBadURL` as a dedicated error type for fast-fail signals.
> - Updates [`EncryptedImagePrefetcher`](https://github.com/xmtplabs/convos-ios/pull/1240/files#diff-5db71b0b3eb2bdc6b2eba8b537e4ef4bd43e3892118baf98226ee90cb5f67524) to catch permanent failures and return immediately instead of retrying; transient errors (e.g. timeouts) continue to use bounded retry with backoff.
> - Deduplicates concurrent loads for the same URL in [`ImageCache`](https://github.com/xmtplabs/convos-ios/pull/1240/files#diff-445c3a2d9023d5d29469046555d79fa387c40b98bfcf772c84cdf1679fc38b91) via a new `withSharedLoadingTask` helper, and marks undecodable decrypted payloads as known-bad.
> - Adds an optional HEAD-based size preflight to reject oversized payloads before downloading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15e9a34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->