### PR TITLE
CON-807: agent lost-power surfaces bind to backend owner-computed agentPowerDepleted, not the viewer's wallet

### DIFF
--- a/Convos/Conversation Detail/ConversationMemberView.swift
+++ b/Convos/Conversation Detail/ConversationMemberView.swift
@@ -7,7 +7,6 @@ struct ConversationMemberView: View {
     let member: ConversationMember
 
     @State private var presentingBlockConfirmation: Bool = false
-    @State private var creditsBalance: CreditBalance? = CreditsServices.shared.currentBalance
     @State private var presentingPaywall: Bool = false
     @Environment(\.dismiss) private var dismiss: DismissAction
     @Environment(\.openURL) private var openURL: OpenURLAction
@@ -25,14 +24,11 @@ struct ConversationMemberView: View {
         }
         .scrollContentBackground(.hidden)
         .background(.colorBackgroundRaisedSecondary)
-        .onReceive(CreditsServices.shared.balancePublisher) { newBalance in
-            creditsBalance = newBalance
-        }
         .task {
-            // Refresh credits when the contact sheet appears so the
-            // "out of credits" section + upgrade CTA reflect current
-            // backend state. TTL-debounced inside the service.
-            await CreditsServices.shared.refresh()
+            // Re-read the backend's owner-computed per-agent power signal when
+            // the contact sheet appears, so the "No power" section reflects
+            // current backend state (never the viewer's wallet — CON-807).
+            await viewModel.refreshAgentPowerStatus()
         }
         .sheet(isPresented: $presentingPaywall) {
             let paywallViewModel = PaywallViewModel(
@@ -60,23 +56,29 @@ struct ConversationMemberView: View {
         if shouldShowOutOfCredits {
             Section {
                 outOfCreditsRow
-                upgradeButton
+                if showsUpgradeCTA {
+                    upgradeButton
+                }
             }
             .listRowBackground(Color.colorBackgroundRaised)
         }
     }
 
     private var shouldShowOutOfCredits: Bool {
-        // `creditsBalance.isDepleted` is the LOCAL viewer's wallet, so this
-        // "No power" row is only correct for agents the viewer OWNS. On a
-        // non-owned agent's card it would wrongly attribute depletion to that
-        // agent. Gate on ownership (same fix as the in-stream cell); non-owners
-        // see nothing until a backend per-agent power signal exists.
-        guard member.isAgent,
-              viewModel.conversation.creator.isCurrentUser,
-              !ConfigManager.shared.currentEnvironment.isProduction,
-              let creditsBalance else { return false }
-        return creditsBalance.isDepleted
+        // Bound to the backend's owner-computed `agentPowerDepleted` for THIS
+        // agent (matched by inboxId) — the same fact for every member, so it
+        // shows to everyone. A missing entry is unknown (old backend, or an
+        // agent the backend has no bookkeeping for) and shows nothing. The
+        // viewer's own wallet is never consulted (CON-807).
+        guard member.isAgent else { return false }
+        return viewModel.agentPowerDepletedByInboxId[member.profile.inboxId] == true
+    }
+
+    private var showsUpgradeCTA: Bool {
+        // The backend doesn't expose agent ownership, so conversation
+        // creatorship is the closest proxy for "the viewer is who tops this
+        // agent up". CTA only — the row above shows for everyone.
+        viewModel.conversation.creator.isCurrentUser
     }
 
     @ViewBuilder
@@ -89,7 +91,7 @@ struct ConversationMemberView: View {
                 Text("No power")
                     .font(.body.weight(.semibold))
                     .foregroundStyle(.colorTextPrimary)
-                Text("Your agents are in read-only mode until power is restored.")
+                Text("\(member.profile.displayName) is in read-only mode until power is restored.")
                     .font(.caption)
                     .foregroundStyle(.colorTextSecondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Convos/Conversation Detail/ConversationMemberView.swift
+++ b/Convos/Conversation Detail/ConversationMemberView.swift
@@ -27,7 +27,7 @@ struct ConversationMemberView: View {
         .task {
             // Re-read the backend's owner-computed per-agent power signal when
             // the contact sheet appears, so the "No power" section reflects
-            // current backend state (never the viewer's wallet — CON-807).
+            // current backend state (never the viewer's wallet).
             await viewModel.refreshAgentPowerStatus()
         }
         .sheet(isPresented: $presentingPaywall) {
@@ -69,7 +69,8 @@ struct ConversationMemberView: View {
         // agent (matched by inboxId) — the same fact for every member, so it
         // shows to everyone. A missing entry is unknown (old backend, or an
         // agent the backend has no bookkeeping for) and shows nothing. The
-        // viewer's own wallet is never consulted (CON-807).
+        // viewer's own wallet is never consulted — a zero-balance viewer must
+        // see a funded owner's agent as working.
         guard member.isAgent else { return false }
         return viewModel.agentPowerDepletedByInboxId[member.profile.inboxId] == true
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -325,7 +325,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             onFileSelected: viewModel.addFileAttachment(url:filename:mimeType:fileSize:),
             onAboutAgents: { showingAgentsInfo = true },
             onAgentOutOfCredits: { viewModel.presentingPaywall = true },
-            creditsDepleted: viewModel.creditsDepleted,
+            agentPowerDepletedByInboxId: viewModel.agentPowerDepletedByInboxId,
             onTapUpdateMember: { viewModel.presentingProfileForMember = $0 },
             onTapCapabilityConnect: { prompt in
                 // Read-only viewers see the pill but can't answer the request

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -985,7 +985,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// every member, so the "lost power" surfaces show to everyone. A missing
     /// key is UNKNOWN (old backend, or an agent the backend has no bookkeeping
     /// for) and renders nothing. The viewer's own wallet is never an input
-    /// here (CON-807).
+    /// here — a zero-balance viewer must see other people's funded agents as
+    /// working.
     var agentPowerDepletedByInboxId: [String: Bool] = [:]
 
     @ObservationIgnored
@@ -994,6 +995,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// churn that doesn't touch agents doesn't re-fetch.
     @ObservationIgnored
     private var lastAgentPowerAgentInboxIds: Set<String> = []
+    /// Bumped at the start of every power refresh. A response only lands if no
+    /// newer refresh started while it was in flight — `refreshAgentPowerStatus`
+    /// is also called directly (member card `.task`), so two reads can overlap
+    /// and resolve out of order; without this the older response could
+    /// overwrite the fresher one.
+    @ObservationIgnored
+    private var agentPowerFetchGeneration: Int = 0
 
     var agentJoinForceErrorCode: Int?
 
@@ -1576,6 +1584,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             }
             return
         }
+        agentPowerFetchGeneration += 1
+        let generation = agentPowerFetchGeneration
         do {
             let client = ConvosAPIClientFactory.client(
                 environment: ConfigManager.shared.currentEnvironment
@@ -1584,6 +1594,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 conversationId: conversation.id,
                 variantId: FeatureFlags.shared.selectedAgentVariant?.slug
             )
+            // A newer refresh started while this one was in flight; its
+            // response is the fresher truth, so this one must not land.
+            guard generation == agentPowerFetchGeneration else { return }
             guard let map = response.agentPowerDepletedByInboxId else { return }
             if agentPowerDepletedByInboxId != map {
                 agentPowerDepletedByInboxId = map

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -979,10 +979,21 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// "<agent> is out of processing power" cell. Surfaces `PaywallView`
     /// against `SubscriptionServices.shared`.
     var presentingPaywall: Bool = false
-    /// Mirrors `CreditsServices.shared.currentBalance?.isDepleted`, refreshed
-    /// via the balance publisher. Drives the in-stream out-of-credits cell
-    /// insertion in `MessagesViewController` and the inline status surfaces.
-    var creditsDepleted: Bool = CreditsServices.shared.currentBalance?.isDepleted ?? false
+    /// Owner-computed per-agent power map keyed by agent inboxId, read from
+    /// `GET /v2/conversations/:id/participation` (`agents[].agentPowerDepleted`).
+    /// `true` means that agent's OWNER cannot fund a turn — the same fact for
+    /// every member, so the "lost power" surfaces show to everyone. A missing
+    /// key is UNKNOWN (old backend, or an agent the backend has no bookkeeping
+    /// for) and renders nothing. The viewer's own wallet is never an input
+    /// here (CON-807).
+    var agentPowerDepletedByInboxId: [String: Bool] = [:]
+
+    @ObservationIgnored
+    private var agentPowerRefreshTask: Task<Void, Never>?
+    /// Agent inbox ids the last power refresh was scheduled for, so membership
+    /// churn that doesn't touch agents doesn't re-fetch.
+    @ObservationIgnored
+    private var lastAgentPowerAgentInboxIds: Set<String> = []
 
     var agentJoinForceErrorCode: Int?
 
@@ -1552,6 +1563,43 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             }
     }
 
+    /// Re-reads the backend's owner-computed per-agent power signal for this
+    /// conversation. The ONLY source for the "lost power" surfaces — never the
+    /// viewer's wallet. Quiet on failure and on old backends (no `agents`
+    /// array): the last known state is kept, because "unknown" must not clear
+    /// or invent an indicator.
+    func refreshAgentPowerStatus() async {
+        let conversation = self.conversation
+        guard !conversation.isDraft, conversation.members.contains(where: \.isAgent) else {
+            if !agentPowerDepletedByInboxId.isEmpty {
+                agentPowerDepletedByInboxId = [:]
+            }
+            return
+        }
+        do {
+            let client = ConvosAPIClientFactory.client(
+                environment: ConfigManager.shared.currentEnvironment
+            )
+            let response = try await client.getAgentParticipation(
+                conversationId: conversation.id,
+                variantId: FeatureFlags.shared.selectedAgentVariant?.slug
+            )
+            guard let map = response.agentPowerDepletedByInboxId else { return }
+            if agentPowerDepletedByInboxId != map {
+                agentPowerDepletedByInboxId = map
+            }
+        } catch {
+            Log.error("agent power read failed: \(error)")
+        }
+    }
+
+    private func scheduleAgentPowerRefresh() {
+        agentPowerRefreshTask?.cancel()
+        agentPowerRefreshTask = Task { [weak self] in
+            await self?.refreshAgentPowerStatus()
+        }
+    }
+
     private func observe() {
         messagesListRepository.startObserving()
         setupTypingIndicatorHandler()
@@ -1559,10 +1607,19 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         observeDirectBuildGeneration()
         setupVoiceMemoPlaybackObserver()
         observeCapabilityRequests()
+        scheduleAgentPowerRefresh()
         CreditsServices.shared.balancePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] balance in
-                self?.creditsDepleted = balance?.isDepleted ?? false
+            .map { $0?.isDepleted ?? false }
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] _ in
+                // The viewer's balance no longer drives any agent indicator,
+                // but a flip of their own wallet is the cheapest local hint
+                // that — if they own agents here — the backend's owner-computed
+                // answer may have changed (e.g. right after buying credits).
+                // Re-ask the backend; the truth stays server-side.
+                self?.scheduleAgentPowerRefresh()
             }
             .store(in: &cancellables)
         messagesListRepository.messagesListPublisher
@@ -1628,6 +1685,14 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 let wasViewingConversation = self.isViewingConversation
                 self.conversation = displayConversation
                 self.loadConversationImage(for: conversation)
+                // Re-read the owner-computed power signal when the agent set
+                // changes (or the conversation swaps), so a just-joined agent
+                // gets an entry and a removed one stops being looked up.
+                let agentInboxIds = Set(displayConversation.members.filter(\.isAgent).map(\.profile.inboxId))
+                if conversation.id != previousId || agentInboxIds != self.lastAgentPowerAgentInboxIds {
+                    self.lastAgentPowerAgentInboxIds = agentInboxIds
+                    self.scheduleAgentPowerRefresh()
+                }
                 if conversation.id != previousId {
                     self.observePhotoPreferences(for: conversation.id)
                     self.loadPhotoPreferences()

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -81,7 +81,7 @@ struct MessagesView<BottomBarContent: View>: View {
     let onFileSelected: (URL, String, String, Int) -> Void
     let onAboutAgents: () -> Void
     let onAgentOutOfCredits: () -> Void
-    let creditsDepleted: Bool
+    let agentPowerDepletedByInboxId: [String: Bool]
     let onTapUpdateMember: (ConversationMember) -> Void
     var onTapCapabilityConnect: (CapabilityConnectPrompt) -> Void = { _ in }
     let onRetryMessage: (AnyMessage) -> Void
@@ -195,7 +195,7 @@ struct MessagesView<BottomBarContent: View>: View {
             contextMenuState: contextMenuState,
             onPhotoDimensionsLoaded: onPhotoDimensionsLoaded,
             onAgentOutOfCredits: onAgentOutOfCredits,
-            creditsDepleted: creditsDepleted,
+            agentPowerDepletedByInboxId: agentPowerDepletedByInboxId,
             onTapUpdateMember: onTapUpdateMember,
             onTapCapabilityConnect: onTapCapabilityConnect,
             onRetryMessage: onRetryMessage,

--- a/Convos/Conversation Detail/ThinkingDetailView.swift
+++ b/Convos/Conversation Detail/ThinkingDetailView.swift
@@ -205,7 +205,7 @@ struct ThinkingDetailView: View {
             contextMenuState: .init(),
             onPhotoDimensionsLoaded: { _, _, _ in },
             onAgentOutOfCredits: {},
-            creditsDepleted: false,
+            agentPowerDepletedByInboxId: [:],
             onTapUpdateMember: { _ in },
             onRetryMessage: { _ in },
             onDeleteMessage: { _ in },

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -120,10 +120,10 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                     .padding(.vertical, DesignConstants.Spacing.step4x)
                     .padding(.horizontal, DesignConstants.Spacing.step4x)
 
-                case let .agentOutOfCredits(member, isCurrentUserCreator):
+                case let .agentOutOfCredits(member, showsUpgradeCTA):
                     AgentLostPowerStatus(
                         agentName: member.profile.displayName,
-                        isCreator: isCurrentUserCreator,
+                        isCreator: showsUpgradeCTA,
                         onUpgrade: config.onAgentOutOfCredits
                     )
                     .padding(.vertical, DesignConstants.Spacing.step4x)
@@ -251,7 +251,7 @@ class MessagesListItemTypeCell: UICollectionViewCell {
             onRetryTranscript: config.onRetryTranscript,
             allVoiceMemoTranscripts: config.allVoiceMemoTranscripts,
             htmlAttachmentTransitionNamespace: config.htmlAttachmentTransitionNamespace,
-            creditsDepleted: config.creditsDepleted,
+            agentPowerDepletedByInboxId: config.agentPowerDepletedByInboxId,
             memberContactOverride: config.memberContactOverride
         )
     }

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -42,7 +42,7 @@ struct CellConfig {
     let onAgentOutOfCredits: () -> Void
     /// Backend owner-computed per-agent power map (inboxId -> depleted).
     /// Absent key = unknown = no indicator; the viewer's wallet is never
-    /// an input (CON-807).
+    /// an input.
     let agentPowerDepletedByInboxId: [String: Bool]
     let onRetryAgentJoin: () -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/CellFactory.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/CellFactory.swift
@@ -40,7 +40,10 @@ struct CellConfig {
     let onToggleMessageExpanded: (String) -> Void
     let contextMenuState: MessageContextMenuState
     let onAgentOutOfCredits: () -> Void
-    let creditsDepleted: Bool
+    /// Backend owner-computed per-agent power map (inboxId -> depleted).
+    /// Absent key = unknown = no indicator; the viewer's wallet is never
+    /// an input (CON-807).
+    let agentPowerDepletedByInboxId: [String: Bool]
     let onRetryAgentJoin: () -> Void
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onTapUpdateMember: (ConversationMember) -> Void

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift
@@ -25,7 +25,7 @@ protocol MessagesCollectionDataSource: UICollectionViewDataSource, MessagesLayou
     var conversationId: String { get set }
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)? { get set }
     var onAgentOutOfCredits: (() -> Void)? { get set }
-    var creditsDepleted: Bool { get set }
+    var agentPowerDepletedByInboxId: [String: Bool] { get set }
     var agentBuilderSummaryProvider: ((AgentBuilderCardContent) -> AnyView)? { get set }
     var currentUserProfileImage: (() -> UIImage?)? { get set }
     var backwardsSecrecyInfoSheet: (() -> AnyView)? { get set }

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Data Source/MessagesCollectionViewDataSource.swift
@@ -32,7 +32,7 @@ final class MessagesCollectionViewDataSource: NSObject {
     var contextMenuState: MessageContextMenuState?
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)?
     var onAgentOutOfCredits: (() -> Void)?
-    var creditsDepleted: Bool = false
+    var agentPowerDepletedByInboxId: [String: Bool] = [:]
     var onTapUpdateMember: ((ConversationMember) -> Void)?
     var onTapCapabilityConnect: ((CapabilityConnectPrompt) -> Void)?
     var onOpenFile: ((HydratedAttachment, AnyMessage) -> Void)?
@@ -142,7 +142,7 @@ extension MessagesCollectionViewDataSource: UICollectionViewDataSource {
             onAgentOutOfCredits: { [weak self] in
                 self?.onAgentOutOfCredits?()
             },
-            creditsDepleted: creditsDepleted,
+            agentPowerDepletedByInboxId: agentPowerDepletedByInboxId,
             onRetryAgentJoin: { [weak self] in
                 self?.onRetryAgentJoin?()
             },

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/MessagesViewController.swift
@@ -422,16 +422,19 @@ public final class MessagesViewController: UIViewController {
 
     var onPhotoDimensionsLoaded: ((String, Int, Int) -> Void)?
     var onAgentOutOfCredits: (() -> Void)?
-    /// Drives the in-stream out-of-credits cell. Set from
-    /// `MessagesViewRepresentable` off `ConversationViewModel.creditsDepleted`
-    /// (which mirrors `CreditsServices.shared.currentBalance?.isDepleted`).
-    /// When this flips while a state is already applied, we replay the
-    /// last processed state so the cell appears / disappears without
-    /// needing the messages publisher to emit again.
-    var creditsDepleted: Bool = false {
+    /// Drives the in-stream "lost power" cell. Set from
+    /// `MessagesViewRepresentable` off
+    /// `ConversationViewModel.agentPowerDepletedByInboxId` — the backend's
+    /// OWNER-computed per-agent power signal, keyed by agent inboxId. The
+    /// viewer's own wallet is never an input; an agent missing from the map
+    /// is unknown and renders nothing (CON-807). When this changes while a
+    /// state is already applied, we replay the last processed state so the
+    /// cell appears / disappears without needing the messages publisher to
+    /// emit again.
+    var agentPowerDepletedByInboxId: [String: Bool] = [:] {
         didSet {
-            dataSource.creditsDepleted = creditsDepleted
-            guard oldValue != creditsDepleted, isViewLoaded, let state else { return }
+            dataSource.agentPowerDepletedByInboxId = agentPowerDepletedByInboxId
+            guard oldValue != agentPowerDepletedByInboxId, isViewLoaded, let state else { return }
             self.state = state
         }
     }
@@ -989,22 +992,26 @@ extension MessagesViewController {
             }
         }
 
-        // Only surface the per-agent "lost power" cell for agents the viewer
-        // OWNS. `creditsDepleted` reflects the LOCAL viewer's wallet, which is
-        // only the right signal for the viewer's own agents - for someone
-        // else's funded agent it would mislabel a working agent as depleted.
-        // Gating on `isCurrentUserCreator` keeps the wallet check correct;
-        // non-owners see nothing until a backend per-agent power signal exists.
-        let isCurrentUserCreator: Bool = conversation.creator.isCurrentUser
-        if creditsDepleted, isCurrentUserCreator, let agentMember = conversation.members.first(where: { $0.isAgent }) {
+        // The per-agent "lost power" cell derives ONLY from the backend's
+        // owner-computed `agentPowerDepleted` signal, matched by inboxId.
+        // `true` is the same fact for every member, so the cell shows to
+        // everyone; an agent missing from the map is UNKNOWN (old backend,
+        // or an agent the backend has no bookkeeping for) and shows nothing.
+        // The viewer's own wallet is never consulted here — a zero-balance
+        // viewer looking at a funded agent sees a working agent (CON-807).
+        // Only the upgrade CTA stays gated: the backend doesn't expose agent
+        // ownership, so conversation creatorship is the closest proxy for
+        // "the viewer is who tops this agent up".
+        let showsUpgradeCTA: Bool = conversation.creator.isCurrentUser
+        for agentMember in conversation.members.agentsWithDepletedPower(agentPowerDepletedByInboxId) {
             let agentInboxId = agentMember.profile.inboxId
             if let lastAgentIndex = cells.lastIndex(where: {
                 if case .messages(let group) = $0 { return group.sender.profile.inboxId == agentInboxId }
                 return false
             }) {
-                cells.insert(.agentOutOfCredits(agentMember, isCurrentUserCreator: isCurrentUserCreator), at: lastAgentIndex + 1)
+                cells.insert(.agentOutOfCredits(agentMember, showsUpgradeCTA: showsUpgradeCTA), at: lastAgentIndex + 1)
             } else {
-                cells.append(.agentOutOfCredits(agentMember, isCurrentUserCreator: isCurrentUserCreator))
+                cells.append(.agentOutOfCredits(agentMember, showsUpgradeCTA: showsUpgradeCTA))
             }
         }
 

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/MessagesViewController.swift
@@ -427,7 +427,7 @@ public final class MessagesViewController: UIViewController {
     /// `ConversationViewModel.agentPowerDepletedByInboxId` — the backend's
     /// OWNER-computed per-agent power signal, keyed by agent inboxId. The
     /// viewer's own wallet is never an input; an agent missing from the map
-    /// is unknown and renders nothing (CON-807). When this changes while a
+    /// is unknown and renders nothing. When this changes while a
     /// state is already applied, we replay the last processed state so the
     /// cell appears / disappears without needing the messages publisher to
     /// emit again.
@@ -435,6 +435,17 @@ public final class MessagesViewController: UIViewController {
         didSet {
             dataSource.agentPowerDepletedByInboxId = agentPowerDepletedByInboxId
             guard oldValue != agentPowerDepletedByInboxId, isViewLoaded, let state else { return }
+            // The sender-label bolt lives inside `.messages` cells whose items
+            // don't change when the map flips, so the state replay below
+            // carries no DifferenceKit changeset for them — an already-visible
+            // group would keep rendering the stale bolt until cell reuse.
+            // Reconfigure the groups sent by the agents whose signal changed
+            // before replaying (the replay only inserts/removes the standalone
+            // lost-power cells).
+            let changedInboxIds: Set<String> = Set(oldValue.keys)
+                .union(agentPowerDepletedByInboxId.keys)
+                .filter { oldValue[$0] != agentPowerDepletedByInboxId[$0] }
+            reconfigureCells(forSenderInboxIds: changedInboxIds)
             self.state = state
         }
     }
@@ -928,6 +939,34 @@ public final class MessagesViewController: UIViewController {
     }
 }
 
+// MARK: - Agent power reconfigure
+
+extension MessagesViewController {
+    /// Reconfigures the visible message cells sent by any of the given inbox
+    /// ids. Used when the owner-computed power map flips for a sender: the
+    /// `.messages` items themselves are unchanged, so — exactly like the
+    /// long-body expansion set — the change carries no DifferenceKit
+    /// changeset of its own and visible cells must be reconfigured by hand.
+    private func reconfigureCells(forSenderInboxIds inboxIds: Set<String>) {
+        guard !inboxIds.isEmpty else { return }
+        var indexPaths: [IndexPath] = []
+        for (sectionIndex, section) in dataSource.sections.enumerated() {
+            for (itemIndex, cell) in section.cells.enumerated() {
+                guard case .messages(let group) = cell else { continue }
+                if inboxIds.contains(group.sender.profile.inboxId) {
+                    indexPaths.append(IndexPath(item: itemIndex, section: sectionIndex))
+                }
+            }
+        }
+        guard !indexPaths.isEmpty else { return }
+        collectionView.reconfigureItems(at: indexPaths)
+        // Pair with the layout call, matching `reconfigureCells(forMessageIds:)`
+        // — the custom layout only re-measures cells stashed by its own
+        // `reconfigureItems`.
+        messagesLayout.reconfigureItems(at: indexPaths)
+    }
+}
+
 // MARK: - MessagesControllerDelegate
 
 extension MessagesViewController {
@@ -998,7 +1037,7 @@ extension MessagesViewController {
         // everyone; an agent missing from the map is UNKNOWN (old backend,
         // or an agent the backend has no bookkeeping for) and shows nothing.
         // The viewer's own wallet is never consulted here — a zero-balance
-        // viewer looking at a funded agent sees a working agent (CON-807).
+        // viewer looking at a funded agent sees a working agent.
         // Only the upgrade CTA stays gated: the backend doesn't expose agent
         // ownership, so conversation creatorship is the closest proxy for
         // "the viewer is who tops this agent up".

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
@@ -41,10 +41,12 @@ struct MessagesGroupView: View {
     /// `AttachmentPreviewSheet` zoom transition. nil outside the main
     /// messages list path.
     var htmlAttachmentTransitionNamespace: Namespace.ID?
-    /// Mirrors `ConversationViewModel.creditsDepleted`. Drives the inline
-    /// `bolt.fill` glyph next to an agent sender's display name when
-    /// the global credit balance is depleted.
-    var creditsDepleted: Bool = false
+    /// Mirrors `ConversationViewModel.agentPowerDepletedByInboxId` — the
+    /// backend's owner-computed per-agent power map. Drives the inline
+    /// `bolt.fill` glyph next to an agent sender's display name when THAT
+    /// agent's owner cannot fund a turn. Absent key = unknown = no glyph;
+    /// the viewer's own wallet is never an input (CON-807).
+    var agentPowerDepletedByInboxId: [String: Bool] = [:]
     /// Resolves an inbox id to the local contact-name override so the sender
     /// label matches the contact card and conversation title (contact name ->
     /// per-conversation profile name -> "Somebody"). Without this the label
@@ -122,7 +124,7 @@ struct MessagesGroupView: View {
         return Button(action: tapAction) {
             HStack(spacing: DesignConstants.Spacing.stepX) {
                 Text(senderDisplayName)
-                if displayGroup.sender.isAgent && creditsDepleted {
+                if displayGroup.sender.isAgent && agentPowerDepletedByInboxId[displayGroup.sender.profile.inboxId] == true {
                     Image(systemName: "bolt.fill")
                         .foregroundStyle(.colorLava)
                 }

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
@@ -45,7 +45,7 @@ struct MessagesGroupView: View {
     /// backend's owner-computed per-agent power map. Drives the inline
     /// `bolt.fill` glyph next to an agent sender's display name when THAT
     /// agent's owner cannot fund a turn. Absent key = unknown = no glyph;
-    /// the viewer's own wallet is never an input (CON-807).
+    /// the viewer's own wallet is never an input.
     var agentPowerDepletedByInboxId: [String: Bool] = [:]
     /// Resolves an inbox id to the local contact-name override so the sender
     /// label matches the contact card and conversation title (contact name ->

--- a/ConvosCore/Sources/ConvosComposer/MessagesViewRepresentable.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesViewRepresentable.swift
@@ -34,7 +34,9 @@ public struct MessagesViewRepresentable: UIViewControllerRepresentable {
     let contextMenuState: MessageContextMenuState
     let onPhotoDimensionsLoaded: (String, Int, Int) -> Void
     let onAgentOutOfCredits: () -> Void
-    let creditsDepleted: Bool
+    /// Backend owner-computed per-agent power map (inboxId -> depleted).
+    /// Empty means unknown for every agent -> no power indicator anywhere.
+    let agentPowerDepletedByInboxId: [String: Bool]
     let onTapUpdateMember: (ConversationMember) -> Void
     var onTapCapabilityConnect: (CapabilityConnectPrompt) -> Void = { _ in }
     let onRetryMessage: (AnyMessage) -> Void
@@ -111,7 +113,7 @@ public struct MessagesViewRepresentable: UIViewControllerRepresentable {
         contextMenuState: MessageContextMenuState,
         onPhotoDimensionsLoaded: @escaping (String, Int, Int) -> Void,
         onAgentOutOfCredits: @escaping () -> Void,
-        creditsDepleted: Bool,
+        agentPowerDepletedByInboxId: [String: Bool],
         onTapUpdateMember: @escaping (ConversationMember) -> Void,
         onTapCapabilityConnect: @escaping (CapabilityConnectPrompt) -> Void = { _ in },
         onRetryMessage: @escaping (AnyMessage) -> Void,
@@ -165,7 +167,7 @@ public struct MessagesViewRepresentable: UIViewControllerRepresentable {
         self.contextMenuState = contextMenuState
         self.onPhotoDimensionsLoaded = onPhotoDimensionsLoaded
         self.onAgentOutOfCredits = onAgentOutOfCredits
-        self.creditsDepleted = creditsDepleted
+        self.agentPowerDepletedByInboxId = agentPowerDepletedByInboxId
         self.onTapUpdateMember = onTapUpdateMember
         self.onTapCapabilityConnect = onTapCapabilityConnect
         self.onRetryMessage = onRetryMessage
@@ -245,7 +247,7 @@ public struct MessagesViewRepresentable: UIViewControllerRepresentable {
             self.onPhotoDimensionsLoaded(key, width, height)
         }
         messagesViewController.onAgentOutOfCredits = onAgentOutOfCredits
-        messagesViewController.creditsDepleted = creditsDepleted
+        messagesViewController.agentPowerDepletedByInboxId = agentPowerDepletedByInboxId
         messagesViewController.agentBuilderSummaryProvider = agentBuilderSummaryProvider
         messagesViewController.currentUserProfileImage = currentUserProfileImage
         messagesViewController.backwardsSecrecyInfoSheet = backwardsSecrecyInfoSheet

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -305,6 +305,10 @@ public enum ConvosAPI {
         public let inboxId: String?
         public let conversationId: String?
         public let joinFailureReason: String?
+        /// Owner-computed "cannot fund a turn" signal for the polled instance.
+        /// Absent on old backends and for instances that predate the backend's
+        /// bookkeeping — absent means UNKNOWN, never depleted.
+        public let agentPowerDepleted: Bool?
 
         public init(
             success: Bool,
@@ -313,7 +317,8 @@ public enum ConvosAPI {
             joined: Bool,
             inboxId: String? = nil,
             conversationId: String? = nil,
-            joinFailureReason: String? = nil
+            joinFailureReason: String? = nil,
+            agentPowerDepleted: Bool? = nil
         ) {
             self.success = success
             self.instanceId = instanceId
@@ -322,6 +327,7 @@ public enum ConvosAPI {
             self.inboxId = inboxId
             self.conversationId = conversationId
             self.joinFailureReason = joinFailureReason
+            self.agentPowerDepleted = agentPowerDepleted
         }
 
         /// Typed view of the wire `joinStatus`. Switch over this (not the
@@ -347,16 +353,56 @@ public enum ConvosAPI {
         }
     }
 
+    /// One agent's owner-computed power entry on the participation payload.
+    /// `agentPowerDepleted` is computed by the backend from the agent OWNER's
+    /// wallet (never the viewer's), so it is identical for every caller.
+    public struct ParticipationAgent: Codable {
+        public let inboxId: String
+        /// `true` ⇔ the agent's payer cannot fund a turn right now. Optional:
+        /// the backend omits it when it cannot compute the owner's balance.
+        public let agentPowerDepleted: Bool?
+
+        public init(inboxId: String, agentPowerDepleted: Bool? = nil) {
+            self.inboxId = inboxId
+            self.agentPowerDepleted = agentPowerDepleted
+        }
+    }
+
     public struct AgentParticipationResponse: Codable {
         public let success: Bool
         public let conversationId: String
         /// The level now in force — echoed on a write, read on a fetch.
         public let mode: String
+        /// Owner-computed power entries for the conversation's known agents.
+        /// Absent on old backends and on enrichment failure — absent means
+        /// UNKNOWN, never depleted. Bind entries by `inboxId` against the
+        /// actual member list; agents that predate the backend's bookkeeping
+        /// have no entry.
+        public let agents: [ParticipationAgent]?
 
-        public init(success: Bool, conversationId: String, mode: String) {
+        public init(
+            success: Bool,
+            conversationId: String,
+            mode: String,
+            agents: [ParticipationAgent]? = nil
+        ) {
             self.success = success
             self.conversationId = conversationId
             self.mode = mode
+            self.agents = agents
+        }
+
+        /// Per-agent power map keyed by inboxId. `nil` when the backend sent
+        /// no `agents` array at all (old backend / enrichment failure) —
+        /// callers must treat that as UNKNOWN and keep their last state
+        /// rather than clearing to "everyone healthy". Entries whose
+        /// `agentPowerDepleted` is absent are dropped (unknown per-agent).
+        public var agentPowerDepletedByInboxId: [String: Bool]? {
+            guard let agents else { return nil }
+            return agents.reduce(into: [:]) { map, agent in
+                guard let depleted = agent.agentPowerDepleted else { return }
+                map[agent.inboxId] = depleted
+            }
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
@@ -119,6 +119,20 @@ public extension Array where Element == ConversationMember {
         map { $0.profile }.formattedNamesString(memberNameOverride: memberNameOverride)
     }
 
+    /// Agent members whose backend owner-computed power signal says depleted.
+    ///
+    /// The map is keyed by agent inboxId and comes from
+    /// `GET /v2/conversations/:id/participation` (`agents[].agentPowerDepleted`),
+    /// which the backend computes from the agent OWNER's wallet — never the
+    /// viewer's. A member missing from the map is UNKNOWN (old backend, or an
+    /// agent that predates the backend's bookkeeping) and is never returned:
+    /// unknown must render as nothing, not as depleted (CON-807).
+    func agentsWithDepletedPower(
+        _ agentPowerDepletedByInboxId: [String: Bool]
+    ) -> [ConversationMember] {
+        filter { $0.isAgent && agentPowerDepletedByInboxId[$0.profile.inboxId] == true }
+    }
+
     func sortedByRole() -> [ConversationMember] {
         sorted { member1, member2 in
             if member1.isCurrentUser { return true }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationMember.swift
@@ -126,7 +126,7 @@ public extension Array where Element == ConversationMember {
     /// which the backend computes from the agent OWNER's wallet — never the
     /// viewer's. A member missing from the map is UNKNOWN (old backend, or an
     /// agent that predates the backend's bookkeeping) and is never returned:
-    /// unknown must render as nothing, not as depleted (CON-807).
+    /// unknown must render as nothing, not as depleted.
     func agentsWithDepletedPower(
         _ agentPowerDepletedByInboxId: [String: Bool]
     ) -> [ConversationMember] {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
@@ -48,7 +48,7 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
     case messages(MessagesGroup)
     case invite(Invite)
     case conversationInfo(Conversation)
-    case agentOutOfCredits(ConversationMember, isCurrentUserCreator: Bool)
+    case agentOutOfCredits(ConversationMember, showsUpgradeCTA: Bool)
     case agentJoinStatus(AgentJoinStatus, requesterName: String?, date: Date)
     case agentPresentInfo(agent: ConversationMember, inviterName: String?)
     case connectionEvent(id: String, summary: ConnectionEventSummary, origin: AnyMessage.Origin)

--- a/ConvosCore/Tests/ConvosCoreTests/AgentPowerSignalTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentPowerSignalTests.swift
@@ -1,0 +1,116 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Coverage for the owner-computed per-agent power signal (CON-807).
+///
+/// The backend computes `agentPowerDepleted` from the agent OWNER's wallet and
+/// serves it per agent on `GET /v2/conversations/:id/participation`
+/// (`agents[].agentPowerDepleted`) and `GET /v2/agents/join/:instanceId`. The
+/// client binds every "lost power" surface to that field alone — the viewer's
+/// own wallet is never an input. These tests pin the decode tolerance (the
+/// field is additive; old backends omit it) and the display decision.
+@Suite("Agent power signal")
+struct AgentPowerSignalTests {
+    private func member(inboxId: String, isAgent: Bool, isCurrentUser: Bool = false) -> ConversationMember {
+        ConversationMember(
+            profile: Profile(
+                inboxId: inboxId,
+                conversationId: "convo-1",
+                name: inboxId,
+                avatar: nil
+            ),
+            role: .member,
+            isCurrentUser: isCurrentUser,
+            isAgent: isAgent
+        )
+    }
+
+    // MARK: - Decode tolerance (additive field, old backends)
+
+    @Test("Legacy participation payload (no agents array) decodes; map is nil = unknown")
+    func legacyParticipationPayloadDecodes() throws {
+        let json = Data(#"{"success":true,"conversationId":"c1","mode":"speak"}"#.utf8)
+        let response = try JSONDecoder().decode(ConvosAPI.AgentParticipationResponse.self, from: json)
+        #expect(response.success)
+        #expect(response.mode == "speak")
+        #expect(response.agents == nil)
+        // nil (unknown), NOT an empty "everyone healthy" map — callers keep
+        // their last state instead of clearing.
+        #expect(response.agentPowerDepletedByInboxId == nil)
+    }
+
+    @Test("Participation payload with agents builds the inboxId map; flagless entries stay unknown")
+    func participationPayloadBuildsMap() throws {
+        let json = Data("""
+        {"success":true,"conversationId":"c1","mode":"speak","agents":[
+            {"inboxId":"agent-a","agentPowerDepleted":true},
+            {"inboxId":"agent-b","agentPowerDepleted":false},
+            {"inboxId":"agent-c"}
+        ]}
+        """.utf8)
+        let response = try JSONDecoder().decode(ConvosAPI.AgentParticipationResponse.self, from: json)
+        #expect(response.agents?.count == 3)
+        #expect(response.agentPowerDepletedByInboxId == ["agent-a": true, "agent-b": false])
+    }
+
+    @Test("Join-status payload decodes with and without agentPowerDepleted")
+    func joinStatusPayloadDecodes() throws {
+        let legacy = Data(#"{"success":true,"instanceId":"i1","joinStatus":"joined","joined":true}"#.utf8)
+        let legacyResponse = try JSONDecoder().decode(ConvosAPI.AgentJoinStatusResponse.self, from: legacy)
+        #expect(legacyResponse.agentPowerDepleted == nil)
+
+        let enriched = Data(#"{"success":true,"instanceId":"i1","joinStatus":"joined","joined":true,"agentPowerDepleted":true}"#.utf8)
+        let enrichedResponse = try JSONDecoder().decode(ConvosAPI.AgentJoinStatusResponse.self, from: enriched)
+        #expect(enrichedResponse.agentPowerDepleted == true)
+    }
+
+    // MARK: - Display decision
+
+    /// The CON-807 regression: a viewer at 0 credits looks at someone else's
+    /// FUNDED agent. The viewer's own wallet says depleted, but the wallet is
+    /// not an input — the owner-computed signal says false, so no indicator.
+    @Test("Zero-balance viewer sees a funded owner's agent as working")
+    func zeroBalanceViewerSeesFundedAgentAsWorking() {
+        let viewerBalance = CreditBalance(
+            balance: 0,
+            monthlyGrant: 500_000,
+            monthlyGrantUsed: 500_000,
+            nextRefreshAt: Date(),
+            periodLabel: "July"
+        )
+        #expect(viewerBalance.isDepleted) // Quarter's wallet state...
+
+        let members = [
+            member(inboxId: "viewer", isAgent: false, isCurrentUser: true),
+            member(inboxId: "carolines-agent", isAgent: true),
+        ]
+        // ...and the backend's owner-computed answer for Caroline's agent.
+        let depleted = members.agentsWithDepletedPower(["carolines-agent": false])
+        #expect(depleted.isEmpty)
+    }
+
+    @Test("Absent signal (old backend / unregistered agent) shows nothing")
+    func absentSignalShowsNothing() {
+        let members = [
+            member(inboxId: "viewer", isAgent: false, isCurrentUser: true),
+            member(inboxId: "agent-a", isAgent: true),
+        ]
+        #expect(members.agentsWithDepletedPower([:]).isEmpty)
+        #expect(members.agentsWithDepletedPower(["other-agent": true]).isEmpty)
+    }
+
+    @Test("Depleted owner flags exactly that agent, for any viewer")
+    func depletedOwnerFlagsAgent() {
+        let members = [
+            member(inboxId: "viewer", isAgent: false, isCurrentUser: true),
+            member(inboxId: "agent-a", isAgent: true),
+            member(inboxId: "agent-b", isAgent: true),
+        ]
+        let map = ["agent-a": true, "agent-b": false, "viewer": true]
+        let depleted = members.agentsWithDepletedPower(map)
+        #expect(depleted.map(\.profile.inboxId) == ["agent-a"])
+        // A non-agent member can never be flagged, whatever the map says.
+        #expect(!depleted.contains(where: { !$0.isAgent }))
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AgentPowerSignalTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentPowerSignalTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-/// Coverage for the owner-computed per-agent power signal (CON-807).
+/// Coverage for the owner-computed per-agent power signal.
 ///
 /// The backend computes `agentPowerDepleted` from the agent OWNER's wallet and
 /// serves it per agent on `GET /v2/conversations/:id/participation`
@@ -67,9 +67,10 @@ struct AgentPowerSignalTests {
 
     // MARK: - Display decision
 
-    /// The CON-807 regression: a viewer at 0 credits looks at someone else's
-    /// FUNDED agent. The viewer's own wallet says depleted, but the wallet is
-    /// not an input — the owner-computed signal says false, so no indicator.
+    /// The core regression this feature retires: a viewer at 0 credits looks
+    /// at someone else's FUNDED agent. The viewer's own wallet says depleted,
+    /// but the wallet is not an input — the owner-computed signal says false,
+    /// so no indicator.
     @Test("Zero-balance viewer sees a funded owner's agent as working")
     func zeroBalanceViewerSeesFundedAgentAsWorking() {
         let viewerBalance = CreditBalance(

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -1131,7 +1131,7 @@ struct ShareComposeView: View {
                 contextMenuState: contextMenuState,
                 onPhotoDimensionsLoaded: { _, _, _ in },
                 onAgentOutOfCredits: {},
-                creditsDepleted: false,
+                agentPowerDepletedByInboxId: [:],
                 onTapUpdateMember: { _ in },
                 onRetryMessage: { _ in },
                 onDeleteMessage: { _ in },


### PR DESCRIPTION
## What

Rebinds every per-agent "lost power" surface to the backend's new owner-computed `agentPowerDepleted` field — the iOS half of CON-807 (backend half: xmtplabs/convos-backend#395).

Previously the in-stream "X lost power" cell, the bolt glyph next to an agent sender's name, and the member-card "No power" row all derived from the VIEWER's own wallet (`CreditsServices.shared.currentBalance?.isDepleted`), so any viewer at 0 credits saw other people's funded agents as dead — Quarter at 0 credits seeing Caroline's healthy agent dark is exactly this bug.

## How

- **Decode (additive, optional)** — `ConvosAPI.AgentParticipationResponse` gains `agents: [ParticipationAgent]?` (`{ inboxId, agentPowerDepleted }`) from `GET /v2/conversations/:id/participation`; `ConvosAPI.AgentJoinStatusResponse` gains `agentPowerDepleted: Bool?` from `GET /v2/agents/join/:instanceId`. Both optional with defaulted inits — nothing breaks against old backends.
- **Rebind** — `ConversationViewModel` now holds `agentPowerDepletedByInboxId: [String: Bool]`, refreshed from the participation endpoint (on observe, on agent-set change, on the member card appearing, and when the viewer's own balance flips as a cheap owner-side hint). The map threads through `MessagesView` → `MessagesViewRepresentable` → `MessagesViewController` → cell config, replacing the old `creditsDepleted: Bool` everywhere. The viewer-wallet path for agent state is gone.
- **Semantics** (per the backend PR's contract): `true` ⇒ indicator visible to ALL members identically; healthy owner ⇒ nothing for anyone, including a zero-balance viewer; absent field/entry (old backend, or an agent the backend has no bookkeeping for) ⇒ unknown ⇒ show NOTHING. The #1093 conversation-creator gate on the indicator is removed; only the "Upgrade" CTA stays creator-gated (closest client proxy for the paying owner — the backend doesn't expose agent ownership).
- Viewer-scoped out-of-power surfaces for the viewer's OWN wallet (home pill `ConversationsView`, tab indicator `MainTabView`, settings `AppSettingsView`) are untouched.
- The member-card row also loses its dev-only gate (`!isProduction`): the signal is now correct in prod. Copy is agent-scoped ("<Agent> is in read-only mode…") since non-owners see it too.

## Absent-field tolerance / rollout

The client tolerates a missing `agents` array (and missing per-entry flags) end to end: `nil` decodes fine, maps to "unknown", and unknown renders nothing — so this ships safely against today's backend and the full behavior lights up when xmtplabs/convos-backend#395 deploys. No request schema is touched.

## Testing

- New `ConvosCore/Tests/ConvosCoreTests/AgentPowerSignalTests.swift` (6 tests, all green), including the CON-807 regression case "Zero-balance viewer sees a funded owner's agent as working" — pins that the viewer's `CreditBalance.isDepleted` is not an input to the display decision — plus decode-tolerance pins for both payloads (old-backend shapes must keep decoding).
- `xcodebuild build` of `Convos (Local)` green (app + ShareExtension + ConvosComposer).
- Full `swift test --package-path ConvosCore`: 1654 tests, 1 unrelated flake (`VoiceMemoTranscriptionService` "happy path" — passes standalone, no voice-memo code touched).

## Manual QA (the UIKit cell insertion has no unit-test seam)

1. **Quarter/Caroline case**: viewer at 0 credits in a convo containing an agent owned by a FUNDED account → no bolt, no "lost power" cell, no "No power" row on the agent's card.
2. Deplete the OWNER's wallet below the turn floor → every member (owner and non-owners) sees the in-stream "X lost power" cell for that agent; only the conversation creator sees the Upgrade CTA.
3. Against an old backend (no `agents` in the participation response): no power indicator anywhere, for anyone.
4. Owner tops up → indicator clears for everyone on the next refresh (balance flip owner-side, member card open, or agent membership change).

CON-807

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787926367&installation_model_id=20076&pr_number=1243&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1243&signature=4f648e1efac60a4676914583d6d6e46abc29e2b725fde3f8b1c772143c17d82f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace global credits-depleted flag with per-agent backend-computed power depletion map in conversation views
> - The 'No power' status cell and bolt icon in agent message threads previously keyed off the viewer's own wallet balance; they now reflect a per-agent `agentPowerDepletedByInboxId` map fetched from the backend via `ConvosAPIClient.getAgentParticipation`.
> - `ConversationViewModel` replaces the `creditsDepleted` Bool with an `agentPowerDepletedByInboxId: [String: Bool]` map, refreshed on appear, on balance change, on conversation swap, and when the agent membership set changes. A generation counter prevents out-of-order responses from overwriting newer state.
> - The upgrade CTA in the lost-power cell is now shown only to the conversation creator (`showsUpgradeCTA`), not all viewers.
> - The `creditsDepleted` Bool is removed from `CellConfig`, `MessagesCollectionDataSource`, `MessagesViewRepresentable`, and all call sites, replaced by the new map throughout the stack.
> - New `AgentPowerSignalTests` cover decode tolerance for participation/join-status payloads and the `agentsWithDepletedPower` filter helper.
> - Behavioral Change: agents in a conversation will show the lost-power indicator to all participants (not just the viewer who ran out of credits), and only the creator sees the upgrade prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ad1558.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->