### PR TITLE
Bugfix/add account id property

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8b5f741bb0368c1a4edea87f00c1ec0463b181bb"
+        "revision" : "da310944a7c7ec3aa40369a22951e114749e5474"
       }
     },
     {

--- a/Convos/Conversation Detail/ConversationNavigatorImpl.swift
+++ b/Convos/Conversation Detail/ConversationNavigatorImpl.swift
@@ -29,9 +29,6 @@ final class ConversationNavigatorImpl: @preconcurrency ConversationNavigator, Na
     func present(lockedConvoInfo: LockedConvoInfoNavigatorArgs) {}
     func present(fullConvoInfo: FullConvoInfoNavigatorArgs) {}
     func present(conversationForkedInfo: ConversationForkedInfoNavigatorArgs) {}
-    // Required by the convos-shared ConversationNavigator protocol, so it cannot be
-    // dropped here. Now a no-op since the reveal-media feature was removed.
-    func present(revealMediaInfo: RevealMediaInfoNavigatorArgs) {}
     func present(photosInfo: PhotosInfoNavigatorArgs) {}
     func present(assistantConfirmation: AssistantConfirmationNavigatorArgs) {}
     func present(agentInfo: AgentInfoNavigatorArgs) {}

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -178,9 +178,16 @@ struct ConvosApp: App {
                 let messagingService = metricsSession.messagingService()
                 let inboxReady = try await messagingService.sessionStateManager.waitForInboxReadyResult()
                 coreMetrics.identify(privateKey: Data(inboxReady.client.inboxId.utf8))
+                // The backend accountId (not the XMTP inbox id) lets product
+                // analytics cross-link to backend records. Backend SIWE auth
+                // caches it in the keychain before the session reaches inbox
+                // ready, so this network-free keychain read has it by now.
+                let identityStore = KeychainIdentityStore(accessGroup: environment.keychainAccessGroup)
+                let accountId = await DeviceIdentitySnapshot.current(identityStore: identityStore).accountId
                 let builder = UserPropertiesBuilder(
                     contactsRepository: messagingService.contactsRepository(),
-                    conversationsRepository: metricsSession.conversationsRepository(for: .all)
+                    conversationsRepository: metricsSession.conversationsRepository(for: .all),
+                    accountId: accountId
                 )
                 metricsDelegate.userPropertiesCancellable = builder.publisher()
                     .sink { properties in

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3e62d21768fe925827a3661d9cbb98928ffd5071149bb6f84f00d717e287aaf7",
+  "originHash" : "f69f6a73a70ced5aee5850da0a38d9e5b06551d660cce8026403e4cc36795af8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -34,7 +34,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8b5f741bb0368c1a4edea87f00c1ec0463b181bb"
+        "revision" : "da310944a7c7ec3aa40369a22951e114749e5474"
       }
     },
     {

--- a/ConvosCore/Sources/ConvosCore/Metrics/UserPropertiesBuilder.swift
+++ b/ConvosCore/Sources/ConvosCore/Metrics/UserPropertiesBuilder.swift
@@ -5,17 +5,20 @@ import Foundation
 public final class UserPropertiesBuilder: @unchecked Sendable {
     private let contactsRepository: any ContactsRepositoryProtocol
     private let conversationsRepository: any ConversationsRepositoryProtocol
+    private let accountId: String?
     private let throttleInterval: TimeInterval
     private let throttleQueue: DispatchQueue
 
     public init(
         contactsRepository: any ContactsRepositoryProtocol,
         conversationsRepository: any ConversationsRepositoryProtocol,
+        accountId: String?,
         throttleInterval: TimeInterval = 30,
         throttleQueue: DispatchQueue = .main
     ) {
         self.contactsRepository = contactsRepository
         self.conversationsRepository = conversationsRepository
+        self.accountId = accountId
         self.throttleInterval = throttleInterval
         self.throttleQueue = throttleQueue
     }
@@ -30,8 +33,8 @@ public final class UserPropertiesBuilder: @unchecked Sendable {
         contactsRepository.contactsPublisher
             .combineLatest(conversationsRepository.conversationsPublisher)
             .throttle(for: .seconds(throttleInterval), scheduler: throttleQueue, latest: true)
-            .map { contacts, conversations in
-                Self.makeProperties(contacts: contacts, conversations: conversations)
+            .map { [accountId] contacts, conversations in
+                Self.makeProperties(contacts: contacts, conversations: conversations, accountId: accountId)
             }
             .removeDuplicates(by: Self.isEffectivelyEqual)
             .eraseToAnyPublisher()
@@ -54,7 +57,8 @@ public final class UserPropertiesBuilder: @unchecked Sendable {
 
     private static func makeProperties(
         contacts: [Contact],
-        conversations: [Conversation]
+        conversations: [Conversation],
+        accountId: String?
     ) -> UserProperties {
         let now: Date = Date()
         let cutoff24h: Date = now.addingTimeInterval(-24 * 60 * 60)
@@ -86,7 +90,8 @@ public final class UserPropertiesBuilder: @unchecked Sendable {
             assistantConversationCount: agentConversations.count,
             conversationCount24Hours: conversationCount24Hours,
             conversationCount7Days: conversationCount7Days,
-            maxActiveConvoAge: maxActiveConvoAge
+            maxActiveConvoAge: maxActiveConvoAge,
+            accountId: accountId
         )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
@@ -117,6 +117,7 @@ struct UserPropertiesBuilderTests {
         let builder = UserPropertiesBuilder(
             contactsRepository: contactsRepository,
             conversationsRepository: conversationsRepository,
+            accountId: "account-123",
             throttleInterval: 0.05,
             throttleQueue: DispatchQueue(label: "test.userprops")
         )
@@ -128,6 +129,7 @@ struct UserPropertiesBuilderTests {
         #expect(received)
         #expect(collector.values.first?.contactCount == 3)
         #expect(collector.values.first?.conversationCount == 2)
+        #expect(collector.values.first?.accountId == "account-123")
     }
 
     @Test("A burst of upstream changes collapses to a handful of emissions")
@@ -137,6 +139,7 @@ struct UserPropertiesBuilderTests {
         let builder = UserPropertiesBuilder(
             contactsRepository: contactsRepository,
             conversationsRepository: conversationsRepository,
+            accountId: nil,
             throttleInterval: 0.2,
             throttleQueue: DispatchQueue(label: "test.userprops")
         )
@@ -171,6 +174,7 @@ struct UserPropertiesBuilderTests {
         let builder = UserPropertiesBuilder(
             contactsRepository: contactsRepository,
             conversationsRepository: conversationsRepository,
+            accountId: nil,
             throttleInterval: 0.05,
             throttleQueue: DispatchQueue(label: "test.userprops")
         )


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127587&installation_model_id=20076&pr_number=1265&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1265&signature=c3214b38655166b3783aa26243c2d3f8f2ea223b8fdde14e6fd10b8c1c5e0325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `accountId` property to `UserPropertiesBuilder` in the metrics pipeline
> - Adds an optional `accountId` field to [`UserPropertiesBuilder`](https://github.com/xmtplabs/convos-ios/pull/1265/files#diff-00e70c490709bd2155dd99e126463cdddc2dbc172ce2b8fa6c8ea927c17dd108), populated at init time and forwarded into emitted `UserProperties`.
> - In [`ConvosApp`](https://github.com/xmtplabs/convos-ios/pull/1265/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014), reads the backend `accountId` from `KeychainIdentityStore` via `DeviceIdentitySnapshot.current(identityStore:)` (no network call) and passes it into the builder.
> - Removes a no-op `present(revealMediaInfo:)` method from [`ConversationNavigatorImpl`](https://github.com/xmtplabs/convos-ios/pull/1265/files#diff-a47ed57b2250013c44fa248486479d66390749cae49a691eb3c49b8ba62d1cdd).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ae15ab6. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->