### PR TITLE
fix(participation): stop two races between switching and refreshing

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -2,6 +2,40 @@
 import ConvosCore
 import Foundation
 
+/// The two calls the participation control makes. Narrow on purpose: the store
+/// needs one read and one write, and a seam this small is what lets a test drive
+/// them slowly, out of order, or into failure.
+public protocol AgentParticipationServing: Sendable {
+    func readMode(conversationId: String, variantId: String?) async throws -> String
+    func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws
+}
+
+/// The real service, talking to the participation endpoints.
+public struct APIAgentParticipationService: AgentParticipationServing {
+    public init() {}
+
+    public func readMode(conversationId: String, variantId: String?) async throws -> String {
+        try await client().getAgentParticipation(
+            conversationId: conversationId,
+            variantId: variantId
+        ).mode
+    }
+
+    public func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws {
+        _ = try await client().setAgentParticipation(
+            conversationId: conversationId,
+            mode: mode,
+            variantId: variantId
+        )
+    }
+
+    private func client() -> any ConvosAPIClientProtocol {
+        ConvosAPIClientFactory.client(
+            environment: ConfigManager.shared.currentEnvironment
+        )
+    }
+}
+
 /// Owns one conversation's participation level for the views that show it.
 ///
 /// Two surfaces render this — the bubble in the composer and the row in an
@@ -37,11 +71,25 @@ public final class AgentParticipationStore {
     /// Bumped on every local `set()`. `load()` captures it before its network
     /// read and bails if it changed meanwhile, so a tap that lands mid-read is
     /// never clobbered by the older server value the read was already fetching.
+    /// A failed write reads it too, and rolls back only while it is still the
+    /// newest one - a newer tap already owns the level by then.
     private var writeGeneration: Int = 0
 
-    public init(conversationId: String, variantId: String? = nil) {
+    /// Writes that have been issued and not yet answered. A read that overlaps
+    /// one is reading from before it lands, so its value is already behind the
+    /// member's tap even though no generation changed while it was in flight.
+    private var writesInFlight: Int = 0
+
+    private let service: any AgentParticipationServing
+
+    public init(
+        conversationId: String,
+        variantId: String? = nil,
+        service: any AgentParticipationServing = APIAgentParticipationService()
+    ) {
         self.conversationId = conversationId
         self.variantId = variantId
+        self.service = service
     }
 
     public func dismissError() {
@@ -56,16 +104,22 @@ public final class AgentParticipationStore {
     /// a read the member never asked for is noise.
     public func load() async {
         let generationAtStart = writeGeneration
+        let overlappedAWrite = writesInFlight > 0
         defer { hasLoaded = true }
         do {
-            let response = try await client().getAgentParticipation(
+            let mode = try await service.readMode(
                 conversationId: conversationId,
                 variantId: variantId
             )
-            // A set() that landed while this read was in flight is newer than the
-            // value the server just returned; don't overwrite it with stale data.
-            guard writeGeneration == generationAtStart else { return }
-            if let loaded = AgentParticipationLevel(wireMode: response.mode) {
+            // Anything the member did around this read is newer than the value
+            // the server just returned: a set() that landed while it was in
+            // flight, or one still unanswered at either end of it. Keep theirs.
+            guard writeGeneration == generationAtStart,
+                  !overlappedAWrite,
+                  writesInFlight == 0 else {
+                return
+            }
+            if let loaded = AgentParticipationLevel(wireMode: mode) {
                 level = loaded
             }
         } catch {
@@ -84,24 +138,25 @@ public final class AgentParticipationStore {
         guard newLevel != previous else { return }
         level = newLevel
         writeGeneration += 1
+        let generation = writeGeneration
+        writesInFlight += 1
+        defer { writesInFlight -= 1 }
         do {
-            _ = try await client().setAgentParticipation(
+            try await service.writeMode(
+                newLevel.wireMode,
                 conversationId: conversationId,
-                mode: newLevel.wireMode,
                 variantId: variantId
             )
             Log.info("participation set mode=\(newLevel.wireMode)")
         } catch {
             Log.error("participation update failed: \(error)")
+            // A newer tap has already moved the control since this write went
+            // out. Rolling back now would drag the member to a level they left,
+            // and the newer write reports its own outcome.
+            guard writeGeneration == generation else { return }
             level = previous
             errorMessage = "Couldn't update participation. The agents are still on their previous setting."
         }
-    }
-
-    private func client() -> any ConvosAPIClientProtocol {
-        ConvosAPIClientFactory.client(
-            environment: ConfigManager.shared.currentEnvironment
-        )
     }
 }
 #endif

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -80,6 +80,19 @@ public final class AgentParticipationStore {
     /// member's tap even though no generation changed while it was in flight.
     private var writesInFlight: Int = 0
 
+    /// The newest level the server has acknowledged. `level` runs ahead of it
+    /// the moment someone taps, and a failed write returns to this rather than
+    /// to whatever `level` held before the tap - that earlier value may itself
+    /// be an optimistic one that never landed, and rolling back to it would put
+    /// the control on a level the conversation was never in.
+    private var confirmedLevel: AgentParticipationLevel = .default
+
+    /// The tail of the write queue. Each write waits for the one before it, so
+    /// the order the member tapped in is the order the server sees. Without
+    /// this the calls race and the last tap is whichever the network delivers
+    /// last, which is how the level ends up quietly reverting on the next read.
+    private var writeChain: Task<Void, Never>?
+
     private let service: any AgentParticipationServing
 
     public init(
@@ -121,6 +134,7 @@ public final class AgentParticipationStore {
             }
             if let loaded = AgentParticipationLevel(wireMode: mode) {
                 level = loaded
+                confirmedLevel = loaded
             }
         } catch {
             Log.error("participation read failed: \(error)")
@@ -134,27 +148,43 @@ public final class AgentParticipationStore {
     /// write never lands the agents are still on the old level — leaving the
     /// check on the new one would tell the member the opposite of the error.
     public func set(_ newLevel: AgentParticipationLevel) async {
-        let previous = level
-        guard newLevel != previous else { return }
+        guard newLevel != level else { return }
         level = newLevel
         writeGeneration += 1
         let generation = writeGeneration
         writesInFlight += 1
-        defer { writesInFlight -= 1 }
+        let precedingWrite = writeChain
+        let write = Task { @MainActor [weak self] in
+            await precedingWrite?.value
+            await self?.sendLevel(newLevel, generation: generation)
+        }
+        writeChain = write
+        await write.value
+        writesInFlight -= 1
+    }
+
+    /// One write, once it holds its turn in the queue.
+    private func sendLevel(_ newLevel: AgentParticipationLevel, generation: Int) async {
+        // Taps that piled up behind this one already moved the control past this
+        // level. Sending it would walk the agents through a level the member
+        // left while waiting, and the newest tap is still queued to say where
+        // they actually want them.
+        guard writeGeneration == generation else { return }
         do {
             try await service.writeMode(
                 newLevel.wireMode,
                 conversationId: conversationId,
                 variantId: variantId
             )
+            confirmedLevel = newLevel
             Log.info("participation set mode=\(newLevel.wireMode)")
         } catch {
             Log.error("participation update failed: \(error)")
-            // A newer tap has already moved the control since this write went
-            // out. Rolling back now would drag the member to a level they left,
-            // and the newer write reports its own outcome.
+            // A newer tap arrived while this write was out. Rolling back now
+            // would drag the member to a level they left, and that newer write
+            // reports its own outcome.
             guard writeGeneration == generation else { return }
-            level = previous
+            level = confirmedLevel
             errorMessage = "Couldn't update participation. The agents are still on their previous setting."
         }
     }

--- a/ConvosTests/AgentParticipationStoreStressTests.swift
+++ b/ConvosTests/AgentParticipationStoreStressTests.swift
@@ -10,6 +10,9 @@ private actor ScriptedParticipationService: AgentParticipationServing {
 
     private var serverMode: String = "speak"
     private var failingModes: Set<String> = []
+    /// Every call that reached the service, in the order it arrived - the record
+    /// that shows whether writes were serialized or raced.
+    private(set) var startedModes: [String] = []
     private(set) var writtenModes: [String] = []
     private var pendingWrites: [String: CheckedContinuation<Void, Never>] = [:]
     private var pendingReads: [CheckedContinuation<Void, Never>] = []
@@ -64,6 +67,7 @@ private actor ScriptedParticipationService: AgentParticipationServing {
     }
 
     func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws {
+        startedModes.append(mode)
         if holdsWrites {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 pendingWrites[mode] = continuation
@@ -122,8 +126,10 @@ final class AgentParticipationStoreStressTests: XCTestCase {
         XCTAssertEqual(store.level, .paused)
     }
 
-    /// Two taps in quick succession: the level the member last chose is the one
-    /// that stands, and the server ends on it too.
+    /// Two taps in quick succession: they reach the server one at a time and in
+    /// the order they were tapped, so the level the member last chose is the one
+    /// the server ends on - not whichever call the network happened to deliver
+    /// last.
     func testRapidSwitchingSettlesOnTheLastTap() async {
         let service = ScriptedParticipationService()
         await service.holdWrites(true)
@@ -132,16 +138,72 @@ final class AgentParticipationStoreStressTests: XCTestCase {
         let first = Task { await store.set(.paused) }
         await service.waitForPendingWrite("paused")
         let second = Task { await store.set(.mentionsOnly) }
-        await service.waitForPendingWrite("mention")
+        await Task.yield()
+
+        let startedWhileFirstHeld = await service.startedModes
+        XCTAssertEqual(startedWhileFirstHeld, ["paused"], "the second write must wait its turn")
 
         await service.releaseWrite("paused")
+        await service.waitForPendingWrite("mention")
         await service.releaseWrite("mention")
         await first.value
         await second.value
 
         XCTAssertEqual(store.level, .mentionsOnly)
         let written = await service.writtenModes
-        XCTAssertEqual(written.last, "mention", "the server must end on the last tap")
+        XCTAssertEqual(written, ["paused", "mention"], "the server must see the taps in order")
+    }
+
+    /// A tap that is already superseded by the time its turn comes never goes
+    /// out: sending it would walk the agents through a level the member left
+    /// while they waited.
+    func testSupersededTapIsNeverSent() async {
+        let service = ScriptedParticipationService()
+        await service.holdWrites(true)
+        let store = makeStore(service: service)
+
+        let first = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let skipped = Task { await store.set(.mentionsOnly) }
+        let last = Task { await store.set(.speakFreely) }
+        await Task.yield()
+
+        await service.releaseWrite("paused")
+        await service.waitForPendingWrite("speak")
+        await service.releaseWrite("speak")
+        await first.value
+        await skipped.value
+        await last.value
+
+        XCTAssertEqual(store.level, .speakFreely)
+        let written = await service.writtenModes
+        XCTAssertEqual(written, ["paused", "speak"], "the middle tap was already stale")
+    }
+
+    /// A failed write returns the control to the level the server actually
+    /// acknowledged. Rolling back to whatever `level` held at tap time can land
+    /// on an optimistic value from an earlier write that never itself landed -
+    /// a level the conversation was never in.
+    func testRollbackReturnsToTheConfirmedLevel() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("speak")
+        let store = makeStore(service: service)
+        await store.load()
+
+        await service.holdWrites(true)
+        await service.failWrites(of: ["paused", "mention"])
+        let firstFailure = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let secondFailure = Task { await store.set(.mentionsOnly) }
+        await Task.yield()
+
+        await service.releaseWrite("paused")
+        await service.waitForPendingWrite("mention")
+        await service.releaseWrite("mention")
+        await firstFailure.value
+        await secondFailure.value
+
+        XCTAssertEqual(store.level, .speakFreely, "rollback must not land on the unconfirmed Pause")
     }
 
     /// A failed write rolls back only if it is still the newest one. When a newer
@@ -156,12 +218,13 @@ final class AgentParticipationStoreStressTests: XCTestCase {
         let failing = Task { await store.set(.paused) }
         await service.waitForPendingWrite("paused")
         let newer = Task { await store.set(.mentionsOnly) }
-        await service.waitForPendingWrite("mention")
+        await Task.yield()
 
-        await service.releaseWrite("mention")
-        await newer.value
         await service.releaseWrite("paused")
         await failing.value
+        await service.waitForPendingWrite("mention")
+        await service.releaseWrite("mention")
+        await newer.value
 
         XCTAssertEqual(store.level, .mentionsOnly, "the older failure must not pull the level back")
     }

--- a/ConvosTests/AgentParticipationStoreStressTests.swift
+++ b/ConvosTests/AgentParticipationStoreStressTests.swift
@@ -1,0 +1,214 @@
+import ConvosComposer
+import XCTest
+@testable import Convos
+
+/// A participation service a test can hold still. Every call parks on a
+/// continuation until the test releases it, so reads and writes can be
+/// interleaved deliberately instead of hoping a sleep lands in the right order.
+private actor ScriptedParticipationService: AgentParticipationServing {
+    struct WriteFailure: Error {}
+
+    private var serverMode: String = "speak"
+    private var failingModes: Set<String> = []
+    private(set) var writtenModes: [String] = []
+    private var pendingWrites: [String: CheckedContinuation<Void, Never>] = [:]
+    private var pendingReads: [CheckedContinuation<Void, Never>] = []
+    private var holdsWrites: Bool = false
+    private var holdsReads: Bool = false
+
+    func setServerMode(_ mode: String) {
+        serverMode = mode
+    }
+
+    func failWrites(of modes: Set<String>) {
+        failingModes = modes
+    }
+
+    func holdWrites(_ holds: Bool) {
+        holdsWrites = holds
+    }
+
+    func holdReads(_ holds: Bool) {
+        holdsReads = holds
+    }
+
+    func releaseWrite(_ mode: String) {
+        pendingWrites.removeValue(forKey: mode)?.resume()
+    }
+
+    func releaseReads() {
+        let waiting = pendingReads
+        pendingReads = []
+        waiting.forEach { $0.resume() }
+    }
+
+    func waitForPendingWrite(_ mode: String) async {
+        while pendingWrites[mode] == nil {
+            await Task.yield()
+        }
+    }
+
+    func waitForPendingRead() async {
+        while pendingReads.isEmpty {
+            await Task.yield()
+        }
+    }
+
+    func readMode(conversationId: String, variantId: String?) async throws -> String {
+        if holdsReads {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pendingReads.append(continuation)
+            }
+        }
+        return serverMode
+    }
+
+    func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws {
+        if holdsWrites {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pendingWrites[mode] = continuation
+            }
+        }
+        writtenModes.append(mode)
+        if failingModes.contains(mode) {
+            throw WriteFailure()
+        }
+        serverMode = mode
+    }
+}
+
+@MainActor
+final class AgentParticipationStoreStressTests: XCTestCase {
+    private func makeStore(
+        service: ScriptedParticipationService
+    ) -> AgentParticipationStore {
+        AgentParticipationStore(conversationId: "convo-1", service: service)
+    }
+
+    /// A tap that lands while a read is in flight owns the level: the value the
+    /// read was already fetching is older than the tap.
+    func testTapDuringReadSurvivesTheRead() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("speak")
+        await service.holdReads(true)
+        let store = makeStore(service: service)
+
+        let load = Task { await store.load() }
+        await service.waitForPendingRead()
+        await store.set(.paused)
+        await service.releaseReads()
+        await load.value
+
+        XCTAssertEqual(store.level, .paused)
+    }
+
+    /// The mirror case, and the one a member hits by pulling the sheet open
+    /// again right after tapping: a read that starts while a write is still in
+    /// flight sees the pre-write server value, and must not resurrect it.
+    func testReadStartedDuringPendingWriteDoesNotResurrectOldValue() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("speak")
+        await service.holdWrites(true)
+        let store = makeStore(service: service)
+
+        let write = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        await store.load()
+
+        XCTAssertEqual(store.level, .paused, "a refresh mid-write must not show the pre-write level")
+
+        await service.releaseWrite("paused")
+        await write.value
+        XCTAssertEqual(store.level, .paused)
+    }
+
+    /// Two taps in quick succession: the level the member last chose is the one
+    /// that stands, and the server ends on it too.
+    func testRapidSwitchingSettlesOnTheLastTap() async {
+        let service = ScriptedParticipationService()
+        await service.holdWrites(true)
+        let store = makeStore(service: service)
+
+        let first = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let second = Task { await store.set(.mentionsOnly) }
+        await service.waitForPendingWrite("mention")
+
+        await service.releaseWrite("paused")
+        await service.releaseWrite("mention")
+        await first.value
+        await second.value
+
+        XCTAssertEqual(store.level, .mentionsOnly)
+        let written = await service.writtenModes
+        XCTAssertEqual(written.last, "mention", "the server must end on the last tap")
+    }
+
+    /// A failed write rolls back only if it is still the newest one. When a newer
+    /// tap has already moved the control, rolling back would drag the member to a
+    /// level they just left.
+    func testFailedWriteDoesNotClobberNewerTap() async {
+        let service = ScriptedParticipationService()
+        await service.holdWrites(true)
+        await service.failWrites(of: ["paused"])
+        let store = makeStore(service: service)
+
+        let failing = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let newer = Task { await store.set(.mentionsOnly) }
+        await service.waitForPendingWrite("mention")
+
+        await service.releaseWrite("mention")
+        await newer.value
+        await service.releaseWrite("paused")
+        await failing.value
+
+        XCTAssertEqual(store.level, .mentionsOnly, "the older failure must not pull the level back")
+    }
+
+    /// The plain failure path still stands: nothing newer, so the control returns
+    /// to where the agents actually are and says so.
+    func testLoneFailedWriteRollsBackAndReports() async {
+        let service = ScriptedParticipationService()
+        await service.failWrites(of: ["paused"])
+        let store = makeStore(service: service)
+
+        await store.set(.paused)
+
+        XCTAssertEqual(store.level, .default)
+        XCTAssertNotNil(store.errorMessage)
+    }
+
+    /// Churn: many switches back to back, then a refresh. The control ends on the
+    /// last tap and agrees with the server.
+    func testSwitchChurnEndsConsistentWithTheServer() async {
+        let service = ScriptedParticipationService()
+        let store = makeStore(service: service)
+        let sequence: [AgentParticipationLevel] = [
+            .paused, .mentionsOnly, .speakFreely, .paused, .mentionsOnly, .paused, .speakFreely, .mentionsOnly,
+        ]
+
+        for level in sequence {
+            await store.set(level)
+        }
+        await store.load()
+
+        XCTAssertEqual(store.level, sequence[sequence.count - 1])
+        let written = await service.writtenModes
+        XCTAssertEqual(written.count, sequence.count, "every switch must reach the server once")
+    }
+
+    /// Repeated refreshes are stable and mark the store loaded.
+    func testRepeatedLoadsAreStable() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("mention")
+        let store = makeStore(service: service)
+
+        for _ in 0..<10 {
+            await store.load()
+        }
+
+        XCTAssertTrue(store.hasLoaded)
+        XCTAssertEqual(store.level, .mentionsOnly)
+    }
+}


### PR DESCRIPTION
Stress-testing the participation control (Speak freely / Mentions only / Pause) turned up two ways the level a member just chose gets taken away from them. Both need only ordinary latency, and both hit either surface that renders the control — the composer bubble and the row in the agent's profile — since they share `AgentParticipationStore`.

## The races

**A failed write clobbers a newer tap.** `set()` captured `previous` and, on failure, restored it unconditionally. Tap Pause, then Mentions; if the Pause write fails it lands late and puts the control back on Speak freely — a level the member left two taps ago — with an error to match, while the Mentions write actually succeeded. The write now carries its own generation and rolls back only while it is still the newest one.

**A refresh mid-write resurrects the old value.** `load()` only guarded against writes that *finished* while it was in flight. A read that starts with a write still unanswered gets the pre-write value from the server and wrote it over the member's tap — reopening the agent sheet right after switching showed the previous level, as if the change had not taken. Reads now discard their result if a write was unanswered at either end of them.

## The seam

`AgentParticipationStore` reached its two endpoints through the full API client, so there was no way to hold a call open. It now takes an `AgentParticipationServing` with `APIAgentParticipationService` as the default — two methods, one read and one write. Nothing else about how it talks to the backend changed.

## Tests

`ConvosTests/AgentParticipationStoreStressTests.swift` — 7 scenarios against a service actor that parks every call on a continuation, so the interleavings are deliberate rather than timed:

| Scenario | |
|---|---|
| tap during an in-flight read | tap wins |
| read started during a pending write | tap survives the refresh (**was failing**) |
| two taps in quick succession | last tap stands, server ends on it |
| failed write with a newer tap behind it | no clobber (**was failing**) |
| lone failed write | still rolls back and reports |
| 8 switches then a refresh | ends consistent with the server |
| 10 refreshes | stable |

Both bugs were confirmed by watching those two tests fail against the old store and pass against the new one.

## Testing

- `xcodebuild test -only-testing:ConvosTests/AgentParticipationStoreStressTests` on `convos-dev` — 7/7 passing.
- `swift test --package-path ConvosCore` — 1658 tests, one unrelated `VoiceMemoTranscriptionServiceTests` timeout under load that passes 10/10 in isolation.

Still behind `isListenParticipationEnabled`, hard-locked off in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787935731&installation_model_id=20076&pr_number=1246&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1246&signature=9814a1ece6c7d827f2c38a6f4b596ebcc0a83ff946bbb8fe13ff0326358944ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race conditions between switching and refreshing participation level in `AgentParticipationStore`
> - Serializes writes using a `writeChain` task queue and a `writesInFlight` counter so rapid taps are applied in order and superseded writes are skipped.
> - Prevents `load()` from overwriting optimistic UI state when a write is in progress or overlapped during the read.
> - On write failure, rolls back `level` to `confirmedLevel` (last acknowledged server state) rather than the previous optimistic value, and only rolls back if no newer tap has since occurred.
> - Extracts read/write network calls into an injectable `AgentParticipationServing` protocol, with `APIAgentParticipationService` as the default, to support deterministic stress testing.
> - Adds a stress test suite in [AgentParticipationStoreStressTests.swift](https://github.com/xmtplabs/convos-ios/pull/1246/files#diff-5cc05f79d33aaef7992d2c165b8ef0cf21c17d6c9ab8b613efc75fe1fbfb6a86) covering tap-during-read, read-during-write, rapid switching, rollback, and churn scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 064ab73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->