### PR TITLE
Listen defaults on for the builds that go to TestFlight, off in production

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -50,19 +50,30 @@ final class FeatureFlags {
         }
     }
 
-    /// Off by default -- gates the per-conversation agent participation control
-    /// ("Listen"): Speak freely / Mentions only / Paused. Toggle from
-    /// App Settings -> Debug in non-production builds, or from the curated prod
-    /// debug menu in production. Deliberately not prod-locked like the flags
-    /// above: the control is opt-in per install and exists to dogfood Listen in
-    /// TestFlight. Default-off keeps it out of every other build.
+    /// Gates the per-conversation agent participation control ("Listen"):
+    /// Speak freely / Mentions only / Paused. Toggle from App Settings -> Debug
+    /// in non-production builds, or from the curated prod debug menu in
+    /// production. Deliberately not prod-locked like the flags above: the
+    /// control is reachable everywhere so Listen can be dogfooded in TestFlight.
+    ///
+    /// The default follows the build: on for the internal Dev/local builds that
+    /// ship to TestFlight, off for production, so end users still have to opt in
+    /// from the prod debug menu. An explicit toggle in either direction is
+    /// remembered and wins over the default.
     var isListenParticipationEnabled: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: Constant.listenParticipationEnabledKey)
+            guard let stored = UserDefaults.standard.object(forKey: Constant.listenParticipationEnabledKey) as? Bool else {
+                return Self.listenParticipationDefault
+            }
+            return stored
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Constant.listenParticipationEnabledKey)
         }
+    }
+
+    private static var listenParticipationDefault: Bool {
+        !ConfigManager.shared.currentEnvironment.isProduction
     }
 
     /// Off by default -- opts libxmtp streams onto the shared bidi wire by


### PR DESCRIPTION
The Listen participation control (Speak freely / Mentions only / Paused) has been reachable in every build but off until someone found the toggle, so each internal TestFlight install had to opt in by hand before Listen could be dogfooded.

`isListenParticipationEnabled` now falls back to a build-dependent default when no value is stored:

- **Dev / local builds** (what the internal team gets through TestFlight): on.
- **Production**: off — an end user still has to flip it from the curated prod debug menu.

An explicit toggle in either direction is persisted and wins over the default, so anyone who turns it off stays off across launches.

The default keys off `ConfigManager.shared.currentEnvironment.isProduction`, i.e. the environment/config, not the distribution channel. A production-config build shipped through TestFlight as a release candidate would still default off.

Verified with a Dev simulator build (`Convos (Dev)`, config Dev) — compiles clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788130613&installation_model_id=20076&pr_number=1266&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1266&signature=b02c639fe087d2b631463089bc820b179f5690fdfd74bf771a1c658a790ddfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `isListenParticipationEnabled` to true for TestFlight builds and false for production
> Updates `FeatureFlags.isListenParticipationEnabled` in [FeatureFlags.swift](https://github.com/xmtplabs/convos-ios/pull/1266/files#diff-9e8aa9971f330243a3592cb6d2c4793ba683385e20db0ff00777e56f02272f7c) to return an environment-based default when no stored value exists. A new private `listenParticipationDefault` property returns `true` in non-production builds and `false` in production. Previously, `bool(forKey:)` always defaulted to `false` when unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be3a580.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->