### PR TITLE
Composer: the attachments card is ours, so it stops wearing the system's arrow

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -962,6 +962,7 @@ private extension ConversationView {
                 attachmentsMenu.dismiss()
             } card: {
                 ComposerAttachmentsMenu(
+                    actions: attachmentsMenu.actions,
                     disabledActions: attachmentsMenu.disabledActions,
                     showsBackground: true,
                     onSelect: attachmentsMenu.select

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -66,6 +66,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// the conversation; the composer only draws the control.
     @State private var participation: AgentParticipationStore?
     @State private var showingParticipationMenu: Bool = false
+    /// The attachments card the composer's `+` opens. Drawn here for the same
+    /// reason the participation card is: the composer can't float a card of its
+    /// own out past the bar it lives in.
+    @State private var attachmentsMenu: ComposerAttachmentsMenuCoordinator = .init()
     @State private var pagerSelectedPage: ConversationPagerPage = .messages
     /// Tracks keyboard visibility so the pager dots hide and the pager-dots
     /// inset collapses while the keyboard is up.
@@ -399,46 +403,17 @@ struct ConversationView<MessagesBottomBar: View>: View {
         // Only where there is an agent to govern, and only while the Listen
         // flag is on. Absent, the composer draws no bubble at all.
         .environment(\.agentParticipation, participationContext)
+        .environment(\.composerAttachmentsMenu, attachmentsMenu)
         .task(id: participationTaskKey) { await prepareParticipation() }
-        // The participation card floats just ABOVE the composer, placed against
-        // the composer's real bounds — so it never reflows the message list,
-        // never scrolls with it, and never covers the input. A full-screen scrim
-        // behind it dismisses on an outside tap without eating the card's taps.
+        // Both composer cards float just ABOVE the composer, placed against the
+        // composer's real bounds — so they never reflow the message list, never
+        // scroll with it, and never cover the input. A full-screen scrim behind
+        // each dismisses on an outside tap without eating the card's taps.
         .overlayPreferenceValue(ComposerBoundsKey.self) { anchor in
             GeometryReader { proxy in
-                if showingParticipationMenu, let participation, let anchor {
-                    let composerRect = proxy[anchor]
-                    ZStack(alignment: .bottomLeading) {
-                        Color.black.opacity(0.001)
-                            .ignoresSafeArea()
-                            .contentShape(.rect)
-                            .onTapGesture {
-                                withAnimation(.snappy(duration: 0.2)) {
-                                    showingParticipationMenu = false
-                                }
-                            }
-
-                        AgentParticipationMenu(
-                            selection: participation.level,
-                            showsBackground: true
-                        ) { level in
-                            withAnimation(.snappy(duration: 0.2)) {
-                                showingParticipationMenu = false
-                            }
-                            Task { await participation.set(level) }
-                        }
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, DesignConstants.Spacing.step4x)
-                        .padding(
-                            .bottom,
-                            proxy.size.height - composerRect.minY + DesignConstants.Spacing.step3x
-                        )
-                        // Grows out of the bubble's own corner rather than
-                        // sliding up from the edge, so the card reads as opened
-                        // by the control that was tapped.
-                        .transition(.scale(scale: 0.92, anchor: .bottomLeading).combined(with: .opacity))
-                    }
+                if let anchor {
+                    let bottomInset: CGFloat = proxy.size.height - proxy[anchor].minY + DesignConstants.Spacing.step3x
+                    composerCards(bottomInset: bottomInset)
                 }
             }
         }
@@ -957,6 +932,72 @@ extension ConversationView {
 }
 
 private extension ConversationView {
+    /// The cards the composer's controls open: participation from the bubble,
+    /// attachments from the `+`. Never both: whichever is open puts its scrim
+    /// over the composer, so the next tap closes it rather than reaching the
+    /// other control.
+    @ViewBuilder
+    func composerCards(bottomInset: CGFloat) -> some View {
+        if showingParticipationMenu, let participation {
+            composerCard(bottomInset: bottomInset) {
+                withAnimation(.snappy(duration: 0.2)) {
+                    showingParticipationMenu = false
+                }
+            } card: {
+                AgentParticipationMenu(
+                    selection: participation.level,
+                    showsBackground: true
+                ) { level in
+                    withAnimation(.snappy(duration: 0.2)) {
+                        showingParticipationMenu = false
+                    }
+                    Task { await participation.set(level) }
+                }
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        if attachmentsMenu.isPresented {
+            composerCard(bottomInset: bottomInset) {
+                attachmentsMenu.dismiss()
+            } card: {
+                ComposerAttachmentsMenu(
+                    disabledActions: attachmentsMenu.disabledActions,
+                    showsBackground: true,
+                    onSelect: attachmentsMenu.select
+                )
+                // Hugs its rows: the list is four short names, and a card
+                // stretched to the composer's width would be mostly empty.
+                .fixedSize()
+            }
+        }
+    }
+
+    /// The shared placement for a card opened from the composer: floated above
+    /// the bar, leading-aligned with it, over a scrim that takes the outside tap.
+    @ViewBuilder
+    func composerCard<Card: View>(
+        bottomInset: CGFloat,
+        onDismiss: @escaping () -> Void,
+        @ViewBuilder card: () -> Card
+    ) -> some View {
+        ZStack(alignment: .bottomLeading) {
+            Color.black.opacity(0.001)
+                .ignoresSafeArea()
+                .contentShape(.rect)
+                .onTapGesture(perform: onDismiss)
+
+            card()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+                .padding(.bottom, bottomInset)
+                // Grows out of the control's own corner rather than sliding up
+                // from the edge, so the card reads as opened by the control that
+                // was tapped.
+                .transition(.scale(scale: 0.92, anchor: .bottomLeading).combined(with: .opacity))
+        }
+    }
+
     /// What the composer needs to draw the bubble: the level, and the tap.
     /// `nil` in a conversation with no agent — a control for agents has no
     /// business in a room without one.

--- a/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenu.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenu.swift
@@ -7,6 +7,15 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
     case camera
     case files
     case voiceNote
+    /// Injects a canned attachment for testing. Only ever offered behind
+    /// `FeatureFlags.isDebugInjectorEnabled`, which is hard-locked off in
+    /// production - so it is absent from `standard` and a host has to ask for
+    /// it by name.
+    case debugInjector
+
+    /// What the menu offers a member. Everything real, and nothing a build
+    /// without the debug flag should ever see.
+    public static let standard: [ComposerAttachmentAction] = [.photos, .camera, .files, .voiceNote]
 
     public var id: String { rawValue }
 
@@ -16,6 +25,7 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
         case .camera: "Camera"
         case .files: "Files"
         case .voiceNote: "Voice note"
+        case .debugInjector: "Test attachment"
         }
     }
 
@@ -28,6 +38,7 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
         case .camera: "camera"
         case .files: "document"
         case .voiceNote: "waveform"
+        case .debugInjector: "testtube.2"
         }
     }
 }
@@ -37,6 +48,9 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
 /// wears the participation card's surface and rows, since the two open from
 /// adjacent controls and are the same kind of object.
 public struct ComposerAttachmentsMenu: View {
+    /// The rows to draw, in order. Defaults to the real attachments; a host
+    /// running with the debug injector on appends `.debugInjector`.
+    let actions: [ComposerAttachmentAction]
     let disabledActions: Set<ComposerAttachmentAction>
     /// Draws the glass card around the rows. Set `false` when the host already
     /// provides a surface.
@@ -44,10 +58,12 @@ public struct ComposerAttachmentsMenu: View {
     let onSelect: (ComposerAttachmentAction) -> Void
 
     public init(
+        actions: [ComposerAttachmentAction] = ComposerAttachmentAction.standard,
         disabledActions: Set<ComposerAttachmentAction> = [],
         showsBackground: Bool = true,
         onSelect: @escaping (ComposerAttachmentAction) -> Void
     ) {
+        self.actions = actions
         self.disabledActions = disabledActions
         self.showsBackground = showsBackground
         self.onSelect = onSelect
@@ -57,7 +73,7 @@ public struct ComposerAttachmentsMenu: View {
         let sideInset: CGFloat = showsBackground ? ComposerMenuMetrics.cardSideInset : 0
         let verticalInset: CGFloat = showsBackground ? DesignConstants.Spacing.step4x : 0
         VStack(alignment: .leading, spacing: ComposerMenuMetrics.rowSpacing) {
-            ForEach(ComposerAttachmentAction.allCases) { action in
+            ForEach(actions) { action in
                 row(for: action)
             }
         }

--- a/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenuEnvironment.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenuEnvironment.swift
@@ -15,6 +15,9 @@ import SwiftUI
 @Observable
 public final class ComposerAttachmentsMenuCoordinator {
     public private(set) var isPresented: Bool = false
+    /// The rows to draw, as the composer offered them - which is where the
+    /// debug injector's row appears or doesn't.
+    public private(set) var actions: [ComposerAttachmentAction] = ComposerAttachmentAction.standard
     /// What the composer couldn't offer at the moment the menu opened. The rows
     /// grey rather than vanish, so the list keeps its length.
     public private(set) var disabledActions: Set<ComposerAttachmentAction> = []
@@ -23,9 +26,11 @@ public final class ComposerAttachmentsMenuCoordinator {
     public init() {}
 
     func present(
+        actions: [ComposerAttachmentAction],
         disabledActions: Set<ComposerAttachmentAction>,
         onSelect: @escaping (ComposerAttachmentAction) -> Void
     ) {
+        self.actions = actions
         self.disabledActions = disabledActions
         self.onSelect = onSelect
         withAnimation(.snappy(duration: 0.2)) {

--- a/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenuEnvironment.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerAttachmentsMenuEnvironment.swift
@@ -1,0 +1,67 @@
+#if canImport(UIKit)
+import Observation
+import SwiftUI
+
+/// Carries the attachments menu between the composer's `+` and the host that
+/// draws the card.
+///
+/// The composer can't draw it itself: the bar lives in a `safeAreaBar`, so an
+/// overlay of its own is clipped by the bar's bounds. The host floats the card
+/// above the composer from its root overlay instead - the same placement the
+/// participation card uses, see `ConversationView`. The composer still owns the
+/// pickers each row raises, so it hands its handler over when it opens the menu
+/// and the card calls back into it.
+@MainActor
+@Observable
+public final class ComposerAttachmentsMenuCoordinator {
+    public private(set) var isPresented: Bool = false
+    /// What the composer couldn't offer at the moment the menu opened. The rows
+    /// grey rather than vanish, so the list keeps its length.
+    public private(set) var disabledActions: Set<ComposerAttachmentAction> = []
+    private var onSelect: ((ComposerAttachmentAction) -> Void)?
+
+    public init() {}
+
+    func present(
+        disabledActions: Set<ComposerAttachmentAction>,
+        onSelect: @escaping (ComposerAttachmentAction) -> Void
+    ) {
+        self.disabledActions = disabledActions
+        self.onSelect = onSelect
+        withAnimation(.snappy(duration: 0.2)) {
+            isPresented = true
+        }
+    }
+
+    public func dismiss() {
+        guard isPresented else { return }
+        onSelect = nil
+        withAnimation(.snappy(duration: 0.2)) {
+            isPresented = false
+        }
+    }
+
+    /// Closes the card and runs the pick. The handler is read before the
+    /// dismissal clears it.
+    public func select(_ action: ComposerAttachmentAction) {
+        let handler = onSelect
+        dismiss()
+        handler?(action)
+    }
+}
+
+private struct ComposerAttachmentsMenuEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ComposerAttachmentsMenuCoordinator?
+    = nil
+}
+
+public extension EnvironmentValues {
+    /// Set by hosts that draw the attachments card. `nil` means nobody is
+    /// listening, and the composer's `+` stays inert rather than opening a menu
+    /// that would never appear.
+    var composerAttachmentsMenu: ComposerAttachmentsMenuCoordinator? {
+        get { self[ComposerAttachmentsMenuEnvironmentKey.self] }
+        set { self[ComposerAttachmentsMenuEnvironmentKey.self] = newValue }
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -139,13 +139,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @State private var isImagePickerPresented: Bool = false
     @State private var isCameraPresented: Bool = false
     @State private var isFilePickerPresented: Bool = false
-    /// The attachments menu the `+` opens. A popover, so it presents in its own
-    /// window: it dismisses on an outside tap and is never clipped by the
-    /// composer's bounds - neither of which a bar living in `safeAreaBar` can do
-    /// for an overlay of its own.
-    @State private var showingAttachmentsMenu: Bool = false
-    /// The row the member picked, held until the menu finishes closing.
-    @State private var pendingAttachmentAction: ComposerAttachmentAction?
     @State private var showFileTooLargeAlert: Bool = false
     @State private var showFileTruncatedAlert: Bool = false
     @State private var selectedPhotos: [PhotosPickerItem] = []
@@ -157,6 +150,9 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     // Injected by the host on conversations that hold an agent; nil elsewhere,
     // and the bubble simply isn't drawn.
     @Environment(\.agentParticipation) private var agentParticipation: AgentParticipationContext?
+    // The host draws the attachments card, floated above the composer from its
+    // root overlay; nil in hosts that draw none, and the `+` stays inert.
+    @Environment(\.composerAttachmentsMenu) private var attachmentsMenu: ComposerAttachmentsMenuCoordinator?
 
     public init(
         profile: Profile,
@@ -573,26 +569,19 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         return disabled
     }
 
-    /// The `+`, plus the bookkeeping that runs the picked action only once the
-    /// menu has actually closed.
-    @ViewBuilder
-    private var attachmentsControl: some View {
-        attachmentsButton
-            .onChange(of: showingAttachmentsMenu) { _, isPresented in
-                handleAttachmentsMenuPresentationChanged(to: isPresented)
-            }
-    }
-
     /// Opens the attachments menu. It sits inside the input field as a leading
     /// accessory, so it is drawn bare: the field's own capsule is the surface it
     /// belongs to, and a glass circle in there would read as a chip stuck on the
     /// field. The icon row it used to swap places with lives in the menu now.
     @ViewBuilder
-    private var attachmentsButton: some View {
-        let isInert: Bool = pinsExpandedInput
+    private var attachmentsControl: some View {
+        let isInert: Bool = pinsExpandedInput || attachmentsMenu == nil
         let buttonOpacity: Double = messagesTextFieldEnabled && !isInert ? 1.0 : 0.4
         Button {
-            showingAttachmentsMenu = true
+            attachmentsMenu?.present(
+                disabledActions: disabledAttachmentActions,
+                onSelect: handleAttachmentSelected
+            )
         } label: {
             Image(systemName: "plus")
                 .font(.system(size: 18.0, weight: .medium))
@@ -605,39 +594,11 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         .accessibilityIdentifier("attachments-button")
         .disabled(isInert)
         .opacity(buttonOpacity)
-        // No explicit arrowEdge: the composer sits at the bottom of the screen,
-        // so let the system place the card and point the arrow wherever the
-        // space actually is.
-        .popover(isPresented: $showingAttachmentsMenu) {
-            attachmentsMenuPopover
-        }
     }
 
-    /// The menu's content. Bare, because the popover's own chrome is already the
-    /// surface - a card in here would be a card inside a card.
-    @ViewBuilder
-    private var attachmentsMenuPopover: some View {
-        ComposerAttachmentsMenu(
-            disabledActions: disabledAttachmentActions,
-            showsBackground: false,
-            onSelect: handleAttachmentSelected
-        )
-        .padding(.vertical, DesignConstants.Spacing.step3x)
-        .padding(.horizontal, DesignConstants.Spacing.step2x)
-        .presentationCompactAdaptation(.popover)
-    }
-
-    /// Records the pick and closes the menu. The action itself waits for the
-    /// dismissal: a picker raised while the popover is still going down is a
-    /// second presentation on top of the first, and the system drops it.
+    /// Runs the picked row. The card is an overlay rather than a presentation, so
+    /// there is nothing for a picker to collide with and it can go up right away.
     private func handleAttachmentSelected(_ action: ComposerAttachmentAction) {
-        pendingAttachmentAction = action
-        showingAttachmentsMenu = false
-    }
-
-    private func handleAttachmentsMenuPresentationChanged(to isPresented: Bool) {
-        guard !isPresented, let action = pendingAttachmentAction else { return }
-        pendingAttachmentAction = nil
         switch action {
         case .photos: isPhotoPickerPresented = true
         case .camera: isCameraPresented = true

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -552,6 +552,14 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         }
     }
 
+    /// The rows the menu draws. The debug injector joins them only where the
+    /// host handed one over, which it does behind `isDebugInjectorEnabled` -
+    /// hard-locked off in production, so no member ever sees the row.
+    private var offeredAttachmentActions: [ComposerAttachmentAction] {
+        guard onDebugAttachmentTap != nil else { return ComposerAttachmentAction.standard }
+        return ComposerAttachmentAction.standard + [.debugInjector]
+    }
+
     /// What the composer can't offer right now. The menu greys these rows rather
     /// than dropping them, so the list doesn't change length as attachments come
     /// and go and a member can see why an option is unavailable.
@@ -579,6 +587,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         let buttonOpacity: Double = messagesTextFieldEnabled && !isInert ? 1.0 : 0.4
         Button {
             attachmentsMenu?.present(
+                actions: offeredAttachmentActions,
                 disabledActions: disabledAttachmentActions,
                 onSelect: handleAttachmentSelected
             )
@@ -604,6 +613,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         case .camera: isCameraPresented = true
         case .files: isFilePickerPresented = true
         case .voiceNote: startVoiceMemoRecording()
+        case .debugInjector: onDebugAttachmentTap?()
         }
     }
 


### PR DESCRIPTION
Rebased onto current `dev` — the participation and attachments-menu commits this branch used to carry shipped in #1247, so what is left is one commit.

The `+` opened a `.popover`, chosen for what it does rather than what it draws: its own window, so it dismisses on an outside tap and is never clipped by the bar the composer lives in. The arrow is chrome that comes with that window and there is no API to take it off, so the card sat under a little triangle pointing back at the `+` that nothing else in the composer wears.

It uses the participation card's pattern now. `ConversationView` floats it from its root overlay against the composer's real bounds, leading-aligned, over a scrim that takes the outside tap, growing out of the tapped corner. Both cards share one placement helper so the two can't drift apart, and the card carries the same glass surface the participation one does instead of the popover's.

`ComposerAttachmentsMenuCoordinator` carries the menu between the two: the `+` presents with the rows it can't offer and hands over its handler, the card calls back. The composer keeps its pickers, and a host that injects no coordinator (the share extension) leaves the `+` inert.

Drops the deferred-action bookkeeping with it — an overlay is not a presentation, so a picker has nothing to collide with and goes up right away.

Neither card can open over the other: whichever is up has its scrim across the composer, so the next tap closes it rather than reaching the other control.

**Also fixes a regression from #1247:** the testtube debug-injector button had become unreachable. `MessagesMediaButtonsView` was the only thing rendering `onDebugAttachmentTap`, and the composer stopped using that view in #1247 — the handler was still threaded from `ConversationView` down to `MessagesBottomBar` and dropped on the floor. It is a row in the attachments card now (`Test attachment`, same testtube mark), offered only where the host hands a handler over, which it does behind `isDebugInjectorEnabled` — hard-locked off in production. `.debugInjector` is deliberately absent from `ComposerAttachmentAction.standard` and the card draws the list it is handed rather than `allCases`, so the row can't reach a real build by being forgotten in a loop.

**Verification**

- Built and run on the dev simulator.
- `swiftlint --strict` clean.
- `swift test --package-path ConvosCore`: 1658 tests, one failure — `VoiceMemoTranscriptionService/happy path` timing out under full-suite load. It passes in 0.05s in isolation against this same code, and nothing here touches transcription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace popover-based attachments menu in composer with a host-drawn overlay card
> - Removes the local popover and deferred-presentation logic from [`MessagesBottomBar`](https://github.com/xmtplabs/convos-ios/pull/1249/files#diff-15ef93166cd135cbcb601be8008789f84343afa5434a110b42fc9d4369870cd5); the `+` button now calls `attachmentsMenu.present(...)` on an environment-injected `ComposerAttachmentsMenuCoordinator`.
> - Adds [`ComposerAttachmentsMenuCoordinator`](https://github.com/xmtplabs/convos-ios/pull/1249/files#diff-042e9ce718cf4c3ee6886c730c75a676b6164c83a2f959c1edd81bc6f8816ea9) as a new `@Observable` coordinator that manages presentation state, available actions, disabled actions, and a selection callback via the SwiftUI environment.
> - [`ConversationView`](https://github.com/xmtplabs/convos-ios/pull/1249/files#diff-315e38ca52e75c79370579c65f3a218ca32afe08c50f49e8165bc2d562a1ce58) renders the attachments card in a shared `composerCard` overlay alongside the existing agent-participation card, using a consistent scrim, scale+opacity transition, and bottom-leading anchor.
> - Adds a `ComposerAttachmentAction.debugInjector` case (hidden from `standard` actions) that appears only when the host supplies an `onDebugAttachmentTap` handler.
> - Behavioral Change: in hosts that do not inject a coordinator, the `+` button is inert; attachment selection now fires immediately rather than waiting for a popover to dismiss.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39b5b6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
