### PR TITLE
Type subscription verify failures and surface a sync attention state

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -108,6 +108,7 @@ struct AppSettingsView: View {
             .toolbar { topToolbar }
             .onReceive(CreditsServices.shared.balancePublisher) { creditBalance = $0 }
             .onReceive(SubscriptionServices.shared.subscriptionPublisher) { currentSubscription = $0 }
+            .onReceive(SubscriptionServices.shared.syncStatePublisher) { subscriptionSyncState = $0 }
             .onAppear {
                 ensureNavigator()
                 navState.markScreenAppeared()
@@ -273,14 +274,22 @@ struct AppSettingsView: View {
     @State private var presentingPaywall: Bool = false
     @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
     @State private var currentSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
+    @State private var subscriptionSyncState: SubscriptionSyncState = SubscriptionServices.shared.currentSyncState
 
     private var membershipFooterLabel: String {
+        if subscriptionNeedsAttention { return SubscriptionCopy.syncNeedsAttentionRowLabel }
         if currentSubscription != nil { return "Plus membership" }
         return "Basic membership"
     }
 
     private var isPowerDepleted: Bool {
         creditBalance?.isDepleted == true
+    }
+
+    /// Only the dead-end state badges the row; syncing is transient and
+    /// would be noise here. The paywall the row opens carries the details.
+    private var subscriptionNeedsAttention: Bool {
+        subscriptionSyncState == .needsAttention
     }
 
     @ViewBuilder
@@ -316,7 +325,7 @@ struct AppSettingsView: View {
 
             Spacer()
 
-            if isPowerDepleted {
+            if isPowerDepleted || subscriptionNeedsAttention {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.colorLava)
             }
@@ -509,5 +518,21 @@ struct AppSettingsView: View {
             coreActions: NoOpCoreActions(),
             onDeleteAllData: {}
         )
+    }
+}
+
+#Preview("Subscription needs attention") {
+    let profileSettingsViewModel = ProfileSettingsViewModel.shared
+    NavigationStack {
+        AppSettingsView(
+            viewModel: .mock,
+            profileSettingsViewModel: profileSettingsViewModel,
+            session: MockInboxesService(),
+            coreActions: NoOpCoreActions(),
+            onDeleteAllData: {}
+        )
+        .onAppear {
+            MockSubscriptionService.shared.setSyncState(.needsAttention)
+        }
     }
 }

--- a/Convos/Subscription/PaywallView.swift
+++ b/Convos/Subscription/PaywallView.swift
@@ -322,10 +322,44 @@ struct PaywallView: View {
             switchPeriodButton
         } else if viewModel.isSubscribed {
             manageSubscriptionButton
+        } else if viewModel.showsActivatingInsteadOfCTA {
+            activatingNotice
         } else if viewModel.selectedPlan == .basic {
+            unsubscribedAttentionNotice
             basicCTA
         } else {
+            unsubscribedAttentionNotice
             upgradeButton
+        }
+    }
+
+    /// Replaces the subscribe CTA while a StoreKit entitlement awaits
+    /// backend confirmation; pitching an upgrade to someone who already
+    /// paid would be misleading.
+    @ViewBuilder
+    private var activatingNotice: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            ProgressView()
+                .controlSize(.small)
+            Text(SubscriptionCopy.syncActivatingNotice)
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.vertical, DesignConstants.Spacing.step3x)
+    }
+
+    /// A verify dead-end deserves a visible line even when the paywall
+    /// otherwise renders the unsubscribed pitch; the purchase and restore
+    /// affordances stay available.
+    @ViewBuilder
+    private var unsubscribedAttentionNotice: some View {
+        if viewModel.syncState == .needsAttention {
+            Text(SubscriptionCopy.syncNeedsAttentionNotice)
+                .font(.footnote)
+                .foregroundStyle(.colorLava)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, DesignConstants.Spacing.step3x)
         }
     }
 
@@ -420,7 +454,13 @@ struct PaywallView: View {
 
     @ViewBuilder
     private var subscriberFooter: some View {
-        if let sub = viewModel.currentSubscription {
+        if let notice = viewModel.syncNotice {
+            let noticeColor: Color = viewModel.syncState == .needsAttention ? .colorLava : .colorTextSecondary
+            Text(notice)
+                .font(.footnote)
+                .foregroundStyle(noticeColor)
+                .frame(maxWidth: .infinity)
+        } else if let sub = viewModel.currentSubscription {
             let tierName: String = SubscriptionCopy.displayName(for: sub.tier)
             let periodName: String = sub.period == .monthly ? "Monthly" : "Annual"
             Text("You subscribe to \(tierName) \(periodName)")
@@ -476,6 +516,27 @@ struct PaywallView: View {
 
 #Preview("Plus - Subscribed") {
     let service = MockSubscriptionService(initialPreset: .plusAmple)
+    let viewModel = PaywallViewModel(subscriptionService: service, paywallSource: .settings, coreActions: NoOpCoreActions())
+    return PaywallView(viewModel: viewModel)
+}
+
+#Preview("Plus - Activating") {
+    let service = MockSubscriptionService(initialPreset: .noSubNoTrial)
+    service.setSyncState(.syncing)
+    let viewModel = PaywallViewModel(subscriptionService: service, paywallSource: .settings, coreActions: NoOpCoreActions())
+    return PaywallView(viewModel: viewModel)
+}
+
+#Preview("Plus - Needs Attention") {
+    let service = MockSubscriptionService(initialPreset: .plusAmple)
+    service.setSyncState(.needsAttention)
+    let viewModel = PaywallViewModel(subscriptionService: service, paywallSource: .settings, coreActions: NoOpCoreActions())
+    return PaywallView(viewModel: viewModel)
+}
+
+#Preview("Needs Attention - Unsubscribed") {
+    let service = MockSubscriptionService(initialPreset: .noSubNoTrial)
+    service.setSyncState(.needsAttention)
     let viewModel = PaywallViewModel(subscriptionService: service, paywallSource: .settings, coreActions: NoOpCoreActions())
     return PaywallView(viewModel: viewModel)
 }

--- a/Convos/Subscription/PaywallViewModel.swift
+++ b/Convos/Subscription/PaywallViewModel.swift
@@ -19,10 +19,31 @@ final class PaywallViewModel {
     var alertMessage: String?
     private(set) var products: [PaywallProduct] = []
     private(set) var currentSubscription: UserSubscription?
+    private(set) var syncState: SubscriptionSyncState
     private(set) var isLoadingProducts: Bool = false
     @ObservationIgnored private var loadProductsTask: Task<Void, Never>?
 
     var isSubscribed: Bool { currentSubscription != nil }
+
+    /// Copy for the paywall's sync-status line, nil when nothing needs
+    /// surfacing. Kept as a pure mapping so tests can pin state -> copy.
+    var syncNotice: String? {
+        switch syncState {
+        case .needsAttention:
+            return SubscriptionCopy.syncNeedsAttentionNotice
+        case .syncing:
+            return SubscriptionCopy.syncActivatingNotice
+        case .idle, .confirmed:
+            return nil
+        }
+    }
+
+    /// A StoreKit entitlement awaiting backend confirmation must not be
+    /// pitched the subscribe CTA; the paywall shows an activating notice
+    /// in its place until the state resolves.
+    var showsActivatingInsteadOfCTA: Bool {
+        syncState == .syncing && !isSubscribed
+    }
 
     var isChangingPeriod: Bool {
         guard let current = currentSubscription,
@@ -60,6 +81,7 @@ final class PaywallViewModel {
         self.coreActions = coreActions
         let initial: UserSubscription? = subscriptionService.currentSubscription
         self.currentSubscription = initial
+        self.syncState = subscriptionService.currentSyncState
         if initial != nil {
             self.selectedPlan = .plus
         }
@@ -68,6 +90,14 @@ final class PaywallViewModel {
             .sink { [weak self] sub in
                 Task { @MainActor [weak self] in
                     self?.currentSubscription = sub
+                }
+            }
+            .store(in: &cancellables)
+        subscriptionService.syncStatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                Task { @MainActor [weak self] in
+                    self?.syncState = state
                 }
             }
             .store(in: &cancellables)

--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -29,7 +29,17 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// in this process. See `refreshFromEntitlements()` for why per-launch
     /// forwarding (not persisted) is the right granularity.
     private var forwardedTransactionIds: Set<UInt64> = []
+    /// Transaction ids whose verify failed permanently (account mismatch,
+    /// bad request); never re-sent for the rest of the process. Per-process
+    /// only: the app has no sign-out or account-switch flow (identities are
+    /// per-install), so there is no hook that could clear this set for a
+    /// different account. If such a flow is ever added, clear this set and
+    /// `forwardedTransactionIds` there.
     private var permanentlyFailedTransactionIds: Set<UInt64> = []
+    /// Counts verify failures across transactions and refresh ticks within
+    /// this process. "Consecutive" means uninterrupted by any successful
+    /// verify: only a success resets it; offline failures neither count
+    /// nor reset.
     private var consecutiveVerifyFailures: Int = 0
 
     public init(apiClient: any ConvosAPIClientProtocol) {

--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -15,10 +15,11 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     private let apiClient: any ConvosAPIClientProtocol
     /// `CurrentValueSubject` is internally synchronized but not declared
-    /// `Sendable`. `nonisolated(unsafe)` lets the actor expose the
-    /// publisher + current value synchronously without bridging through
+    /// `Sendable`. `nonisolated(unsafe)` lets the actor expose publishers
+    /// and current values synchronously without bridging through
     /// `@preconcurrency import Combine`.
     nonisolated(unsafe) private let subscriptionSubject: CurrentValueSubject<UserSubscription?, Never>
+    nonisolated(unsafe) private let syncStateSubject: CurrentValueSubject<SubscriptionSyncState, Never>
     /// Set once during init, cancelled in deinit. `nonisolated(unsafe)`
     /// keeps deinit able to reach it under Swift 6 actor-deinit isolation
     /// rules; no concurrent mutation happens past init.
@@ -28,6 +29,8 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// in this process. See `refreshFromEntitlements()` for why per-launch
     /// forwarding (not persisted) is the right granularity.
     private var forwardedTransactionIds: Set<UInt64> = []
+    private var permanentlyFailedTransactionIds: Set<UInt64> = []
+    private var consecutiveVerifyFailures: Int = 0
 
     public init(apiClient: any ConvosAPIClientProtocol) {
         self.apiClient = apiClient
@@ -41,6 +44,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
         // Plus at every cold start. The cache is corrected by every
         // subsequent publish (refresh / purchase / Apple update).
         self.subscriptionSubject = CurrentValueSubject(Self.loadCachedSubscription())
+        self.syncStateSubject = CurrentValueSubject(.idle)
         let listenerTask = Task.detached { [weak self] in
             guard let self else { return }
             await self.refreshFromEntitlements()
@@ -69,6 +73,14 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
 
     nonisolated public var currentSubscription: UserSubscription? {
         subscriptionSubject.value
+    }
+
+    nonisolated public var syncStatePublisher: AnyPublisher<SubscriptionSyncState, Never> {
+        syncStateSubject.eraseToAnyPublisher()
+    }
+
+    nonisolated public var currentSyncState: SubscriptionSyncState {
+        syncStateSubject.value
     }
 
     public func availableProducts() async throws -> [PaywallProduct] {
@@ -197,20 +209,64 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     /// payload itself, authenticates the caller via JWT, and refuses cross-
     /// account binding attempts — so the iOS side only needs to pass the JWS.
     ///
-    /// Returns `true` on success so callers that track forwarded transactions
+    /// Returns the outcome so callers that track forwarded transactions
     /// (`refreshFromEntitlements`) can retry on the next refresh after a
     /// transient failure instead of waiting for an app relaunch. Failures
     /// are logged but never propagate — `Transaction.currentEntitlements`
     /// is still authoritative for local UI state.
     @discardableResult
-    private func sendToBackendVerify(jwsRepresentation: String, transactionId: UInt64) async -> Bool {
+    private func sendToBackendVerify(
+        jwsRepresentation: String,
+        transactionId: UInt64
+    ) async -> VerifyResult {
+        guard !permanentlyFailedTransactionIds.contains(transactionId) else {
+            return .permanent
+        }
+        if syncStateSubject.value != .confirmed,
+           syncStateSubject.value != .needsAttention {
+            syncStateSubject.send(.syncing)
+        }
         do {
             _ = try await apiClient.verifySubscription(jwsRepresentation: jwsRepresentation)
-            return true
+            consecutiveVerifyFailures = 0
+            syncStateSubject.send(.confirmed)
+            return .success
+        } catch let error as APIError {
+            switch error {
+            case .subscriptionAccountMismatch, .badRequest:
+                permanentlyFailedTransactionIds.insert(transactionId)
+                syncStateSubject.send(.needsAttention)
+                Log.error("Subscription verify permanently failed for transaction \(transactionId): \(error)")
+                return .permanent
+            default:
+                return handleRetryableVerifyFailure(error, transactionId: transactionId)
+            }
         } catch {
-            Log.error("Backend verify failed for transaction \(transactionId): \(error)")
-            return false
+            return handleRetryableVerifyFailure(error, transactionId: transactionId)
         }
+    }
+
+    private func handleRetryableVerifyFailure(_ error: any Error, transactionId: UInt64) -> VerifyResult {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .dataNotAllowed:
+                if syncStateSubject.value != .confirmed {
+                    syncStateSubject.send(.syncing)
+                }
+                Log.error("Backend verify failed for transaction \(transactionId): \(error)")
+                return .retryable
+            default:
+                break
+            }
+        }
+        consecutiveVerifyFailures += 1
+        if consecutiveVerifyFailures >= 3 {
+            syncStateSubject.send(.needsAttention)
+        } else if syncStateSubject.value != .confirmed {
+            syncStateSubject.send(.syncing)
+        }
+        Log.error("Backend verify failed for transaction \(transactionId): \(error)")
+        return .retryable
     }
 
     public func refresh(force: Bool) async {
@@ -225,8 +281,10 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     private func refreshFromEntitlements() async {
         var latest: UserSubscription?
         var forwardedAnyEntitlement: Bool = false
+        var sawAnyEntitlement: Bool = false
         for await result in Transaction.currentEntitlements {
             guard let transaction = try? verifiedTransaction(result) else { continue }
+            sawAnyEntitlement = true
             // Forward each entitlement to the backend at most once per
             // process. Covers entitlements iOS reads locally that the
             // backend doesn't know about yet:
@@ -241,8 +299,9 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             // The verify endpoint is idempotent on `originalTransactionId`,
             // so the server already deduplicates; the in-memory set just
             // avoids hammering it every refresh (TTL is 15s).
-            if !forwardedTransactionIds.contains(transaction.id) {
-                let succeeded = await sendToBackendVerify(
+            if !forwardedTransactionIds.contains(transaction.id),
+               !permanentlyFailedTransactionIds.contains(transaction.id) {
+                let verifyResult = await sendToBackendVerify(
                     jwsRepresentation: result.jwsRepresentation,
                     transactionId: transaction.id
                 )
@@ -250,7 +309,7 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
                 // (network blip, transient 5xx, backend deploy in flight)
                 // retries on the next refresh tick rather than waiting for
                 // an app relaunch.
-                if succeeded {
+                if verifyResult == .success {
                     forwardedTransactionIds.insert(transaction.id)
                     forwardedAnyEntitlement = true
                 }
@@ -259,6 +318,13 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
             latest = sub
         }
         publish(latest)
+        if !sawAnyEntitlement {
+            syncStateSubject.send(.idle)
+        } else if !forwardedAnyEntitlement,
+                  currentSyncState != .confirmed,
+                  currentSyncState != .needsAttention {
+            syncStateSubject.send(.syncing)
+        }
         // If the backend just learned about an entitlement it didn't
         // previously have, its `GET /credits` answer changes (tier-based
         // grant kicks in). Force-refresh credits so the local depleted
@@ -403,6 +469,12 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
     private struct StoreKitSubscriptionSnapshot {
         let status: ConvosCore.SubscriptionStatus
         let willRenew: Bool
+    }
+
+    private enum VerifyResult: Equatable {
+        case success
+        case retryable
+        case permanent
     }
 
     private enum Constant {

--- a/Convos/Subscription/StoreKitSubscriptionService.swift
+++ b/Convos/Subscription/StoreKitSubscriptionService.swift
@@ -222,8 +222,11 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
         guard !permanentlyFailedTransactionIds.contains(transactionId) else {
             return .permanent
         }
-        if syncStateSubject.value != .confirmed,
-           syncStateSubject.value != .needsAttention {
+        // A send attempt means this transaction is not yet backend-confirmed,
+        // even if an earlier transaction was: drop any stale .confirmed so the
+        // state reflects the entitlement actually being verified. A standing
+        // .needsAttention is preserved until a verify succeeds.
+        if syncStateSubject.value != .needsAttention {
             syncStateSubject.send(.syncing)
         }
         do {
@@ -250,9 +253,10 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
         if let urlError = error as? URLError {
             switch urlError.code {
             case .notConnectedToInternet, .networkConnectionLost, .dataNotAllowed:
-                if syncStateSubject.value != .confirmed {
-                    syncStateSubject.send(.syncing)
-                }
+                // Offline failures neither count toward the attention
+                // threshold nor move the state: the pre-send transition
+                // already set .syncing, and a standing .needsAttention
+                // must not be masked by connectivity loss.
                 Log.error("Backend verify failed for transaction \(transactionId): \(error)")
                 return .retryable
             default:
@@ -262,8 +266,6 @@ public actor StoreKitSubscriptionService: SubscriptionServiceProtocol {
         consecutiveVerifyFailures += 1
         if consecutiveVerifyFailures >= 3 {
             syncStateSubject.send(.needsAttention)
-        } else if syncStateSubject.value != .confirmed {
-            syncStateSubject.send(.syncing)
         }
         Log.error("Backend verify failed for transaction \(transactionId): \(error)")
         return .retryable

--- a/Convos/Subscription/SubscriptionCopy.swift
+++ b/Convos/Subscription/SubscriptionCopy.swift
@@ -50,6 +50,9 @@ enum SubscriptionCopy {
     static let upgradeAnytimeLabel: String = "Upgrade anytime"
     static let upgradeLabel: String = "Upgrade"
     static let manageSubscriptionLabel: String = "Manage subscription"
+    static let syncActivatingNotice: String = "Activating your subscription..."
+    static let syncNeedsAttentionNotice: String = "Subscription needs attention. Contact support."
+    static let syncNeedsAttentionRowLabel: String = "Subscription needs attention"
 
     static let legalDisclaimer: String = """
         Auto-renewing subscription. You'll be charged at the rate shown until you cancel. \

--- a/Convos/Subscription/SubscriptionSettingsView.swift
+++ b/Convos/Subscription/SubscriptionSettingsView.swift
@@ -11,6 +11,7 @@ struct SubscriptionSettingsView: View {
     // `.onReceive` still drives updates on subsequent fetches.
     @State private var balance: CreditBalance? = CreditsServices.shared.currentBalance
     @State private var subscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
+    @State private var syncState: SubscriptionSyncState = SubscriptionServices.shared.currentSyncState
     @State private var presentingPaywall: Bool = false
     @State private var presentingManageSubscriptions: Bool = false
     @State private var navState: SubscriptionSettingsNavigatorImpl = .init()
@@ -46,6 +47,9 @@ struct SubscriptionSettingsView: View {
         }
         .onReceive(SubscriptionServices.shared.subscriptionPublisher) { newSubscription in
             subscription = newSubscription
+        }
+        .onReceive(SubscriptionServices.shared.syncStatePublisher) { newSyncState in
+            syncState = newSyncState
         }
         .task {
             // Refresh on appear (TTL-debounced) so the screen reflects
@@ -144,6 +148,14 @@ struct SubscriptionSettingsView: View {
     private var statusSubtitle: String {
         guard let subscription else {
             return "Subscribe to power your agents"
+        }
+        switch syncState {
+        case .syncing:
+            return "Activating your subscription..."
+        case .needsAttention:
+            return "Subscription needs attention. Contact support."
+        case .idle, .confirmed:
+            break
         }
         let periodText: String = subscription.period == .monthly ? "Monthly" : "Annual"
         let dateString: String = Self.dateFormatter.string(from: subscription.currentPeriodEnd)

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -662,13 +662,15 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             throw APIError.forbidden
         case 404:
             throw APIError.notFound
+        case 409:
+            let json: [String: Any]? = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let code: String? = json?["code"] as? String
+            guard code == "subscription_account_mismatch" else {
+                throw APIError.serverError(parseErrorMessage(from: data))
+            }
+            throw APIError.subscriptionAccountMismatch(parseErrorMessage(from: data))
         default:
-            // 409 (subscription_account_mismatch) falls through deliberately.
-            // The backend still returns it (PR #215 strict-ownership invariant),
-            // but iOS treats it as a generic retryable server fault instead
-            // of a typed dead-end — purchase + restore flows already surface
-            // .serverError with a "try again" affordance, and refresh logic
-            // (foreground + view-appear) will reconcile any transient state.
+            // Unhandled statuses remain generic server errors.
             throw APIError.serverError(parseErrorMessage(from: data))
         }
     }
@@ -1377,6 +1379,7 @@ public enum APIError: Error {
     case invalidResponse
     case invalidRequest
     case serverError(String?)
+    case subscriptionAccountMismatch(String?)
     case rateLimitExceeded
     case noAgentsAvailable
     case agentPoolTimeout
@@ -1407,6 +1410,8 @@ extension APIError: DisplayError {
             return "Invalid request"
         case .serverError:
             return "Server error"
+        case .subscriptionAccountMismatch:
+            return "Subscription needs attention"
         case .rateLimitExceeded:
             return "Too many requests"
         case .noAgentsAvailable:
@@ -1442,6 +1447,8 @@ extension APIError: DisplayError {
             return "The request could not be created."
         case .serverError(let message):
             return message ?? "The server encountered an error."
+        case .subscriptionAccountMismatch(let message):
+            return message ?? "This subscription belongs to a different account. Contact support."
         case .rateLimitExceeded:
             return "Too many requests. Please try again later."
         case .noAgentsAvailable:

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
@@ -14,6 +14,10 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
     /// service can survive a refresh after a mock purchase without reverting
     /// to the preset's subscription.
     private var currentSubscriptionSnapshot: UserSubscription?
+    /// Non-nil overrides the subscription-derived sync state so previews and
+    /// tests can render the syncing / needs-attention surfaces, which the
+    /// derived mapping (nil -> idle, non-nil -> confirmed) can never reach.
+    private var forcedSyncState: SubscriptionSyncState?
     private let mockProducts: [PaywallProduct]
 
     public init(initialPreset: CreditsStatePreset = .plusAmple) {
@@ -68,7 +72,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
             currentSubscriptionSnapshot = updated
         }
         subscriptionSubject.send(updated)
-        syncStateSubject.send(Self.syncState(for: updated))
+        syncStateSubject.send(resolvedSyncState(for: updated))
     }
 
     public func restorePurchases() async throws {
@@ -78,7 +82,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
     public func refresh(force: Bool) async {
         let snapshot = queue.sync { currentSubscriptionSnapshot }
         subscriptionSubject.send(snapshot)
-        syncStateSubject.send(Self.syncState(for: snapshot))
+        syncStateSubject.send(resolvedSyncState(for: snapshot))
     }
 
     public func setPreset(_ preset: CreditsStatePreset) {
@@ -88,7 +92,22 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
             currentSubscriptionSnapshot = presetSubscription
         }
         subscriptionSubject.send(presetSubscription)
-        syncStateSubject.send(Self.syncState(for: presetSubscription))
+        syncStateSubject.send(resolvedSyncState(for: presetSubscription))
+    }
+
+    /// Force a sync state for previews/tests; pass nil to return to the
+    /// subscription-derived state.
+    public func setSyncState(_ state: SubscriptionSyncState?) {
+        let snapshot: UserSubscription? = queue.sync {
+            forcedSyncState = state
+            return currentSubscriptionSnapshot
+        }
+        syncStateSubject.send(state ?? Self.syncState(for: snapshot))
+    }
+
+    private func resolvedSyncState(for subscription: UserSubscription?) -> SubscriptionSyncState {
+        let forced: SubscriptionSyncState? = queue.sync { forcedSyncState }
+        return forced ?? Self.syncState(for: subscription)
     }
 
     private static func syncState(for subscription: UserSubscription?) -> SubscriptionSyncState {

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/MockSubscriptionService.swift
@@ -6,6 +6,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
     public static let shared: MockSubscriptionService = MockSubscriptionService()
 
     private let subscriptionSubject: CurrentValueSubject<UserSubscription?, Never>
+    private let syncStateSubject: CurrentValueSubject<SubscriptionSyncState, Never>
     private let queue: DispatchQueue = DispatchQueue(label: "convos.mock-subscription-service")
     private var currentPreset: CreditsStatePreset
     /// Source of truth for what `refresh()` should re-publish. Initially seeded
@@ -20,6 +21,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
         self.currentPreset = initialPreset
         self.currentSubscriptionSnapshot = initialSubscription
         self.subscriptionSubject = CurrentValueSubject(initialSubscription)
+        self.syncStateSubject = CurrentValueSubject(Self.syncState(for: initialSubscription))
         self.mockProducts = Self.defaultMockProducts()
     }
 
@@ -29,6 +31,14 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
 
     public var currentSubscription: UserSubscription? {
         subscriptionSubject.value
+    }
+
+    public var syncStatePublisher: AnyPublisher<SubscriptionSyncState, Never> {
+        syncStateSubject.eraseToAnyPublisher()
+    }
+
+    public var currentSyncState: SubscriptionSyncState {
+        syncStateSubject.value
     }
 
     public func availableProducts() async throws -> [PaywallProduct] {
@@ -58,6 +68,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
             currentSubscriptionSnapshot = updated
         }
         subscriptionSubject.send(updated)
+        syncStateSubject.send(Self.syncState(for: updated))
     }
 
     public func restorePurchases() async throws {
@@ -67,6 +78,7 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
     public func refresh(force: Bool) async {
         let snapshot = queue.sync { currentSubscriptionSnapshot }
         subscriptionSubject.send(snapshot)
+        syncStateSubject.send(Self.syncState(for: snapshot))
     }
 
     public func setPreset(_ preset: CreditsStatePreset) {
@@ -76,6 +88,11 @@ public final class MockSubscriptionService: SubscriptionServiceProtocol, @unchec
             currentSubscriptionSnapshot = presetSubscription
         }
         subscriptionSubject.send(presetSubscription)
+        syncStateSubject.send(Self.syncState(for: presetSubscription))
+    }
+
+    private static func syncState(for subscription: UserSubscription?) -> SubscriptionSyncState {
+        subscription == nil ? .idle : .confirmed
     }
 
     private static func defaultMockProducts() -> [PaywallProduct] {

--- a/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Subscription/SubscriptionServiceProtocol.swift
@@ -1,9 +1,18 @@
 import Combine
 import Foundation
 
+public enum SubscriptionSyncState: Equatable, Sendable {
+    case idle
+    case syncing
+    case confirmed
+    case needsAttention
+}
+
 public protocol SubscriptionServiceProtocol: AnyObject, Sendable {
     var subscriptionPublisher: AnyPublisher<UserSubscription?, Never> { get }
     var currentSubscription: UserSubscription? { get }
+    var syncStatePublisher: AnyPublisher<SubscriptionSyncState, Never> { get }
+    nonisolated var currentSyncState: SubscriptionSyncState { get }
 
     func availableProducts() async throws -> [PaywallProduct]
     func purchase(productId: String) async throws

--- a/ConvosCore/Tests/ConvosCoreTests/MockSubscriptionServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MockSubscriptionServiceTests.swift
@@ -1,4 +1,5 @@
 @testable import ConvosCore
+import Combine
 import Foundation
 import Testing
 
@@ -56,8 +57,24 @@ struct MockSubscriptionServiceTests {
     @Test func init_seedsCurrentSubscriptionFromPreset() {
         let plus: MockSubscriptionService = MockSubscriptionService(initialPreset: .plusAmple)
         #expect(plus.currentSubscription?.tier == .plus)
+        #expect(plus.currentSyncState == .confirmed)
 
         let none: MockSubscriptionService = MockSubscriptionService(initialPreset: .noSubNoTrial)
         #expect(none.currentSubscription == nil)
+        #expect(none.currentSyncState == .idle)
+    }
+
+    @Test func subscriptionChanges_publishDerivedSyncState() async throws {
+        let service: MockSubscriptionService = MockSubscriptionService(initialPreset: .noSubNoTrial)
+        var states: [SubscriptionSyncState] = []
+        let cancellable = service.syncStatePublisher.sink { state in
+            states.append(state)
+        }
+
+        try await service.purchase(productId: SubscriptionProductIDs.plusMonthly)
+        service.setPreset(.noSubNoTrial)
+
+        #expect(states == [.idle, .confirmed, .idle])
+        withExtendedLifetime(cancellable) {}
     }
 }

--- a/ConvosTests/PaywallViewModelTests.swift
+++ b/ConvosTests/PaywallViewModelTests.swift
@@ -108,6 +108,56 @@ final class PaywallViewModelTests: XCTestCase {
         XCTAssertEqual(callbackCount, 1)
         XCTAssertFalse(viewModel.isShowingAlert, "Success path must not show an error alert")
     }
+
+    // MARK: - Sync-state surfacing (state -> copy mapping)
+
+    func testSyncNotice_needsAttention_mapsToAttentionCopy() {
+        let service: MockSubscriptionService = MockSubscriptionService(initialPreset: .plusAmple)
+        service.setSyncState(.needsAttention)
+        let viewModel: PaywallViewModel = PaywallViewModel(subscriptionService: service, paywallSource: .debug)
+
+        XCTAssertEqual(viewModel.syncNotice, SubscriptionCopy.syncNeedsAttentionNotice)
+        XCTAssertFalse(
+            viewModel.showsActivatingInsteadOfCTA,
+            "needsAttention surfaces a notice but must not swap the CTA area for the activating spinner"
+        )
+    }
+
+    func testSyncNotice_syncingWhileUnsubscribed_replacesSubscribeCTA() {
+        let service: MockSubscriptionService = MockSubscriptionService(initialPreset: .noSubNoTrial)
+        service.setSyncState(.syncing)
+        let viewModel: PaywallViewModel = PaywallViewModel(subscriptionService: service, paywallSource: .debug)
+
+        XCTAssertEqual(viewModel.syncNotice, SubscriptionCopy.syncActivatingNotice)
+        XCTAssertTrue(
+            viewModel.showsActivatingInsteadOfCTA,
+            "An entitlement awaiting backend confirmation must not be pitched the subscribe CTA"
+        )
+    }
+
+    func testSyncNotice_syncingWhileSubscribed_keepsManageCTA() {
+        let service: MockSubscriptionService = MockSubscriptionService(initialPreset: .plusAmple)
+        service.setSyncState(.syncing)
+        let viewModel: PaywallViewModel = PaywallViewModel(subscriptionService: service, paywallSource: .debug)
+
+        XCTAssertEqual(viewModel.syncNotice, SubscriptionCopy.syncActivatingNotice)
+        XCTAssertFalse(
+            viewModel.showsActivatingInsteadOfCTA,
+            "A subscribed render keeps the manage button; the activating copy rides the footer line instead"
+        )
+    }
+
+    func testSyncNotice_confirmedAndIdle_surfaceNothing() {
+        let confirmed: MockSubscriptionService = MockSubscriptionService(initialPreset: .plusAmple)
+        let confirmedViewModel: PaywallViewModel = PaywallViewModel(subscriptionService: confirmed, paywallSource: .debug)
+        XCTAssertNil(confirmedViewModel.syncNotice)
+        XCTAssertFalse(confirmedViewModel.showsActivatingInsteadOfCTA)
+
+        let idle: MockSubscriptionService = MockSubscriptionService(initialPreset: .noSubNoTrial)
+        let idleViewModel: PaywallViewModel = PaywallViewModel(subscriptionService: idle, paywallSource: .debug)
+        XCTAssertNil(idleViewModel.syncNotice)
+        XCTAssertFalse(idleViewModel.showsActivatingInsteadOfCTA)
+    }
 }
 
 // MARK: - Fakes

--- a/ConvosTests/PaywallViewModelTests.swift
+++ b/ConvosTests/PaywallViewModelTests.swift
@@ -129,6 +129,10 @@ private final class SlowAvailableProductsService: SubscriptionServiceProtocol, @
         Just<UserSubscription?>(nil).eraseToAnyPublisher()
     }
     var currentSubscription: UserSubscription? { nil }
+    var syncStatePublisher: AnyPublisher<SubscriptionSyncState, Never> {
+        Just(.idle).eraseToAnyPublisher()
+    }
+    var currentSyncState: SubscriptionSyncState { .idle }
 
     func availableProducts() async throws -> [PaywallProduct] {
         countQueue.sync { _availableProductsCallCount += 1 }
@@ -154,6 +158,10 @@ private final class StubSubscriptionService: SubscriptionServiceProtocol, @unche
         Just<UserSubscription?>(nil).eraseToAnyPublisher()
     }
     var currentSubscription: UserSubscription? { nil }
+    var syncStatePublisher: AnyPublisher<SubscriptionSyncState, Never> {
+        Just(.idle).eraseToAnyPublisher()
+    }
+    var currentSyncState: SubscriptionSyncState { .idle }
 
     func availableProducts() async throws -> [PaywallProduct] { [] }
 


### PR DESCRIPTION
## What

The backend's `409 subscription_account_mismatch` on `POST /subscription/verify` was deliberately flattened into a generic retryable `.serverError`, and `StoreKitSubscriptionService` swallowed every verify failure and silently re-POSTed the same receipt on every 15s refresh tick, forever. A user whose verify permanently fails sees full "Plus" UI while the backend has no subscription and grants no credits (the Quarter / CON-807 causal chain).

## Changes

- `ConvosAPIClient.performRequest`: 409 responses now parse the body's `code` field; `subscription_account_mismatch` throws a typed `APIError.subscriptionAccountMismatch` (other 409s keep the previous `.serverError` behavior). The stale "falls through deliberately" comment is gone.
- `SubscriptionServiceProtocol` gains a published `SubscriptionSyncState` (`idle` / `syncing` / `confirmed` / `needsAttention`), implemented by the StoreKit service and the mock.
- `StoreKitSubscriptionService`:
  - Permanent failures (`subscriptionAccountMismatch`, `badRequest`) stop being retried for the rest of the process and publish `.needsAttention` with an error-log breadcrumb.
  - Transient failures still retry each refresh tick, but three consecutive misses publish `.needsAttention`. Offline-type `URLError`s (`notConnectedToInternet`, `networkConnectionLost`, `dataNotAllowed`) do not count toward the threshold, so airplane mode cannot produce a false "contact support".
- `SubscriptionSettingsView` renders the sync state: "Activating your subscription..." while a StoreKit entitlement awaits backend confirmation, "Subscription needs attention. Contact support." on permanent/persistent failure.

## Validation

- `swift build --package-path ConvosCore` and full `swift test --package-path ConvosCore` pass.
- `xcodebuild build -scheme "Convos (Dev)"` (iOS Simulator, arm64) passes.
- `MockSubscriptionServiceTests` extended for the sync-state derivation.
- A focused URL-level test for the 409 mapping was skipped: `ConvosAPIClient` has no injectable URLSession harness and standing one up was out of scope.

## Manual QA (TestFlight reviewer)

1. Fresh install, sign in, no purchase: Settings > Subscription shows "Free plan" (state `idle`; no change from before).
2. Purchase Plus with a working backend: badge flips to Plus as before; subtitle shows the normal renewal line once verify succeeds.
3. Purchase or hold an entitlement while the backend rejects verify (e.g. receipt bound to another account, backend returns 409): the screen must show "Subscription needs attention. Contact support." instead of an unqualified plan line, and the device log contains "Subscription verify permanently failed for transaction ...". The app must stop re-POSTing that receipt (no repeated verify lines in the backend log beyond the first).
4. Kill network mid-activation: subtitle shows "Activating your subscription..." and must not escalate to "needs attention" from connectivity loss alone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787926801&installation_model_id=20076&pr_number=1244&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1244&signature=eac81ccc60e3d162c774906dd2fed3784ac666353ec70c84296c07be2601b3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface subscription sync attention state in paywall and settings UI
> - Adds a `SubscriptionSyncState` enum (`idle`, `syncing`, `confirmed`, `needsAttention`) to `SubscriptionServiceProtocol` and implements it in `StoreKitSubscriptionService` and `MockSubscriptionService`.
> - `StoreKitSubscriptionService` sets `.syncing` before backend verification, `.confirmed` on success, and `.needsAttention` on permanent failures (account mismatch, bad request) or after 3 consecutive retryable failures. Permanently failed transaction IDs are skipped on retry.
> - The paywall replaces the subscribe CTA with an 'Activating your subscription...' notice while `.syncing`, and shows a lava-colored attention notice above subscribe/upgrade actions when `.needsAttention`.
> - The Settings subscription row badges with an exclamation icon and shows a 'Subscription needs attention' footer when sync state is `.needsAttention`.
> - `ConvosAPIClient` now parses HTTP 409 with `subscription_account_mismatch` into a typed `APIError.subscriptionAccountMismatch` with user-friendly copy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e4101f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

## Reachability follow-up: paywall + settings power row

Audit found the sync states were only rendered on `SubscriptionSettingsView`, which is reachable solely from the debug menu ("Credits & Subscription Details") — the screen real users reach from settings is `PaywallView`, which knew nothing of sync state. Now:

- `PaywallViewModel` binds the sync-state publisher and exposes a tested state-to-copy mapping (`syncNotice`, `showsActivatingInsteadOfCTA`).
- Paywall: an entitlement awaiting backend confirmation replaces the subscribe CTA with an "Activating your subscription..." notice; a verify dead-end renders a visible "Subscription needs attention. Contact support." line in both the subscribed footer and the unsubscribed pitch. Confirmed/idle render exactly as before.
- Settings power row: reuses the existing depleted-credits warning triangle (same `colorLava` affordance) when the state is needs-attention only — syncing never badges the row — and the footer swaps to "Subscription needs attention". The row already opens the paywall, which now explains the state.
- `MockSubscriptionService.setSyncState(_:)` lets previews/tests force syncing / needs-attention; new `#Preview`s: "Plus - Activating", "Plus - Needs Attention", "Needs Attention - Unsubscribed" (PaywallView) and "Subscription needs attention" (AppSettingsView) — all states witnessable in the Xcode canvas with zero runtime setup.
- Tests: `PaywallViewModelTests` pins the state-to-copy mapping for all four states.
