### PR TITLE
Preview an artifact from disk, on both surfaces, without sending a message

### DIFF
--- a/Convos/Conversation Detail/AttachmentPreviewSheet.swift
+++ b/Convos/Conversation Detail/AttachmentPreviewSheet.swift
@@ -247,6 +247,7 @@ struct AttachmentHTMLContent: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
         webView.navigationDelegate = context.coordinator
+        webView.enableInspectionOutsideProduction()
         return webView
     }
 
@@ -471,6 +472,7 @@ private struct MarkdownWebView: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
         webView.navigationDelegate = context.coordinator
+        webView.enableInspectionOutsideProduction()
         return webView
     }
 

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -9,6 +9,9 @@ import XMTPiOS
 struct ConvosApp: App {
     @UIApplicationDelegateAdaptor(ConvosAppDelegate.self) private var appDelegate: ConvosAppDelegate
     @Environment(\.scenePhase) private var scenePhase: ScenePhase
+    /// Seeded in `init` rather than here: the gate reads the resolved
+    /// environment, which only exists after `ConfigManager.configure`.
+    @State private var isPresentingArtifactPreview: Bool = false
 
     private let convos: ConvosClient
     let metricsDelegate: PostHogCollector
@@ -192,6 +195,8 @@ struct ConvosApp: App {
         }
 
         Self.configureTabBarItemColors()
+
+        _isPresentingArtifactPreview = State(initialValue: ArtifactPreviewGate.isAutoPresentRequested)
     }
 
     /// Tints the unselected tab items tertiary. The selected color is
@@ -233,7 +238,16 @@ struct ConvosApp: App {
                     break
                 }
             }
+            .fullScreenCover(isPresented: $isPresentingArtifactPreview) {
+                artifactPreviewCover
+            }
         }
+    }
+
+    @ViewBuilder
+    private var artifactPreviewCover: some View {
+        let dismiss = { isPresentingArtifactPreview = false }
+        ArtifactPreviewView(onClose: dismiss)
     }
 
     private func handleScenePhaseActive() {

--- a/Convos/Debug View/ArtifactPreviewStore.swift
+++ b/Convos/Debug View/ArtifactPreviewStore.swift
@@ -1,0 +1,186 @@
+import ConvosCore
+import CryptoKit
+import Foundation
+import Observation
+
+/// Gate for the artifact live-preview harness.
+///
+/// Reachable two ways: manually from the debug menu, or auto-presented at
+/// launch when `dev/artifact-preview` starts the app with
+/// `CONVOS_ARTIFACT_PREVIEW=1`. Both paths are non-production only.
+enum ArtifactPreviewGate {
+    static func isAvailable(for environment: AppEnvironment) -> Bool {
+        !environment.isProduction
+    }
+
+    /// True when the launch environment asked for the harness to open by
+    /// itself. Pass to a simulator app as `SIMCTL_CHILD_CONVOS_ARTIFACT_PREVIEW`.
+    static var isAutoPresentRequested: Bool {
+        guard isAvailable(for: ConfigManager.shared.currentEnvironment) else { return false }
+        return ProcessInfo.processInfo.environment["CONVOS_ARTIFACT_PREVIEW"] == "1"
+    }
+}
+
+/// Watches a drop directory inside the app container and republishes
+/// whichever HTML file was written most recently, so an artifact edited on
+/// the Mac re-renders in the app on save.
+///
+/// The published `attachmentKey` carries a hash of the file's bytes. Both
+/// `HTMLThumbnailRenderer` and `HTMLContentPrewarmer` key their caches on
+/// that string, so a changed file lands on a fresh key and neither cache
+/// can serve the previous render.
+@MainActor
+@Observable
+final class ArtifactPreviewStore {
+    struct Artifact: Equatable {
+        let fileURL: URL
+        let filename: String
+        let contentHash: String
+        let byteCount: Int
+        let loadedAt: Date
+
+        /// Namespaced so a preview render can never collide with a real
+        /// attachment's cache entry.
+        var attachmentKey: String {
+            Constant.attachmentKeyPrefix + contentHash
+        }
+    }
+
+    private(set) var artifact: Artifact?
+    private(set) var reloadCount: Int = 0
+    private(set) var lastError: String?
+
+    private var watcher: DispatchSourceFileSystemObject?
+    private var pendingReload: Task<Void, Never>?
+
+    /// `Documents/` rather than `Caches/` deliberately: the caches directory
+    /// is evictable under disk pressure, and a preview that vanishes
+    /// mid-session reads as a bug in the harness.
+    static var dropDirectory: URL {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return documents.appendingPathComponent(Constant.directoryName, isDirectory: true)
+    }
+
+    func start() {
+        createDropDirectoryIfNeeded()
+        reload()
+        startWatching()
+    }
+
+    func stop() {
+        pendingReload?.cancel()
+        pendingReload = nil
+        watcher?.cancel()
+        watcher = nil
+    }
+
+    /// Rescans the drop directory. Republishes only when the bytes actually
+    /// changed, so an editor's touch-without-save (or the directory event
+    /// raised by our own read) does not churn the render.
+    func reload() {
+        guard let candidate = newestHTMLFile() else {
+            artifact = nil
+            lastError = nil
+            return
+        }
+        do {
+            let data = try Data(contentsOf: candidate)
+            let hash = Self.shortHash(of: data)
+            guard hash != artifact?.contentHash else { return }
+            artifact = Artifact(
+                fileURL: candidate,
+                filename: candidate.lastPathComponent,
+                contentHash: hash,
+                byteCount: data.count,
+                loadedAt: Date()
+            )
+            reloadCount += 1
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+            Log.error("ArtifactPreviewStore: failed reading \(candidate.lastPathComponent): \(error)")
+        }
+    }
+
+    private func createDropDirectoryIfNeeded() {
+        do {
+            try FileManager.default.createDirectory(
+                at: Self.dropDirectory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            lastError = error.localizedDescription
+            Log.error("ArtifactPreviewStore: failed creating drop directory: \(error)")
+        }
+    }
+
+    private func newestHTMLFile() -> URL? {
+        let contents = try? FileManager.default.contentsOfDirectory(
+            at: Self.dropDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+        guard let contents else { return nil }
+        let htmlFiles: [URL] = contents.filter { $0.pathExtension.lowercased() == "html" }
+        return htmlFiles.max { lhs, rhs in
+            Self.modificationDate(of: lhs) < Self.modificationDate(of: rhs)
+        }
+    }
+
+    private static func modificationDate(of url: URL) -> Date {
+        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+        return values?.contentModificationDate ?? .distantPast
+    }
+
+    /// Watches the directory rather than the file. The delivery script
+    /// replaces the artifact atomically (write to a temp name, then rename),
+    /// which unlinks the inode a file-level watch is holding - that watch
+    /// would fire once and then go permanently deaf.
+    private func startWatching() {
+        guard watcher == nil else { return }
+        let descriptor = open(Self.dropDirectory.path, O_EVTONLY)
+        guard descriptor >= 0 else {
+            lastError = "Could not watch \(Constant.directoryName) (errno \(errno))"
+            Log.error("ArtifactPreviewStore: open() failed with errno \(errno)")
+            return
+        }
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                self?.scheduleReload()
+            }
+        }
+        source.setCancelHandler {
+            close(descriptor)
+        }
+        source.resume()
+        watcher = source
+    }
+
+    /// Coalesces the burst of directory events a single save produces
+    /// (create temp, rename, unlink) into one reload, and lets the writer
+    /// finish before we read.
+    private func scheduleReload() {
+        pendingReload?.cancel()
+        pendingReload = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(Constant.debounceMilliseconds))
+            guard !Task.isCancelled else { return }
+            self?.reload()
+        }
+    }
+
+    private static func shortHash(of data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private enum Constant {
+        static let directoryName: String = "ArtifactPreview"
+        static let attachmentKeyPrefix: String = "artifact-preview-"
+        static let debounceMilliseconds: Int = 150
+    }
+}

--- a/Convos/Debug View/ArtifactPreviewView.swift
+++ b/Convos/Debug View/ArtifactPreviewView.swift
@@ -1,0 +1,207 @@
+import ConvosComposer
+import ConvosCore
+import SwiftUI
+import UIKit
+
+/// Live preview for an HTML artifact written on the Mac.
+///
+/// Renders the file through the same two paths a real agent attachment
+/// takes - `HTMLThumbnailRenderer` for the 160pt message tile and
+/// `AttachmentHTMLContent` for the full-screen sheet - because the two
+/// disagree on purpose: the thumbnail pass pins `data-convos-surface`
+/// to "small", so an artifact can look right in one and broken in the
+/// other. Seeing both at once is the point of the harness.
+///
+/// Delivery is `dev/artifact-preview <file.html>`, which copies the file
+/// into the app container and re-copies it on every save.
+struct ArtifactPreviewView: View {
+    var onClose: (() -> Void)?
+
+    @State private var store: ArtifactPreviewStore = ArtifactPreviewStore()
+    @State private var thumbnail: UIImage?
+    @State private var isRenderingThumbnail: Bool = false
+    @State private var previewScheme: ColorScheme = .light
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if let artifact = store.artifact {
+                surfaces(for: artifact)
+            } else {
+                emptyState
+            }
+        }
+        .background(Color.colorBackgroundSurfaceless)
+        .task(id: thumbnailTaskKey) {
+            await renderThumbnail()
+        }
+        .onAppear(perform: store.start)
+        .onDisappear(perform: store.stop)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            HStack(spacing: DesignConstants.Spacing.step3x) {
+                VStack(alignment: .leading, spacing: 2.0) {
+                    Text(store.artifact?.filename ?? "No artifact")
+                        .font(.system(.subheadline, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+                Spacer(minLength: 0.0)
+                Button(action: store.reload) {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                if let onClose {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            Picker("Appearance", selection: $previewScheme) {
+                Text("Light").tag(ColorScheme.light)
+                Text("Dark").tag(ColorScheme.dark)
+            }
+            .pickerStyle(.segmented)
+            if let lastError = store.lastError {
+                Text(lastError)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(DesignConstants.Spacing.step3x)
+        .padding(.top, DesignConstants.Spacing.step2x)
+    }
+
+    private var subtitle: String {
+        guard let artifact = store.artifact else {
+            return "Waiting for a file"
+        }
+        let kilobytes: Double = Double(artifact.byteCount) / 1024.0
+        let size: String = String(format: "%.1f KB", kilobytes)
+        return "\(artifact.contentHash) - \(size) - reload #\(store.reloadCount)"
+    }
+
+    // MARK: - Surfaces
+
+    @ViewBuilder
+    private func surfaces(for artifact: ArtifactPreviewStore.Artifact) -> some View {
+        VStack(spacing: 0) {
+            tileSurface
+            Divider()
+            fullSurface(for: artifact)
+        }
+    }
+
+    private var tileSurface: some View {
+        HStack(alignment: .top, spacing: DesignConstants.Spacing.step4x) {
+            tileContent
+                .frame(width: Constant.tileSize, height: Constant.tileSize)
+                .background(Color.colorFillMinimal)
+                .clipShape(RoundedRectangle(cornerRadius: Constant.tileCornerRadius, style: .continuous))
+            VStack(alignment: .leading, spacing: 4.0) {
+                Text("Message tile")
+                    .font(.footnote.weight(.medium))
+                Text("160pt, data-convos-surface=small")
+                    .font(.caption2)
+                    .foregroundStyle(.colorTextSecondary)
+            }
+            Spacer(minLength: 0.0)
+        }
+        .padding(DesignConstants.Spacing.step3x)
+    }
+
+    @ViewBuilder
+    private var tileContent: some View {
+        if let thumbnail {
+            Image(uiImage: thumbnail)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: Constant.tileSize, height: Constant.tileSize, alignment: .top)
+                .clipped()
+        } else {
+            ZStack {
+                Color.clear
+                if isRenderingThumbnail {
+                    ProgressView()
+                } else {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    /// Keyed on the reload count so every save tears down the representable
+    /// and its coordinator. `AttachmentHTMLContent.updateUIView` short-
+    /// circuits when the file URL is unchanged, and the path is stable
+    /// across saves, so without a fresh identity an edit would never repaint.
+    ///
+    /// No `attachmentKey` is passed: that opts the sheet into borrowing a
+    /// prewarmed WebView, which for a live preview is exactly the stale
+    /// content we are trying to avoid.
+    private func fullSurface(for artifact: ArtifactPreviewStore.Artifact) -> some View {
+        AttachmentHTMLContent(fileURL: artifact.fileURL)
+            .id(store.reloadCount)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .environment(\.colorScheme, previewScheme)
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            Spacer()
+            Text("Drop an artifact to preview it")
+                .font(.headline)
+            Text("dev/artifact-preview path/to/artifact.html")
+                .font(.system(.footnote, design: .monospaced))
+                .foregroundStyle(.colorTextSecondary)
+            Text(ArtifactPreviewStore.dropDirectory.path)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.center)
+                .textSelection(.enabled)
+                .padding(.horizontal, DesignConstants.Spacing.step6x)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Thumbnail
+
+    private var thumbnailTaskKey: AttachmentColorSchemeKey {
+        AttachmentColorSchemeKey(
+            key: store.artifact?.attachmentKey ?? "",
+            scheme: previewScheme
+        )
+    }
+
+    private func renderThumbnail() async {
+        guard let artifact = store.artifact else {
+            thumbnail = nil
+            return
+        }
+        isRenderingThumbnail = true
+        let rendered = await HTMLThumbnailRenderer.shared.thumbnail(
+            for: artifact.attachmentKey,
+            fileURL: artifact.fileURL,
+            appearance: previewScheme.uiUserInterfaceStyle
+        )
+        isRenderingThumbnail = false
+        thumbnail = rendered
+    }
+
+    private enum Constant {
+        static let tileSize: CGFloat = 160.0
+        static let tileCornerRadius: CGFloat = 20.0
+    }
+}

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -56,6 +56,7 @@ struct DebugViewSection: View {
             subscriptionSection
             pushNotificationsSection
             debugSection
+            artifactPreviewSection
             authProbeSection
             sentryTestingSection
             pendingInvitesSection
@@ -260,6 +261,23 @@ struct DebugViewSection: View {
                 }
                 .buttonStyle(.borderless)
                 .disabled(token.isEmpty)
+            }
+        }
+    }
+
+    /// Gated here as well as by the caller: this section is only ever
+    /// reached from the non-prod debug menu today, but the harness reads a
+    /// directory any process can write to, so it states its own condition.
+    @ViewBuilder
+    private var artifactPreviewSection: some View {
+        if ArtifactPreviewGate.isAvailable(for: environment) {
+            Section("Artifacts") {
+                NavigationLink {
+                    ArtifactPreviewView()
+                } label: {
+                    Text("Artifact Live Preview")
+                        .foregroundStyle(.colorTextPrimary)
+                }
             }
         }
     }

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLContentPrewarmer.swift
@@ -173,6 +173,7 @@ public final class HTMLContentPrewarmer {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
         webView.navigationDelegate = coordinator
+        webView.enableInspectionOutsideProduction()
         window.addSubview(webView)
         let readAccessURL = fileURL.deletingLastPathComponent()
         webView.loadFileURL(fileURL, allowingReadAccessTo: readAccessURL)

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLWebViewInspection.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/HTMLWebViewInspection.swift
@@ -1,0 +1,22 @@
+#if canImport(UIKit)
+import ConvosCore
+import WebKit
+
+public extension WKWebView {
+    /// Opts the WebView into Safari's Web Inspector outside production.
+    ///
+    /// Since iOS 16.4 the inspector refuses to attach unless the WebView
+    /// sets `isInspectable`, so without this the agent-authored HTML we
+    /// render has no console, no DOM tree, and no network panel - a broken
+    /// artifact just paints blank. Production stays closed so a shipped
+    /// build never exposes its render tree to a paired Mac.
+    ///
+    /// Gated at runtime rather than behind `#if DEBUG`: the flag does not
+    /// propagate into SPM packages, so a compile-time check here would be
+    /// dead in every build of this module.
+    func enableInspectionOutsideProduction() {
+        guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+        isInspectable = true
+    }
+}
+#endif

--- a/dev/artifact-preview
+++ b/dev/artifact-preview
@@ -1,0 +1,148 @@
+#!/bin/bash
+set -eou pipefail
+
+# Usage: dev/artifact-preview <file.html> [--sim <udid>] [--scheme <name>] [--once]
+#
+# Copies an HTML artifact into the running app's container and re-copies it
+# every time the file changes, so editing the artifact on this Mac
+# re-renders it in the app. The app watches the drop directory and
+# repaints on its own; nothing needs to be rebuilt or relaunched.
+#
+# The app side lives behind ArtifactPreviewGate (non-production only) and
+# is reachable from Debug > Artifacts > Artifact Live Preview, or opened
+# automatically at launch with CONVOS_ARTIFACT_PREVIEW=1. simctl forwards
+# any SIMCTL_CHILD_-prefixed variable into the app process:
+#
+#   SIMCTL_CHILD_CONVOS_ARTIFACT_PREVIEW=1 \
+#     xcrun simctl launch --terminate-running-process <udid> <bundle-id>
+#
+# --once skips watching and copies a single time.
+
+SOURCE_FILE=""
+SIM_UDID=""
+SCHEME="Convos (Dev)"
+WATCH=true
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sim)
+            SIM_UDID="$2"
+            shift 2
+            ;;
+        --scheme)
+            SCHEME="$2"
+            shift 2
+            ;;
+        --once)
+            WATCH=false
+            shift
+            ;;
+        --help|-h)
+            sed -n '3,20p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            SOURCE_FILE="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$SOURCE_FILE" ]]; then
+    echo "error: no HTML file given" >&2
+    echo "usage: dev/artifact-preview <file.html> [--sim <udid>] [--scheme <name>] [--once]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SOURCE_FILE" ]]; then
+    echo "error: $SOURCE_FILE does not exist" >&2
+    exit 1
+fi
+
+case "$SCHEME" in
+    "Convos (Dev)")   BUNDLE_ID="org.convos.ios-preview" ;;
+    "Convos (Local)") BUNDLE_ID="org.convos.ios-local" ;;
+    "Convos (Prod)")
+        echo "error: the artifact preview harness is disabled in production builds" >&2
+        exit 1
+        ;;
+    *)
+        echo "error: unknown scheme '$SCHEME' (expected 'Convos (Dev)' or 'Convos (Local)')" >&2
+        exit 1
+        ;;
+esac
+
+repo_root="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+# Simulator resolution mirrors /run: the worktree's pinned id, then the
+# convos-task name, then whatever is booted.
+if [[ -z "$SIM_UDID" ]]; then
+    if [[ -f "$repo_root/.claude/.simulator_id" ]]; then
+        SIM_UDID="$(cat "$repo_root/.claude/.simulator_id")"
+    elif [[ -f "$repo_root/.convos-task" ]]; then
+        sim_name="$(grep '^SIMULATOR_NAME=' "$repo_root/.convos-task" | cut -d= -f2)"
+        SIM_UDID="$(xcrun simctl list devices -j | python3 -c \
+            "import json,sys; d=json.load(sys.stdin); print(next((x['udid'] for rt in d['devices'].values() for x in rt if x['name']=='$sim_name'), ''))")"
+    fi
+fi
+
+if [[ -z "$SIM_UDID" ]]; then
+    SIM_UDID="$(xcrun simctl list devices booted -j | python3 -c \
+        "import json,sys; d=json.load(sys.stdin); print(next((x['udid'] for rt in d['devices'].values() for x in rt), ''))")"
+fi
+
+if [[ -z "$SIM_UDID" ]]; then
+    echo "error: no simulator found (pass --sim <udid>, or boot one)" >&2
+    exit 1
+fi
+
+if ! container="$(xcrun simctl get_app_container "$SIM_UDID" "$BUNDLE_ID" data 2>/dev/null)"; then
+    echo "error: $BUNDLE_ID is not installed on $SIM_UDID - build and run it first" >&2
+    exit 1
+fi
+
+DROP_DIR="$container/Documents/ArtifactPreview"
+mkdir -p "$DROP_DIR"
+
+# One artifact at a time: the app picks the most recently modified .html in
+# the directory, so leftovers from a previous run would be ambiguous.
+find "$DROP_DIR" -maxdepth 1 -name '*.html' ! -name "$(basename "$SOURCE_FILE")" -delete
+
+DEST="$DROP_DIR/$(basename "$SOURCE_FILE")"
+
+# Write to a temp name and rename so the app never reads a half-written
+# file. The app watches the directory (not the file) precisely so this
+# atomic replace still wakes it.
+deliver() {
+    local tmp="$DROP_DIR/.incoming.tmp"
+    cp "$SOURCE_FILE" "$tmp"
+    mv -f "$tmp" "$DEST"
+    echo "$(date '+%H:%M:%S')  delivered $(basename "$SOURCE_FILE") ($(wc -c < "$DEST" | tr -d ' ') bytes)"
+}
+
+deliver
+echo "drop dir: $DROP_DIR"
+
+if [[ "$WATCH" == false ]]; then
+    exit 0
+fi
+
+echo "watching $SOURCE_FILE - edit and save to re-render, ctrl-c to stop"
+
+if command -v fswatch >/dev/null 2>&1; then
+    fswatch -o "$SOURCE_FILE" | while read -r _; do
+        deliver
+    done
+else
+    # No fswatch: poll the mtime. Cheap enough at 1 Hz and keeps the script
+    # dependency-free on a fresh machine.
+    last_mtime="$(stat -f %m "$SOURCE_FILE")"
+    while true; do
+        sleep 1
+        current_mtime="$(stat -f %m "$SOURCE_FILE")"
+        if [[ "$current_mtime" != "$last_mtime" ]]; then
+            last_mtime="$current_mtime"
+            deliver
+        fi
+    done
+fi


### PR DESCRIPTION
## Why

Debugging agent-authored HTML meant sending it as a real attachment and reading the result off a message bubble. Two things made that worse than it needed to be:

- **No console.** Safari's Web Inspector refuses to attach to a `WKWebView` that hasn't set `isInspectable` (iOS 16.4+), and nothing in the app set it. A broken artifact just painted blank.
- **The two surfaces disagree on purpose.** The thumbnail pass pins `data-convos-surface` to `small` (`HTMLThumbnailRenderer.swift:52`), so an artifact can look right in the tile and be broken in the sheet. You couldn't see both at once without shipping it through a conversation.

## What

```bash
./dev/artifact-preview mi-artifact.html
```

Copies the file into the app container and re-copies it on every save. The harness watches the drop directory and republishes — edit, save, the app repaints. No rebuild, no relaunch, no backend, no agent.

It renders through **the same two paths a real attachment takes**, side by side:

| Surface | Path | `data-convos-surface` |
|---|---|---|
| Message tile (160pt) | `HTMLThumbnailRenderer` | `small` |
| Full sheet | `AttachmentHTMLContent` | not set |

Plus an appearance toggle that overrides the system, so you can check both themes without touching Settings.

Reachable from **Debug → Artifacts → Artifact Live Preview**, or auto-presented at launch:

```bash
SIMCTL_CHILD_CONVOS_ARTIFACT_PREVIEW=1 xcrun simctl launch --terminate-running-process <udid> org.convos.ios-preview
```

Both entry points are non-production only (`ArtifactPreviewGate`).

## Details worth a reviewer's eye

- **Cache-busting is structural.** The published `attachmentKey` carries a SHA-256 of the file's bytes. `HTMLThumbnailRenderer` and `HTMLContentPrewarmer` both key their caches on that string, so a changed file lands on a fresh key and neither cache can serve the previous render.
- **The watch is on the directory, not the file.** The script replaces atomically (temp + rename), which unlinks the inode a file-level watch holds — that watch fires once and then goes permanently deaf.
- **The full render is keyed on the reload count.** `AttachmentHTMLContent.updateUIView` short-circuits when the file URL is unchanged, and the path is stable across saves, so without a fresh identity an edit would never repaint. It deliberately passes **no** `attachmentKey`: that opts into borrowing a prewarmed WebView holding exactly the stale content we're trying to replace.
- **`isInspectable` gating is a runtime check, not `#if DEBUG`.** The compile-time flag doesn't propagate into SPM packages and would be dead in every build of `ConvosComposer`. Enabled on the WebViews that render live content; the two thumbnail renderers are left out, since they live ~1s and would only fill Safari's target list with ghosts.

## Verification

- Build clean, no type-check warnings. SwiftLint `--strict` clean.
- Full suite: 1678 tests. One failure in `VoiceMemoTranscriptionServiceTests` (`TimeoutError`) that passes in isolation in 0.05s and only times out under full-suite load — pre-existing contention flake, unrelated to this diff.
- Exercised against **a real 373 KB agent artifact** (103 `data-convos-surface` branches, 7 inline scripts, inlined hero image), not a toy fixture: renders correctly on both surfaces and live-reloads on save.

## Known scope

Covers the inline preview and full viewer surfaces. The **starterpack tile** and **browser tab** surfaces aren't shown yet.

It also previews the **frozen** artifact — the self-contained output of the dispatch pipeline. It does **not** run the authoring pipeline, so a hand-written file in agent authoring format (bare `<convos-*>`, no `<head>`, no CSS) won't render usefully here; steps 03–08 (expand elements, canonical CSS injection, component JS) never run. Worth a follow-up if we want local authoring to match what an agent writes.

Two things I'd like a second opinion on, found while reconciling this against the runtime contract:

1. `fullPagePNGURL` / `fullPageImage` (390×844, sets `data-convos-surface = 'large'`) have **no callers anywhere in the app** — and `large` isn't a value the runtime surface list uses. Orphaned, or contract drift?
2. The dispatch contract describes the inline preview at `h≈1200`; the renderer lays the tile out at 160×160 and forces `<meta viewport width=160>`.

Neither is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788122562&installation_model_id=20076&pr_number=1263&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1263&signature=51f1e55beeb055a1bc125dca39e9a4fc40a51d685ce750c41dec32a708e449e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-app artifact live preview that renders HTML files from disk on both surfaces without sending a message
> - Adds `ArtifactPreviewView` ([ArtifactPreviewView.swift](https://github.com/xmtplabs/convos-ios/pull/1263/files#diff-5542532318dd7eb0c427debdd9df3610738314f119a6d2b6c45fffe7d451b09b)) that renders an HTML artifact both as a thumbnail tile and full-screen WebView, with a light/dark appearance toggle and live reload as the source file changes.
> - Adds `ArtifactPreviewStore` ([ArtifactPreviewStore.swift](https://github.com/xmtplabs/convos-ios/pull/1263/files#diff-9a0a08f1cffa84f5fb7f281912fe523f15e352d4d29b9ebfcf073ee20ed541c5)) to watch `Documents/ArtifactPreview` for the newest `.html` file using a `DispatchSource` file system watcher, debouncing events and computing a short content hash to detect changes.
> - A developer shell script ([artifact-preview](https://github.com/xmtplabs/convos-ios/pull/1263/files#diff-7609b2f4a180bfff2a1fd215b3ee6e8830bb13184c7728a6d937a8eb028edabc)) copies an HTML file into the simulator app container and optionally watches for changes, triggering atomic replaces to wake the watcher.
> - `ConvosApp` auto-presents the preview as a full-screen cover on launch when `CONVOS_ARTIFACT_PREVIEW=1` is set in the process environment (non-production only).
> - Adds `WKWebView.enableInspectionOutsideProduction()` ([HTMLWebViewInspection.swift](https://github.com/xmtplabs/convos-ios/pull/1263/files#diff-092e0ad953e2e51f259cb3f470764bbfdc0333450f45e849eae67df8656b72ff)) and applies it to all relevant `WKWebView` instances to allow Safari Web Inspector attachment in non-production builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d5b97cc. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->