### PR TITLE
Reach the Listen flag from a production build

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -5,6 +5,16 @@ import Foundation
 final class FeatureFlags {
     static let shared: FeatureFlags = FeatureFlags()
 
+    // Reaching a flag in a production build takes two changes, not one, and
+    // missing either looks identical from the device: the control just is not
+    // there.
+    // 1. The flag itself has to read UserDefaults in production rather than
+    //    returning false behind an `isProduction` guard, as most below do.
+    // 2. `ProdDebugMenuView` has to carry a row for it. That menu is a curated,
+    //    hardcoded list, not a render of every flag here, so a flag unlocked in
+    //    step 1 is still unreachable until it is listed there. The full
+    //    `DebugView` features section is non-production only.
+
     /// Off by default — gates the testtube debug-injector button in the composer
     /// media bar. Toggle from App Settings → Debug. Hard-locked off in production
     /// builds so the flag can never be `true` for end users, even if a UserDefaults
@@ -42,15 +52,15 @@ final class FeatureFlags {
 
     /// Off by default -- gates the per-conversation agent participation control
     /// ("Listen"): Speak freely / Mentions only / Paused. Toggle from
-    /// App Settings -> Debug. Hard-locked off in production while the feature is
-    /// still in development.
+    /// App Settings -> Debug in non-production builds, or from the curated prod
+    /// debug menu in production. Deliberately not prod-locked like the flags
+    /// above: the control is opt-in per install and exists to dogfood Listen in
+    /// TestFlight. Default-off keeps it out of every other build.
     var isListenParticipationEnabled: Bool {
         get {
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.listenParticipationEnabledKey)
         }
         set {
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
             UserDefaults.standard.set(newValue, forKey: Constant.listenParticipationEnabledKey)
         }
     }

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -20,10 +20,14 @@ import UserNotifications
 //
 // Hard rules enforced here:
 // - No mutating controls (no "Request Now", no "Register Device Again", no
-//   purchase / change-plan CTAs, no mock-credit toggles). One deliberate
-//   exception: the XMTP bidi streaming opt-in flips only a local default
-//   that selects the stream transport at next launch -- nothing account- or
-//   network-mutating -- and exists to dogfood bidi in production.
+//   purchase / change-plan CTAs, no mock-credit toggles). Two deliberate
+//   exceptions, both flipping only a local default so a tester can opt this
+//   install into a feature we are dogfooding in production:
+//   - the XMTP bidi streaming opt-in, which selects the stream transport at
+//     next launch -- nothing account- or network-mutating.
+//   - the Listen opt-in, which only decides whether the participation control
+//     is built. Turning it on mutates nothing by itself; the writes happen
+//     later, in the control, when a member actually picks a level.
 // - The live `BackendAuthProbe` (JWT minter) is never imported or instantiated
 //   here. The identity readout uses `DeviceIdentitySnapshot`, which is
 //   network-free and carries no JWT.
@@ -171,8 +175,9 @@ struct ProdDebugMenuView: View {
         let injectorEnabled: Bool = FeatureFlags.shared.isDebugInjectorEnabled
         Section("Feature flags") {
             labeledRow("Debug injector", injectorEnabled ? "On" : "Off")
-            // The one interactive control in this curated menu; see the
-            // module overview for why it is allowed here.
+            // The two interactive controls in this curated menu; see the
+            // module overview for why they are allowed here.
+            Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
         }
     }


### PR DESCRIPTION
Listen was invisible in the TestFlight build, which is what prompted this. It turned out to be unreachable for two independent reasons, and missing either one looks identical from the device: the control is just not there.

1. `FeatureFlags.isListenParticipationEnabled` returned `false` behind an `isProduction` guard, so nothing could turn it on in prod.
2. `ProdDebugMenuView` carried no row for it. That menu is a curated, hardcoded list rather than a render of every flag, so unlocking the flag alone would still leave it unreachable. The full `DebugView` features section, which does have the toggle, is non-production only.

This drops the guard and adds the row, next to the bidi opt-in that already lives there.

## Why this is safe to put in that menu

The menu's hard rule is no mutating controls, with one documented exception (bidi). This adds a second, on the same grounds: the toggle only decides whether the participation control is *built*. Flipping it mutates nothing by itself. The participation writes happen later, in the control, when a member actually picks a level. The module-overview comment is updated to say so.

Default-off is unchanged, so this surfaces for nobody who does not deliberately opt in.

## Backend dependency, please confirm before this ships

**I have not verified that the production backend serves `v2/conversations/:id/participation`.** `APIAgentParticipationService` calls it against the current environment. If prod does not serve it yet, a tester who flips this gets a control that renders at the product default and fails on write, rather than a working feature.

The failure is at least graceful: `AgentParticipationStore` holds the default on a failed read, and rolls a failed write back into `errorMessage` for the host to surface. But someone who knows the backend state should confirm before we point testers at it.

## Known rough edge, pre-existing

The toggle takes effect on reopening a conversation. `prepareParticipation()` runs from a `.task(id:)` keyed on conversation id plus has-agent, not on the flag, so flipping it with a conversation already open does nothing until you back out and re-enter. Same behavior as in Dev today. Left alone here; it is a one-line fix if we want it instant for testers.

## Testing

- SwiftLint `--strict` clean on both files.
- `Convos (Dev)` builds for the simulator with zero warnings, so no type-check-budget regressions.
- Full `ConvosCore` suite run. One failure, `ExpiredConversationsWorkerTests / "Cleans up already-expired conversations on init"`, which is a pre-existing flake unrelated to this change: the suite is ConvosCore and neither file touched here is imported by it, and the test passes 3/3 in isolation. Its `waitForCondition` waits on *any* `leftConversationNotification` and then asserts on one matching its own `conversationId`, so under parallel load another suite's notification ends the wait early. The sibling test in the same file waits on the id-matching predicate instead. Not fixed here, since it is unrelated to a UI flag change.

Note the diff is against current `dev`. The branch this started on had already been squash-merged as #1249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788023513&installation_model_id=20076&pr_number=1250&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1250&signature=70dcac1f6327f3ac95c9a906281aebc9575ecc3ab0cc0f9f07e818ec3008a3d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose the Listen participation flag in production builds via the debug menu
> - Removes the production environment guard from `FeatureFlags.isListenParticipationEnabled` so it reads from and writes to `UserDefaults` in all builds instead of always returning `false`.
> - Adds a toggle for "Listen (agent participation)" to `ProdDebugMenuView.featureFlagsSection` so it can be flipped on a per-install basis from the production debug menu.
> - Behavioral Change: in production, `isListenParticipationEnabled` now defaults to whatever is stored in `UserDefaults` rather than a hardcoded `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b6e94f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->