### PR TITLE
Add agent verification status for convo photos

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/ClusteredAvatarView.swift
+++ b/ConvosCore/Sources/ConvosComposer/ClusteredAvatarView.swift
@@ -3,7 +3,7 @@ import ConvosCore
 import SwiftUI
 
 public struct ClusteredAvatarView: View {
-    let profiles: [Profile]
+    let members: [ClusteredAvatarMember]
     /// When set, the cluster lays out at this exact side length without a
     /// `GeometryReader`. The cluster nests one sub-avatar per member, so the
     /// self-sizing path otherwise stacks ~N+1 geometry-feedback passes per
@@ -12,8 +12,8 @@ public struct ClusteredAvatarView: View {
 
     private let containerBase: CGFloat = 44.0
 
-    public init(profiles: [Profile], size: CGFloat? = nil) {
-        self.profiles = profiles
+    public init(members: [ClusteredAvatarMember], size: CGFloat? = nil) {
+        self.members = members
         self.size = size
     }
 
@@ -33,11 +33,11 @@ public struct ClusteredAvatarView: View {
     private func clusterContent(side: CGFloat) -> some View {
         let scale = side / containerBase
         ZStack {
-            switch profiles.count {
+            switch members.count {
             case 0:
                 MonogramView(name: "", size: side)
             case 1:
-                singleAvatar(profile: profiles[0], size: side)
+                singleAvatar(member: members[0], size: side)
             case 2:
                 twoAvatarLayout(scale: scale)
             case 3:
@@ -58,152 +58,174 @@ public struct ClusteredAvatarView: View {
     }
 
     @ViewBuilder
-    private func singleAvatar(profile: Profile, size: CGFloat) -> some View {
-        ProfileAvatarView(profile: profile, profileImage: nil, useSystemPlaceholder: false, size: size)
-            .frame(width: size, height: size)
+    private func singleAvatar(member: ClusteredAvatarMember, size: CGFloat) -> some View {
+        ProfileAvatarView(
+            profile: member.profile,
+            profileImage: nil,
+            useSystemPlaceholder: false,
+            agentVerification: member.agentVerification,
+            size: size
+        )
+        .frame(width: size, height: size)
     }
 
     @ViewBuilder
     private func twoAvatarLayout(scale: CGFloat) -> some View {
-        avatarCircle(profile: profiles[0], size: 23 * scale)
+        avatarCircle(member: members[0], size: 23 * scale)
             .offset(x: -5.5 * scale, y: -5.5 * scale)
 
-        avatarCircle(profile: profiles[1], size: 14 * scale)
+        avatarCircle(member: members[1], size: 14 * scale)
             .offset(x: 9 * scale, y: 9 * scale)
     }
 
     @ViewBuilder
     private func threeAvatarLayout(scale: CGFloat) -> some View {
-        avatarCircle(profile: profiles[0], size: 21 * scale)
+        avatarCircle(member: members[0], size: 21 * scale)
             .offset(x: -6.5 * scale, y: -6.5 * scale)
 
-        avatarCircle(profile: profiles[1], size: 16 * scale)
+        avatarCircle(member: members[1], size: 16 * scale)
             .offset(x: 10.81 * scale, y: 3.89 * scale)
 
-        avatarCircle(profile: profiles[2], size: 14 * scale)
+        avatarCircle(member: members[2], size: 14 * scale)
             .offset(x: -3.57 * scale, y: 12.49 * scale)
     }
 
     @ViewBuilder
     private func fourAvatarLayout(scale: CGFloat) -> some View {
-        avatarCircle(profile: profiles[0], size: 21 * scale)
+        avatarCircle(member: members[0], size: 21 * scale)
             .offset(x: -6.5 * scale, y: -6.5 * scale)
 
-        avatarCircle(profile: profiles[1], size: 16 * scale)
+        avatarCircle(member: members[1], size: 16 * scale)
             .offset(x: 10.81 * scale, y: 3.89 * scale)
 
-        avatarCircle(profile: profiles[2], size: 14 * scale)
+        avatarCircle(member: members[2], size: 14 * scale)
             .offset(x: -3.57 * scale, y: 12.49 * scale)
 
-        avatarCircle(profile: profiles[3], size: 10 * scale)
+        avatarCircle(member: members[3], size: 10 * scale)
             .offset(x: 9.81 * scale, y: -10.27 * scale)
     }
 
     @ViewBuilder
     private func fiveAvatarLayout(scale: CGFloat) -> some View {
-        avatarCircle(profile: profiles[0], size: 21 * scale)
+        avatarCircle(member: members[0], size: 21 * scale)
             .offset(x: -6.5 * scale, y: -6.5 * scale)
 
-        avatarCircle(profile: profiles[1], size: 16 * scale)
+        avatarCircle(member: members[1], size: 16 * scale)
             .offset(x: 10.81 * scale, y: 3.89 * scale)
 
-        avatarCircle(profile: profiles[2], size: 14 * scale)
+        avatarCircle(member: members[2], size: 14 * scale)
             .offset(x: -3.57 * scale, y: 12.49 * scale)
 
-        avatarCircle(profile: profiles[3], size: 10 * scale)
+        avatarCircle(member: members[3], size: 10 * scale)
             .offset(x: 9.81 * scale, y: -10.27 * scale)
 
-        avatarCircle(profile: profiles[4], size: 8 * scale)
+        avatarCircle(member: members[4], size: 8 * scale)
             .offset(x: -14.5 * scale, y: 7 * scale)
     }
 
     @ViewBuilder
     private func sixAvatarLayout(scale: CGFloat) -> some View {
-        avatarCircle(profile: profiles[0], size: 21 * scale)
+        avatarCircle(member: members[0], size: 21 * scale)
             .offset(x: -6.5 * scale, y: -6.5 * scale)
 
-        avatarCircle(profile: profiles[1], size: 16 * scale)
+        avatarCircle(member: members[1], size: 16 * scale)
             .offset(x: 10.81 * scale, y: 3.89 * scale)
 
-        avatarCircle(profile: profiles[2], size: 14 * scale)
+        avatarCircle(member: members[2], size: 14 * scale)
             .offset(x: -3.57 * scale, y: 12.49 * scale)
 
-        avatarCircle(profile: profiles[3], size: 10 * scale)
+        avatarCircle(member: members[3], size: 10 * scale)
             .offset(x: 9.81 * scale, y: -10.27 * scale)
 
-        avatarCircle(profile: profiles[4], size: 8 * scale)
+        avatarCircle(member: members[4], size: 8 * scale)
             .offset(x: -14.5 * scale, y: 7 * scale)
 
-        avatarCircle(profile: profiles[5], size: 5 * scale)
+        avatarCircle(member: members[5], size: 5 * scale)
             .offset(x: 3.5 * scale, y: -17 * scale)
     }
 
     @ViewBuilder
     private func sevenAvatarLayout(scale: CGFloat) -> some View {
-        avatarCircle(profile: profiles[0], size: 21 * scale)
+        avatarCircle(member: members[0], size: 21 * scale)
             .offset(x: -6.5 * scale, y: -6.5 * scale)
 
-        avatarCircle(profile: profiles[1], size: 16 * scale)
+        avatarCircle(member: members[1], size: 16 * scale)
             .offset(x: 9.81 * scale, y: 6.04 * scale)
 
-        avatarCircle(profile: profiles[2], size: 11 * scale)
+        avatarCircle(member: members[2], size: 11 * scale)
             .offset(x: 10.5 * scale, y: -8.29 * scale)
 
-        avatarCircle(profile: profiles[3], size: 10 * scale)
+        avatarCircle(member: members[3], size: 10 * scale)
             .offset(x: -11.01 * scale, y: 10.25 * scale)
 
-        avatarCircle(profile: profiles[4], size: 8 * scale)
+        avatarCircle(member: members[4], size: 8 * scale)
             .offset(x: 1 * scale, y: 15.75 * scale)
 
-        avatarCircle(profile: profiles[5], size: 5 * scale)
+        avatarCircle(member: members[5], size: 5 * scale)
             .offset(x: 4.31 * scale, y: -16.29 * scale)
 
-        avatarCircle(profile: profiles[6], size: 5 * scale)
+        avatarCircle(member: members[6], size: 5 * scale)
             .offset(x: -2.09 * scale, y: 7.88 * scale)
     }
 
     @ViewBuilder
-    private func avatarCircle(profile: Profile, size: CGFloat) -> some View {
-        ProfileAvatarView(profile: profile, profileImage: nil, useSystemPlaceholder: false, size: size)
-            .frame(width: size, height: size)
-            .clipShape(Circle())
-            .overlay {
-                Circle()
-                    .strokeBorder(.colorBorderEdge, lineWidth: 1)
-            }
+    private func avatarCircle(member: ClusteredAvatarMember, size: CGFloat) -> some View {
+        ProfileAvatarView(
+            profile: member.profile,
+            profileImage: nil,
+            useSystemPlaceholder: false,
+            agentVerification: member.agentVerification,
+            size: size
+        )
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay {
+            Circle()
+                .strokeBorder(.colorBorderEdge, lineWidth: 1)
+        }
     }
 }
 
 #Preview {
-    let profiles: [Profile] = [
-        .mock(inboxId: "1", name: "Alice"),
-        .mock(inboxId: "2", name: "Bob"),
-        .mock(inboxId: "3", name: "Carol"),
-        .mock(inboxId: "4", name: "Dave"),
-        .mock(inboxId: "5", name: "Eve"),
-        .mock(inboxId: "6", name: "Frank"),
-        .mock(inboxId: "7", name: "Grace"),
+    let members: [ClusteredAvatarMember] = [
+        ClusteredAvatarMember(
+            profile: Profile(
+                inboxId: "1",
+                conversationId: "preview",
+                name: "Convos Agent",
+                avatar: nil,
+                isAgent: true,
+                metadata: ["emoji": .string("🤖")]
+            ),
+            agentVerification: .verified(.convos)
+        ),
+        ClusteredAvatarMember(profile: .mock(inboxId: "2", name: "Bob")),
+        ClusteredAvatarMember(profile: .mock(inboxId: "3", name: "Carol")),
+        ClusteredAvatarMember(profile: .mock(inboxId: "4", name: "Dave")),
+        ClusteredAvatarMember(profile: .mock(inboxId: "5", name: "Eve")),
+        ClusteredAvatarMember(profile: .mock(inboxId: "6", name: "Frank")),
+        ClusteredAvatarMember(profile: .mock(inboxId: "7", name: "Grace")),
     ]
 
     VStack(spacing: 16) {
         HStack(spacing: 16) {
-            ClusteredAvatarView(profiles: Array(profiles.prefix(1)))
+            ClusteredAvatarView(members: Array(members.prefix(1)))
                 .frame(width: 44, height: 44)
-            ClusteredAvatarView(profiles: Array(profiles.prefix(2)))
+            ClusteredAvatarView(members: Array(members.prefix(2)))
                 .frame(width: 44, height: 44)
-            ClusteredAvatarView(profiles: Array(profiles.prefix(3)))
+            ClusteredAvatarView(members: Array(members.prefix(3)))
                 .frame(width: 44, height: 44)
-            ClusteredAvatarView(profiles: Array(profiles.prefix(4)))
+            ClusteredAvatarView(members: Array(members.prefix(4)))
                 .frame(width: 44, height: 44)
         }
         HStack(spacing: 16) {
-            ClusteredAvatarView(profiles: Array(profiles.prefix(5)))
+            ClusteredAvatarView(members: Array(members.prefix(5)))
                 .frame(width: 44, height: 44)
-            ClusteredAvatarView(profiles: Array(profiles.prefix(6)))
+            ClusteredAvatarView(members: Array(members.prefix(6)))
                 .frame(width: 44, height: 44)
-            ClusteredAvatarView(profiles: Array(profiles.prefix(7)))
+            ClusteredAvatarView(members: Array(members.prefix(7)))
                 .frame(width: 44, height: 44)
-            ClusteredAvatarView(profiles: profiles)
+            ClusteredAvatarView(members: members)
                 .frame(width: 56, height: 56)
         }
     }

--- a/ConvosCore/Sources/ConvosComposer/ConversationAvatarViews.swift
+++ b/ConvosCore/Sources/ConvosComposer/ConversationAvatarViews.swift
@@ -123,8 +123,8 @@ public struct ConversationAvatarView: View {
             } else {
                 MonogramView(name: profile.displayName, agentVerification: verification, size: size)
             }
-        case .clustered(let profiles):
-            ClusteredAvatarView(profiles: profiles, size: size)
+        case .clustered(let members):
+            ClusteredAvatarView(members: members, size: size)
         case .emoji(let emoji):
             EmojiAvatarView(emoji: emoji, size: size)
         case .monogram(let name):

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -252,7 +252,10 @@ public extension Conversation {
         // suppress the member cluster.
         let otherProfiles = otherMembers.map(\.profile)
         if !otherProfiles.isEmpty, otherProfiles.hasAnyAvatar {
-            return .clustered(Array(otherProfiles.sortedForCluster().prefix(7)))
+            let clusterMembers = otherMembers.map {
+                ClusteredAvatarMember(profile: $0.profile, agentVerification: $0.agentVerification)
+            }
+            return .clustered(Array(clusterMembers.sortedForCluster().prefix(7)))
         }
         return .emoji(defaultEmoji)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationAvatarType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationAvatarType.swift
@@ -1,9 +1,23 @@
 import Foundation
 
+/// A single member rendered inside a clustered group avatar. Pairs the
+/// profile with its `agentVerification` so each sub-avatar can show the
+/// verified agent background color, mirroring the single-member
+/// `.profile(Profile, AgentVerification)` case.
+public struct ClusteredAvatarMember: Sendable, Equatable {
+    public let profile: Profile
+    public let agentVerification: AgentVerification
+
+    public init(profile: Profile, agentVerification: AgentVerification = .unverified) {
+        self.profile = profile
+        self.agentVerification = agentVerification
+    }
+}
+
 public enum ConversationAvatarType: Sendable, Equatable {
     case customImage
     case profile(Profile, AgentVerification)
-    case clustered([Profile])
+    case clustered([ClusteredAvatarMember])
     case emoji(String)
     case monogram(String)
     /// An Agent-Builder conversation whose verified agent hasn't joined

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Profile.swift
@@ -394,16 +394,30 @@ public extension Array where Element == Profile {
     }
 
     func sortedForCluster() -> [Profile] {
-        sorted { p1, p2 in
-            let p1HasAvatar = p1.avatarURL != nil || p1.profileEmoji != nil
-            let p2HasAvatar = p2.avatarURL != nil || p2.profileEmoji != nil
-            if p1HasAvatar != p2HasAvatar { return p1HasAvatar }
+        sorted(by: Profile.clusterSortsBefore)
+    }
+}
 
-            let p1HasName = p1.name != nil && !(p1.name ?? "").isEmpty
-            let p2HasName = p2.name != nil && !(p2.name ?? "").isEmpty
-            if p1HasName != p2HasName { return p1HasName }
+public extension Profile {
+    /// Ordering used when laying out members in a clustered group avatar:
+    /// profiles with an avatar first, then named profiles, then by inboxId
+    /// for a stable tiebreak. Shared by the profile and
+    /// `ClusteredAvatarMember` sort helpers so both order identically.
+    static func clusterSortsBefore(_ p1: Profile, _ p2: Profile) -> Bool {
+        let p1HasAvatar = p1.avatarURL != nil || p1.profileEmoji != nil
+        let p2HasAvatar = p2.avatarURL != nil || p2.profileEmoji != nil
+        if p1HasAvatar != p2HasAvatar { return p1HasAvatar }
 
-            return p1.inboxId < p2.inboxId
-        }
+        let p1HasName = p1.name != nil && !(p1.name ?? "").isEmpty
+        let p2HasName = p2.name != nil && !(p2.name ?? "").isEmpty
+        if p1HasName != p2HasName { return p1HasName }
+
+        return p1.inboxId < p2.inboxId
+    }
+}
+
+public extension Array where Element == ClusteredAvatarMember {
+    func sortedForCluster() -> [ClusteredAvatarMember] {
+        sorted { Profile.clusterSortsBefore($0.profile, $1.profile) }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DefaultConversationDisplayTests.swift
@@ -540,11 +540,49 @@ struct DefaultConversationDisplayTests {
             )
         ]
         let conversation = Conversation.mock(name: nil, members: members)
-        if case .clustered(let profiles) = conversation.avatarType {
-            #expect(profiles.contains { $0.profileEmoji == "🦊" })
+        if case .clustered(let members) = conversation.avatarType {
+            #expect(members.contains { $0.profile.profileEmoji == "🦊" })
         } else {
             #expect(Bool(false), "Expected clustered avatar type when a member has an emoji avatar")
         }
+    }
+
+    @Test("avatarType carries each member's verification into the cluster")
+    func avatarTypeClusterPreservesAgentVerification() {
+        // The clustered group avatar must thread each member's verification
+        // through so a verified agent's emoji sub-avatar renders with its
+        // agent background color instead of the plain unverified fill.
+        let members = [
+            ConversationMember.mock(isCurrentUser: true, name: "You"),
+            ConversationMember(
+                profile: Profile(
+                    inboxId: "agent1",
+                    conversationId: "test-conv",
+                    name: "Convos Agent",
+                    avatar: nil,
+                    isAgent: true,
+                    metadata: ["emoji": .string("🤖")]
+                ),
+                role: .member,
+                isCurrentUser: false,
+                isAgent: true,
+                agentVerification: .verified(.convos)
+            ),
+            ConversationMember(
+                profile: Profile(inboxId: "human1", conversationId: "test-conv", name: "Bob", avatar: nil, metadata: ["emoji": .string("🦊")]),
+                role: .member,
+                isCurrentUser: false
+            )
+        ]
+        let conversation = Conversation.mock(name: nil, members: members)
+        guard case .clustered(let clusterMembers) = conversation.avatarType else {
+            #expect(Bool(false), "Expected clustered avatar type for a group with member avatars")
+            return
+        }
+        let agent = clusterMembers.first { $0.profile.inboxId == "agent1" }
+        #expect(agent?.agentVerification == .verified(.convos))
+        let human = clusterMembers.first { $0.profile.inboxId == "human1" }
+        #expect(human?.agentVerification == .unverified)
     }
 
     @Test("avatarType clusters a group with member avatars even when a conversation emoji is seeded")
@@ -602,8 +640,8 @@ struct DefaultConversationDisplayTests {
             wasCreatedFromAgentBuilder: false
         )
 
-        if case .clustered(let profiles) = conversation.avatarType {
-            #expect(profiles.count == 2)
+        if case .clustered(let members) = conversation.avatarType {
+            #expect(members.count == 2)
         } else {
             #expect(Bool(false), "Expected clustered avatar type - a seeded conversation emoji must not suppress the member cluster")
         }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127572&installation_model_id=20076&pr_number=1264&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1264&signature=7b15798f04281cf96e744aaf5b251595219d83973938f630457cc84be83381c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent verification status to conversation photo avatars
> - Introduces `ClusteredAvatarMember` struct in [`ConversationAvatarType.swift`](https://github.com/xmtplabs/convos-ios/pull/1264/files#diff-f01e0d7ef44a4f2e5cc933e75cc76e3646f540ce7f4cb579d17b4fb77b5feaa2) pairing a `Profile` with an `AgentVerification`, replacing the bare `[Profile]` associated value on the `.clustered` case.
> - Updates [`Conversation.avatarType`](https://github.com/xmtplabs/convos-ios/pull/1264/files#diff-0f2282bb29485aa591c36f01b7679dc5a8a33d489f6535e6c332d8f13da0b859) to map each `ConversationMember` to a `ClusteredAvatarMember`, preserving per-member agent verification through to rendering.
> - Updates [`ClusteredAvatarView`](https://github.com/xmtplabs/convos-ios/pull/1264/files#diff-34953e8d4597ddfcb9bb2740d9da4557e3345dee81971b3fd78a62100b76ffa2) to accept `[ClusteredAvatarMember]` and forward each member's `agentVerification` to `ProfileAvatarView`, enabling verified-agent styling per sub-avatar.
> - Adds a test asserting that `.clustered` carries `AgentVerification` through for both verified agents and unverified humans.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33b704e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->