### PR TITLE
fix: unbreak dev — migrate AgentDmPageView off the deleted composer attachments menu

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -43,10 +43,6 @@ struct AgentDmPageView: View {
     @State private var draftText: String = ""
     @State private var isCreatingDm: Bool = false
     @State private var draftPhotoPickerPresented: Bool = false
-    /// The attachments card the composer's `+` opens on the full DM page.
-    /// Drawn here for the same reason ConversationView draws its own: the
-    /// composer lives in a safe-area bar and can't float a card past it.
-    @State private var attachmentsMenu: ComposerAttachmentsMenuCoordinator = .init()
 
     private var agent: ConversationMember? {
         viewModel.conversation.members.first { $0.profile.inboxId == agentInboxId }
@@ -60,8 +56,6 @@ struct AgentDmPageView: View {
         Group {
             if let dmViewModel {
                 dmMessagesViewWithSheets(dmViewModel)
-                    .environment(\.composerAttachmentsMenu, attachmentsMenu)
-                    .overlay { attachmentsOverlay }
             } else {
                 emptyStateWithComposer
             }
@@ -430,54 +424,6 @@ struct AgentDmPageView: View {
             coreActions: dmVm.coreActions
         )
         PaywallView(viewModel: paywallViewModel)
-    }
-
-    // MARK: - Attachments card
-
-    /// The card the composer's `+` opens on the full DM page. Floated just above
-    /// the composer over a scrim that takes the outside tap, mirroring
-    /// ConversationView's own attachments card. Empty until the `+` is tapped.
-    @ViewBuilder
-    private var attachmentsOverlay: some View {
-        if attachmentsMenu.isPresented {
-            composerCard(bottomInset: extraBottomInset) {
-                attachmentsMenu.dismiss()
-            } card: {
-                ComposerAttachmentsMenu(
-                    actions: attachmentsMenu.actions,
-                    disabledActions: attachmentsMenu.disabledActions,
-                    showsBackground: true,
-                    onSelect: attachmentsMenu.select
-                )
-                // Hugs its rows: the list is a few short names, and a card
-                // stretched to the composer's width would be mostly empty.
-                .fixedSize()
-            }
-        }
-    }
-
-    /// The shared placement for a card opened from the DM composer: floated above
-    /// the bar, leading-aligned with it, over a scrim that takes the outside tap.
-    @ViewBuilder
-    private func composerCard<Card: View>(
-        bottomInset: CGFloat,
-        onDismiss: @escaping () -> Void,
-        @ViewBuilder card: () -> Card
-    ) -> some View {
-        ZStack(alignment: .bottomLeading) {
-            Color.black.opacity(0.001)
-                .ignoresSafeArea()
-                .contentShape(.rect)
-                .onTapGesture(perform: onDismiss)
-
-            card()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, DesignConstants.Spacing.step4x)
-                .padding(.bottom, bottomInset)
-                // Grows out of the control's own corner rather than sliding up
-                // from the edge, so the card reads as opened by the `+`.
-                .transition(.scale(scale: 0.92, anchor: .bottomLeading).combined(with: .opacity))
-        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Dev is red: the [Dev TestFlight run](https://github.com/xmtplabs/convos-ios/actions/runs/30836741781) fails to compile `AgentDmPageView.swift` (`cannot find type 'ComposerAttachmentsMenuCoordinator' in scope`, etc.).

**Root cause — a semantic merge conflict from the 2.3.0 back-merge (#1269).** The release branch refactored the composer's attachments menu: `ComposerAttachmentsMenu.swift` / `ComposerAttachmentsMenuEnvironment.swift` were deleted and the `+` now opens a system `Menu` owned by `MessagesBottomBar` itself (`AttachmentsMenuControl` + `ComposerAttachmentAction`), with photo/camera/file/voice handled internally. `AgentDmPageView` — added on dev by #1236 (CON-761) and unknown to the release branch — still used the old coordinator/environment/overlay API. No textual conflict, so the merge landed clean and broke the build.

## Fix

Pure deletion (54 lines), mirroring what the refactor did to `ConversationView`:
- the `ComposerAttachmentsMenuCoordinator` `@State` and its `.environment(\.composerAttachmentsMenu, …)` / `.overlay` wiring
- the `attachmentsOverlay` card and its `composerCard` placement helper (only used by the overlay)

The DM composer's `+` keeps working: the bar now presents its own menu and needs nothing from the host.

## Verification

- Full `Convos (Dev)` simulator build passes locally at this commit (it fails at dev tip)
- No remaining references to the deleted symbols anywhere in the tree; no type-check-time warnings in the build log
- SwiftLint clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788376814&installation_model_id=20076&pr_number=1270&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1270&signature=6f5340c8b335b6be964c03e3009e87a67734084bbbc6569aa65dadb3f23f4420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove composer attachments menu from `AgentDmPageView`
> Removes the `ComposerAttachmentsMenuCoordinator` state, its environment injection, and the attachments overlay from [AgentDmPageView.swift](https://github.com/xmtplabs/convos-ios/pull/1270/files#diff-d3c09c173a2b279a809729d0bb25db13ede2e56e7b1c18bd65422a32610eab57) to fix a build break caused by a deleted component. Behavioral Change: the Agent DM page no longer presents a composer attachments menu; any UI that depended on the `composerAttachmentsMenu` environment value from this view will not receive it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd3882e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->