### PR TITLE
fix(consent): consent was only determined by group creator when it should take into account sender of the welcome as well

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Extensions/Group+AdderResolution.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/Group+AdderResolution.swift
@@ -1,0 +1,55 @@
+import Foundation
+@preconcurrency import XMTPiOS
+
+/// Outcome of looking up who added the local user to a group.
+///
+/// `.none` and `.unresolved` are deliberately distinct: "nobody added us" is a
+/// fact we can act on, while "the lookup failed" means we know nothing.
+/// Collapsing them lets a failed read pass as a self-created group, which would
+/// let a blocked inviter's welcome through on the creator's contact status
+/// alone.
+enum AdderResolution: Equatable {
+    /// The adder is known.
+    case known(String)
+    /// There is genuinely no adder - a group the local user created.
+    case none
+    /// The lookup itself failed. We don't know who invited us.
+    case unresolved
+
+    /// The adder when we actually resolved one, else nil. Callers that only
+    /// need "who do I record" (as opposed to "may I trust this") use this;
+    /// `.none` and `.unresolved` both mean there is nothing to persist.
+    var knownInboxId: String? {
+        switch self {
+        case let .known(inboxId): return inboxId
+        case .none, .unresolved: return nil
+        }
+    }
+}
+
+extension XMTPiOS.Group {
+    /// Who added the local user to this group.
+    ///
+    /// `addedByInboxId()` is a local libxmtp read of a NOT NULL column
+    /// (`added_by_inbox_id`), so an empty string is the genuine "no adder"
+    /// signal and it throws only when the lookup fails (a storage error, or the
+    /// group row is missing). Never rethrows - a failed read must not sink an
+    /// inbound welcome - but the failure is surfaced as `.unresolved` rather
+    /// than silently flattened, so trust decisions can fail closed.
+    ///
+    /// Single definition on purpose. Both the consent gate
+    /// (`StreamProcessor.contactsVouch`) and the persistence path
+    /// (`ConversationWriter.createDBConversation`) resolve the adder, and these
+    /// empty-vs-throw semantics are subtle enough that two copies would drift.
+    func resolvedAdder() -> AdderResolution {
+        do {
+            let addedByInboxId = try addedByInboxId()
+            return addedByInboxId.isEmpty ? .none : .known(addedByInboxId)
+        } catch {
+            Log.warning(
+                "addedByInboxId failed for \(id); treating adder as unresolved: \(error.localizedDescription)"
+            )
+            return .unresolved
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Extensions/Group+AdderResolution.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/Group+AdderResolution.swift
@@ -1,9 +1,22 @@
 import Foundation
+import GRDB
 @preconcurrency import XMTPiOS
 
-/// Outcome of looking up who added the local user to a group.
+/// Persisted discriminator for `DBConversation.adder`. Named after what was
+/// observed, not what it implies: `noAdder` is XMTP reporting no adder, which
+/// today means a group the local user created.
+enum AdderStatus: String, Codable, Hashable, CaseIterable, Sendable {
+    case resolved
+    case noAdder = "no_adder"
+    case unresolved
+    case notRecorded = "not_recorded"
+}
+
+extension AdderStatus: DatabaseValueConvertible {}
+
+/// Who added the local user to a group.
 ///
-/// `.none` and `.unresolved` are deliberately distinct: "nobody added us" is a
+/// `none` and `unresolved` are deliberately distinct: "nobody added us" is a
 /// fact we can act on, while "the lookup failed" means we know nothing.
 /// Collapsing them lets a failed read pass as a self-created group, which would
 /// let a blocked inviter's welcome through on the creator's contact status
@@ -11,18 +24,36 @@ import Foundation
 enum AdderResolution: Equatable {
     /// The adder is known.
     case known(String)
-    /// There is genuinely no adder - a group the local user created.
+    /// XMTP reports no adder - a group the local user created.
     case none
     /// The lookup itself failed. We don't know who invited us.
     case unresolved
+    /// The row predates the `addedById` column. Adjudicated on the creator
+    /// alone, matching the behavior before the column existed; upgraded on the
+    /// next write. Never returned by `resolvedAdder()`.
+    case notRecorded
 
-    /// The adder when we actually resolved one, else nil. Callers that only
-    /// need "who do I record" (as opposed to "may I trust this") use this;
-    /// `.none` and `.unresolved` both mean there is nothing to persist.
-    var knownInboxId: String? {
+    var status: AdderStatus {
         switch self {
-        case let .known(inboxId): return inboxId
-        case .none, .unresolved: return nil
+        case .known: return .resolved
+        case .none: return .noAdder
+        case .unresolved: return .unresolved
+        case .notRecorded: return .notRecorded
+        }
+    }
+
+    /// The adder when we actually resolved one, else nil.
+    var knownInboxId: String? {
+        guard case let .known(inboxId) = self else { return nil }
+        return inboxId
+    }
+
+    init(status: AdderStatus, addedById: String?) {
+        switch status {
+        case .resolved: self = addedById.map { .known($0) } ?? .unresolved
+        case .noAdder: self = .none
+        case .unresolved: self = .unresolved
+        case .notRecorded: self = .notRecorded
         }
     }
 }
@@ -32,15 +63,10 @@ extension XMTPiOS.Group {
     ///
     /// `addedByInboxId()` is a local libxmtp read of a NOT NULL column
     /// (`added_by_inbox_id`), so an empty string is the genuine "no adder"
-    /// signal and it throws only when the lookup fails (a storage error, or the
-    /// group row is missing). Never rethrows - a failed read must not sink an
-    /// inbound welcome - but the failure is surfaced as `.unresolved` rather
-    /// than silently flattened, so trust decisions can fail closed.
-    ///
-    /// Single definition on purpose. Both the consent gate
-    /// (`StreamProcessor.contactsVouch`) and the persistence path
-    /// (`ConversationWriter.createDBConversation`) resolve the adder, and these
-    /// empty-vs-throw semantics are subtle enough that two copies would drift.
+    /// signal and it throws only when the lookup fails. Never rethrows - a
+    /// failed read must not sink an inbound welcome - but the failure surfaces
+    /// as `unresolved` rather than being silently flattened, so trust decisions
+    /// can fail closed.
     func resolvedAdder() -> AdderResolution {
         do {
             let addedByInboxId = try addedByInboxId()

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -52,6 +52,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         static let hasHadVerifiedAgent: Column = Column(CodingKeys.hasHadVerifiedAgent)
         static let isAgentDm: Column = Column(CodingKeys.isAgentDm)
         static let addedById: Column = Column(CodingKeys.addedById)
+        static let adderStatus: Column = Column(CodingKeys.adderStatus)
     }
 
     let id: String
@@ -77,17 +78,21 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
     let isUnused: Bool
     let hasHadVerifiedAgent: Bool
     let isAgentDm: Bool
-    /// The inbox that added the local user to this conversation (the XMTP
-    /// welcome sender), which is *not* necessarily `creatorId` — anyone with
-    /// add permission can pull a member into a group somebody else created.
-    /// `nil` for self-created conversations, for rows written before the
-    /// column existed, and whenever libxmtp can't report an adder.
-    ///
-    /// Persisted so the passes that run long after the welcome —
-    /// `ConversationConsentReconciler` and the block-driven demote in
-    /// `ContactsWriter` — can key on the same identity `StreamProcessor` used
-    /// when it decided whether to consent on the user's behalf.
+    /// Storage for `adder` - read that instead, and set it through `init`.
+    /// The pair is kept consistent by a CHECK constraint: `addedById` is
+    /// non-null exactly when `adderStatus` is `resolved`.
     let addedById: String?
+    let adderStatus: AdderStatus
+
+    /// The inbox that added the local user, which is *not* necessarily
+    /// `creatorId` - anyone with add permission can pull a member into a group
+    /// somebody else created. Persisted so the passes that run long after the
+    /// welcome (`ConversationConsentReconciler`, the block demote in
+    /// `ContactsWriter`) key on the same identity `StreamProcessor` used when
+    /// it decided whether to consent on the user's behalf.
+    var adder: AdderResolution {
+        .init(status: adderStatus, addedById: addedById)
+    }
 
     init(
         id: String,
@@ -113,7 +118,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         isUnused: Bool,
         hasHadVerifiedAgent: Bool,
         isAgentDm: Bool = false,
-        addedById: String? = nil
+        adder: AdderResolution = .notRecorded
     ) {
         self.id = id
         self.clientConversationId = clientConversationId
@@ -138,7 +143,8 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         self.isUnused = isUnused
         self.hasHadVerifiedAgent = hasHadVerifiedAgent
         self.isAgentDm = isAgentDm
-        self.addedById = addedById
+        self.addedById = adder.knownInboxId
+        self.adderStatus = adder.status
     }
 
     static let creatorForeignKey: ForeignKey = ForeignKey(
@@ -324,7 +330,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -353,7 +359,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -382,7 +388,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -411,7 +417,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -440,7 +446,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -471,7 +477,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -500,7 +506,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -529,7 +535,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -558,7 +564,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -587,7 +593,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -616,7 +622,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -645,7 +651,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -674,7 +680,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -703,7 +709,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -732,7 +738,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -761,7 +767,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -818,7 +824,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
@@ -847,11 +853,11 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 
-    func with(addedById: String?) -> Self {
+    func with(adder: AdderResolution) -> Self {
         .init(
             id: id,
             clientConversationId: clientConversationId,
@@ -876,7 +882,7 @@ extension DBConversation {
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
-            addedById: addedById
+            adder: adder
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -51,6 +51,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         static let isUnused: Column = Column(CodingKeys.isUnused)
         static let hasHadVerifiedAgent: Column = Column(CodingKeys.hasHadVerifiedAgent)
         static let isAgentDm: Column = Column(CodingKeys.isAgentDm)
+        static let addedById: Column = Column(CodingKeys.addedById)
     }
 
     let id: String
@@ -76,6 +77,17 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
     let isUnused: Bool
     let hasHadVerifiedAgent: Bool
     let isAgentDm: Bool
+    /// The inbox that added the local user to this conversation (the XMTP
+    /// welcome sender), which is *not* necessarily `creatorId` — anyone with
+    /// add permission can pull a member into a group somebody else created.
+    /// `nil` for self-created conversations, for rows written before the
+    /// column existed, and whenever libxmtp can't report an adder.
+    ///
+    /// Persisted so the passes that run long after the welcome —
+    /// `ConversationConsentReconciler` and the block-driven demote in
+    /// `ContactsWriter` — can key on the same identity `StreamProcessor` used
+    /// when it decided whether to consent on the user's behalf.
+    let addedById: String?
 
     init(
         id: String,
@@ -100,7 +112,8 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         imageLastRenewed: Date?,
         isUnused: Bool,
         hasHadVerifiedAgent: Bool,
-        isAgentDm: Bool = false
+        isAgentDm: Bool = false,
+        addedById: String? = nil
     ) {
         self.id = id
         self.clientConversationId = clientConversationId
@@ -125,6 +138,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         self.isUnused = isUnused
         self.hasHadVerifiedAgent = hasHadVerifiedAgent
         self.isAgentDm = isAgentDm
+        self.addedById = addedById
     }
 
     static let creatorForeignKey: ForeignKey = ForeignKey(
@@ -309,7 +323,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -337,7 +352,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -365,7 +381,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -393,7 +410,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -421,7 +439,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -451,7 +470,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -479,7 +499,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -507,7 +528,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -535,7 +557,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -563,7 +586,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -591,7 +615,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -619,7 +644,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -647,7 +673,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -675,7 +702,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -703,7 +731,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -731,7 +760,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -787,7 +817,8 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 
@@ -815,7 +846,37 @@ extension DBConversation {
             imageLastRenewed: imageLastRenewed,
             isUnused: isUnused,
             hasHadVerifiedAgent: hasHadVerifiedAgent,
-            isAgentDm: isAgentDm
+            isAgentDm: isAgentDm,
+            addedById: addedById
+        )
+    }
+
+    func with(addedById: String?) -> Self {
+        .init(
+            id: id,
+            clientConversationId: clientConversationId,
+            inviteTag: inviteTag,
+            creatorId: creatorId,
+            kind: kind,
+            consent: consent,
+            createdAt: createdAt,
+            name: name,
+            description: description,
+            imageURLString: imageURLString,
+            publicImageURLString: publicImageURLString,
+            includeInfoInPublicPreview: includeInfoInPublicPreview,
+            expiresAt: expiresAt,
+            debugInfo: debugInfo,
+            isLocked: isLocked,
+            imageSalt: imageSalt,
+            imageNonce: imageNonce,
+            imageEncryptionKey: imageEncryptionKey,
+            conversationEmoji: conversationEmoji,
+            imageLastRenewed: imageLastRenewed,
+            isUnused: isUnused,
+            hasHadVerifiedAgent: hasHadVerifiedAgent,
+            isAgentDm: isAgentDm,
+            addedById: addedById
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -210,10 +210,14 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addProfilePublishJobProfileUpdatedAt", migrate: Self.addProfilePublishJobProfileUpdatedAt)
         migrator.registerMigration("addConversationLastMessagePointers", migrate: Self.addConversationLastMessagePointers)
 
-        // Must stay last: this migration was appended after the two above landed
-        // on dev, so existing installs applied those first. Registering it ahead
-        // of them re-triggers the erase described above.
+        // Appended after the two above landed on dev, so existing installs
+        // applied those first. Registering it ahead of them re-triggers the
+        // erase described above.
         Self.registerAgentDmMigrations(on: &migrator)
+
+        // Must stay last: shipped after the agent-DM migration, so installs on
+        // dev already applied that one.
+        migrator.registerMigration("addConversationAddedById", migrate: Self.addConversationAddedById)
 
         return migrator
     }
@@ -394,6 +398,28 @@ extension SharedDatabaseMigrator {
                 ORDER BY dateNs DESC LIMIT 1
             )
             """)
+    }
+
+    /// Records the XMTP welcome sender (`Group.addedByInboxId()`) on the
+    /// conversation row.
+    ///
+    /// `creatorId` is the group's original creator, which is *not* necessarily
+    /// whoever invited the local user: anyone with add permission can pull a
+    /// new member into a group somebody else created. Consent for an inbound
+    /// welcome (`StreamProcessor`), the consent reconciler, and the
+    /// block-driven demote all keyed on `creatorId` alone, so a contact adding
+    /// you to a stranger's group left the conversation at `.unknown` -
+    /// persisted, but invisible in the `.allowed`-scoped feed, and eventually
+    /// reclaimed by the stale-stranger GC.
+    ///
+    /// NULL for self-created conversations and for every row written before
+    /// this migration; those backfill naturally, since `ConversationWriter`
+    /// rebuilds the row from XMTP on the conversation's next inbound welcome
+    /// or message.
+    static func addConversationAddedById(_ db: Database) throws {
+        try db.alter(table: "conversation") { t in
+            t.add(column: "addedById", .text)
+        }
     }
 
     private static let conversationPointerExcludedContentTypes: String = """
@@ -1245,27 +1271,6 @@ extension SharedDatabaseMigrator {
     private static func registerAgentTemplateContactMigrations(on migrator: inout DatabaseMigrator) {
         migrator.registerMigration("createAgentTemplateContactTable") { db in
             try SharedDatabaseMigrator.createAgentTemplateContactSchema(db)
-        }
-
-        // `creatorId` is the group's original creator, which is *not*
-        // necessarily whoever invited the local user: anyone with add
-        // permission can pull a new member into a group somebody else
-        // created. Consent for an inbound welcome (`StreamProcessor`), the
-        // consent reconciler, and the block-driven demote all keyed on
-        // `creatorId` alone, so a contact adding you to a stranger's group
-        // left the conversation at `.unknown` — persisted, but invisible in
-        // the `.allowed`-scoped feed, and eventually reclaimed by the
-        // stale-stranger GC.
-        //
-        // `addedById` records the XMTP welcome sender
-        // (`Group.addedByInboxId()`). NULL for self-created conversations
-        // and for every row written before this migration; those backfill
-        // naturally, since `ConversationWriter` rebuilds the row from XMTP
-        // on the conversation's next inbound welcome or message.
-        migrator.registerMigration("addConversationAddedById") { db in
-            try db.alter(table: "conversation") { t in
-                t.add(column: "addedById", .text)
-            }
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -199,27 +199,27 @@ extension SharedDatabaseMigrator {
         Self.registerTailMigrations(on: &migrator)
         Self.registerMemberDepartureMigrations(on: &migrator)
 
-        // Registration is append-only across releases: new migrations go here,
-        // after every already-shipped one. Inserting earlier (e.g. into a
-        // register* group above) reorders the registered list relative to
-        // databases that already applied the later migrations, which the DEBUG
-        // eraseDatabaseOnSchemaChange replay treats as a schema change and
-        // erases an upgrading user's database.
+        Self.registerAppendOnlyMigrations(on: &migrator)
+
+        return migrator
+    }
+
+    /// Registration is append-only across releases: new migrations go here, at
+    /// the bottom, after every already-shipped one. Inserting earlier (e.g. into
+    /// a register* group above) reorders the registered list relative to
+    /// databases that already applied the later migrations, which the DEBUG
+    /// eraseDatabaseOnSchemaChange replay treats as a schema change and erases
+    /// an upgrading user's database.
+    ///
+    /// Grouped into a helper to keep `createMigrator` under the function-length
+    /// budget, the same way `registerTailMigrations` is.
+    private static func registerAppendOnlyMigrations(on migrator: inout DatabaseMigrator) {
         migrator.registerMigration("addAgentTemplateGenerationJoinIdempotencyKey",
                                    migrate: Self.addAgentTemplateGenerationJoinIdempotencyKey)
         migrator.registerMigration("addProfilePublishJobProfileUpdatedAt", migrate: Self.addProfilePublishJobProfileUpdatedAt)
         migrator.registerMigration("addConversationLastMessagePointers", migrate: Self.addConversationLastMessagePointers)
-
-        // Appended after the two above landed on dev, so existing installs
-        // applied those first. Registering it ahead of them re-triggers the
-        // erase described above.
         Self.registerAgentDmMigrations(on: &migrator)
-
-        // Must stay last: shipped after the agent-DM migration, so installs on
-        // dev already applied that one.
         migrator.registerMigration("addConversationAddedById", migrate: Self.addConversationAddedById)
-
-        return migrator
     }
 
     /// Per-conversation catch-up cursor (see DBConversationCatchUpCursor).

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -401,7 +401,7 @@ extension SharedDatabaseMigrator {
     }
 
     /// Records the XMTP welcome sender (`Group.addedByInboxId()`) on the
-    /// conversation row.
+    /// conversation row, plus how that value was arrived at.
     ///
     /// `creatorId` is the group's original creator, which is *not* necessarily
     /// whoever invited the local user: anyone with add permission can pull a
@@ -412,14 +412,18 @@ extension SharedDatabaseMigrator {
     /// persisted, but invisible in the `.allowed`-scoped feed, and eventually
     /// reclaimed by the stale-stranger GC.
     ///
-    /// NULL for self-created conversations and for every row written before
-    /// this migration; those backfill naturally, since `ConversationWriter`
-    /// rebuilds the row from XMTP on the conversation's next inbound welcome
-    /// or message.
+    /// `adderStatus` carries what a nullable `addedById` cannot: whether NULL
+    /// means "nobody added us" or "the lookup failed". Existing rows default to
+    /// `notRecorded`, which adjudicates on the creator alone exactly as before
+    /// this migration; they upgrade on the next write, since
+    /// `ConversationWriter` rebuilds the row from XMTP on every welcome and
+    /// message. The CHECK keeps the pair consistent.
     static func addConversationAddedById(_ db: Database) throws {
-        try db.alter(table: "conversation") { t in
-            t.add(column: "addedById", .text)
-        }
+        try db.execute(sql: "ALTER TABLE conversation ADD COLUMN addedById TEXT")
+        try db.execute(sql: """
+            ALTER TABLE conversation ADD COLUMN adderStatus TEXT NOT NULL DEFAULT 'not_recorded'
+                CHECK ((adderStatus = 'resolved') = (addedById IS NOT NULL))
+            """)
     }
 
     private static let conversationPointerExcludedContentTypes: String = """

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -1246,6 +1246,27 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("createAgentTemplateContactTable") { db in
             try SharedDatabaseMigrator.createAgentTemplateContactSchema(db)
         }
+
+        // `creatorId` is the group's original creator, which is *not*
+        // necessarily whoever invited the local user: anyone with add
+        // permission can pull a new member into a group somebody else
+        // created. Consent for an inbound welcome (`StreamProcessor`), the
+        // consent reconciler, and the block-driven demote all keyed on
+        // `creatorId` alone, so a contact adding you to a stranger's group
+        // left the conversation at `.unknown` — persisted, but invisible in
+        // the `.allowed`-scoped feed, and eventually reclaimed by the
+        // stale-stranger GC.
+        //
+        // `addedById` records the XMTP welcome sender
+        // (`Group.addedByInboxId()`). NULL for self-created conversations
+        // and for every row written before this migration; those backfill
+        // naturally, since `ConversationWriter` rebuilds the row from XMTP
+        // on the conversation's next inbound welcome or message.
+        migrator.registerMigration("addConversationAddedById") { db in
+            try db.alter(table: "conversation") { t in
+                t.add(column: "addedById", .text)
+            }
+        }
     }
 
     /// Tighten capabilityResolution + connectionEnablement + connectionGrant so a grant

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ContactsWriter.swift
@@ -162,7 +162,7 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
             if existing.blockedAt == nil {
                 try existing.with(blockedAt: Date()).save(db)
             }
-            return try Self.demoteVisibleConversations(db: db, creatorId: inboxId)
+            return try Self.demoteVisibleConversations(db: db, inboxId: inboxId)
         }
         // Feed is already hidden (window 0). Flip XMTP consent best-effort for
         // cross-device + re-sync durability; the local DB is authoritative so
@@ -192,14 +192,20 @@ final class ContactsWriter: ContactsWriterProtocol, @unchecked Sendable {
         }
     }
 
-    /// Demotes every still-visible conversation created by `creatorId` to
-    /// `.denied` and returns their ids. Mirrors the
-    /// `ConversationConsentReconciler` join (`conversation.creatorId =
-    /// contact.inboxId`), so shared groups the local user created stay
-    /// visible. Conversations already `.denied` are left untouched.
-    private static func demoteVisibleConversations(db: Database, creatorId: String) throws -> [String] {
+    /// Demotes every still-visible conversation `inboxId` is responsible for
+    /// to `.denied` and returns their ids. "Responsible" matches the
+    /// `ConversationConsentReconciler` predicate: conversations `inboxId`
+    /// created *or* added us to. Both are needed because either can be why
+    /// the conversation is visible at all, so demoting by creator alone
+    /// would leave groups the blocked inbox pulled us into sitting in the
+    /// feed. Shared groups the local user created stay visible, and
+    /// conversations already `.denied` are left untouched.
+    private static func demoteVisibleConversations(db: Database, inboxId: String) throws -> [String] {
         let conversationIds: [String] = try DBConversation
-            .filter(DBConversation.Columns.creatorId == creatorId)
+            .filter(
+                DBConversation.Columns.creatorId == inboxId ||
+                DBConversation.Columns.addedById == inboxId
+            )
             .filter(DBConversation.Columns.consent != Consent.denied)
             .fetchAll(db)
             .map(\.id)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -913,10 +913,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             isUnused: false,
             hasHadVerifiedAgent: metadata.hasHadVerifiedAgent,
             isAgentDm: metadata.isAgentDm,
-            // Best-effort: libxmtp throws rather than returning empty when a
-            // group has no adder (one we created ourselves), and a read
-            // failure must not sink the whole conversation write. The save
-            // path preserves any previously stored value when this is nil.
+            // nil covers both "no adder" (a group we created - libxmtp stores
+            // an empty string) and "the read failed", because neither is
+            // something to persist: we only ever record an adder we actually
+            // resolved. A read failure must not sink the whole conversation
+            // write, and the save path preserves any previously stored value
+            // when this is nil, so a transient failure can't erase one either.
+            // The trust decision keeps the two apart - see
+            // `StreamProcessor.resolveAdder`.
             addedById: (try? conversation.addedByInboxId()).flatMap { $0.isEmpty ? nil : $0 }
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -913,15 +913,20 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             isUnused: false,
             hasHadVerifiedAgent: metadata.hasHadVerifiedAgent,
             isAgentDm: metadata.isAgentDm,
-            // nil covers both "no adder" (a group we created - libxmtp stores
-            // an empty string) and "the read failed", because neither is
-            // something to persist: we only ever record an adder we actually
-            // resolved. A read failure must not sink the whole conversation
-            // write, and the save path preserves any previously stored value
-            // when this is nil, so a transient failure can't erase one either.
-            // The trust decision keeps the two apart - see
-            // `StreamProcessor.resolveAdder`.
-            addedById: (try? conversation.addedByInboxId()).flatMap { $0.isEmpty ? nil : $0 }
+            // Shares one definition of the empty-vs-throw semantics with the
+            // consent gate (`StreamProcessor.contactsVouch`), and logs rather
+            // than silently flattening a failed read.
+            //
+            // nil here covers both "no adder" and "the read failed", because
+            // neither is something to record - we only persist an adder we
+            // actually resolved. A read failure must not sink the whole
+            // conversation write, and the save path preserves any previously
+            // stored value when this is nil, so a failure can't erase one. On a
+            // brand-new row there is nothing to preserve, so a failure leaves
+            // `addedById` nil until the next store re-reads it (every welcome
+            // and catch-up runs through here) - during that window the consent
+            // reconciler and the block demote see no inviter for this row.
+            addedById: conversation.resolvedAdder().knownInboxId
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -912,7 +912,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             imageLastRenewed: imageLastRenewed,
             isUnused: false,
             hasHadVerifiedAgent: metadata.hasHadVerifiedAgent,
-            isAgentDm: metadata.isAgentDm
+            isAgentDm: metadata.isAgentDm,
+            // Best-effort: libxmtp throws rather than returning empty when a
+            // group has no adder (one we created ourselves), and a read
+            // failure must not sink the whole conversation write. The save
+            // path preserves any previously stored value when this is nil.
+            addedById: (try? conversation.addedByInboxId()).flatMap { $0.isEmpty ? nil : $0 }
         )
     }
 
@@ -984,6 +989,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         if let existingConversation {
             let mergedHasAgent: Bool = existingConversation.hasHadVerifiedAgent || conversationToSave.hasHadVerifiedAgent
             conversationToSave = conversationToSave.with(hasHadVerifiedAgent: mergedHasAgent)
+            // `addedById` is write-once: it records who invited us, which
+            // never changes. Callers with no XMTP handle (the invite
+            // placeholder path) pass nil, and a transient libxmtp read
+            // failure also yields nil — neither may erase a stored adder,
+            // since the reconciler and the block demote depend on it.
+            if conversationToSave.addedById == nil, let existingAddedById = existingConversation.addedById {
+                conversationToSave = conversationToSave.with(addedById: existingAddedById)
+            }
         }
 
         let existingConversationByTag = try existingConversationMatchingInviteTag(
@@ -1051,6 +1064,11 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 memberCount: memberCount,
                 otherMemberIsVerifiedAgent: try Self.conversationHasVerifiedAgentMember(db, conversationId: localConversation.id)
             )
+            // Same write-once rule as the by-id branch above: the row being
+            // replaced may hold the adder this read couldn't produce.
+            if conversationToSave.addedById == nil, let localAddedById = localConversation.addedById {
+                conversationToSave = conversationToSave.with(addedById: localAddedById)
+            }
             try conversationToSave.save(db, onConflict: .replace)
             firstTimeSeeingConversationExpired = conversationToSave.isExpired && conversationToSave.expiresAt != localConversation.expiresAt
             actualClientConversationId = preferredClientConversationId

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -872,6 +872,19 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         return incoming.with(isAgentDm: true)
     }
 
+    /// A resolved adder is write-once: it records who invited us, which never
+    /// changes. The invite placeholder path has no XMTP handle and a failed
+    /// libxmtp read yields `.unresolved`; neither may erase a stored adder,
+    /// since the reconciler and the block demote depend on it.
+    static func preservingResolvedAdder(incoming: DBConversation, existing: DBConversation?) -> DBConversation {
+        guard incoming.adderStatus != .resolved,
+              let existing,
+              existing.adderStatus == .resolved else {
+            return incoming
+        }
+        return incoming.with(adder: existing.adder)
+    }
+
     private func createDBConversation(
         from conversation: XMTPiOS.Group,
         metadata: ConversationMetadata,
@@ -914,19 +927,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             hasHadVerifiedAgent: metadata.hasHadVerifiedAgent,
             isAgentDm: metadata.isAgentDm,
             // Shares one definition of the empty-vs-throw semantics with the
-            // consent gate (`StreamProcessor.contactsVouch`), and logs rather
-            // than silently flattening a failed read.
-            //
-            // nil here covers both "no adder" and "the read failed", because
-            // neither is something to record - we only persist an adder we
-            // actually resolved. A read failure must not sink the whole
-            // conversation write, and the save path preserves any previously
-            // stored value when this is nil, so a failure can't erase one. On a
-            // brand-new row there is nothing to preserve, so a failure leaves
-            // `addedById` nil until the next store re-reads it (every welcome
-            // and catch-up runs through here) - during that window the consent
-            // reconciler and the block demote see no inviter for this row.
-            addedById: conversation.resolvedAdder().knownInboxId
+            // consent gate (`StreamProcessor.contactsVouch`). A failed read
+            // persists as `.unresolved` rather than being flattened to "no
+            // adder", so the reconciler can fail closed on it.
+            adder: conversation.resolvedAdder()
         )
     }
 
@@ -998,14 +1002,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         if let existingConversation {
             let mergedHasAgent: Bool = existingConversation.hasHadVerifiedAgent || conversationToSave.hasHadVerifiedAgent
             conversationToSave = conversationToSave.with(hasHadVerifiedAgent: mergedHasAgent)
-            // `addedById` is write-once: it records who invited us, which
-            // never changes. Callers with no XMTP handle (the invite
-            // placeholder path) pass nil, and a transient libxmtp read
-            // failure also yields nil — neither may erase a stored adder,
-            // since the reconciler and the block demote depend on it.
-            if conversationToSave.addedById == nil, let existingAddedById = existingConversation.addedById {
-                conversationToSave = conversationToSave.with(addedById: existingAddedById)
-            }
+            conversationToSave = Self.preservingResolvedAdder(
+                incoming: conversationToSave,
+                existing: existingConversation
+            )
         }
 
         let existingConversationByTag = try existingConversationMatchingInviteTag(
@@ -1075,9 +1075,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             )
             // Same write-once rule as the by-id branch above: the row being
             // replaced may hold the adder this read couldn't produce.
-            if conversationToSave.addedById == nil, let localAddedById = localConversation.addedById {
-                conversationToSave = conversationToSave.with(addedById: localAddedById)
-            }
+            conversationToSave = Self.preservingResolvedAdder(
+                incoming: conversationToSave,
+                existing: localConversation
+            )
             try conversationToSave.save(db, onConflict: .replace)
             firstTimeSeeingConversationExpired = conversationToSave.isExpired && conversationToSave.expiresAt != localConversation.expiresAt
             actualClientConversationId = preferredClientConversationId

--- a/ConvosCore/Sources/ConvosCore/Syncing/ConversationConsentReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/ConversationConsentReconciler.swift
@@ -159,8 +159,12 @@ final class ConversationConsentReconciler: @unchecked Sendable {
         let allowed: String = Consent.allowed.rawValue
         let denied: String = Consent.denied.rawValue
         let unknown: String = Consent.unknown.rawValue
-        // `IN (creatorId, addedById)` handles a NULL `addedById` naturally:
-        // NULL matches no contact row.
+        // `IN (creatorId, addedById)` matches no contact row when `addedById`
+        // is NULL, so an unresolved adder would otherwise be adjudicated on the
+        // creator alone - promoting a conversation whose inviter might be
+        // blocked. `adderIsAccountedFor` excludes those from promotion only;
+        // demotion stays inclusive, since narrowing it would hide less.
+        let adderIsAccountedFor = "conversation.adderStatus <> '\(AdderStatus.unresolved.rawValue)'"
         let anyRelatedContact = """
             EXISTS (
                 SELECT 1 FROM contact
@@ -180,7 +184,7 @@ final class ConversationConsentReconciler: @unchecked Sendable {
             FROM conversation
             WHERE \(anyRelatedContact)
               AND (
-                    (NOT \(anyRelatedContactBlocked) AND conversation.consent = ?)
+                    (NOT \(anyRelatedContactBlocked) AND \(adderIsAccountedFor) AND conversation.consent = ?)
                  OR (\(anyRelatedContactBlocked) AND conversation.consent <> ?)
               )
             """, arguments: [denied, allowed, unknown, denied])

--- a/ConvosCore/Sources/ConvosCore/Syncing/ConversationConsentReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/ConversationConsentReconciler.swift
@@ -3,13 +3,16 @@ import GRDB
 import os
 import XMTPiOS
 
-/// Keeps each conversation's consent in sync with its creator's contact
-/// state, which is the source of truth for feed visibility:
+/// Keeps each conversation's consent in sync with the contact state of the
+/// people responsible for it, which is the source of truth for feed
+/// visibility. "Responsible" means either the inbox that added the local
+/// user (`addedById`) or the group's creator (`creatorId`) - they differ
+/// whenever a contact adds us to a group somebody else created:
 ///
-/// - creator is a non-blocked contact -> consent `.allowed` (visible)
-/// - creator is a blocked contact     -> consent `.denied`  (hidden)
+/// - either is a non-blocked contact -> consent `.allowed` (visible)
+/// - either is a blocked contact     -> consent `.denied`  (hidden)
 ///
-/// Conversations whose creator is not a contact are left untouched: an
+/// Conversations where neither inbox is a contact are left untouched: an
 /// unsolicited stranger stays `.unknown` (hidden) and a conversation the
 /// local user joined stays `.allowed` (flipped at arrival by
 /// `StreamProcessor`). The reconciler covers two contact-state visibility
@@ -126,28 +129,61 @@ final class ConversationConsentReconciler: @unchecked Sendable {
         }
     }
 
-    /// Conversations whose stored consent disagrees with their creator's
-    /// contact-block state. The `JOIN contact` self-limits to
-    /// contact-created conversations; strangers and self-joined
-    /// stranger conversations have no matching contact row and are
-    /// ignored. Once a target is flipped its consent matches and it
-    /// drops out of this result, so the observation converges.
+    /// Conversations whose stored consent disagrees with the contact-block
+    /// state of the people responsible for them. A conversation has up to
+    /// two such inboxes and both count: `addedById` (who added the local
+    /// user) and `creatorId` (who made the group). They differ whenever a
+    /// contact adds us to a group somebody else created — matching on the
+    /// creator alone never promoted those, so a conversation a contact
+    /// invited us to stayed `.unknown` and out of the feed.
+    ///
+    /// Conversations with no contact row on either inbox are ignored:
+    /// strangers and self-joined stranger conversations. Once a target is
+    /// flipped its consent matches and it drops out of this result, so the
+    /// observation converges.
+    ///
+    /// Blocking dominates: if *either* inbox is a blocked contact the
+    /// target is `.denied`, so a contact can't be used as a conduit for
+    /// someone the user blocked. Otherwise a contact on either inbox makes
+    /// the target `.allowed`.
     ///
     /// Promotion fires only for `.unknown` (a stranger that just became a
     /// contact), never for `.denied` - a `.denied` conversation from a
     /// non-blocked contact is one the user deleted, and must stay hidden.
+    ///
+    /// Written with EXISTS sub-queries rather than a `JOIN contact`: with
+    /// two candidate inboxes a join would emit one row per matching
+    /// contact, and a conversation whose adder and creator disagree on
+    /// block state would yield two conflicting targets for the same id.
     static func fetchMismatchedTargets(db: Database) throws -> [Target] {
         let allowed: String = Consent.allowed.rawValue
         let denied: String = Consent.denied.rawValue
         let unknown: String = Consent.unknown.rawValue
+        // `IN (creatorId, addedById)` handles a NULL `addedById` naturally:
+        // NULL matches no contact row.
+        let anyRelatedContact = """
+            EXISTS (
+                SELECT 1 FROM contact
+                WHERE contact.inboxId IN (conversation.creatorId, conversation.addedById)
+            )
+            """
+        let anyRelatedContactBlocked = """
+            EXISTS (
+                SELECT 1 FROM contact
+                WHERE contact.inboxId IN (conversation.creatorId, conversation.addedById)
+                  AND contact.blockedAt IS NOT NULL
+            )
+            """
         let rows = try Row.fetchAll(db, sql: """
             SELECT conversation.id AS id,
-                   CASE WHEN contact.blockedAt IS NULL THEN ? ELSE ? END AS target
+                   CASE WHEN \(anyRelatedContactBlocked) THEN ? ELSE ? END AS target
             FROM conversation
-            JOIN contact ON contact.inboxId = conversation.creatorId
-            WHERE (contact.blockedAt IS NULL AND conversation.consent = ?)
-               OR (contact.blockedAt IS NOT NULL AND conversation.consent <> ?)
-            """, arguments: [allowed, denied, unknown, denied])
+            WHERE \(anyRelatedContact)
+              AND (
+                    (NOT \(anyRelatedContactBlocked) AND conversation.consent = ?)
+                 OR (\(anyRelatedContactBlocked) AND conversation.consent <> ?)
+              )
+            """, arguments: [denied, allowed, unknown, denied])
         return rows.compactMap { row -> Target? in
             guard let id: String = row["id"],
                   let rawConsent: String = row["target"],

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -715,10 +715,18 @@ actor StreamProcessor: StreamProcessorProtocol {
     /// reads as `.allowed` only once the local user has consented to it.
     /// As a side effect, this bumps XMTP consent `.unknown -> .allowed`
     /// when the local user has either requested to join (invite handshake)
-    /// or already has the creator as a non-blocked contact. Unsolicited
-    /// strangers stay `.unknown` (delivered but hidden from the feed) until
-    /// the creator becomes a contact, at which point `SyncingManager`'s
-    /// consent promoter flips them.
+    /// or already has a non-blocked contact vouching for the conversation.
+    /// Unsolicited strangers stay `.unknown` (delivered but hidden from the
+    /// feed) until someone involved becomes a contact, at which point
+    /// `ConversationConsentReconciler` flips them.
+    ///
+    /// "Vouching" means either of two inboxes, and both are consulted: the
+    /// **adder** (`addedByInboxId` — who actually pulled us in, i.e. the
+    /// welcome sender) and the **creator** (who originally made the group).
+    /// They differ whenever a contact adds us to a group somebody else
+    /// created, which is the common case for an established group; keying
+    /// only on the creator left those conversations at `.unknown` and so
+    /// permanently out of the feed.
     private func decideInboundConversation(
         _ conversation: XMTPiOS.Group,
         params: SyncClientParams
@@ -748,11 +756,20 @@ actor StreamProcessor: StreamProcessorProtocol {
 
         // Bump XMTP consent to `.allowed` only when the local user has
         // consented to this conversation - either by requesting to join,
-        // or because the creator is already a non-blocked contact. Strangers
-        // are delivered but left `.unknown` so they stay out of the feed.
+        // or because a non-blocked contact (the adder or the creator)
+        // vouches for it. Strangers are delivered but left `.unknown` so
+        // they stay out of the feed.
         if decision == .deliver, consent == .unknown, creatorInboxId != clientInboxId {
-            let creatorIsContact = try await isNonBlockedContact(creatorInboxId)
-            if hasOutgoingJoinRequest || creatorIsContact {
+            // Not a `||`: the right side is async-throwing, and we want the
+            // short-circuit anyway so an invite-handshake join skips the
+            // contact lookup entirely.
+            let isConsented: Bool
+            if hasOutgoingJoinRequest {
+                isConsented = true
+            } else {
+                isConsented = try await aContactVouchesFor(conversation, creatorInboxId: creatorInboxId)
+            }
+            if isConsented {
                 try await conversation.updateConsentState(state: .allowed)
             }
         }
@@ -760,14 +777,31 @@ actor StreamProcessor: StreamProcessorProtocol {
         return decision
     }
 
-    /// True when `inboxId` is a stored contact that is not blocked. Mirrors
-    /// the join used by the feed query and the consent promoter.
-    private func isNonBlockedContact(_ inboxId: String) async throws -> Bool {
-        try await databaseReader.read { db in
-            try DBContact
-                .filter(DBContact.Columns.inboxId == inboxId)
-                .filter(DBContact.Columns.blockedAt == nil)
-                .fetchCount(db) > 0
+    /// True when someone the local user trusts is responsible for this
+    /// conversation: the inbox that added us, or the group's creator, is a
+    /// stored non-blocked contact.
+    ///
+    /// Blocking wins in both directions - if *either* inbox is blocked this
+    /// returns false, so a contact cannot be used as a conduit to reach us
+    /// on behalf of someone we blocked, and blocking the adder keeps us out
+    /// of a group even when its creator is a contact.
+    private func aContactVouchesFor(
+        _ conversation: XMTPiOS.Group,
+        creatorInboxId: String
+    ) async throws -> Bool {
+        // libxmtp throws rather than returning empty when there is no adder
+        // (a group we created). Degrading to nil falls back to creator-only,
+        // which is the pre-`addedByInboxId` behavior.
+        let addedByInboxId: String? = (try? conversation.addedByInboxId()).flatMap { $0.isEmpty ? nil : $0 }
+        let inboxIds: [String] = [addedByInboxId, creatorInboxId].compactMap { $0 }
+
+        return try await databaseReader.read { db in
+            let contacts = try DBContact
+                .filter(inboxIds.contains(DBContact.Columns.inboxId))
+                .fetchAll(db)
+            guard !contacts.isEmpty else { return false }
+            guard contacts.allSatisfy({ $0.blockedAt == nil }) else { return false }
+            return true
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -767,7 +767,11 @@ actor StreamProcessor: StreamProcessorProtocol {
             if hasOutgoingJoinRequest {
                 isConsented = true
             } else {
-                isConsented = try await aContactVouchesFor(conversation, creatorInboxId: creatorInboxId)
+                isConsented = try await aContactVouchesFor(
+                    conversation,
+                    creatorInboxId: creatorInboxId,
+                    clientInboxId: clientInboxId
+                )
             }
             if isConsented {
                 try await conversation.updateConsentState(state: .allowed)
@@ -787,11 +791,13 @@ actor StreamProcessor: StreamProcessorProtocol {
     /// of a group even when its creator is a contact.
     private func aContactVouchesFor(
         _ conversation: XMTPiOS.Group,
-        creatorInboxId: String
+        creatorInboxId: String,
+        clientInboxId: String
     ) async throws -> Bool {
         try await Self.contactsVouch(
             adder: conversation.resolvedAdder(),
             creatorInboxId: creatorInboxId,
+            clientInboxId: clientInboxId,
             databaseReader: databaseReader
         )
     }
@@ -808,6 +814,7 @@ actor StreamProcessor: StreamProcessorProtocol {
     static func contactsVouch(
         adder: AdderResolution,
         creatorInboxId: String,
+        clientInboxId: String,
         databaseReader: any DatabaseReader
     ) async throws -> Bool {
         let inboxIds: [String]
@@ -815,6 +822,16 @@ actor StreamProcessor: StreamProcessorProtocol {
         case .unresolved:
             return false
         case .none:
+            // "No adder" is supposed to mean we created the group, so a foreign
+            // creator means that assumption is wrong. Logged rather than
+            // declined: unlike `.unresolved` this state is stable, so declining
+            // would hide the conversation permanently if it turns out to be
+            // reachable. Tighten only once this is known never to fire.
+            if creatorInboxId != clientInboxId {
+                Log.warning("contactsVouch: no adder on a group we did not create (creator \(creatorInboxId))")
+            }
+            inboxIds = [creatorInboxId]
+        case .notRecorded:
             inboxIds = [creatorInboxId]
         case let .known(addedByInboxId):
             inboxIds = [addedByInboxId, creatorInboxId]

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -789,11 +789,70 @@ actor StreamProcessor: StreamProcessorProtocol {
         _ conversation: XMTPiOS.Group,
         creatorInboxId: String
     ) async throws -> Bool {
-        // libxmtp throws rather than returning empty when there is no adder
-        // (a group we created). Degrading to nil falls back to creator-only,
-        // which is the pre-`addedByInboxId` behavior.
-        let addedByInboxId: String? = (try? conversation.addedByInboxId()).flatMap { $0.isEmpty ? nil : $0 }
-        let inboxIds: [String] = [addedByInboxId, creatorInboxId].compactMap { $0 }
+        try await Self.contactsVouch(
+            adder: Self.resolveAdder(conversation),
+            creatorInboxId: creatorInboxId,
+            databaseReader: databaseReader
+        )
+    }
+
+    /// Outcome of looking up who added the local user to a group. `.none` and
+    /// `.unresolved` are deliberately distinct: "nobody added us" is a fact we
+    /// can act on, while "the lookup failed" means we know nothing. Collapsing
+    /// them lets a failed read pass as a self-created group, which would let a
+    /// blocked inviter's welcome through on the creator's contact status alone.
+    enum AdderResolution: Equatable {
+        /// The adder is known.
+        case known(String)
+        /// There is genuinely no adder - a group the local user created.
+        case none
+        /// The lookup itself failed. We don't know who invited us.
+        case unresolved
+    }
+
+    /// Who added the local user to `conversation`.
+    ///
+    /// `addedByInboxId()` is a local libxmtp read of a NOT NULL column
+    /// (`added_by_inbox_id`), so an empty string is the genuine "no adder"
+    /// signal and it throws only when the lookup fails (a storage error, or
+    /// the group row is missing). Never rethrows - a failed read must not
+    /// sink the welcome - but the failure is reported as `.unresolved` so
+    /// trust decisions can fail closed.
+    static func resolveAdder(_ conversation: XMTPiOS.Group) -> AdderResolution {
+        do {
+            let addedByInboxId = try conversation.addedByInboxId()
+            return addedByInboxId.isEmpty ? .none : .known(addedByInboxId)
+        } catch {
+            Log.warning(
+                "addedByInboxId failed for \(conversation.id); treating adder as unresolved: \(error.localizedDescription)"
+            )
+            return .unresolved
+        }
+    }
+
+    /// The trust decision itself, split out from the XMTP read so it can be
+    /// exercised without a live client.
+    ///
+    /// An `.unresolved` adder never vouches: we can't rule out that a blocked
+    /// inbox invited us, so we decline to consent on the user's behalf rather
+    /// than fall back to the creator's contact status. The conversation is
+    /// still persisted, just left at `.unknown` (hidden), and the next store
+    /// re-reads the adder - `ConversationWriter` runs on every welcome and
+    /// message - so a transient failure resolves itself.
+    static func contactsVouch(
+        adder: AdderResolution,
+        creatorInboxId: String,
+        databaseReader: any DatabaseReader
+    ) async throws -> Bool {
+        let inboxIds: [String]
+        switch adder {
+        case .unresolved:
+            return false
+        case .none:
+            inboxIds = [creatorInboxId]
+        case let .known(addedByInboxId):
+            inboxIds = [addedByInboxId, creatorInboxId]
+        }
 
         return try await databaseReader.read { db in
             let contacts = try DBContact

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -790,44 +790,10 @@ actor StreamProcessor: StreamProcessorProtocol {
         creatorInboxId: String
     ) async throws -> Bool {
         try await Self.contactsVouch(
-            adder: Self.resolveAdder(conversation),
+            adder: conversation.resolvedAdder(),
             creatorInboxId: creatorInboxId,
             databaseReader: databaseReader
         )
-    }
-
-    /// Outcome of looking up who added the local user to a group. `.none` and
-    /// `.unresolved` are deliberately distinct: "nobody added us" is a fact we
-    /// can act on, while "the lookup failed" means we know nothing. Collapsing
-    /// them lets a failed read pass as a self-created group, which would let a
-    /// blocked inviter's welcome through on the creator's contact status alone.
-    enum AdderResolution: Equatable {
-        /// The adder is known.
-        case known(String)
-        /// There is genuinely no adder - a group the local user created.
-        case none
-        /// The lookup itself failed. We don't know who invited us.
-        case unresolved
-    }
-
-    /// Who added the local user to `conversation`.
-    ///
-    /// `addedByInboxId()` is a local libxmtp read of a NOT NULL column
-    /// (`added_by_inbox_id`), so an empty string is the genuine "no adder"
-    /// signal and it throws only when the lookup fails (a storage error, or
-    /// the group row is missing). Never rethrows - a failed read must not
-    /// sink the welcome - but the failure is reported as `.unresolved` so
-    /// trust decisions can fail closed.
-    static func resolveAdder(_ conversation: XMTPiOS.Group) -> AdderResolution {
-        do {
-            let addedByInboxId = try conversation.addedByInboxId()
-            return addedByInboxId.isEmpty ? .none : .known(addedByInboxId)
-        } catch {
-            Log.warning(
-                "addedByInboxId failed for \(conversation.id); treating adder as unresolved: \(error.localizedDescription)"
-            )
-            return .unresolved
-        }
     }
 
     /// The trust decision itself, split out from the XMTP read so it can be

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
@@ -46,7 +46,7 @@ struct ContactsWriterTests {
         id: String,
         creatorId: String,
         consent: Consent,
-        addedById: String? = nil
+        adder: AdderResolution = .notRecorded
     ) throws {
         try DBMember(inboxId: creatorId).save(db, onConflict: .ignore)
         try DBConversation(
@@ -72,7 +72,7 @@ struct ContactsWriterTests {
             imageLastRenewed: nil,
             isUnused: false,
             hasHadVerifiedAgent: false,
-            addedById: addedById
+            adder: adder
         ).insert(db)
     }
 
@@ -565,7 +565,7 @@ struct ContactsWriterTests {
                 id: "conv-added-by-blocked",
                 creatorId: "stranger-creator",
                 consent: .allowed,
-                addedById: blockedInboxId
+                adder: .known(blockedInboxId)
             )
             // Untouched control: neither created nor added by the blocked inbox.
             try Self.seedConversation(
@@ -573,7 +573,7 @@ struct ContactsWriterTests {
                 id: "conv-unrelated",
                 creatorId: "other-creator",
                 consent: .allowed,
-                addedById: "other-adder"
+                adder: .known("other-adder")
             )
         }
         try await writer.upsertContact(

--- a/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContactsWriterTests.swift
@@ -45,7 +45,8 @@ struct ContactsWriterTests {
         _ db: Database,
         id: String,
         creatorId: String,
-        consent: Consent
+        consent: Consent,
+        addedById: String? = nil
     ) throws {
         try DBMember(inboxId: creatorId).save(db, onConflict: .ignore)
         try DBConversation(
@@ -70,7 +71,8 @@ struct ContactsWriterTests {
             conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            addedById: addedById
         ).insert(db)
     }
 
@@ -546,6 +548,50 @@ struct ContactsWriterTests {
         // A conversation created by someone else (e.g. a shared group the
         // local user created) stays visible - mirrors the reconciler join.
         #expect(mineConsent == .allowed)
+    }
+
+    @Test("block demotes conversations the blocked inbox added us to, not just ones it created")
+    func testBlockDemotesConversationsTheBlockedInboxAddedUsTo() async throws {
+        // A conversation can be visible because its *adder* is a contact, not
+        // only its creator, so a creator-only demote would leave the groups a
+        // blocked inbox pulled us into sitting in the feed.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = ContactsWriter(databaseWriter: dbManager.dbWriter)
+        let blockedInboxId = "blocked-adder"
+
+        try await dbManager.dbWriter.write { db in
+            try Self.seedConversation(
+                db,
+                id: "conv-added-by-blocked",
+                creatorId: "stranger-creator",
+                consent: .allowed,
+                addedById: blockedInboxId
+            )
+            // Untouched control: neither created nor added by the blocked inbox.
+            try Self.seedConversation(
+                db,
+                id: "conv-unrelated",
+                creatorId: "other-creator",
+                consent: .allowed,
+                addedById: "other-adder"
+            )
+        }
+        try await writer.upsertContact(
+            inboxId: blockedInboxId,
+            addedViaConversationId: nil,
+            profile: ContactProfileSnapshot(displayName: "Blocked adder")
+        )
+
+        try await writer.block(inboxId: blockedInboxId)
+
+        let (addedByBlocked, unrelated) = try await dbManager.dbReader.read { db in
+            try (
+                DBConversation.fetchOne(db, key: "conv-added-by-blocked")?.consent,
+                DBConversation.fetchOne(db, key: "conv-unrelated")?.consent
+            )
+        }
+        #expect(addedByBlocked == .denied)
+        #expect(unrelated == .allowed)
     }
 
     @Test("agentVerification persists on a new contact via upsert")

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationAddedByIdMigrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationAddedByIdMigrationTests.swift
@@ -68,7 +68,7 @@ struct ConversationAddedByIdMigrationTests {
         }
     }
 
-    @Test("Rows written before the migration survive it, defaulting to NULL")
+    @Test("Rows written before the migration survive it, defaulting to notRecorded")
     func testPreExistingRowsSurviveWithNullAdder() throws {
         let database = try DatabaseQueue()
         try SharedDatabaseMigrator.shared.migrate(
@@ -103,8 +103,93 @@ struct ConversationAddedByIdMigrationTests {
         }
         #expect(row != nil)
         #expect(row?.addedById == nil)
+        // Legacy rows adjudicate on the creator alone, as they did before the
+        // column existed - not fail-closed, which would freeze them out of
+        // promotion until something rewrote them.
+        #expect(row?.adderStatus == .notRecorded)
+        #expect(row?.adder == .notRecorded)
         // The migration must not disturb the rest of the row.
         #expect(row?.creatorId == "creator-inbox")
         #expect(row?.consent == .allowed)
+    }
+
+    @Test("The CHECK rejects a status that disagrees with addedById")
+    func testCheckConstraintRejectsInconsistentPair() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: database)
+
+        let debugInfo = String(decoding: try JSONEncoder().encode(ConversationDebugInfo.empty), as: UTF8.self)
+        let insertInconsistent: (Database, String, String?, String) throws -> Void = { db, id, addedById, status in
+            try db.execute(
+                sql: """
+                    INSERT INTO conversation
+                        (id, clientConversationId, inviteTag, creatorId, kind, consent,
+                         createdAt, includeInfoInPublicPreview, isLocked, isUnused,
+                         hasHadVerifiedAgent, debugInfo, addedById, adderStatus)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, ?, ?, ?)
+                    """,
+                arguments: [
+                    id, "client-\(id)", "tag-\(id)", "creator-inbox",
+                    ConversationKind.group.rawValue, Consent.allowed.rawValue, Date(), debugInfo,
+                    addedById, status
+                ]
+            )
+        }
+
+        // resolved without an id, and an id without resolved.
+        #expect(throws: DatabaseError.self) {
+            try database.write { db in try insertInconsistent(db, "bad-1", nil, AdderStatus.resolved.rawValue) }
+        }
+        #expect(throws: DatabaseError.self) {
+            try database.write { db in try insertInconsistent(db, "bad-2", "adder-inbox", AdderStatus.unresolved.rawValue) }
+        }
+        try database.write { db in
+            try insertInconsistent(db, "good", "adder-inbox", AdderStatus.resolved.rawValue)
+        }
+    }
+
+    @Test("Every AdderResolution case round-trips through the row")
+    func testAdderRoundTrips() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: database)
+
+        let cases: [AdderResolution] = [.known("adder-inbox"), .none, .unresolved, .notRecorded]
+        for (index, adder) in cases.enumerated() {
+            let id = "convo-\(index)"
+            try database.write { db in
+                try DBMember(inboxId: "creator-inbox").save(db, onConflict: .ignore)
+                try Self.makeConversation(id: id, adder: adder).insert(db)
+            }
+            let row = try database.read { db in try DBConversation.fetchOne(db, key: id) }
+            #expect(row?.adder == adder)
+        }
+    }
+
+    private static func makeConversation(id: String, adder: AdderResolution) -> DBConversation {
+        DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: "creator-inbox",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+            adder: adder
+        )
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationAddedByIdMigrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationAddedByIdMigrationTests.swift
@@ -1,0 +1,110 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Guards `addConversationAddedById` — specifically its *position* in the
+/// migrator.
+///
+/// Migration registration is append-only. A migration inserted ahead of an
+/// already-shipped one reorders the registered list relative to databases that
+/// already applied the later ones, and the DEBUG `eraseDatabaseOnSchemaChange`
+/// replay then treats that as a schema change and erases an upgrading user's
+/// database. DEBUG covers the Dev and PR TestFlight configs, so the blast
+/// radius is real users, not just local builds.
+///
+/// A fresh migrate passes either way — which is exactly why this slipped
+/// through review once. These tests drive the *upgrade* path: migrate to the
+/// migration that shipped immediately before this one, then finish, and check
+/// the column arrives in place.
+@Suite("addConversationAddedById migration", .serialized)
+struct ConversationAddedByIdMigrationTests {
+    /// The last migration registered before `addConversationAddedById`.
+    private static let previousTailMigration: String = "addConversationIsAgentDm"
+
+    private static func conversationHasAddedById(_ db: Database) throws -> Bool {
+        try db.columns(in: "conversation").contains { $0.name == "addedById" }
+    }
+
+    @Test("Registered after the previously-shipped tail migration, not ahead of it")
+    func testRegisteredAfterPreviousTail() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(
+            database: database,
+            upTo: Self.previousTailMigration
+        )
+
+        // If this migration were registered earlier in the list, stopping at
+        // the previous tail would already have added the column.
+        try database.read { db in
+            let hasColumn = try Self.conversationHasAddedById(db)
+            #expect(!hasColumn)
+        }
+    }
+
+    @Test("Applies in place to a database that stopped before it")
+    func testAppliesOnUpgrade() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(
+            database: database,
+            upTo: Self.previousTailMigration
+        )
+        try SharedDatabaseMigrator.shared.migrate(database: database)
+
+        try database.read { db in
+            let hasColumn = try Self.conversationHasAddedById(db)
+            #expect(hasColumn)
+        }
+    }
+
+    @Test("A fresh install gets the column too")
+    func testAppliesOnFreshInstall() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: database)
+
+        try database.read { db in
+            let hasColumn = try Self.conversationHasAddedById(db)
+            #expect(hasColumn)
+        }
+    }
+
+    @Test("Rows written before the migration survive it, defaulting to NULL")
+    func testPreExistingRowsSurviveWithNullAdder() throws {
+        let database = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(
+            database: database,
+            upTo: Self.previousTailMigration
+        )
+
+        // Raw SQL: `DBConversation` encodes today's full column set, which the
+        // historical schema doesn't have yet. `debugInfo` is non-optional on
+        // the model, so it still has to be supplied for the read-back below.
+        let debugInfo = String(decoding: try JSONEncoder().encode(ConversationDebugInfo.empty), as: UTF8.self)
+        try database.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO conversation
+                        (id, clientConversationId, inviteTag, creatorId, kind, consent,
+                         createdAt, includeInfoInPublicPreview, isLocked, isUnused,
+                         hasHadVerifiedAgent, debugInfo)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, ?)
+                    """,
+                arguments: [
+                    "convo-legacy", "client-convo-legacy", "tag-convo-legacy", "creator-inbox",
+                    ConversationKind.group.rawValue, Consent.allowed.rawValue, Date(), debugInfo
+                ]
+            )
+        }
+
+        try SharedDatabaseMigrator.shared.migrate(database: database)
+
+        let row = try database.read { db in
+            try DBConversation.fetchOne(db, key: "convo-legacy")
+        }
+        #expect(row != nil)
+        #expect(row?.addedById == nil)
+        // The migration must not disturb the rest of the row.
+        #expect(row?.creatorId == "creator-inbox")
+        #expect(row?.consent == .allowed)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationConsentReconcilerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationConsentReconcilerTests.swift
@@ -92,7 +92,7 @@ struct ConversationConsentReconcilerTests {
                 id: "convo-added-by-contact",
                 creatorId: "stranger-creator",
                 consent: .unknown,
-                addedById: "contact-adder"
+                adder: .known("contact-adder")
             )
         }
 
@@ -116,7 +116,7 @@ struct ConversationConsentReconcilerTests {
                 id: "convo-blocked-adder",
                 creatorId: "contact-creator",
                 consent: .allowed,
-                addedById: "blocked-adder"
+                adder: .known("blocked-adder")
             )
         }
 
@@ -140,7 +140,7 @@ struct ConversationConsentReconcilerTests {
                 id: "convo-blocked-creator",
                 creatorId: "blocked-creator",
                 consent: .allowed,
-                addedById: "contact-adder"
+                adder: .known("contact-adder")
             )
         }
 
@@ -165,7 +165,7 @@ struct ConversationConsentReconcilerTests {
                 id: "convo-two-contacts",
                 creatorId: "contact-creator",
                 consent: .unknown,
-                addedById: "contact-adder"
+                adder: .known("contact-adder")
             )
         }
 
@@ -185,7 +185,7 @@ struct ConversationConsentReconcilerTests {
                 id: "convo-stranger-adder",
                 creatorId: "stranger-creator",
                 consent: .unknown,
-                addedById: "stranger-adder"
+                adder: .known("stranger-adder")
             )
         }
 
@@ -194,6 +194,74 @@ struct ConversationConsentReconcilerTests {
         }
 
         #expect(targets.isEmpty)
+    }
+
+    @Test("An unresolved adder is not promoted on the creator's contact status")
+    func testUnresolvedAdderIsNotPromoted() throws {
+        // The inviter could be anyone, including someone blocked, so promoting
+        // on the creator alone would undo `contactsVouch`'s fail-closed choice.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "contact-creator", blockedAt: nil)
+            try Self.seedConversation(
+                db: db,
+                id: "convo-unresolved-adder",
+                creatorId: "contact-creator",
+                consent: .unknown,
+                adder: .unresolved
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets.isEmpty)
+    }
+
+    @Test("An unresolved adder is still demoted when the creator is blocked")
+    func testUnresolvedAdderIsStillDemoted() throws {
+        // Fail-closed narrows promotion only - demotion stays inclusive.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "blocked-creator", blockedAt: Date())
+            try Self.seedConversation(
+                db: db,
+                id: "convo-unresolved-blocked",
+                creatorId: "blocked-creator",
+                consent: .allowed,
+                adder: .unresolved
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets == [.init(conversationId: "convo-unresolved-blocked", consent: .denied)])
+    }
+
+    @Test("A row predating the adder column is still promoted on the creator")
+    func testNotRecordedAdderIsPromotedOnCreator() throws {
+        // Preserves the behavior these rows had before the column existed;
+        // they upgrade on the next write.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "contact-creator", blockedAt: nil)
+            try Self.seedConversation(
+                db: db,
+                id: "convo-legacy",
+                creatorId: "contact-creator",
+                consent: .unknown,
+                adder: .notRecorded
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets == [.init(conversationId: "convo-legacy", consent: .allowed)])
     }
 
     private static func seedContact(db: Database, inboxId: String, blockedAt: Date?) throws {
@@ -217,7 +285,7 @@ struct ConversationConsentReconcilerTests {
         id: String,
         creatorId: String,
         consent: Consent,
-        addedById: String? = nil
+        adder: AdderResolution = .notRecorded
     ) throws {
         try DBMember(inboxId: creatorId).save(db, onConflict: .ignore)
         try DBConversation(
@@ -243,7 +311,7 @@ struct ConversationConsentReconcilerTests {
             imageLastRenewed: nil,
             isUnused: false,
             hasHadVerifiedAgent: false,
-            addedById: addedById
+            adder: adder
         ).insert(db)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationConsentReconcilerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationConsentReconcilerTests.swift
@@ -78,6 +78,124 @@ struct ConversationConsentReconcilerTests {
         #expect(targets.isEmpty)
     }
 
+    @Test("Contact who added us promotes .unknown even though the creator is a stranger")
+    func testPromotesWhenAdderIsAContactAndCreatorIsNot() throws {
+        // The regression: an established group made by someone we don't know,
+        // which a contact of ours pulls us into. Matching only on creatorId
+        // never promoted this, so the conversation stayed .unknown and never
+        // reached the .allowed-scoped feed.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "contact-adder", blockedAt: nil)
+            try Self.seedConversation(
+                db: db,
+                id: "convo-added-by-contact",
+                creatorId: "stranger-creator",
+                consent: .unknown,
+                addedById: "contact-adder"
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets == [.init(conversationId: "convo-added-by-contact", consent: .allowed)])
+    }
+
+    @Test("A blocked adder demotes even when the creator is a non-blocked contact")
+    func testBlockedAdderDemotesDespiteContactCreator() throws {
+        // Blocking dominates: a blocked inbox must not reach us by adding us
+        // to a group someone we trust happens to have created.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "contact-creator", blockedAt: nil)
+            try Self.seedContact(db: db, inboxId: "blocked-adder", blockedAt: Date())
+            try Self.seedConversation(
+                db: db,
+                id: "convo-blocked-adder",
+                creatorId: "contact-creator",
+                consent: .allowed,
+                addedById: "blocked-adder"
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets == [.init(conversationId: "convo-blocked-adder", consent: .denied)])
+    }
+
+    @Test("A blocked creator demotes even when a non-blocked contact added us")
+    func testBlockedCreatorDemotesDespiteContactAdder() throws {
+        // The mirror case: a contact can't be used as a conduit to pull us
+        // into a group made by someone we blocked.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "blocked-creator", blockedAt: Date())
+            try Self.seedContact(db: db, inboxId: "contact-adder", blockedAt: nil)
+            try Self.seedConversation(
+                db: db,
+                id: "convo-blocked-creator",
+                creatorId: "blocked-creator",
+                consent: .allowed,
+                addedById: "contact-adder"
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets == [.init(conversationId: "convo-blocked-creator", consent: .denied)])
+    }
+
+    @Test("A conversation whose adder and creator are both contacts yields exactly one target")
+    func testTwoMatchingContactsDoNotDuplicateTargets() throws {
+        // Guards the switch from `JOIN contact` to EXISTS sub-queries: a join
+        // emits one row per matching contact, so this conversation would have
+        // produced two identical targets and reconciled twice.
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: "contact-creator", blockedAt: nil)
+            try Self.seedContact(db: db, inboxId: "contact-adder", blockedAt: nil)
+            try Self.seedConversation(
+                db: db,
+                id: "convo-two-contacts",
+                creatorId: "contact-creator",
+                consent: .unknown,
+                addedById: "contact-adder"
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets == [.init(conversationId: "convo-two-contacts", consent: .allowed)])
+    }
+
+    @Test("A stranger adder leaves the conversation untouched")
+    func testStrangerAdderIsNotPromoted() throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try dbManager.dbWriter.write { db in
+            try Self.seedConversation(
+                db: db,
+                id: "convo-stranger-adder",
+                creatorId: "stranger-creator",
+                consent: .unknown,
+                addedById: "stranger-adder"
+            )
+        }
+
+        let targets = try dbManager.dbReader.read { db in
+            try ConversationConsentReconciler.fetchMismatchedTargets(db: db)
+        }
+
+        #expect(targets.isEmpty)
+    }
+
     private static func seedContact(db: Database, inboxId: String, blockedAt: Date?) throws {
         try DBContact(
             inboxId: inboxId,
@@ -98,7 +216,8 @@ struct ConversationConsentReconcilerTests {
         db: Database,
         id: String,
         creatorId: String,
-        consent: Consent
+        consent: Consent,
+        addedById: String? = nil
     ) throws {
         try DBMember(inboxId: creatorId).save(db, onConflict: .ignore)
         try DBConversation(
@@ -123,7 +242,8 @@ struct ConversationConsentReconcilerTests {
             conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            addedById: addedById
         ).insert(db)
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/StreamProcessorAdderVouchingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/StreamProcessorAdderVouchingTests.swift
@@ -18,6 +18,7 @@ import Testing
 struct StreamProcessorAdderVouchingTests {
     private static let creator: String = "creator-inbox"
     private static let adder: String = "adder-inbox"
+    private static let client: String = "client-inbox"
 
     @Test("A non-blocked contact who added us vouches, even when the creator is a stranger")
     func testKnownContactAdderVouches() async throws {
@@ -29,6 +30,24 @@ struct StreamProcessorAdderVouchingTests {
         let vouched = try await StreamProcessor.contactsVouch(
             adder: .known(Self.adder),
             creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(vouched)
+    }
+
+    @Test("A non-blocked contact creator vouches for a row that predates the adder column")
+    func testContactCreatorVouchesWhenAdderNotRecorded() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: Self.creator, blockedAt: nil)
+        }
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .notRecorded,
+            creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
             databaseReader: dbManager.dbReader
         )
 
@@ -37,6 +56,8 @@ struct StreamProcessorAdderVouchingTests {
 
     @Test("A non-blocked contact creator vouches when there is genuinely no adder")
     func testContactCreatorVouchesWhenNoAdder() async throws {
+        // A foreign creator here is logged as an anomaly but deliberately still
+        // vouches - see `contactsVouch`.
         let dbManager = MockDatabaseManager.makeTestDatabase()
         try await dbManager.dbWriter.write { db in
             try Self.seedContact(db: db, inboxId: Self.creator, blockedAt: nil)
@@ -45,6 +66,7 @@ struct StreamProcessorAdderVouchingTests {
         let vouched = try await StreamProcessor.contactsVouch(
             adder: .none,
             creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
             databaseReader: dbManager.dbReader
         )
 
@@ -68,6 +90,7 @@ struct StreamProcessorAdderVouchingTests {
         let vouched = try await StreamProcessor.contactsVouch(
             adder: .unresolved,
             creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
             databaseReader: dbManager.dbReader
         )
 
@@ -85,6 +108,7 @@ struct StreamProcessorAdderVouchingTests {
         let vouched = try await StreamProcessor.contactsVouch(
             adder: .known(Self.adder),
             creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
             databaseReader: dbManager.dbReader
         )
 
@@ -102,6 +126,7 @@ struct StreamProcessorAdderVouchingTests {
         let vouched = try await StreamProcessor.contactsVouch(
             adder: .known(Self.adder),
             creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
             databaseReader: dbManager.dbReader
         )
 
@@ -115,6 +140,7 @@ struct StreamProcessorAdderVouchingTests {
         let vouched = try await StreamProcessor.contactsVouch(
             adder: .known(Self.adder),
             creatorInboxId: Self.creator,
+            clientInboxId: Self.client,
             databaseReader: dbManager.dbReader
         )
 

--- a/ConvosCore/Tests/ConvosCoreTests/StreamProcessorAdderVouchingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/StreamProcessorAdderVouchingTests.swift
@@ -1,0 +1,139 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for `StreamProcessor.contactsVouch` - the trust decision behind the
+/// `.unknown -> .allowed` consent bump on an inbound welcome.
+///
+/// A conversation is consented to on the local user's behalf when someone they
+/// trust is responsible for it: the inbox that *added* them, or the group's
+/// creator. Those differ whenever a contact adds you to a group somebody else
+/// made, which is the case the creator-only rule used to get wrong.
+///
+/// The adder lookup is a local libxmtp read that can fail. A failed read is not
+/// the same as "there is no adder", and collapsing the two would let a blocked
+/// inviter's welcome through on the creator's contact status alone.
+@Suite("StreamProcessor adder vouching", .serialized)
+struct StreamProcessorAdderVouchingTests {
+    private static let creator: String = "creator-inbox"
+    private static let adder: String = "adder-inbox"
+
+    @Test("A non-blocked contact who added us vouches, even when the creator is a stranger")
+    func testKnownContactAdderVouches() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: Self.adder, blockedAt: nil)
+        }
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .known(Self.adder),
+            creatorInboxId: Self.creator,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(vouched)
+    }
+
+    @Test("A non-blocked contact creator vouches when there is genuinely no adder")
+    func testContactCreatorVouchesWhenNoAdder() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: Self.creator, blockedAt: nil)
+        }
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .none,
+            creatorInboxId: Self.creator,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(vouched)
+    }
+
+    @Test("An unresolved adder never vouches, even when the creator is a contact")
+    func testUnresolvedAdderNeverVouches() async throws {
+        // The regression: a failed adder read used to degrade to nil and fall
+        // back to creator-only, so a blocked inviter reached the local user on
+        // the creator's contact status. We can't rule that out, so we decline
+        // to consent and leave the conversation at `.unknown` (hidden).
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: Self.creator, blockedAt: nil)
+            // The (unreadable) adder happens to be blocked - the case the
+            // fail-closed rule exists to protect.
+            try Self.seedContact(db: db, inboxId: Self.adder, blockedAt: Date())
+        }
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .unresolved,
+            creatorInboxId: Self.creator,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(!vouched)
+    }
+
+    @Test("A blocked adder blocks vouching even when the creator is a contact")
+    func testBlockedAdderVetoesContactCreator() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: Self.creator, blockedAt: nil)
+            try Self.seedContact(db: db, inboxId: Self.adder, blockedAt: Date())
+        }
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .known(Self.adder),
+            creatorInboxId: Self.creator,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(!vouched)
+    }
+
+    @Test("A blocked creator blocks vouching even when a contact added us")
+    func testBlockedCreatorVetoesContactAdder() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        try await dbManager.dbWriter.write { db in
+            try Self.seedContact(db: db, inboxId: Self.creator, blockedAt: Date())
+            try Self.seedContact(db: db, inboxId: Self.adder, blockedAt: nil)
+        }
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .known(Self.adder),
+            creatorInboxId: Self.creator,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(!vouched)
+    }
+
+    @Test("Strangers on both sides do not vouch")
+    func testStrangersDoNotVouch() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+
+        let vouched = try await StreamProcessor.contactsVouch(
+            adder: .known(Self.adder),
+            creatorInboxId: Self.creator,
+            databaseReader: dbManager.dbReader
+        )
+
+        #expect(!vouched)
+    }
+
+    private static func seedContact(db: Database, inboxId: String, blockedAt: Date?) throws {
+        try DBContact(
+            inboxId: inboxId,
+            addedAt: Date(),
+            addedViaConversationId: nil,
+            displayName: nil,
+            avatarURL: nil,
+            avatarSalt: nil,
+            avatarNonce: nil,
+            avatarKey: nil,
+            profileUpdatedAt: Date(),
+            blockedAt: blockedAt,
+            agentVerification: nil
+        ).insert(db)
+    }
+}


### PR DESCRIPTION
fix(consent): consent was only determined by group creator when it should take into account sender of the welcome as well

fix(consent): don't let a failed adder lookup pass as no adder

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788135401&installation_model_id=20076&pr_number=1267&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1267&signature=06b542a926edbc416a28511f53034dcb4f689f28772d81225fddb8662500f38c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix group consent to account for the sender of the welcome, not just the group creator
> - Adds `addedById` and `adderStatus` columns to the conversation table via a new migration, storing who added the local user to a group alongside a discriminator enum (`resolved`, `unresolved`, `none`, `not_recorded`).
> - Updates `StreamProcessor.contactsVouch` to require both the adder and creator to be non-blocked contacts before auto-consenting an inbound conversation; an unresolved adder blocks promotion entirely (fail-closed).
> - Updates `ConversationConsentReconciler.fetchMismatchedTargets` to promote conversations where the adder is a contact (even if the creator is a stranger), demote when either responsible inbox is blocked, and skip promotion when adder status is unresolved.
> - Updates `ContactsWriter.demoteVisibleConversations` to demote conversations where the blocked inbox is the adder, not only the creator.
> - Risk: conversations with an unresolved adder (e.g. XMTP read failure) will not be auto-consented even if the creator is a trusted contact, changing prior behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 112b07f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->