### PR TITLE
CON-761: Agent-DM push notifications — suppress DM banner in-view + route DM/group taps

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -75,6 +75,12 @@ struct AgentDmPageView: View {
         .onChange(of: isActivePage) { _, active in
             handleActivePageChange(active)
         }
+        // Every pager page stays mounted, so this fires when the whole
+        // conversation closes; clear the on-screen DM lane so its pushes are no
+        // longer suppressed once the user has left.
+        .onDisappear {
+            if isActivePage { updateActiveDmLane(isActive: false) }
+        }
     }
 
     /// Transfers composer focus onto this DM page when it becomes active while a
@@ -91,10 +97,27 @@ struct AgentDmPageView: View {
             // stuck in reply mode.
             contextMenuState.cancelInFlightSwipe()
             dmViewModel?.replyingToMessage = nil
+            updateActiveDmLane(isActive: false)
             return
         }
         focusState = keyboardVisible ? .message : focusCoordinator.defaultFocus
         markDmAsRead()
+        updateActiveDmLane(isActive: true)
+    }
+
+    /// Registers (or clears) this DM lane as the on-screen conversation with the
+    /// session so a push for the DM the user is currently viewing is silenced.
+    /// The lane is its own conversation whose id never appears in the parent's
+    /// `activeConversationChanged` signal (that carries the group id), so it has
+    /// to be tracked explicitly. Cleared when the page is paged away or the
+    /// conversation closes; a nil id when no DM is bound yet is a harmless clear.
+    private func updateActiveDmLane(isActive: Bool) {
+        let conversationId: String? = isActive ? dmViewModel?.conversation.id : nil
+        NotificationCenter.default.post(
+            name: .activeDmConversationChanged,
+            object: nil,
+            userInfo: conversationId.map { ["conversationId": $0] } ?? [:]
+        )
     }
 
     /// Clears the agent-DM lane's unread flag when the user views this page.
@@ -153,9 +176,11 @@ struct AgentDmPageView: View {
         dmViewModel = dmVm
         // If the DM binds while its page is already active (the reconciler
         // created it while the user waited here), mark it read now — the
-        // on-activate hook fired before the view model existed.
+        // on-activate hook fired before the view model existed — and register
+        // it as the on-screen lane so its pushes are suppressed.
         if isActivePage {
             markDmAsRead()
+            updateActiveDmLane(isActive: true)
         }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -293,6 +293,21 @@ struct ConversationView<MessagesBottomBar: View>: View {
         pagerSelectedPage = .agentDm(agentInboxId: inboxId)
     }
 
+    /// Switches to a specific agent-DM page when a DM notification is tapped while
+    /// this conversation is already on screen (a fresh open seeds the page from
+    /// `initialAgentDmInboxId`, but re-selecting the same conversation is a no-op,
+    /// so an already-open view has to be told directly). Ignores requests for a
+    /// different conversation or an agent without a DM page here.
+    private func handleSelectAgentDmPageRequest(_ note: Notification) {
+        guard let conversationId = note.userInfo?["conversationId"] as? String,
+              conversationId == viewModel.conversation.id,
+              let agentInboxId = note.userInfo?["agentInboxId"] as? String,
+              agentDmPageInboxIds.contains(agentInboxId) else {
+            return
+        }
+        pagerSelectedPage = .agentDm(agentInboxId: agentInboxId)
+    }
+
     @ToolbarContentBuilder
     private var topBarTrailing: some ToolbarContent {
         // The embedded Scan/Invite toggle owns scanning, so the lone viewfinder
@@ -536,6 +551,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
             navState.markScreenAppeared()
             viewModel.onConversationAppeared()
             seedInitialPageIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .selectAgentDmPageRequested)) { note in
+            handleSelectAgentDmPageRequest(note)
         }
         .onDisappear {
             focusCoordinator.dismissThingsSearchIfNeeded()

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -305,6 +305,12 @@ final class ConversationsViewModel {
     /// Resolved to a selection once the row appears.
     @ObservationIgnored
     private var pendingScanNavigationConversationId: String?
+    /// A notification tap whose destination conversation (or a DM's parent
+    /// group) wasn't in the list yet — e.g. a cold launch from the banner.
+    /// Replayed by `resolvePendingConversationTapIfPossible` once conversations
+    /// load. Mirrors `pendingScanNavigationConversationId`.
+    @ObservationIgnored
+    private var pendingConversationTapId: String?
     /// A connection-grant deep link that arrived before its conversation was
     /// in the list (cold launch races the initial load). Resolved once the
     /// conversation appears; mirrors `pendingScanNavigationConversationId`.
@@ -654,6 +660,7 @@ final class ConversationsViewModel {
 
                 resolvePendingScanNavigationIfPossible()
                 resolvePendingConnectionGrantIfPossible()
+                resolvePendingConversationTapIfPossible()
 
                 if !conversations.contains(where: { !$0.isPinned && $0.kind == .group }) {
                     activeFilter = .all
@@ -673,26 +680,6 @@ final class ConversationsViewModel {
                 }
             }
             .store(in: &cancellables)
-    }
-
-    private func handleConversationNotificationTap(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let inboxId = userInfo["inboxId"] as? String,
-              let conversationId = userInfo["conversationId"] as? String else {
-            Log.warning("Conversation notification tapped but missing required userInfo")
-            return
-        }
-
-        Log.info(
-            "Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)"
-        )
-
-        if let conversation = conversations.first(where: { $0.id == conversationId }) {
-            Log.info("Found conversation, selecting it")
-            selectedConversation = conversation
-        } else {
-            Log.warning("Conversation \(conversationId) not found in current conversation list")
-        }
     }
 
     func toggleMute(conversation: Conversation) {
@@ -1519,5 +1506,78 @@ extension ConversationsViewModel {
               conversations.contains(where: { $0.id == link.conversationId }) else { return }
         pendingConnectionGrantLink = nil
         openConnectionGrant(serviceId: link.serviceId, conversationId: link.conversationId)
+    }
+}
+
+// MARK: - Notification tap routing
+
+extension ConversationsViewModel {
+    func handleConversationNotificationTap(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let inboxId = userInfo["inboxId"] as? String,
+              let conversationId = userInfo["conversationId"] as? String else {
+            Log.warning("Conversation notification tapped but missing required userInfo")
+            return
+        }
+
+        Log.info(
+            "Handling conversation notification tap for inboxId: \(inboxId), conversationId: \(conversationId)"
+        )
+
+        if !routeToTappedConversation(conversationId) {
+            // The destination isn't in the loaded list yet (cold launch from the
+            // banner, before conversations have streamed in). Park it and replay
+            // once the conversations publisher emits.
+            Log.info("Conversation \(conversationId) not loaded yet; parking tap for replay")
+            pendingConversationTapId = conversationId
+        }
+    }
+
+    /// Routes a tapped notification's conversation id to the right destination:
+    /// a message in an agent DM opens that DM's parent group on the DM page; a
+    /// group message opens the group on the group page. Returns false when the
+    /// destination isn't in the loaded conversation list yet, so the caller can
+    /// defer it (see `pendingConversationTapId`).
+    @discardableResult
+    func routeToTappedConversation(_ conversationId: String) -> Bool {
+        // An agent DM's own id is never in the list (DMs are folded into their
+        // parent group's row), so map it to the parent + agent page first.
+        if let routing = try? conversationsRepository.agentDmTapRouting(forConversationId: conversationId) {
+            guard conversations.contains(where: { $0.id == routing.originConversationId }) else {
+                return false
+            }
+            // Seeds the DM page when the parent opens fresh (or from a different
+            // conversation)...
+            selectedInitialAgentDmInboxId = routing.agentInboxId
+            selectedConversationId = routing.originConversationId
+            // ...and switches the page when the parent is already on screen (where
+            // re-selecting the same id is a no-op).
+            NotificationCenter.default.post(
+                name: .selectAgentDmPageRequested,
+                object: nil,
+                userInfo: [
+                    "conversationId": routing.originConversationId,
+                    "agentInboxId": routing.agentInboxId
+                ]
+            )
+            return true
+        }
+
+        // A group (or any listed conversation): open it on the group page.
+        guard let conversation = conversations.first(where: { $0.id == conversationId }) else {
+            return false
+        }
+        selectedInitialAgentDmInboxId = nil
+        selectedConversation = conversation
+        return true
+    }
+
+    /// Replays a notification tap that was parked because its destination hadn't
+    /// loaded yet. Called when the conversations publisher emits.
+    func resolvePendingConversationTapIfPossible() {
+        guard let pendingId = pendingConversationTapId else { return }
+        if routeToTappedConversation(pendingId) {
+            pendingConversationTapId = nil
+        }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -93,6 +93,21 @@ extension XMTPiOS.Group {
         }
     }
 
+    /// The parent ("origin") conversation this agent DM was created from, as a
+    /// hex conversation id, or nil when not recorded. Written once in
+    /// `markAsAgentDm`; read back so a DM notification tap can route to its
+    /// parent group (the DM is only viewable as a page inside that group).
+    public var agentDmOriginConversationId: String? {
+        get throws {
+            let metadata = try currentCustomMetadata
+            guard metadata.hasAgentDm, metadata.agentDm.hasOriginConversationID else {
+                return nil
+            }
+            let data = metadata.agentDm.originConversationID
+            return data.isEmpty ? nil : data.toHexString()
+        }
+    }
+
     /// Stamps this conversation as a private DM with an agent. Called once by
     /// the device that creates the DM conversation, before adding the agent.
     public func markAsAgentDm(originConversationId: Data? = nil) async throws {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -33,6 +33,10 @@ public final class MockConversationsRepository: ConversationsRepositoryProtocol,
         nil
     }
 
+    public func agentDmTapRouting(forConversationId conversationId: String) throws -> AgentDmTapRouting? {
+        nil
+    }
+
     public func findOneToOne(with inboxId: String, excluding excludedConversationId: String?) throws -> Conversation? {
         mockConversations.first { conversation in
             guard conversation.id != excludedConversationId else { return false }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -8,6 +8,21 @@ import os
 public extension Notification.Name {
     static let leftConversationNotification: Notification.Name = Notification.Name("LeftConversationNotification")
     static let activeConversationChanged: Notification.Name = Notification.Name("ActiveConversationChanged")
+    /// The agent-DM lane page the user is currently viewing, if any. Posted with
+    /// `userInfo["conversationId"]` = the DM lane's own conversation id when its
+    /// pager page becomes active, and with a nil/absent id when it is paged away
+    /// or the conversation closes. The DM lane is its own conversation, so its id
+    /// never appears in `activeConversationChanged` (which carries the parent
+    /// group id); tracking it separately is what lets a push for the
+    /// currently-viewed DM be suppressed.
+    static let activeDmConversationChanged: Notification.Name = Notification.Name("ActiveDmConversationChanged")
+    /// Requests that an already-open conversation switch its pager to a specific
+    /// agent-DM page. Posted (with `userInfo["conversationId"]` = the parent
+    /// group and `userInfo["agentInboxId"]` = the DM's agent) when a DM
+    /// notification is tapped while its parent group is already on screen —
+    /// selecting the group again is a no-op, so the page can't be seeded the way
+    /// a fresh open is.
+    static let selectAgentDmPageRequested: Notification.Name = Notification.Name("SelectAgentDmPageRequested")
 }
 
 public typealias AnyMessagingService = any MessagingServiceProtocol
@@ -40,6 +55,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     private var profileServicesTask: Task<Void, Never>?
     private var cloudConnectionsCancellable: AnyCancellable?
     private var activeConversationObserver: NSObjectProtocol?
+    private var activeDmConversationObserver: NSObjectProtocol?
     private var staleStrangerGCTask: Task<Void, Never>?
 
     /// Tracks the user's current screen context. Used by
@@ -51,6 +67,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
 
     private struct ScreenState {
         var activeConversationId: String?
+        /// The agent-DM lane conversation currently on screen, when the user is
+        /// on the DM page of a conversation. Tracked separately from
+        /// `activeConversationId` (which holds the parent group id) so a push for
+        /// the DM the user is looking at is suppressed.
+        var activeDmConversationId: String?
         var isOnConversationsList: Bool = false
     }
 
@@ -215,6 +236,9 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         if let activeConversationObserver {
             NotificationCenter.default.removeObserver(activeConversationObserver)
         }
+        if let activeDmConversationObserver {
+            NotificationCenter.default.removeObserver(activeDmConversationObserver)
+        }
     }
 
     // MARK: - Private Methods
@@ -239,6 +263,15 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         ) { [weak self] notification in
             let conversationId = notification.userInfo?["conversationId"] as? String
             self?.updateActiveConversation(conversationId)
+        }
+
+        activeDmConversationObserver = NotificationCenter.default.addObserver(
+            forName: .activeDmConversationChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let conversationId = notification.userInfo?["conversationId"] as? String
+            self?.updateActiveDmConversation(conversationId)
         }
 
         scheduleStaleStrangerGC()
@@ -280,6 +313,12 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     private func updateActiveConversation(_ conversationId: String?) {
         screenStateLock.withLock { state in
             state.activeConversationId = (conversationId?.isEmpty == false) ? conversationId : nil
+        }
+    }
+
+    private func updateActiveDmConversation(_ conversationId: String?) {
+        screenStateLock.withLock { state in
+            state.activeDmConversationId = (conversationId?.isEmpty == false) ? conversationId : nil
         }
     }
 
@@ -758,6 +797,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         let state = screenStateLock.withLock { $0 }
         if state.isOnConversationsList { return false }
         if state.activeConversationId == conversationId { return false }
+        if state.activeDmConversationId == conversationId { return false }
         return true
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentDmOrigin.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentDmOrigin.swift
@@ -1,0 +1,43 @@
+import Foundation
+import GRDB
+
+/// The parent ("origin") conversation an agent DM was created from.
+///
+/// An agent DM is its own 2-member conversation, but it is only viewable as a
+/// page inside its parent group's conversation view. Routing a DM notification
+/// tap therefore needs to map the DM's own conversation id back to that parent
+/// group. The link is written to the DM's XMTP custom metadata
+/// (`AgentDmInfo.originConversationID`) but that is not readable synchronously
+/// or before the XMTP client is ready, so it is mirrored here on every save
+/// (extraction) and at creation (`markAsAgentDm`). Kept in its own table rather
+/// than a `conversation` column so it never has to thread through
+/// `DBConversation`'s builders.
+struct DBAgentDmOrigin: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName: String = "agent_dm_origin"
+
+    enum Columns {
+        static let conversationId: Column = Column(CodingKeys.conversationId)
+        static let originConversationId: Column = Column(CodingKeys.originConversationId)
+    }
+
+    /// The agent DM's own conversation id (primary key).
+    let conversationId: String
+    /// The parent group conversation the DM was created from.
+    let originConversationId: String
+}
+
+extension DBAgentDmOrigin {
+    /// The parent group id for an agent DM, or nil when unknown (a DM saved
+    /// before this mapping existed, or a non-DM conversation).
+    static func originConversationId(for conversationId: String, in db: Database) throws -> String? {
+        try fetchOne(db, key: conversationId)?.originConversationId
+    }
+
+    /// Records (or replaces) the DM -> parent link. No-op when `originConversationId`
+    /// is nil or empty so a marker written without an origin never clears a good one.
+    static func record(conversationId: String, originConversationId: String?, in db: Database) throws {
+        guard let originConversationId, !originConversationId.isEmpty else { return }
+        try DBAgentDmOrigin(conversationId: conversationId, originConversationId: originConversationId)
+            .save(db, onConflict: .replace)
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -2,6 +2,19 @@ import Combine
 import Foundation
 import GRDB
 
+/// Where a tapped agent-DM notification should route. A DM is its own
+/// conversation but is only viewable as a page inside its parent group, so a
+/// tap opens `originConversationId` and selects the DM page for `agentInboxId`.
+public struct AgentDmTapRouting: Equatable, Sendable {
+    public let originConversationId: String
+    public let agentInboxId: String
+
+    public init(originConversationId: String, agentInboxId: String) {
+        self.originConversationId = originConversationId
+        self.agentInboxId = agentInboxId
+    }
+}
+
 public protocol ConversationsRepositoryProtocol {
     var conversationsPublisher: AnyPublisher<[Conversation], Never> { get }
     func fetchAll() throws -> [Conversation]
@@ -26,6 +39,12 @@ public protocol ConversationsRepositoryProtocol {
     /// The user's agent DM with this inbox, if one exists (conversations
     /// carrying the agent-DM marker only).
     func findAgentDm(with inboxId: String) throws -> Conversation?
+
+    /// Routing for a tapped agent-DM notification. The tap carries the DM's own
+    /// conversation id; return the parent group to open and the agent whose DM
+    /// page to select. nil when the id is not a routable agent DM (not a DM, no
+    /// recorded parent, or no agent member found).
+    func agentDmTapRouting(forConversationId conversationId: String) throws -> AgentDmTapRouting?
 
     /// Conversations that contain an agent provisioned from `templateId`,
     /// split by who added that agent: `addedByCurrentUser` when the agent
@@ -98,6 +117,43 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
                 onlyAgentDms: true
             )
         }
+    }
+
+    func agentDmTapRouting(forConversationId conversationId: String) throws -> AgentDmTapRouting? {
+        try dbReader.read { db in
+            guard let conversation = try DBConversation.fetchOne(db, key: conversationId),
+                  conversation.isAgentDm else {
+                return nil
+            }
+            guard let originConversationId = try DBAgentDmOrigin
+                .originConversationId(for: conversationId, in: db) else {
+                return nil
+            }
+            guard let agentInboxId = try Self.verifiedAgentInboxId(
+                conversationId: conversationId,
+                in: db
+            ) else {
+                return nil
+            }
+            return AgentDmTapRouting(
+                originConversationId: originConversationId,
+                agentInboxId: agentInboxId
+            )
+        }
+    }
+
+    /// The verified-agent member of a 2-member agent DM (the other member is the
+    /// current user). Drives which pager page a DM tap selects.
+    private static func verifiedAgentInboxId(conversationId: String, in db: Database) throws -> String? {
+        let memberInboxIds = try DBConversationMember
+            .filter(DBConversationMember.Columns.conversationId == conversationId)
+            .fetchAll(db)
+            .map(\.inboxId)
+        guard !memberInboxIds.isEmpty else { return nil }
+        return try DBProfile
+            .fetchAll(db, inboxIds: memberInboxIds)
+            .first { $0.agentVerification.isVerified }?
+            .inboxId
     }
 
     func conversationsPublisher(withAgentTemplateId templateId: String) -> AnyPublisher<AgentTemplateConversations, Never> {

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -1234,6 +1234,18 @@ extension SharedDatabaseMigrator {
                 t.add(column: "isAgentDm", .boolean).notNull().defaults(to: false)
             }
         }
+
+        // Maps an agent DM's own conversation id to its parent group, so a DM
+        // notification tap can open the parent and select the DM page. The link
+        // is authoritative in the DM's XMTP metadata; this mirrors it locally
+        // (see DBAgentDmOrigin).
+        migrator.registerMigration("createAgentDmOrigin") { db in
+            try db.create(table: "agent_dm_origin") { t in
+                t.column("conversationId", .text).notNull().primaryKey()
+                    .references("conversation", onDelete: .cascade)
+                t.column("originConversationId", .text).notNull()
+            }
+        }
     }
 
     /// The templateId-keyed agent-template contact table. Separate from the

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -432,20 +432,23 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
             let updated = try DBConversation
                 .filter(key: conversationId)
                 .updateAll(db, DBConversation.Columns.isAgentDm.set(to: true))
+            guard updated > 0 else {
+                // The local row may not exist yet (marker written before the
+                // first store). Not fatal -- extraction re-derives the flag and
+                // the DM -> parent link from the on-wire marker on the next save.
+                // Recording the link now would violate agent_dm_origin's foreign
+                // key to conversation, so defer it and just log the miss.
+                Log.warning("markAsAgentDm updated no local rows for \(conversationId)")
+                return
+            }
             // Mirror the DM -> parent link locally on the creating device too, so
             // a tap routes correctly before the next full save re-extracts it.
+            // Safe only now that the conversation row is known to exist.
             try DBAgentDmOrigin.record(
                 conversationId: conversationId,
                 originConversationId: originConversationId,
                 in: db
             )
-            if updated == 0 {
-                // The local row may not exist yet (marker written before the
-                // first store). Not fatal -- extraction re-derives the flag
-                // from the on-wire marker on the next save -- but log it so a
-                // persistently missing row is visible.
-                Log.warning("markAsAgentDm updated no local rows for \(conversationId)")
-            }
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -432,6 +432,13 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
             let updated = try DBConversation
                 .filter(key: conversationId)
                 .updateAll(db, DBConversation.Columns.isAgentDm.set(to: true))
+            // Mirror the DM -> parent link locally on the creating device too, so
+            // a tap routes correctly before the next full save re-extracts it.
+            try DBAgentDmOrigin.record(
+                conversationId: conversationId,
+                originConversationId: originConversationId,
+                in: db
+            )
             if updated == 0 {
                 // The local row may not exist yet (marker written before the
                 // first store). Not fatal -- extraction re-derives the flag

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -253,6 +253,9 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let dbConversation: DBConversation
         let dbMembers: [DBConversationMember]
         let memberProfiles: [DBMemberProfile]
+        /// The DM's parent group id, when this conversation is an agent DM that
+        /// recorded one; persisted to `agent_dm_origin` in `persist`.
+        var originConversationId: String?
     }
 
     /// Async, network-bound, transaction-free. Safe to call concurrently for
@@ -278,7 +281,8 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         return PreparedConversation(
             dbConversation: dbConversation,
             dbMembers: dbMembers,
-            memberProfiles: memberProfiles
+            memberProfiles: memberProfiles,
+            originConversationId: metadata.originConversationId
         )
     }
 
@@ -338,6 +342,14 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         // Save conversation (handle local conversation updates).
         // Also handles imageLastRenewed preservation inside the transaction.
         let saveResult = try saveConversation(prepared.dbConversation, memberCount: prepared.dbMembers.count, in: db)
+
+        // Mirror the DM -> parent-group link so a DM notification tap can route
+        // to the parent's DM page. No-op for non-DMs and DMs without an origin.
+        try DBAgentDmOrigin.record(
+            conversationId: prepared.dbConversation.id,
+            originConversationId: prepared.originConversationId,
+            in: db
+        )
 
         // Save local state
         let localState = ConversationLocalState(
@@ -776,6 +788,9 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let isLocked: Bool
         let hasHadVerifiedAgent: Bool
         let isAgentDm: Bool
+        /// The parent group id, for an agent DM that recorded one in its
+        /// metadata; nil for non-DMs or DMs without a recorded origin.
+        let originConversationId: String?
         let memberCount: Int
     }
 
@@ -801,6 +816,12 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         let memberCount = members.count
         let hasVerifiedAgentMember = try await anyMemberIsVerifiedAgent(inboxIds: members.map(\.inboxId))
         let isAgentDm = hasAgentDmMarker && memberCount == 2 && hasVerifiedAgentMember
+        // Only meaningful for a DM; read the parent link the creating device
+        // stamped so a DM notification tap can open the parent group's DM page.
+        // `try?` on a throwing optional yields String??; flatMap collapses it.
+        let originConversationId: String? = isAgentDm
+            ? (try? conversation.agentDmOriginConversationId).flatMap { $0 }
+            : nil
 
         return ConversationMetadata(
             kind: .group,
@@ -816,6 +837,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             isLocked: isLocked,
             hasHadVerifiedAgent: false,
             isAgentDm: isAgentDm,
+            originConversationId: originConversationId,
             memberCount: memberCount
         )
     }

--- a/ConvosCore/Tests/ConvosCoreTests/AgentDmTapRoutingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentDmTapRoutingTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import GRDB
+import Testing
+@testable import ConvosCore
+
+/// Covers the DM -> parent-group routing a tapped DM notification relies on:
+/// `DBAgentDmOrigin` persistence and `ConversationsRepository.agentDmTapRouting`.
+@Suite("Agent DM Tap Routing Tests", .serialized)
+struct AgentDmTapRoutingTests {
+    private static let currentInboxId: String = "inbox-current"
+    private static let agentInboxId: String = "inbox-agent"
+    private static let parentId: String = "parent-group"
+    private static let dmId: String = "dm-conversation"
+
+    private static func makeConversation(id: String, isAgentDm: Bool) -> DBConversation {
+        DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+            isAgentDm: isAgentDm
+        )
+    }
+
+    /// Seeds a parent group and a 2-member agent DM (current user + a verified
+    /// agent). `withOrigin` controls whether the DM -> parent link is recorded;
+    /// `agentVerified` controls whether the agent member reads as verified.
+    private static func seed(
+        _ db: Database,
+        withOrigin: Bool = true,
+        agentVerified: Bool = true
+    ) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBMember(inboxId: agentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(inboxId: currentInboxId, clientId: "client-current").save(db, onConflict: .ignore)
+        try DBProfile(
+            inboxId: agentInboxId,
+            name: "Agent",
+            memberKind: agentVerified ? .verifiedConvos : .agent,
+            profileSource: .profileUpdate,
+            updatedAt: Date()
+        ).save(db)
+
+        try makeConversation(id: parentId, isAgentDm: false).insert(db)
+        try makeConversation(id: dmId, isAgentDm: true).insert(db)
+
+        try DBConversationMember(
+            conversationId: dmId, inboxId: currentInboxId, role: .superAdmin,
+            consent: .allowed, createdAt: Date(), invitedByInboxId: nil
+        ).insert(db)
+        try DBConversationMember(
+            conversationId: dmId, inboxId: agentInboxId, role: .member,
+            consent: .allowed, createdAt: Date(), invitedByInboxId: nil
+        ).insert(db)
+
+        if withOrigin {
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: parentId, in: db)
+        }
+    }
+
+    private static func migratedQueue() throws -> DatabaseQueue {
+        let queue = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: queue)
+        return queue
+    }
+
+    private func repo(_ queue: DatabaseQueue) -> ConversationsRepository {
+        ConversationsRepository(dbReader: queue, consent: [.allowed, .unknown])
+    }
+
+    @Test("A DM tap routes to its parent group and the verified agent")
+    func routesDmToParentAndAgent() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { try Self.seed($0) }
+
+        let routing = try repo(queue).agentDmTapRouting(forConversationId: Self.dmId)
+
+        #expect(routing == AgentDmTapRouting(
+            originConversationId: Self.parentId,
+            agentInboxId: Self.agentInboxId
+        ))
+    }
+
+    @Test("A group tap is not agent-DM routing")
+    func groupTapReturnsNil() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { try Self.seed($0) }
+
+        #expect(try repo(queue).agentDmTapRouting(forConversationId: Self.parentId) == nil)
+    }
+
+    @Test("A DM without a recorded parent link does not route")
+    func dmWithoutOriginReturnsNil() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { try Self.seed($0, withOrigin: false) }
+
+        #expect(try repo(queue).agentDmTapRouting(forConversationId: Self.dmId) == nil)
+    }
+
+    @Test("A DM whose only other member is unverified does not route")
+    func dmWithoutVerifiedAgentReturnsNil() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { try Self.seed($0, agentVerified: false) }
+
+        #expect(try repo(queue).agentDmTapRouting(forConversationId: Self.dmId) == nil)
+    }
+
+    @Test("DBAgentDmOrigin records and reads back the parent link; a nil origin is a no-op")
+    func originRoundTrip() throws {
+        let queue = try Self.migratedQueue()
+        try queue.write { db in
+            try Self.seed(db, withOrigin: false)
+
+            try DBAgentDmOrigin.record(conversationId: Self.dmId, originConversationId: Self.parentId, in: db)
+            #expect(try DBAgentDmOrigin.originConversationId(for: Self.dmId, in: db) == Self.parentId)
+
+            // A marker written without an origin must not clear a good link.
+            try DBAgentDmOrigin.record(conversationId: Self.dmId, originConversationId: nil, in: db)
+            #expect(try DBAgentDmOrigin.originConversationId(for: Self.dmId, in: db) == Self.parentId)
+
+            #expect(try DBAgentDmOrigin.originConversationId(for: "unknown", in: db) == nil)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
@@ -70,6 +70,10 @@ private final class StubConversationsRepository: ConversationsRepositoryProtocol
         nil
     }
 
+    func agentDmTapRouting(forConversationId conversationId: String) throws -> AgentDmTapRouting? {
+        nil
+    }
+
     func conversationsPublisher(withAgentTemplateId templateId: String) -> AnyPublisher<AgentTemplateConversations, Never> {
         Just(AgentTemplateConversations(addedByCurrentUser: [], addedByOthers: [])).eraseToAnyPublisher()
     }


### PR DESCRIPTION
Two agent-DM push-notification fixes.

## 1. Suppress the foreground banner when viewing the DM lane
Foreground suppression already existed (`SessionManager.shouldDisplayNotification`), but `activeConversationId` only ever held the **parent group** id — the DM lane is its own conversation, so a push for the DM the user was looking at was never silenced.

- `SessionManager` tracks an **`activeDmConversationId`** separately (new `.activeDmConversationChanged` post) and suppresses a push matching the active **group or DM** id.
- `AgentDmPageView` registers its resolved DM conversation id when its pager page becomes active and clears it when paged away or the conversation closes.

## 2. Route a notification tap to the correct place (DM vs group), foreground or backgrounded
A DM push carries the **DM's own** conversation id, which isn't in the list (DMs fold into their parent group's row), so the tap was dropped. Groups already worked.

- **Persisted DM→parent mapping:** new `agent_dm_origin` table + `DBAgentDmOrigin`, populated from the DM's XMTP metadata (`AgentDmInfo.originConversationID`, via a new getter) on **extraction** (`ConversationWriter`) and at **creation** (`markAsAgentDm`). Chosen over a live metadata read so it's synchronous, works before the XMTP client is ready (cold launch), and is available to the Notification Service extension.
- `ConversationsRepository.agentDmTapRouting(forConversationId:)` maps a tapped DM → `(parent group, verified-agent inbox)`; returns nil for non-DMs / missing origin / no verified agent.
- The tap handler opens the parent group and selects the `.agentDm` page; a **group** tap opens the group page.
- **Cold-launch parking:** a tap whose destination hasn't loaded yet (banner → cold launch) is parked and replayed once conversations stream in (mirrors the pending-deep-link pattern).
- **Already-open switch:** when the parent group is already on screen (re-selecting it is a no-op), a `.selectAgentDmPageRequested` post drives `ConversationView` to switch to the DM page — this matters because, with fix #1, a DM banner *does* show while you're on the group's messages page.

## Design note
The DM→parent link (`originConversationID`) was previously write-only in XMTP metadata (no getter, no local column). This adds the getter and a dedicated side table (rather than a `DBConversation` column, to avoid threading through its ~28 `with(...)` builders and any wipe-on-mutation risk).

## Testing
- New `AgentDmTapRoutingTests` (5): routing happy path, group→nil, no-origin→nil, unverified-agent→nil, `DBAgentDmOrigin` record/read round-trip (incl. nil-origin no-op).
- Full **ConvosCore suite: 1739 tests / 241 suites pass**.
- **App (Convos Dev) builds clean** (0 errors, 0 type-check-budget warnings); SwiftLint clean.

## Note
Branched off `dev` after #1270 fixed the composer-attachments regression from the 2.3.0 back-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788379964&installation_model_id=20076&pr_number=1271&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1271&signature=68613a068f131d9100ae82ac2e31fd2e895049877b90f93367be8f819012bdac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress in-view agent DM push banners and route DM/group notification taps to the correct page
> - Adds a `agent_dm_origin` DB table to persist the DM-to-parent-group mapping, populated during conversation writes and in [`ConversationMetadataWriter.markAsAgentDm`](https://github.com/xmtplabs/convos-ios/pull/1271/files#diff-ce17de6d3ad64e828d2531d31326211c4a7d54f39e9e4e299402b089d206eeaf).
> - `SessionManager.shouldDisplayNotification` now suppresses in-app banners when the incoming conversation ID matches the agent DM lane currently on screen, tracked via a new `activeDmConversationId` in screen state.
> - [`AgentDmPageView`](https://github.com/xmtplabs/convos-ios/pull/1271/files#diff-d3c09c173a2b279a809729d0bb25db13ede2e56e7b1c18bd65422a32610eab57) posts `activeDmConversationChanged` notifications on appear/disappear so `SessionManager` knows which DM lane is visible.
> - [`ConversationsViewModel.routeToTappedConversation`](https://github.com/xmtplabs/convos-ios/pull/1271/files#diff-e9ac0abeb6f4ab9d1335cf93b09f18a543936af17c742b0f60b5f57e26c07fce) maps a tapped notification to either the parent group (for DM IDs) or directly to a group page, posting `selectAgentDmPageRequested` when needed; taps that arrive before conversations load are parked and replayed once data is ready.
> - [`ConversationView`](https://github.com/xmtplabs/convos-ios/pull/1271/files#diff-8d85226aa6385ce7a0aca11596c32eb20e3c3e89b37f51651c35fceb5e28f6bc) listens for `selectAgentDmPageRequested` and switches the pager to the correct agent DM page when the conversation is already open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23e0ef6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->