### PR TITLE
fix(participation): key the bubble to the keyboard, not to stored focus

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -34,6 +34,35 @@ private struct FilePickerModifier: ViewModifier {
     }
 }
 
+/// Tracks whether the keyboard is on screen. The composer's stored focus is not
+/// a reliable stand-in: the coordinator stops syncing while a focus transition
+/// is open, and an interactive dismissal leaves `@FocusState` set with the
+/// keyboard already gone (see `FocusCoordinator.refocusNonce`), so each signal
+/// lies in one direction. The keyboard itself is the honest one.
+private struct KeyboardVisibilityModifier: ViewModifier {
+    @Binding var isKeyboardVisible: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+                setVisible(true, matching: notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { notification in
+                setVisible(false, matching: notification)
+            }
+    }
+
+    /// Carries the keyboard's own duration into the change, so whatever moves
+    /// with it travels at the keyboard's pace instead of a spring of its own.
+    private func setVisible(_ visible: Bool, matching notification: Notification) {
+        let key: String = UIResponder.keyboardAnimationDurationUserInfoKey
+        let duration: Double = notification.userInfo?[key] as? Double ?? 0.25
+        withAnimation(.easeOut(duration: duration)) {
+            isKeyboardVisible = visible
+        }
+    }
+}
+
 /// A single dot breathing in place, holding the participation bubble while the
 /// conversation's level is read. It rests at a visible opacity, so if the
 /// animation never runs the bubble still reads as occupied rather than empty.
@@ -123,11 +152,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @State private var previousFocus: MessagesViewInputFocus?
     @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
     @State private var didSelectPhotoThisSession: Bool = false
-    /// Hides the participation bubble while the member is actually typing, so
-    /// the composer belongs to them in that moment. Kept as state rather than
-    /// read from the coordinator directly so it changes inside the same
-    /// animation as the rest of the bar.
-    @State private var showsParticipationBubble: Bool = true
+    @State private var isKeyboardVisible: Bool = false
     @Namespace private var namespace: Namespace.ID
     // Injected by the host on conversations that hold an agent; nil elsewhere,
     // and the bubble simply isn't drawn.
@@ -223,6 +248,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     public var body: some View {
         bodyContent
             .modifier(filePickerModifier)
+            .modifier(KeyboardVisibilityModifier(isKeyboardVisible: $isKeyboardVisible))
     }
 
     @ViewBuilder
@@ -318,7 +344,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
                 || newValue == .message
                 || newValue == .voiceMemoRecording
                 || newValue == .sideConvoName
-            showsParticipationBubble = newValue == nil
         }
     }
 
@@ -490,6 +515,14 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         }
     }
 
+    /// Whether the participation bubble stands aside: it does while the keyboard
+    /// is up, so the member typing gets that width back, and comes back the
+    /// moment it goes down. Keyed to the keyboard rather than to focus, which
+    /// desyncs in both directions - see `KeyboardVisibilityModifier`.
+    private var showsParticipationBubble: Bool {
+        !isKeyboardVisible
+    }
+
     /// The agent-participation control: how much the agents speak in this
     /// conversation. It leads the composer row, outside the input field, since
     /// it governs the room rather than the message being written — and it steps
@@ -511,8 +544,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             .frame(width: bubbleSize, height: bubbleSize)
             .clipShape(.circle)
             .glassEffect(.regular.interactive(), in: .circle)
-            .glassEffectID("participation", in: namespace)
-            .glassEffectTransition(.matchedGeometry)
             .transition(.scale.combined(with: .opacity))
             .animation(.easeInOut(duration: 0.2), value: isLoading)
             .accessibilityLabel(label)


### PR DESCRIPTION
The participation bubble was meant to step aside while a composer field holds focus. On device it never did — it sat in the composer row with the keyboard up and the field being typed into.

## Why

It read the coordinator's stored focus. `FocusCoordinator.syncFocusState` bails out while a focus transition is open, so `currentFocus` can still be `nil` with the field already first responder, and the `onChange` that hides the bubble never fires.

Reading `@FocusState` directly only moves the lie: an interactive keyboard dismissal leaves the stored focus at `.message` with the keyboard already gone, and then the bubble stays hidden over an idle composer (confirmed in the simulator — keyboard down at 18:28:53, bubble still absent at 18:28:59). Each signal is wrong in one direction.

The keyboard is what the member actually sees, so that is what the bubble follows now: a small `KeyboardVisibilityModifier` tracks `keyboardWillShow` / `keyboardWillHide`, kept as its own modifier so the already-long `bodyContent` chain doesn't grow.

## Transition

- The change carries the keyboard's own animation duration instead of a spring of its own, so bubble and keyboard travel together.
- The bubble gives up its `glassEffectID` / `matchedGeometry`: inside the `GlassEffectContainer` it tried to morph against the `+` and the input on the way in and out, which read as a flicker. It enters and leaves as its own shape.

## Testing

- `swift test --package-path ConvosCore` — 1658 tests, 231 suites, passing.
- Verified by hand in the simulator: keyboard up, bubble steps aside; keyboard down, bubble comes back.

Still behind `isListenParticipationEnabled`, hard-locked off in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787867182&installation_model_id=20076&pr_number=1241&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1241&signature=c3b257f3826681067b197d32f162ba2c0c2dcc2ff031af55d4644a0ce2bcdac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key participation bubble visibility to keyboard state in `MessagesBottomBar`
> - Replaces the focus-driven `showsParticipationBubble` state with a `isKeyboardVisible` flag driven by a new `KeyboardVisibilityModifier` that subscribes to `UIResponder` keyboard notifications.
> - The bubble now shows when the keyboard is hidden (`!isKeyboardVisible`) rather than when a stored focus flag is set, making visibility track actual keyboard presence.
> - Removes matched-geometry glass effect transitions from the participation bubble; it now uses scale+opacity transition only.
> - The keyboard modifier animates state changes using the keyboard's own `keyboardAnimationDurationUserInfoKey` for sync with system animation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48affa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->