### PR TITLE
Participation store races, glass menus, and attachments inside the input

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -434,7 +434,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
                             .bottom,
                             proxy.size.height - composerRect.minY + DesignConstants.Spacing.step3x
                         )
-                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        // Grows out of the bubble's own corner rather than
+                        // sliding up from the edge, so the card reads as opened
+                        // by the control that was tapped.
+                        .transition(.scale(scale: 0.92, anchor: .bottomLeading).combined(with: .opacity))
                     }
                 }
             }

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -68,14 +68,14 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     }
 }
 
-/// The floating "Agent participation" menu: a frosted card of levels with a
+/// The floating "Agent participation" menu: a glass card of levels with a
 /// leading check on the current one. Presentation-agnostic — drop it in a
 /// popover, a sheet, or an overlay from the composer or the agent's profile.
 public struct AgentParticipationMenu: View {
     let selection: AgentParticipationLevel
-    /// Draws the frosted card + shadow around the rows. Set `false` when the
-    /// host already provides a surface (e.g. inside a sheet) so the panel isn't
-    /// a redundant card-in-a-card.
+    /// Draws the glass card around the rows. Set `false` when the host already
+    /// provides a surface (e.g. inside a sheet) so the panel isn't a redundant
+    /// card-in-a-card, and so glass never sits on glass.
     let showsBackground: Bool
     let onSelect: (AgentParticipationLevel) -> Void
 
@@ -90,35 +90,33 @@ public struct AgentParticipationMenu: View {
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
+        // The card holds only enough horizontal padding for the pressed row fill
+        // to bleed past the text; the row carries the rest, so the highlight
+        // spans the card the way a menu item's does. The two insets sum to the
+        // same gutter the text sat on before.
+        let sideInset: CGFloat = showsBackground ? ComposerMenuMetrics.cardSideInset : 0
+        let topInset: CGFloat = showsBackground ? DesignConstants.Spacing.step6x : 0
+        let bottomInset: CGFloat = showsBackground ? DesignConstants.Spacing.step4x : 0
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
             Text("Agent participation")
                 .font(.subheadline)
                 .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, ComposerMenuMetrics.rowSideInset)
 
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step6x) {
+            VStack(alignment: .leading, spacing: ComposerMenuMetrics.rowSpacing) {
                 ForEach(AgentParticipationLevel.allCases) { level in
                     row(for: level)
                 }
             }
         }
-        .padding(showsBackground ? DesignConstants.Spacing.step6x : 0)
-        .background {
-            if showsBackground {
-                RoundedRectangle(
-                    cornerRadius: DesignConstants.CornerRadius.mediumLargest,
-                    style: .continuous
-                )
-                .fill(.regularMaterial)
-            }
-        }
-        // Tight, single-direction lift — reads as a floating menu, not a halo.
-        // Only when it's a standalone card; a sheet provides its own elevation.
-        .shadow(
-            color: showsBackground ? .black.opacity(0.12) : .clear,
-            radius: showsBackground ? 18 : 0,
-            x: 0,
-            y: showsBackground ? 6 : 0
-        )
+        .padding(.horizontal, sideInset)
+        .padding(.top, topInset)
+        .padding(.bottom, bottomInset)
+        // Real glass, not a frosted fill: it refracts the transcript behind it,
+        // which is what separates the card from the conversation without a
+        // shadow bloomed under it. Non-interactive - the card is a surface, the
+        // rows are the controls.
+        .modifier(ComposerMenuCardSurface(isEnabled: showsBackground))
     }
 
     private func row(for level: AgentParticipationLevel) -> some View {
@@ -130,9 +128,9 @@ public struct AgentParticipationMenu: View {
                 // control the member taps and the level they picked are visibly
                 // the same thing.
                 Image(systemName: level.iconSystemName)
-                    .font(.system(size: 18, weight: .regular))
+                    .font(ComposerMenuMetrics.iconFont)
                     .foregroundStyle(.colorTextPrimary)
-                    .frame(width: DesignConstants.Spacing.step8x, alignment: .center)
+                    .frame(width: ComposerMenuMetrics.iconGutter, alignment: .center)
 
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
                     Text(level.title)
@@ -155,7 +153,7 @@ public struct AgentParticipationMenu: View {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(ComposerMenuRowButtonStyle())
         .accessibilityLabel(level.title)
         .accessibilityHint(level.caption)
         .accessibilityAddTraits(level == selection ? .isSelected : [])
@@ -165,8 +163,8 @@ public struct AgentParticipationMenu: View {
 // MARK: - Previews
 
 /// Interactive: tap a level and the check moves. Backed by a mock chat gradient
-/// so the frosted material has something real to refract (glass over a flat
-/// fill reads as a plain blurred box).
+/// so the glass has something real to refract (glass over a flat fill reads as a
+/// plain blurred box).
 #Preview("Participation menu (interactive)") {
     struct Harness: View {
         @State private var selection: AgentParticipationLevel = .speakFreely

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -2,6 +2,40 @@
 import ConvosCore
 import Foundation
 
+/// The two calls the participation control makes. Narrow on purpose: the store
+/// needs one read and one write, and a seam this small is what lets a test drive
+/// them slowly, out of order, or into failure.
+public protocol AgentParticipationServing: Sendable {
+    func readMode(conversationId: String, variantId: String?) async throws -> String
+    func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws
+}
+
+/// The real service, talking to the participation endpoints.
+public struct APIAgentParticipationService: AgentParticipationServing {
+    public init() {}
+
+    public func readMode(conversationId: String, variantId: String?) async throws -> String {
+        try await client().getAgentParticipation(
+            conversationId: conversationId,
+            variantId: variantId
+        ).mode
+    }
+
+    public func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws {
+        _ = try await client().setAgentParticipation(
+            conversationId: conversationId,
+            mode: mode,
+            variantId: variantId
+        )
+    }
+
+    private func client() -> any ConvosAPIClientProtocol {
+        ConvosAPIClientFactory.client(
+            environment: ConfigManager.shared.currentEnvironment
+        )
+    }
+}
+
 /// Owns one conversation's participation level for the views that show it.
 ///
 /// Two surfaces render this — the bubble in the composer and the row in an
@@ -37,11 +71,25 @@ public final class AgentParticipationStore {
     /// Bumped on every local `set()`. `load()` captures it before its network
     /// read and bails if it changed meanwhile, so a tap that lands mid-read is
     /// never clobbered by the older server value the read was already fetching.
+    /// A failed write reads it too, and rolls back only while it is still the
+    /// newest one - a newer tap already owns the level by then.
     private var writeGeneration: Int = 0
 
-    public init(conversationId: String, variantId: String? = nil) {
+    /// Writes that have been issued and not yet answered. A read that overlaps
+    /// one is reading from before it lands, so its value is already behind the
+    /// member's tap even though no generation changed while it was in flight.
+    private var writesInFlight: Int = 0
+
+    private let service: any AgentParticipationServing
+
+    public init(
+        conversationId: String,
+        variantId: String? = nil,
+        service: any AgentParticipationServing = APIAgentParticipationService()
+    ) {
         self.conversationId = conversationId
         self.variantId = variantId
+        self.service = service
     }
 
     public func dismissError() {
@@ -56,16 +104,22 @@ public final class AgentParticipationStore {
     /// a read the member never asked for is noise.
     public func load() async {
         let generationAtStart = writeGeneration
+        let overlappedAWrite = writesInFlight > 0
         defer { hasLoaded = true }
         do {
-            let response = try await client().getAgentParticipation(
+            let mode = try await service.readMode(
                 conversationId: conversationId,
                 variantId: variantId
             )
-            // A set() that landed while this read was in flight is newer than the
-            // value the server just returned; don't overwrite it with stale data.
-            guard writeGeneration == generationAtStart else { return }
-            if let loaded = AgentParticipationLevel(wireMode: response.mode) {
+            // Anything the member did around this read is newer than the value
+            // the server just returned: a set() that landed while it was in
+            // flight, or one still unanswered at either end of it. Keep theirs.
+            guard writeGeneration == generationAtStart,
+                  !overlappedAWrite,
+                  writesInFlight == 0 else {
+                return
+            }
+            if let loaded = AgentParticipationLevel(wireMode: mode) {
                 level = loaded
             }
         } catch {
@@ -84,24 +138,25 @@ public final class AgentParticipationStore {
         guard newLevel != previous else { return }
         level = newLevel
         writeGeneration += 1
+        let generation = writeGeneration
+        writesInFlight += 1
+        defer { writesInFlight -= 1 }
         do {
-            _ = try await client().setAgentParticipation(
+            try await service.writeMode(
+                newLevel.wireMode,
                 conversationId: conversationId,
-                mode: newLevel.wireMode,
                 variantId: variantId
             )
             Log.info("participation set mode=\(newLevel.wireMode)")
         } catch {
             Log.error("participation update failed: \(error)")
+            // A newer tap has already moved the control since this write went
+            // out. Rolling back now would drag the member to a level they left,
+            // and the newer write reports its own outcome.
+            guard writeGeneration == generation else { return }
             level = previous
             errorMessage = "Couldn't update participation. The agents are still on their previous setting."
         }
-    }
-
-    private func client() -> any ConvosAPIClientProtocol {
-        ConvosAPIClientFactory.client(
-            environment: ConfigManager.shared.currentEnvironment
-        )
     }
 }
 #endif

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationStore.swift
@@ -80,6 +80,19 @@ public final class AgentParticipationStore {
     /// member's tap even though no generation changed while it was in flight.
     private var writesInFlight: Int = 0
 
+    /// The newest level the server has acknowledged. `level` runs ahead of it
+    /// the moment someone taps, and a failed write returns to this rather than
+    /// to whatever `level` held before the tap - that earlier value may itself
+    /// be an optimistic one that never landed, and rolling back to it would put
+    /// the control on a level the conversation was never in.
+    private var confirmedLevel: AgentParticipationLevel = .default
+
+    /// The tail of the write queue. Each write waits for the one before it, so
+    /// the order the member tapped in is the order the server sees. Without
+    /// this the calls race and the last tap is whichever the network delivers
+    /// last, which is how the level ends up quietly reverting on the next read.
+    private var writeChain: Task<Void, Never>?
+
     private let service: any AgentParticipationServing
 
     public init(
@@ -121,6 +134,7 @@ public final class AgentParticipationStore {
             }
             if let loaded = AgentParticipationLevel(wireMode: mode) {
                 level = loaded
+                confirmedLevel = loaded
             }
         } catch {
             Log.error("participation read failed: \(error)")
@@ -134,27 +148,43 @@ public final class AgentParticipationStore {
     /// write never lands the agents are still on the old level — leaving the
     /// check on the new one would tell the member the opposite of the error.
     public func set(_ newLevel: AgentParticipationLevel) async {
-        let previous = level
-        guard newLevel != previous else { return }
+        guard newLevel != level else { return }
         level = newLevel
         writeGeneration += 1
         let generation = writeGeneration
         writesInFlight += 1
-        defer { writesInFlight -= 1 }
+        let precedingWrite = writeChain
+        let write = Task { @MainActor [weak self] in
+            await precedingWrite?.value
+            await self?.sendLevel(newLevel, generation: generation)
+        }
+        writeChain = write
+        await write.value
+        writesInFlight -= 1
+    }
+
+    /// One write, once it holds its turn in the queue.
+    private func sendLevel(_ newLevel: AgentParticipationLevel, generation: Int) async {
+        // Taps that piled up behind this one already moved the control past this
+        // level. Sending it would walk the agents through a level the member
+        // left while waiting, and the newest tap is still queued to say where
+        // they actually want them.
+        guard writeGeneration == generation else { return }
         do {
             try await service.writeMode(
                 newLevel.wireMode,
                 conversationId: conversationId,
                 variantId: variantId
             )
+            confirmedLevel = newLevel
             Log.info("participation set mode=\(newLevel.wireMode)")
         } catch {
             Log.error("participation update failed: \(error)")
-            // A newer tap has already moved the control since this write went
-            // out. Rolling back now would drag the member to a level they left,
-            // and the newer write reports its own outcome.
+            // A newer tap arrived while this write was out. Rolling back now
+            // would drag the member to a level they left, and that newer write
+            // reports its own outcome.
             guard writeGeneration == generation else { return }
-            level = previous
+            level = confirmedLevel
             errorMessage = "Couldn't update participation. The agents are still on their previous setting."
         }
     }

--- a/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenu.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenu.swift
@@ -1,0 +1,118 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// One thing a member can attach, as it appears in the attachments menu.
+public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendable {
+    case photos
+    case camera
+    case files
+    case voiceNote
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .photos: "Photos"
+        case .camera: "Camera"
+        case .files: "Files"
+        case .voiceNote: "Voice note"
+        }
+    }
+
+    /// Outline marks, matching the participation menu's. The two cards open from
+    /// neighbouring controls, so a filled set here would read as a different
+    /// menu borrowed from somewhere else.
+    public var iconSystemName: String {
+        switch self {
+        case .photos: "photo"
+        case .camera: "camera"
+        case .files: "document"
+        case .voiceNote: "waveform"
+        }
+    }
+}
+
+/// The attachments menu: the vertical card the composer's + opens. A named list
+/// rather than a row of bare glyphs, so each option says what it is - and it
+/// wears the participation card's surface and rows, since the two open from
+/// adjacent controls and are the same kind of object.
+public struct ComposerAttachmentsMenu: View {
+    let disabledActions: Set<ComposerAttachmentAction>
+    /// Draws the glass card around the rows. Set `false` when the host already
+    /// provides a surface.
+    let showsBackground: Bool
+    let onSelect: (ComposerAttachmentAction) -> Void
+
+    public init(
+        disabledActions: Set<ComposerAttachmentAction> = [],
+        showsBackground: Bool = true,
+        onSelect: @escaping (ComposerAttachmentAction) -> Void
+    ) {
+        self.disabledActions = disabledActions
+        self.showsBackground = showsBackground
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        let sideInset: CGFloat = showsBackground ? ComposerMenuMetrics.cardSideInset : 0
+        let verticalInset: CGFloat = showsBackground ? DesignConstants.Spacing.step4x : 0
+        VStack(alignment: .leading, spacing: ComposerMenuMetrics.rowSpacing) {
+            ForEach(ComposerAttachmentAction.allCases) { action in
+                row(for: action)
+            }
+        }
+        .padding(.horizontal, sideInset)
+        .padding(.vertical, verticalInset)
+        // Real glass, not a frosted fill: it refracts the transcript behind it,
+        // which is what separates the card from the conversation without a
+        // shadow bloomed under it.
+        .modifier(ComposerMenuCardSurface(isEnabled: showsBackground))
+        .accessibilityIdentifier("composer-attachments-menu")
+    }
+
+    private func row(for action: ComposerAttachmentAction) -> some View {
+        let isDisabled: Bool = disabledActions.contains(action)
+        let tint: Color = isDisabled ? Color.colorTextPrimary.opacity(0.3) : Color.colorTextPrimary
+        return Button {
+            onSelect(action)
+        } label: {
+            HStack(alignment: .center, spacing: DesignConstants.Spacing.step3x) {
+                Image(systemName: action.iconSystemName)
+                    .font(ComposerMenuMetrics.iconFont)
+                    .foregroundStyle(tint)
+                    .frame(width: ComposerMenuMetrics.iconGutter, alignment: .center)
+
+                Text(action.title)
+                    .font(.title3.weight(.regular))
+                    .foregroundStyle(tint)
+
+                Spacer(minLength: DesignConstants.Spacing.step2x)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(ComposerMenuRowButtonStyle())
+        .disabled(isDisabled)
+        .accessibilityLabel(action.title)
+        .accessibilityIdentifier("attachment-\(action.rawValue)-button")
+    }
+}
+
+// MARK: - Previews
+
+/// Backed by a mock chat gradient so the glass has something real to refract
+/// (glass over a flat fill reads as a plain blurred box).
+#Preview("Attachments menu") {
+    ZStack {
+        LinearGradient(
+            colors: [.blue.opacity(0.25), .purple.opacity(0.15), .orange.opacity(0.20)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .ignoresSafeArea()
+
+        ComposerAttachmentsMenu(disabledActions: [.voiceNote]) { _ in }
+            .frame(maxWidth: 360)
+            .padding()
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/ComposerMenu.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerMenu.swift
@@ -1,0 +1,57 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// The shared look of the composer's floating menus - the participation card and
+/// the attachments card. They open from controls sitting next to each other in
+/// the same row, so they have to read as one kind of object appearing twice
+/// rather than two menus that happen to be neighbours.
+enum ComposerMenuMetrics {
+    /// The leading icon gutter. Fixed, so every row's title sits on one axis
+    /// whatever the glyph's own width.
+    static let iconGutter: CGFloat = DesignConstants.Spacing.step8x
+    static let iconFont: Font = .system(size: 18.0, weight: .regular)
+    static let cardRadius: CGFloat = DesignConstants.CornerRadius.mediumLargest
+    /// The card carries only enough side padding for a pressed row's fill to
+    /// bleed past the text; the row carries the rest. Together they make the
+    /// gutter the text actually sits on.
+    static let cardSideInset: CGFloat = DesignConstants.Spacing.step3x
+    static let rowSideInset: CGFloat = DesignConstants.Spacing.step3x
+    static let rowSpacing: CGFloat = DesignConstants.Spacing.step2x
+}
+
+/// Draws the glass card behind a menu's rows, or leaves them bare. A modifier
+/// rather than a branch inside each menu's body, so the card's shape is
+/// described once and the bodies stay single expressions.
+struct ComposerMenuCardSurface: ViewModifier {
+    /// False when the host already provides a surface (e.g. inside a sheet), so
+    /// the card isn't a card-in-a-card and glass never sits on glass.
+    let isEnabled: Bool
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.glassEffect(.regular, in: .rect(cornerRadius: ComposerMenuMetrics.cardRadius))
+        } else {
+            content
+        }
+    }
+}
+
+/// Fills a row while it is held. A tonal step off the glass rather than a tint
+/// laid over it, so the surface itself reads as responding - and the fill spans
+/// the card's width the way a picked menu item's does, which is why the row
+/// carries the side inset instead of the card.
+struct ComposerMenuRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        let fillOpacity: Double = configuration.isPressed ? 0.08 : 0.0
+        let radius: CGFloat = DesignConstants.CornerRadius.regular
+        configuration.label
+            .padding(.horizontal, ComposerMenuMetrics.rowSideInset)
+            .padding(.vertical, DesignConstants.Spacing.step2x)
+            .background {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .fill(Color.colorTextPrimary.opacity(fillOpacity))
+            }
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -136,16 +136,16 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
 
     @State private var voiceMemoKeyboardKeeperText: String = ""
     @State private var isExpanded: Bool = false
-    /// Drives the composer's visual swap between the attachment-icon row
-    /// (`false`) and the single `+` button beside the large text input
-    /// (`true`). Decoupled from actual keyboard focus: it starts `true` so a
-    /// freshly opened chat shows the `+` / large-input treatment without
-    /// raising the keyboard, and `handleFocusChanged` keeps it in sync with
-    /// real focus thereafter.
-    @State private var isMessageInputFocused: Bool = true
     @State private var isImagePickerPresented: Bool = false
     @State private var isCameraPresented: Bool = false
     @State private var isFilePickerPresented: Bool = false
+    /// The attachments menu the `+` opens. A popover, so it presents in its own
+    /// window: it dismisses on an outside tap and is never clipped by the
+    /// composer's bounds - neither of which a bar living in `safeAreaBar` can do
+    /// for an overlay of its own.
+    @State private var showingAttachmentsMenu: Bool = false
+    /// The row the member picked, held until the menu finishes closing.
+    @State private var pendingAttachmentAction: ComposerAttachmentAction?
     @State private var showFileTooLargeAlert: Bool = false
     @State private var showFileTruncatedAlert: Bool = false
     @State private var selectedPhotos: [PhotosPickerItem] = []
@@ -219,7 +219,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         _focusState = focusState
         self.focusCoordinator = focusCoordinator
         self.pinsExpandedInput = pinsExpandedInput
-        self._isMessageInputFocused = State(initialValue: pinsExpandedInput)
         self.messagesTextFieldEnabled = messagesTextFieldEnabled
         self.onSendMessage = onSendMessage
         self.onClearInvite = onClearInvite
@@ -267,9 +266,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
                 // `currentFocus`, so re-run the expand/collapse logic here too or
                 // the bar would stay collapsed.
                 handleFocusChanged(to: focusCoordinator.currentFocus)
-            }
-            .onChange(of: messageText) { _, _ in
-                handleMessageTextChanged()
             }
             .onChange(of: isVoiceMemoActive) { wasActive, isActive in
                 guard wasActive, !isActive else { return }
@@ -340,17 +336,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         guard !isImagePickerPresented else { return }
         withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
             isExpanded = newValue == .displayName
-            isMessageInputFocused = pinsExpandedInput
-                || newValue == .message
-                || newValue == .voiceMemoRecording
-                || newValue == .sideConvoName
-        }
-    }
-
-    private func handleMessageTextChanged() {
-        guard !isMessageInputFocused, focusCoordinator.currentFocus != .displayName else { return }
-        withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
-            isMessageInputFocused = true
         }
     }
 
@@ -571,57 +556,100 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         }
     }
 
+    /// What the composer can't offer right now. The menu greys these rows rather
+    /// than dropping them, so the list doesn't change length as attachments come
+    /// and go and a member can see why an option is unavailable.
+    private var disabledAttachmentActions: Set<ComposerAttachmentAction> {
+        let hasSideConvo: Bool = pendingInviteURL != nil
+        let hasMedia: Bool = !pendingMediaAttachments.isEmpty
+        let isMediaCapacityFull: Bool = pendingMediaAttachments.count >= maxPendingMediaAttachments
+        var disabled: Set<ComposerAttachmentAction> = []
+        if isMediaCapacityFull || hasSideConvo {
+            disabled.formUnion([.photos, .camera, .files])
+        }
+        if hasMedia || hasSideConvo {
+            disabled.insert(.voiceNote)
+        }
+        return disabled
+    }
+
+    /// The `+`, plus the bookkeeping that runs the picked action only once the
+    /// menu has actually closed.
+    @ViewBuilder
+    private var attachmentsControl: some View {
+        attachmentsButton
+            .onChange(of: showingAttachmentsMenu) { _, isPresented in
+                handleAttachmentsMenuPresentationChanged(to: isPresented)
+            }
+    }
+
+    /// Opens the attachments menu. It sits inside the input field as a leading
+    /// accessory, so it is drawn bare: the field's own capsule is the surface it
+    /// belongs to, and a glass circle in there would read as a chip stuck on the
+    /// field. The icon row it used to swap places with lives in the menu now.
+    @ViewBuilder
+    private var attachmentsButton: some View {
+        let isInert: Bool = pinsExpandedInput
+        let buttonOpacity: Double = messagesTextFieldEnabled && !isInert ? 1.0 : 0.4
+        Button {
+            showingAttachmentsMenu = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 18.0, weight: .medium))
+                .foregroundStyle(Color.colorTextPrimary)
+                .frame(width: 32, height: 32)
+                .contentShape(.circle)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Show attachments")
+        .accessibilityIdentifier("attachments-button")
+        .disabled(isInert)
+        .opacity(buttonOpacity)
+        // No explicit arrowEdge: the composer sits at the bottom of the screen,
+        // so let the system place the card and point the arrow wherever the
+        // space actually is.
+        .popover(isPresented: $showingAttachmentsMenu) {
+            attachmentsMenuPopover
+        }
+    }
+
+    /// The menu's content. Bare, because the popover's own chrome is already the
+    /// surface - a card in here would be a card inside a card.
+    @ViewBuilder
+    private var attachmentsMenuPopover: some View {
+        ComposerAttachmentsMenu(
+            disabledActions: disabledAttachmentActions,
+            showsBackground: false,
+            onSelect: handleAttachmentSelected
+        )
+        .padding(.vertical, DesignConstants.Spacing.step3x)
+        .padding(.horizontal, DesignConstants.Spacing.step2x)
+        .presentationCompactAdaptation(.popover)
+    }
+
+    /// Records the pick and closes the menu. The action itself waits for the
+    /// dismissal: a picker raised while the popover is still going down is a
+    /// second presentation on top of the first, and the system drops it.
+    private func handleAttachmentSelected(_ action: ComposerAttachmentAction) {
+        pendingAttachmentAction = action
+        showingAttachmentsMenu = false
+    }
+
+    private func handleAttachmentsMenuPresentationChanged(to isPresented: Bool) {
+        guard !isPresented, let action = pendingAttachmentAction else { return }
+        pendingAttachmentAction = nil
+        switch action {
+        case .photos: isPhotoPickerPresented = true
+        case .camera: isCameraPresented = true
+        case .files: isFilePickerPresented = true
+        case .voiceNote: startVoiceMemoRecording()
+        }
+    }
+
     @ViewBuilder
     private var normalInputView: some View {
         HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
             participationBubble
-
-            if isMessageInputFocused {
-                Button {
-                    withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
-                        isMessageInputFocused = false
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 18.0, weight: .medium))
-                        .foregroundStyle(Color.colorTextPrimary)
-                        .frame(width: 32, height: 32)
-                        .contentShape(.circle)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Show attachments")
-                .accessibilityIdentifier("collapse-input-button")
-                .disabled(pinsExpandedInput)
-                .opacity(messagesTextFieldEnabled && !pinsExpandedInput ? 1.0 : 0.4)
-                .frame(width: DesignConstants.Spacing.step12x, height: DesignConstants.Spacing.step12x)
-                .clipShape(.circle)
-                .glassEffect(.regular.interactive(), in: .circle)
-                .glassEffectID("media", in: namespace)
-                .glassEffectTransition(.matchedGeometry)
-            } else {
-                let hasSideConvo: Bool = pendingInviteURL != nil
-                let hasMedia: Bool = !pendingMediaAttachments.isEmpty
-                let isMediaCapacityFull: Bool = pendingMediaAttachments.count >= maxPendingMediaAttachments
-                let mediaButtonsDisabled: Bool = isMediaCapacityFull || hasSideConvo
-                let voiceMemoDisabled: Bool = hasMedia || hasSideConvo
-                MessagesMediaButtonsView(
-                    isPhotoPickerPresented: $isPhotoPickerPresented,
-                    isCameraPresented: $isCameraPresented,
-                    onVoiceMemoTap: startVoiceMemoRecording,
-                    onFilePickerTap: {
-                        isFilePickerPresented = true
-                    },
-                    isMediaCapacityFull: mediaButtonsDisabled,
-                    isVoiceMemoDisabled: voiceMemoDisabled,
-                    onDebugAttachmentTap: onDebugAttachmentTap
-                )
-                .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
-                .frame(height: DesignConstants.Spacing.step12x)
-                .clipShape(.capsule)
-                .glassEffect(.regular.interactive(), in: .capsule)
-                .glassEffectID("media", in: namespace)
-                .glassEffectTransition(.matchedGeometry)
-            }
 
             MessagesInputView(
                 displayName: $displayName,
@@ -646,7 +674,8 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
                 onClearLinkPreview: onClearLinkPreview,
                 onClearMediaAttachment: onClearMediaAttachment,
                 fileAttachmentPreview: fileAttachmentPreview,
-                agentShareChip: agentShareChip
+                agentShareChip: agentShareChip,
+                attachmentsButton: { attachmentsControl }
             )
             .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
             .fixedSize(horizontal: false, vertical: true)
@@ -654,14 +683,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
             .glassEffectID("input", in: namespace)
             .glassEffectTransition(.matchedGeometry)
-            .simultaneousGesture(
-                TapGesture().onEnded {
-                    guard !isMessageInputFocused else { return }
-                    withAnimation(.bouncy(duration: 0.4, extraBounce: 0.01)) {
-                        isMessageInputFocused = true
-                    }
-                }
-            )
         }
         .disabled(!messagesTextFieldEnabled)
     }

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -4,7 +4,7 @@ import PhotosUI
 import SwiftUI
 import UIKit
 
-public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
+public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsButton: View>: View {
     @Binding var displayName: String
     let emptyDisplayNamePlaceholder: String
     @Binding var messageText: String
@@ -36,6 +36,10 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
     /// App-provided chip for a staged agent-share link. Rendered when
     /// `isShowingAgentShareChip` is true.
     @ViewBuilder let agentShareChip: () -> AgentChip
+    /// The attachments control, rendered as a leading accessory inside the field
+    /// just before the placeholder - see `attachmentsAccessory`. Supplied by the
+    /// host because the menu it opens belongs to the composer's own state.
+    @ViewBuilder let attachmentsButton: () -> AttachmentsButton
 
     private let attachmentPreviewSize: CGFloat = 80.0
     @State private var poofingAttachmentIds: Set<UUID> = []
@@ -64,7 +68,8 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
         onClearLinkPreview: (() -> Void)? = nil,
         onClearMediaAttachment: ((UUID) -> Void)? = nil,
         @ViewBuilder fileAttachmentPreview: @escaping (PendingFileAttachment) -> FilePreview,
-        @ViewBuilder agentShareChip: @escaping () -> AgentChip
+        @ViewBuilder agentShareChip: @escaping () -> AgentChip,
+        @ViewBuilder attachmentsButton: @escaping () -> AttachmentsButton
     ) {
         _displayName = displayName
         self.emptyDisplayNamePlaceholder = emptyDisplayNamePlaceholder
@@ -89,6 +94,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
         self.onClearMediaAttachment = onClearMediaAttachment
         self.fileAttachmentPreview = fileAttachmentPreview
         self.agentShareChip = agentShareChip
+        self.attachmentsButton = attachmentsButton
     }
 
     public static var defaultHeight: CGFloat {
@@ -158,12 +164,25 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View>: View {
             }
 
             HStack(alignment: .bottom, spacing: 0) {
+                attachmentsAccessory
                 messageTextField
                 sendButton
             }
         }
         .padding(DesignConstants.Spacing.step2x)
         .frame(alignment: .bottom)
+    }
+
+    /// The attachments control, living inside the input field as a leading
+    /// accessory just before the placeholder. Bottom-aligned so it stays on the
+    /// placeholder line as the field grows to multiple lines. The host hands it
+    /// over bare - no glass - because it is already inside the input's own
+    /// capsule, and a second glass shape here would read as a chip stuck on the
+    /// field.
+    @ViewBuilder
+    private var attachmentsAccessory: some View {
+        attachmentsButton()
+            .frame(height: Self.defaultHeight)
     }
 
     @ViewBuilder

--- a/ConvosTests/AgentParticipationStoreStressTests.swift
+++ b/ConvosTests/AgentParticipationStoreStressTests.swift
@@ -10,6 +10,9 @@ private actor ScriptedParticipationService: AgentParticipationServing {
 
     private var serverMode: String = "speak"
     private var failingModes: Set<String> = []
+    /// Every call that reached the service, in the order it arrived - the record
+    /// that shows whether writes were serialized or raced.
+    private(set) var startedModes: [String] = []
     private(set) var writtenModes: [String] = []
     private var pendingWrites: [String: CheckedContinuation<Void, Never>] = [:]
     private var pendingReads: [CheckedContinuation<Void, Never>] = []
@@ -64,6 +67,7 @@ private actor ScriptedParticipationService: AgentParticipationServing {
     }
 
     func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws {
+        startedModes.append(mode)
         if holdsWrites {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 pendingWrites[mode] = continuation
@@ -122,8 +126,10 @@ final class AgentParticipationStoreStressTests: XCTestCase {
         XCTAssertEqual(store.level, .paused)
     }
 
-    /// Two taps in quick succession: the level the member last chose is the one
-    /// that stands, and the server ends on it too.
+    /// Two taps in quick succession: they reach the server one at a time and in
+    /// the order they were tapped, so the level the member last chose is the one
+    /// the server ends on - not whichever call the network happened to deliver
+    /// last.
     func testRapidSwitchingSettlesOnTheLastTap() async {
         let service = ScriptedParticipationService()
         await service.holdWrites(true)
@@ -132,16 +138,72 @@ final class AgentParticipationStoreStressTests: XCTestCase {
         let first = Task { await store.set(.paused) }
         await service.waitForPendingWrite("paused")
         let second = Task { await store.set(.mentionsOnly) }
-        await service.waitForPendingWrite("mention")
+        await Task.yield()
+
+        let startedWhileFirstHeld = await service.startedModes
+        XCTAssertEqual(startedWhileFirstHeld, ["paused"], "the second write must wait its turn")
 
         await service.releaseWrite("paused")
+        await service.waitForPendingWrite("mention")
         await service.releaseWrite("mention")
         await first.value
         await second.value
 
         XCTAssertEqual(store.level, .mentionsOnly)
         let written = await service.writtenModes
-        XCTAssertEqual(written.last, "mention", "the server must end on the last tap")
+        XCTAssertEqual(written, ["paused", "mention"], "the server must see the taps in order")
+    }
+
+    /// A tap that is already superseded by the time its turn comes never goes
+    /// out: sending it would walk the agents through a level the member left
+    /// while they waited.
+    func testSupersededTapIsNeverSent() async {
+        let service = ScriptedParticipationService()
+        await service.holdWrites(true)
+        let store = makeStore(service: service)
+
+        let first = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let skipped = Task { await store.set(.mentionsOnly) }
+        let last = Task { await store.set(.speakFreely) }
+        await Task.yield()
+
+        await service.releaseWrite("paused")
+        await service.waitForPendingWrite("speak")
+        await service.releaseWrite("speak")
+        await first.value
+        await skipped.value
+        await last.value
+
+        XCTAssertEqual(store.level, .speakFreely)
+        let written = await service.writtenModes
+        XCTAssertEqual(written, ["paused", "speak"], "the middle tap was already stale")
+    }
+
+    /// A failed write returns the control to the level the server actually
+    /// acknowledged. Rolling back to whatever `level` held at tap time can land
+    /// on an optimistic value from an earlier write that never itself landed -
+    /// a level the conversation was never in.
+    func testRollbackReturnsToTheConfirmedLevel() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("speak")
+        let store = makeStore(service: service)
+        await store.load()
+
+        await service.holdWrites(true)
+        await service.failWrites(of: ["paused", "mention"])
+        let firstFailure = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let secondFailure = Task { await store.set(.mentionsOnly) }
+        await Task.yield()
+
+        await service.releaseWrite("paused")
+        await service.waitForPendingWrite("mention")
+        await service.releaseWrite("mention")
+        await firstFailure.value
+        await secondFailure.value
+
+        XCTAssertEqual(store.level, .speakFreely, "rollback must not land on the unconfirmed Pause")
     }
 
     /// A failed write rolls back only if it is still the newest one. When a newer
@@ -156,12 +218,13 @@ final class AgentParticipationStoreStressTests: XCTestCase {
         let failing = Task { await store.set(.paused) }
         await service.waitForPendingWrite("paused")
         let newer = Task { await store.set(.mentionsOnly) }
-        await service.waitForPendingWrite("mention")
+        await Task.yield()
 
-        await service.releaseWrite("mention")
-        await newer.value
         await service.releaseWrite("paused")
         await failing.value
+        await service.waitForPendingWrite("mention")
+        await service.releaseWrite("mention")
+        await newer.value
 
         XCTAssertEqual(store.level, .mentionsOnly, "the older failure must not pull the level back")
     }

--- a/ConvosTests/AgentParticipationStoreStressTests.swift
+++ b/ConvosTests/AgentParticipationStoreStressTests.swift
@@ -1,0 +1,214 @@
+import ConvosComposer
+import XCTest
+@testable import Convos
+
+/// A participation service a test can hold still. Every call parks on a
+/// continuation until the test releases it, so reads and writes can be
+/// interleaved deliberately instead of hoping a sleep lands in the right order.
+private actor ScriptedParticipationService: AgentParticipationServing {
+    struct WriteFailure: Error {}
+
+    private var serverMode: String = "speak"
+    private var failingModes: Set<String> = []
+    private(set) var writtenModes: [String] = []
+    private var pendingWrites: [String: CheckedContinuation<Void, Never>] = [:]
+    private var pendingReads: [CheckedContinuation<Void, Never>] = []
+    private var holdsWrites: Bool = false
+    private var holdsReads: Bool = false
+
+    func setServerMode(_ mode: String) {
+        serverMode = mode
+    }
+
+    func failWrites(of modes: Set<String>) {
+        failingModes = modes
+    }
+
+    func holdWrites(_ holds: Bool) {
+        holdsWrites = holds
+    }
+
+    func holdReads(_ holds: Bool) {
+        holdsReads = holds
+    }
+
+    func releaseWrite(_ mode: String) {
+        pendingWrites.removeValue(forKey: mode)?.resume()
+    }
+
+    func releaseReads() {
+        let waiting = pendingReads
+        pendingReads = []
+        waiting.forEach { $0.resume() }
+    }
+
+    func waitForPendingWrite(_ mode: String) async {
+        while pendingWrites[mode] == nil {
+            await Task.yield()
+        }
+    }
+
+    func waitForPendingRead() async {
+        while pendingReads.isEmpty {
+            await Task.yield()
+        }
+    }
+
+    func readMode(conversationId: String, variantId: String?) async throws -> String {
+        if holdsReads {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pendingReads.append(continuation)
+            }
+        }
+        return serverMode
+    }
+
+    func writeMode(_ mode: String, conversationId: String, variantId: String?) async throws {
+        if holdsWrites {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                pendingWrites[mode] = continuation
+            }
+        }
+        writtenModes.append(mode)
+        if failingModes.contains(mode) {
+            throw WriteFailure()
+        }
+        serverMode = mode
+    }
+}
+
+@MainActor
+final class AgentParticipationStoreStressTests: XCTestCase {
+    private func makeStore(
+        service: ScriptedParticipationService
+    ) -> AgentParticipationStore {
+        AgentParticipationStore(conversationId: "convo-1", service: service)
+    }
+
+    /// A tap that lands while a read is in flight owns the level: the value the
+    /// read was already fetching is older than the tap.
+    func testTapDuringReadSurvivesTheRead() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("speak")
+        await service.holdReads(true)
+        let store = makeStore(service: service)
+
+        let load = Task { await store.load() }
+        await service.waitForPendingRead()
+        await store.set(.paused)
+        await service.releaseReads()
+        await load.value
+
+        XCTAssertEqual(store.level, .paused)
+    }
+
+    /// The mirror case, and the one a member hits by pulling the sheet open
+    /// again right after tapping: a read that starts while a write is still in
+    /// flight sees the pre-write server value, and must not resurrect it.
+    func testReadStartedDuringPendingWriteDoesNotResurrectOldValue() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("speak")
+        await service.holdWrites(true)
+        let store = makeStore(service: service)
+
+        let write = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        await store.load()
+
+        XCTAssertEqual(store.level, .paused, "a refresh mid-write must not show the pre-write level")
+
+        await service.releaseWrite("paused")
+        await write.value
+        XCTAssertEqual(store.level, .paused)
+    }
+
+    /// Two taps in quick succession: the level the member last chose is the one
+    /// that stands, and the server ends on it too.
+    func testRapidSwitchingSettlesOnTheLastTap() async {
+        let service = ScriptedParticipationService()
+        await service.holdWrites(true)
+        let store = makeStore(service: service)
+
+        let first = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let second = Task { await store.set(.mentionsOnly) }
+        await service.waitForPendingWrite("mention")
+
+        await service.releaseWrite("paused")
+        await service.releaseWrite("mention")
+        await first.value
+        await second.value
+
+        XCTAssertEqual(store.level, .mentionsOnly)
+        let written = await service.writtenModes
+        XCTAssertEqual(written.last, "mention", "the server must end on the last tap")
+    }
+
+    /// A failed write rolls back only if it is still the newest one. When a newer
+    /// tap has already moved the control, rolling back would drag the member to a
+    /// level they just left.
+    func testFailedWriteDoesNotClobberNewerTap() async {
+        let service = ScriptedParticipationService()
+        await service.holdWrites(true)
+        await service.failWrites(of: ["paused"])
+        let store = makeStore(service: service)
+
+        let failing = Task { await store.set(.paused) }
+        await service.waitForPendingWrite("paused")
+        let newer = Task { await store.set(.mentionsOnly) }
+        await service.waitForPendingWrite("mention")
+
+        await service.releaseWrite("mention")
+        await newer.value
+        await service.releaseWrite("paused")
+        await failing.value
+
+        XCTAssertEqual(store.level, .mentionsOnly, "the older failure must not pull the level back")
+    }
+
+    /// The plain failure path still stands: nothing newer, so the control returns
+    /// to where the agents actually are and says so.
+    func testLoneFailedWriteRollsBackAndReports() async {
+        let service = ScriptedParticipationService()
+        await service.failWrites(of: ["paused"])
+        let store = makeStore(service: service)
+
+        await store.set(.paused)
+
+        XCTAssertEqual(store.level, .default)
+        XCTAssertNotNil(store.errorMessage)
+    }
+
+    /// Churn: many switches back to back, then a refresh. The control ends on the
+    /// last tap and agrees with the server.
+    func testSwitchChurnEndsConsistentWithTheServer() async {
+        let service = ScriptedParticipationService()
+        let store = makeStore(service: service)
+        let sequence: [AgentParticipationLevel] = [
+            .paused, .mentionsOnly, .speakFreely, .paused, .mentionsOnly, .paused, .speakFreely, .mentionsOnly,
+        ]
+
+        for level in sequence {
+            await store.set(level)
+        }
+        await store.load()
+
+        XCTAssertEqual(store.level, sequence[sequence.count - 1])
+        let written = await service.writtenModes
+        XCTAssertEqual(written.count, sequence.count, "every switch must reach the server once")
+    }
+
+    /// Repeated refreshes are stable and mark the store loaded.
+    func testRepeatedLoadsAreStable() async {
+        let service = ScriptedParticipationService()
+        await service.setServerMode("mention")
+        let store = makeStore(service: service)
+
+        for _ in 0..<10 {
+            await store.load()
+        }
+
+        XCTAssertTrue(store.hasLoaded)
+        XCTAssertEqual(store.level, .mentionsOnly)
+    }
+}

--- a/qa/tests/20-send-receive-photos.md
+++ b/qa/tests/20-send-receive-photos.md
@@ -24,7 +24,7 @@ Verify end-to-end photo messaging: sending a photo from the app, receiving a pho
 
 ### Send a photo from the app
 
-5. Tap the photo library button (accessibility identifier: `photo-picker-button`). The system PhotosPicker should appear.
+5. Tap the `+` inside the input field (`attachments-button`) to open the attachments menu, then tap "Photos" (`attachment-photos-button`). The system PhotosPicker should appear.
 6. If this is the first time sending a photo, a "Pics are personal" education sheet will appear after selecting a photo. It has a "Got it" button — tap it to dismiss. This sheet only appears once per install.
 7. Select any photo from the picker by tapping a thumbnail.
 8. Verify the attachment preview appears in the composer area (accessibility identifier: `attachment-preview-image`).

--- a/qa/tests/27-send-receive-video.md
+++ b/qa/tests/27-send-receive-video.md
@@ -20,7 +20,7 @@ Verify end-to-end video messaging: selecting a video from the photo picker, send
 
 ### Picker shows photos and videos
 
-6. Tap the media picker button (`photo-picker-button`). The system PhotosPicker should appear showing both photos and videos. Videos are distinguishable by a duration badge in the picker grid.
+6. Tap the `+` inside the input field (`attachments-button`) to open the attachments menu, then tap "Photos" (`attachment-photos-button`). The system PhotosPicker should appear showing both photos and videos. Videos are distinguishable by a duration badge in the picker grid.
 
 ### Send a video from the app
 

--- a/qa/tests/structured/20-send-receive-photos.yaml
+++ b/qa/tests/structured/20-send-receive-photos.yaml
@@ -32,7 +32,11 @@ steps:
   - id: send_photo
     name: "Send photo from app"
     actions:
-      - tap: { id: "photo-picker-button" }
+      - tap: { id: "attachments-button" }
+        note: >
+          The "+" inside the input field opens the attachments menu, a popover
+          listing Photos / Camera / Files / Voice note.
+      - tap: { id: "attachment-photos-button" }
       - wait_for_element: { label: "Photos", timeout: 10 }
       - tap_first_photo: {}
       - dismiss_education_sheet: { button: "Got it" }
@@ -43,7 +47,7 @@ steps:
       - element_exists: { label: "Sent" }
     criteria: photo_sent
     note: >
-      Photo picker button: id="photo-picker-button", label="Photo library".
+      Attachments menu row: id="attachment-photos-button", label="Photos".
       First-time send triggers "Pics are personal" education sheet:
       "Real life is off the record. Pics are encrypted on send and deleted
       from temp storage after delivery. Convos never sees or saves to your

--- a/qa/tests/structured/27-send-receive-video.yaml
+++ b/qa/tests/structured/27-send-receive-video.yaml
@@ -51,7 +51,11 @@ steps:
   - id: picker_shows_videos
     name: "Photo picker shows both photos and videos"
     actions:
-      - tap: { id: "photo-picker-button" }
+      - tap: { id: "attachments-button" }
+        note: >
+          The "+" inside the input field opens the attachments menu, a popover
+          listing Photos / Camera / Files / Voice note.
+      - tap: { id: "attachment-photos-button" }
       - wait_for_element: { label: "Photos", timeout: 10 }
       - screenshot: {}
     verify:
@@ -103,7 +107,11 @@ steps:
   - id: remove_video_before_send
     name: "Remove video attachment before sending"
     actions:
-      - tap: { id: "photo-picker-button" }
+      - tap: { id: "attachments-button" }
+        note: >
+          The "+" inside the input field opens the attachments menu, a popover
+          listing Photos / Camera / Files / Voice note.
+      - tap: { id: "attachment-photos-button" }
       - wait_for_element: { label: "Photos", timeout: 10 }
       - tap_first_video: {}
       - dismiss_education_sheet: { button: "Got it" }
@@ -223,7 +231,11 @@ steps:
   - id: photo_still_works
     name: "Photo sending still works alongside video"
     actions:
-      - tap: { id: "photo-picker-button" }
+      - tap: { id: "attachments-button" }
+        note: >
+          The "+" inside the input field opens the attachments menu, a popover
+          listing Photos / Camera / Files / Voice note.
+      - tap: { id: "attachment-photos-button" }
       - wait_for_element: { label: "Photos", timeout: 10 }
       - tap_first_photo: {}
       - dismiss_education_sheet: { button: "Got it" }

--- a/qa/tests/structured/32-voice-memo-transcription.yaml
+++ b/qa/tests/structured/32-voice-memo-transcription.yaml
@@ -257,11 +257,11 @@ steps:
   - id: no_transcript_under_outgoing_voice_memo
     name: "No transcript appears under an outgoing voice memo"
     actions:
-      - find_elements: { id: "media-buttons" }
+      - tap: { id: "attachments-button" }
         note: >
-          Expand the media buttons bar if collapsed (tap the expand control),
-          then locate the voice memo button.
-      - tap: { id: "voice-memo-button" }
+          The "+" inside the input field opens the attachments menu, a popover
+          listing Photos / Camera / Files / Voice note.
+      - tap: { id: "attachment-voiceNote-button" }
         note: Start recording (grant the microphone permission dialog if shown).
       - on_system_dialog: "allow"
       - wait_for_element: { id: "voice-memo-stop-button", timeout: 10 }


### PR DESCRIPTION
Four commits, two concerns. The first two were already on this branch; the last two are the composer work from review feedback.

## Participation store (`51229cbf`, `064ab73e`)

Serializes the writes so the order a member taps in is the order the server sees, and rolls back a failed write to what the server actually confirmed rather than to whatever the control held before the tap -- that earlier value may itself be an optimistic one that never landed.

## Participation menu is real glass (`b13e6385`)

The card wore `.regularMaterial` with a hand-rolled shadow under it, which read raw next to the bubble and the `+` -- both already real glass. It refracts the transcript now, so separation comes from the material instead of a dark bloom, and the shadow is gone with it.

Rows acknowledge a press (a tonal fill spanning the card, where `.buttonStyle(.plain)` gave no feedback), and the card grows out of the bubble's corner instead of sliding up from the screen edge. Surface, row style and metrics moved to `ComposerMenu` so the composer's menus are one material.

## Attachments as a vertical menu, inside the input (`58cb1e8a`)

Two review notes drove this: attachments were expanded on open, and the menu should be a vertical list rather than a row of glyphs.

The expanded-on-open part was a regression from #1027. It seeded `isMessageInputFocused` from `pinsExpandedInput` to hold the share extension's input open; because that argument defaults to false it overrode the `true` the property's own comment documents, opening every chat on the icon row.

The `+` now sits inside the input field as a leading accessory and opens a named list: Photos, Camera, Files, Voice note. Drawn bare -- the field's capsule is already the surface, and a glass circle in there reads as a chip stuck on the field.

It is a system popover, so it presents in its own window: outside-tap dismissal, never clipped. A bar living in `safeAreaBar` can't manage either for an overlay of its own. A picked row waits for the dismissal before raising its picker, since a picker put up mid-dismissal is a second presentation on top of the first and gets dropped.

Unavailable options grey rather than vanish, so the list keeps its length as attachments come and go.

Removes what the swap needed and nothing else uses: `isMessageInputFocused`, its message-text handler, and the input's tap gesture. `pinsExpandedInput` still makes the share extension's `+` inert; the Agent Builder keeps its horizontal row.

## Testing

- ConvosCore suite: 1657/1658 pass. The one failure is `ExpiredConversationsWorkerTests` -- "Cleans up already-expired conversations on init" -- which asserts on a 2.0s wall-clock wait for an async notification and fails under load. It passes in isolation in 0.131s, and nothing in this diff touches its code path. Worth fixing separately: it should wait on the condition rather than assert after a fixed window.
- Built and installed on simulator and device.
- QA tests 20 / 27 / 32 reach the pickers through the menu now, since the capsule they used to tap no longer renders.

## Not yet verified

The glass, the row press states, and the popover placement have not been eyeballed by me -- no tap tooling available in this session -- so they want a human look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787954699&installation_model_id=20076&pr_number=1247&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1247&signature=a1b932af82b0c57d8d6f828f3832a1768eabd9276ce5e0496b79cf6ab9098213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add attachments popover inside the message input and fix participation store races
> - Replaces the media icon row with a `+` button inside the message input field that opens a `ComposerAttachmentsMenu` popover listing Photos, Camera, Files, and Voice Note; unavailable actions are shown disabled rather than hidden.
> - Adds `MessagesInputView` support for a host-supplied leading accessory control inside the input field via a new `attachmentsButton` closure parameter.
> - Introduces shared composer menu primitives in [ComposerMenu.swift](https://github.com/xmtplabs/convos-ios/pull/1247/files#diff-f87603b12298b23ddb405ed46c8507beb908dd88a69efa5bb3513589385a2c2a): `ComposerMenuMetrics` constants, `ComposerMenuCardSurface` glass modifier, and `ComposerMenuRowButtonStyle` press feedback.
> - Overhauls `AgentParticipationStore` concurrency: serializes writes with a chained `Task`, prevents superseded taps from being sent, stops in-flight reads from overwriting optimistic state, and rolls back to the last server-confirmed level on failure.
> - Updates the participation menu and attachments menu to render with a glass card surface, and updates QA test scripts to reflect the new attachments flow.
> - Behavioral Change: the bottom media button bar is removed; all attachment entry points now go through the `+` popover.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 58cb1e8. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->