### PR TITLE
fix(agent-dm): stop eager DM creation stranding visible "New Convo" shells

### DIFF
--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentCreationFlow.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentCreationFlow.swift
@@ -247,8 +247,16 @@ public enum AgentCreationFlow {
         pollInterval: Duration = Constant.pollInterval
     ) async throws -> String {
         for attempt in 0..<attempts {
-            if case .ready(let result) = stateManager.currentState {
+            switch stateManager.currentState {
+            case .ready(let result):
                 return result.conversationId
+            case .error(let error):
+                // A machine that already failed can only be restarted by a
+                // fresh action; polling out the rest of the budget would just
+                // delay the caller's error path.
+                throw error
+            default:
+                break
             }
             if attempt < attempts - 1 {
                 try await Task.sleep(for: pollInterval)

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentDmFlow.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentDmFlow.swift
@@ -86,9 +86,22 @@ public enum AgentDmFlow {
         try await metadataWriter.markAsAgentDm(conversationId, originConversationId: originConversationId)
         // Surfacing is the last step: `findAgentDm` skips unused rows, so
         // this commit is what makes the DM discoverable to the reconciler
-        // and the DM page (and stops the reconciler minting another).
-        await session.commitClaimedConversation(id: conversationId)
+        // and the DM page (and stops the reconciler minting another). A
+        // failed commit must fail the flow: returning the id anyway would
+        // hand callers a conversation nothing can discover, while the row
+        // stays a hidden, claimed draft - the same inert state as any other
+        // die-partway outcome, so a later attempt can run cleanly.
+        guard await session.commitClaimedConversation(id: conversationId) else {
+            throw FlowError.commitFailed
+        }
         return conversationId
+    }
+
+    public enum FlowError: Error {
+        /// The DM was fully set up but the local commit that surfaces it
+        /// failed to write; the row remains hidden and the flow reports
+        /// failure so the caller can retry.
+        case commitFailed
     }
 
     private enum Constant {

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentDmFlow.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/AgentDmFlow.swift
@@ -61,8 +61,19 @@ public enum AgentDmFlow {
         session: any SessionManagerProtocol
     ) async throws -> String {
         let stateManager = session.messagingService().conversationStateManager()
-        try await stateManager.createConversation(startsUnused: false)
-        let conversationId = try await AgentCreationFlow.awaitReadyConversationId(stateManager: stateManager)
+        // Deferred visibility: the row stays hidden (`isUnused`) until the DM
+        // is fully set up and committed below. Creation on large accounts can
+        // outlive any client-side wait, and a flow that dies partway must
+        // leave only an inert hidden row (it keeps its draft client id, so
+        // the prewarm pool never recycles it) - not a visible, unnamed,
+        // agent-less conversation in the chats list.
+        try await stateManager.createConversation(startsUnused: true)
+        let conversationId = try await AgentCreationFlow.awaitReadyConversationId(
+            stateManager: stateManager,
+            attempts: Constant.readyPollAttempts
+        )
+        // Claim the hidden row so no other flow can consume it mid-setup.
+        await session.registerClaimedConversation(id: conversationId)
         let metadataWriter = stateManager.conversationMetadataWriter
         // Stamp the marker before the agent lands so every welcome observer
         // (our own devices included) classifies the conversation correctly.
@@ -73,6 +84,20 @@ public enum AgentDmFlow {
         // it. Re-stamp after the add so the on-wire state settles with the
         // marker; the local row is additionally latched by the writer.
         try await metadataWriter.markAsAgentDm(conversationId, originConversationId: originConversationId)
+        // Surfacing is the last step: `findAgentDm` skips unused rows, so
+        // this commit is what makes the DM discoverable to the reconciler
+        // and the DM page (and stops the reconciler minting another).
+        await session.commitClaimedConversation(id: conversationId)
         return conversationId
+    }
+
+    private enum Constant {
+        /// Ready-wait budget for the DM create: 600 polls at the default
+        /// 200ms interval, two minutes. Nothing user-facing awaits this flow,
+        /// and the default 10s budget proved far too tight on large accounts,
+        /// where the create-side conversation sync alone routinely runs
+        /// 10-30s - giving up early stranded a half-configured conversation
+        /// per attempt.
+        static let readyPollAttempts: Int = 600
     }
 }

--- a/ConvosCore/Sources/ConvosCore/AgentBuilder/StrandedConversationSweeper.swift
+++ b/ConvosCore/Sources/ConvosCore/AgentBuilder/StrandedConversationSweeper.swift
@@ -1,0 +1,70 @@
+import Foundation
+import GRDB
+
+/// One-shot session-start sweep that hides conversation shells stranded by
+/// interrupted creation flows: visible, self-created rows that never got a
+/// name, an image, another member, a shared invite, or any real content.
+///
+/// The agent-DM create path used to surface such shells at scale: its
+/// ready-wait timed out mid-setup while the conversation still published,
+/// so the marker stamp and agent add never ran and the conversation was
+/// left rendering as "New Convo" in the list - one per agent per session.
+/// The create path now defers visibility until setup completes, so no new
+/// shells form; this sweep cleans up the ones already stranded on affected
+/// devices.
+///
+/// Sweeping flips rows back to `isUnused`, the same hidden state
+/// deferred-visibility creation uses: they leave the list immediately, and
+/// cache-shaped rows return to the prewarm pool instead of being wasted.
+enum StrandedConversationSweeper {
+    /// Hides stranded shells created before `now - minimumAge`; returns how
+    /// many rows were hidden.
+    @discardableResult
+    static func sweep(databaseWriter: any DatabaseWriter, now: Date = Date()) async throws -> Int {
+        let cutoff = now.addingTimeInterval(-Constant.minimumAge)
+        return try await databaseWriter.write { (db: Database) -> Int in
+            // Every predicate is a positive signal the user never touched the
+            // conversation. `contentType <> 'update'` (rather than a last-
+            // message pointer) is the content check because stranded shells
+            // do receive their own metadata commits as update messages.
+            try db.execute(
+                sql: """
+                UPDATE conversation SET isUnused = 1
+                WHERE isUnused = 0
+                  AND isAgentDm = 0
+                  AND id NOT LIKE 'draft-%'
+                  AND (name IS NULL OR name = '')
+                  AND (description IS NULL OR description = '')
+                  AND imageURLString IS NULL
+                  AND createdAt < ?
+                  AND creatorId IN (SELECT inboxId FROM inbox)
+                  AND NOT EXISTS (
+                      SELECT 1 FROM conversation_members cm
+                      WHERE cm.conversationId = conversation.id
+                        AND cm.inboxId NOT IN (SELECT inboxId FROM inbox)
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM message m
+                      WHERE m.conversationId = conversation.id
+                        AND m.contentType <> 'update'
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM conversationLocalState ls
+                      WHERE ls.conversationId = conversation.id
+                        AND (ls.isPinned = 1 OR ls.hasSharedInvite = 1 OR ls.hasHadOtherMembers = 1)
+                  )
+                """,
+                arguments: [cutoff]
+            )
+            return db.changesCount
+        }
+    }
+
+    private enum Constant {
+        /// Rows must be at least this old before they are considered
+        /// stranded, so the sweep can never race a creation still
+        /// legitimately in flight or hide an empty conversation the user
+        /// just made and is about to use.
+        static let minimumAge: TimeInterval = 24 * 60 * 60
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -25,8 +25,10 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         (service: mockMessagingService, conversationId: nil)
     }
 
-    public func commitClaimedConversation(id conversationId: String) async {
+    @discardableResult
+    public func commitClaimedConversation(id conversationId: String) async -> Bool {
         committedConversationIds.append(conversationId)
+        return true
     }
 
     public func releaseClaimedConversation(id conversationId: String) async {

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -38,10 +38,15 @@ public protocol UnusedConversationCacheProtocol: Actor {
     /// flips `isUnused` to `false`, refreshes `createdAt` to now (so the
     /// row sorts at the top of the chats list), and drops the in-memory
     /// claim. Idempotent for ids that aren't currently claimed.
+    /// Returns `false` when the database write failed: the row is still
+    /// hidden and the claim is retained, so callers for whom visibility is
+    /// the point of the commit can propagate the failure instead of
+    /// reporting a conversation that nothing can discover.
+    @discardableResult
     func commitClaimedConversation(
         id conversationId: String,
         databaseWriter: any DatabaseWriter
-    ) async
+    ) async -> Bool
 
     /// Drops the in-memory claim without writing to the DB. Pairs with
     /// `SessionManager.discardClaimedConversation`, which deletes the row
@@ -156,10 +161,11 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             .filter(!DBConversation.Columns.inviteTag.like("\(provisionalInviteTagPrefix)%"))
     }
 
+    @discardableResult
     public func commitClaimedConversation(
         id conversationId: String,
         databaseWriter: any DatabaseWriter
-    ) async {
+    ) async -> Bool {
         let now = Date()
         do {
             try await databaseWriter.write { db in
@@ -174,8 +180,10 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             // hand the same id out to another caller while the original
             // caller may still be using it.
             claimedConversationIds.remove(conversationId)
+            return true
         } catch {
             Log.error("Failed to commit claimed conversation \(conversationId): \(error)")
+            return false
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+AgentDmReconciler.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+AgentDmReconciler.swift
@@ -16,6 +16,25 @@ extension SessionManager {
         }
     }
 
+    /// One-shot cleanup of conversation shells stranded by earlier builds'
+    /// eager DM creates (visible, unnamed, agent-less rows rendering as
+    /// "New Convo" - see `StrandedConversationSweeper`). Gated with the
+    /// reconciler because the shells it targets came from the same path.
+    func sweepStrandedAgentDmShells() {
+        guard eagerAgentDmEnabled else { return }
+        Task(priority: .utility) { [weak self] in
+            guard let self else { return }
+            do {
+                let swept = try await StrandedConversationSweeper.sweep(databaseWriter: self.databaseWriter)
+                if swept > 0 {
+                    Log.info("StrandedConversationSweeper: hid \(swept) stranded conversation shell(s)")
+                }
+            } catch {
+                Log.error("StrandedConversationSweeper failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Stops and clears the session's reconciler; called from inbox teardown
     /// so an in-flight create cannot re-insert rows after the wipe.
     func stopAgentDmReconciler() {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -179,6 +179,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
             // agent-DM reconciler (ensures a DM exists for every verified
             // agent as soon as it appears; non-production only).
             _ = (self.agentBuilderConnectionGrantReplayer(), self.unsentBuilderBriefReplayer(), self.agentDmReconciler())
+            self.sweepStrandedAgentDmShells()
 
             self.assetRenewalTask = Task(priority: .utility) { [weak self] in
                 guard let self, !Task.isCancelled else { return }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -476,7 +476,8 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         return (service, conversationId)
     }
 
-    public func commitClaimedConversation(id conversationId: String) async {
+    @discardableResult
+    public func commitClaimedConversation(id conversationId: String) async -> Bool {
         await unusedConversationCache.commitClaimedConversation(
             id: conversationId,
             databaseWriter: databaseWriter

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -85,7 +85,11 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     /// list. Call this exactly once, when the user has confirmed intent
     /// (sent the builder bundle, generated an invite, sent the first
     /// message, etc.).
-    func commitClaimedConversation(id conversationId: String) async
+    /// Returns `false` when the underlying database write failed and the
+    /// row is still hidden; callers that report the conversation onward
+    /// should treat that as a failed commit rather than a success.
+    @discardableResult
+    func commitClaimedConversation(id conversationId: String) async -> Bool
 
     /// Drops the in-memory cache claim without touching the DB row. The
     /// row stays `isUnused = true` and remains hidden. Use this when the

--- a/ConvosCore/Tests/ConvosCoreTests/StrandedConversationSweeperTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/StrandedConversationSweeperTests.swift
@@ -1,0 +1,281 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Coverage for `StrandedConversationSweeper`: the session-start cleanup for
+/// visible, unnamed, agent-less conversation shells stranded by earlier
+/// builds' eager DM creates. The sweep must hide exactly those shells and
+/// leave every conversation with any sign of user intent untouched.
+@Suite("Stranded conversation sweeper", .serialized)
+struct StrandedConversationSweeperTests {
+    private static let selfInbox = "self-inbox"
+    private static let otherInbox = "other-inbox"
+    private static let oldDate = Date().addingTimeInterval(-3 * 24 * 60 * 60)
+
+    private func makeDatabase() throws -> DatabaseQueue {
+        let dbQueue = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: dbQueue)
+        return dbQueue
+    }
+
+    private func seedInbox(_ db: Database) throws {
+        try DBMember(inboxId: Self.selfInbox).save(db, onConflict: .ignore)
+        try DBInbox(inboxId: Self.selfInbox, clientId: "client-1", createdAt: Date()).insert(db)
+    }
+
+    private func seedMember(_ db: Database, conversationId: String, inboxId: String) throws {
+        try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        try DBConversationMember(
+            conversationId: conversationId,
+            inboxId: inboxId,
+            role: .member,
+            consent: .allowed,
+            createdAt: Self.oldDate,
+            invitedByInboxId: nil
+        ).save(db)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    private func seedConversation(
+        _ db: Database,
+        id: String,
+        createdAt: Date,
+        name: String?,
+        creatorId: String,
+        isAgentDm: Bool,
+        otherMemberInboxId: String?,
+        isPinned: Bool,
+        hasSharedInvite: Bool,
+        hasHadOtherMembers: Bool
+    ) throws {
+        try DBConversation(
+            id: id,
+            clientConversationId: "draft-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: creatorId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: createdAt,
+            name: name,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: true,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+            isAgentDm: isAgentDm
+        ).insert(db)
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: isPinned,
+            isUnread: false,
+            isUnreadUpdatedAt: Date.distantPast,
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            leftHostedInviteSession: false,
+            wasRemoved: false,
+            hasHadOtherMembers: hasHadOtherMembers,
+            hasSharedInvite: hasSharedInvite
+        ).insert(db)
+        try seedMember(db, conversationId: id, inboxId: Self.selfInbox)
+        if let otherMemberInboxId {
+            try seedMember(db, conversationId: id, inboxId: otherMemberInboxId)
+        }
+    }
+
+    /// A canonical stranded shell: old, visible, self-created, unnamed,
+    /// self-only, untouched local state.
+    private func seedShell(_ db: Database, id: String, createdAt: Date = oldDate) throws {
+        try seedConversation(
+            db,
+            id: id,
+            createdAt: createdAt,
+            name: nil,
+            creatorId: Self.selfInbox,
+            isAgentDm: false,
+            otherMemberInboxId: nil,
+            isPinned: false,
+            hasSharedInvite: false,
+            hasHadOtherMembers: false
+        )
+    }
+
+    private func seedMessage(
+        _ db: Database,
+        conversationId: String,
+        id: String,
+        contentType: MessageContentType
+    ) throws {
+        try DBMessage(
+            id: id,
+            clientMessageId: id,
+            conversationId: conversationId,
+            senderId: Self.selfInbox,
+            dateNs: 1_000,
+            date: Self.oldDate,
+            sortId: 1_000,
+            status: .published,
+            messageType: .original,
+            contentType: contentType,
+            text: contentType == .text ? "hello" : nil,
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            attachmentUrls: [],
+            update: nil
+        ).insert(db)
+    }
+
+    private func isUnused(_ dbQueue: DatabaseQueue, _ id: String) throws -> Bool {
+        try dbQueue.read { db in
+            try DBConversation.fetchOne(db, key: id)?.isUnused ?? false
+        }
+    }
+
+    @Test("an old empty self-only shell is hidden")
+    func sweepsStrandedShell() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedShell(db, id: "shell-1")
+        }
+        let swept = try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue)
+        #expect(swept == 1)
+        #expect(try isUnused(dbQueue, "shell-1"))
+    }
+
+    @Test("update-type messages do not protect a shell")
+    func sweepsShellWithOnlyMetadataCommits() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedShell(db, id: "shell-1")
+            try seedMessage(db, conversationId: "shell-1", id: "m-1", contentType: .update)
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 1)
+        #expect(try isUnused(dbQueue, "shell-1"))
+    }
+
+    @Test("any real message keeps the conversation")
+    func keepsConversationWithContent() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedShell(db, id: "kept-1")
+            try seedMessage(db, conversationId: "kept-1", id: "m-1", contentType: .text)
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "kept-1") == false)
+    }
+
+    @Test("a name keeps the conversation")
+    func keepsNamedConversation() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedConversation(
+                db, id: "kept-1", createdAt: Self.oldDate, name: "Weekend plans",
+                creatorId: Self.selfInbox, isAgentDm: false, otherMemberInboxId: nil,
+                isPinned: false, hasSharedInvite: false, hasHadOtherMembers: false
+            )
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "kept-1") == false)
+    }
+
+    @Test("another member keeps the conversation")
+    func keepsConversationWithOtherMember() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedConversation(
+                db, id: "kept-1", createdAt: Self.oldDate, name: nil,
+                creatorId: Self.selfInbox, isAgentDm: false, otherMemberInboxId: Self.otherInbox,
+                isPinned: false, hasSharedInvite: false, hasHadOtherMembers: false
+            )
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "kept-1") == false)
+    }
+
+    @Test("recent shells are left for a later sweep")
+    func keepsRecentShell() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedShell(db, id: "kept-1", createdAt: Date())
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "kept-1") == false)
+    }
+
+    @Test("pin, shared invite, or past members keep the conversation")
+    func keepsTouchedLocalState() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedConversation(
+                db, id: "kept-pinned", createdAt: Self.oldDate, name: nil,
+                creatorId: Self.selfInbox, isAgentDm: false, otherMemberInboxId: nil,
+                isPinned: true, hasSharedInvite: false, hasHadOtherMembers: false
+            )
+            try seedConversation(
+                db, id: "kept-shared", createdAt: Self.oldDate, name: nil,
+                creatorId: Self.selfInbox, isAgentDm: false, otherMemberInboxId: nil,
+                isPinned: false, hasSharedInvite: true, hasHadOtherMembers: false
+            )
+            try seedConversation(
+                db, id: "kept-had-members", createdAt: Self.oldDate, name: nil,
+                creatorId: Self.selfInbox, isAgentDm: false, otherMemberInboxId: nil,
+                isPinned: false, hasSharedInvite: false, hasHadOtherMembers: true
+            )
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "kept-pinned") == false)
+        #expect(try isUnused(dbQueue, "kept-shared") == false)
+        #expect(try isUnused(dbQueue, "kept-had-members") == false)
+    }
+
+    @Test("conversations created by someone else are never touched")
+    func keepsForeignCreator() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try DBMember(inboxId: Self.otherInbox).save(db, onConflict: .ignore)
+            try seedConversation(
+                db, id: "kept-1", createdAt: Self.oldDate, name: nil,
+                creatorId: Self.otherInbox, isAgentDm: false, otherMemberInboxId: nil,
+                isPinned: false, hasSharedInvite: false, hasHadOtherMembers: false
+            )
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "kept-1") == false)
+    }
+
+    @Test("agent DM rows are out of scope")
+    func skipsAgentDms() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedInbox(db)
+            try seedConversation(
+                db, id: "dm-1", createdAt: Self.oldDate, name: nil,
+                creatorId: Self.selfInbox, isAgentDm: true, otherMemberInboxId: nil,
+                isPinned: false, hasSharedInvite: false, hasHadOtherMembers: false
+            )
+        }
+        #expect(try await StrandedConversationSweeper.sweep(databaseWriter: dbQueue) == 0)
+        #expect(try isUnused(dbQueue, "dm-1") == false)
+    }
+
+}

--- a/ConvosCore/Tests/ConvosCoreTests/UnusedConversationCacheCommitTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UnusedConversationCacheCommitTests.swift
@@ -1,0 +1,99 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Pins the commit contract `AgentDmFlow.createDm` relies on: committing a
+/// claimed conversation reports whether the visibility write actually
+/// landed, so a flow whose whole purpose is surfacing the row can fail
+/// loudly instead of returning an id that stays hidden from every lookup.
+@Suite("Unused conversation cache commit", .serialized)
+struct UnusedConversationCacheCommitTests {
+    private static let selfInbox = "self-inbox"
+
+    private func makeDatabase() throws -> DatabaseQueue {
+        let dbQueue = try DatabaseQueue()
+        try SharedDatabaseMigrator.shared.migrate(database: dbQueue)
+        return dbQueue
+    }
+
+    private func seedHiddenConversation(_ db: Database, id: String) throws {
+        try DBMember(inboxId: Self.selfInbox).save(db, onConflict: .ignore)
+        try DBConversation(
+            id: id,
+            clientConversationId: "draft-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: Self.selfInbox,
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: true,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: true,
+            hasHadVerifiedAgent: false,
+            isAgentDm: false
+        ).insert(db)
+    }
+
+    @Test("a successful commit reports true and surfaces the row")
+    func successfulCommitReportsTrue() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedHiddenConversation(db, id: "convo-1")
+        }
+        let cache = UnusedConversationCache(identityStore: UnusedIdentityStoreStub())
+        await cache.registerClaimedConversation(id: "convo-1")
+
+        let committed = await cache.commitClaimedConversation(id: "convo-1", databaseWriter: dbQueue)
+
+        #expect(committed)
+        let isUnused = try await dbQueue.read { db in
+            try DBConversation.fetchOne(db, key: "convo-1")?.isUnused
+        }
+        #expect(isUnused == false)
+    }
+
+    @Test("a failed write reports false so callers can propagate the failure")
+    func failedCommitReportsFalse() async throws {
+        let dbQueue = try makeDatabase()
+        try await dbQueue.write { db in
+            try seedHiddenConversation(db, id: "convo-1")
+        }
+        let cache = UnusedConversationCache(identityStore: UnusedIdentityStoreStub())
+        await cache.registerClaimedConversation(id: "convo-1")
+        // A closed database rejects every write - the cheapest stand-in for
+        // any storage failure (e.g. "Pool needs to reconnect before use").
+        try dbQueue.close()
+
+        let committed = await cache.commitClaimedConversation(id: "convo-1", databaseWriter: dbQueue)
+
+        #expect(committed == false)
+    }
+}
+
+/// The commit path never touches the identity store; every member traps so
+/// an unexpected use fails the test instead of silently succeeding.
+private actor UnusedIdentityStoreStub: KeychainIdentityStoreProtocol {
+    func generateKeys() throws -> KeychainIdentityKeys { fatalError("unused") }
+    func save(inboxId: String, clientId: String, keys: KeychainIdentityKeys) throws -> KeychainIdentity { fatalError("unused") }
+    func load() throws -> KeychainIdentity? { fatalError("unused") }
+    nonisolated func loadSync() throws -> KeychainIdentity? { fatalError("unused") }
+    nonisolated func loadSyncedBackups() throws -> [KeychainIdentityBackup] { fatalError("unused") }
+    func loadInstallationMarker() throws -> InstallationMarker? { fatalError("unused") }
+    func saveInstallationMarker(_ marker: InstallationMarker) throws { fatalError("unused") }
+    func loadConsentBackup() throws -> ConsentBackup? { fatalError("unused") }
+    func saveConsentBackup(_ backup: ConsentBackup) throws { fatalError("unused") }
+    func backfillSyncedBackupIfNeeded() { fatalError("unused") }
+    func delete() throws { fatalError("unused") }
+}

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -363,7 +363,8 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         await base.hasAnyUsedConversations()
     }
 
-    func commitClaimedConversation(id conversationId: String) async {
+    @discardableResult
+    func commitClaimedConversation(id conversationId: String) async -> Bool {
         await base.commitClaimedConversation(id: conversationId)
     }
 


### PR DESCRIPTION
## Summary

After installing the DM-feature build, heavy accounts see unnamed conversations ("New Convo") appear in their list, growing every session. Log analysis of an affected device (build 1211, 2 days of logs): **136 `AgentDmReconciler: failed to create DM` errors, one stranded shell each.**

## Root cause

The eager DM create published a visible conversation first and configured it after:

1. `createConversation(startsUnused: false)` — visible from birth
2. `awaitReadyConversationId` — fixed **10s** poll budget
3. `markAsAgentDm` + `addMembers(agent)` — never reached when 2 times out

On the affected device the create-side `conversation.sync` runs **median 10.7s, p90 16.5s, max 31s** (166 conversations, dev network). So nearly every attempt timed out at 10s while the create still completed seconds later: a real, visible, unnamed, agent-less group with no DM marker. `findAgentDm` can't see it (no marker), so the reconciler's once-per-session dedup retried every launch — one new shell per agent per session, for dozens of agents.

## Fix

**Deferred visibility** (the same claim/commit path the agent builder uses): the DM create now runs `startsUnused: true`, claims the hidden row (`registerClaimedConversation`), stamps the marker, adds the agent, re-stamps, and only then `commitClaimedConversation` flips it visible. A create that dies partway leaves an inert hidden row — it keeps its draft `clientConversationId`, so the prewarm pool's cache-shape filter never hands it out — instead of a visible shell.

**Right-sized ready-wait**: the DM path (nothing user-facing awaits it) passes a 2-minute poll budget; `awaitReadyConversationId` also now throws immediately when the state machine reports `.error` instead of polling out the clock (benefits every caller).

**Cleanup for already-stranded shells**: `StrandedConversationSweeper`, a one-shot session-start sweep gated with the reconciler (dev/local only), hides rows that are visible, self-created, older than 24h, unnamed/undescribed/imageless, never had another member, have no real content (the shells' own metadata commits arrive as `update` messages and are excluded), no shared invite, no pin. Swept rows return to the `isUnused` hidden state, so cache-shaped ones rejoin the prewarm pool. Every predicate is a positive user-intent signal; the 24h floor means the sweep can never race an in-flight creation or a just-made empty convo.

## Tests

- Nine new `StrandedConversationSweeperTests` pinning the predicate from both sides (sweeps: canonical shell, shell with only update-messages; keeps: named, other member, real message, recent, pinned/shared-invite/had-members, foreign creator, agent DMs)
- Full ConvosCore suite: 1745 tests in 241 suites, all passing; SwiftLint clean

## Verification against the affected device

The stranded-shell signature in the attached logs (GroupCreation + KeyUpdate + metadata updates, single member, no name, no marker, creator = self) matches the sweep predicate exactly; the shells' `update`-type messages were specifically accounted for in the content check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788386175&installation_model_id=20076&pr_number=1274&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1274&signature=1a9935e39e94684c4180cf231ba504dd5815e924e21fd527292a370d0d95770b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent DM creation to hide conversation shells until setup completes
> - Agent DMs are now created with `startsUnused: true`, keeping them hidden in the inbox until metadata stamping and member setup finish, then surfaced via `commitClaimedConversation`.
> - `commitClaimedConversation` now returns `Bool` across the protocol stack; failure causes `AgentDmFlow` to throw `FlowError.commitFailed` instead of returning a hidden conversation id.
> - Adds `StrandedConversationSweeper` to hide pre-existing visible shells (empty, self-only, older than 24h) left over from the old eager-creation path; sweep runs at session start when `eagerAgentDmEnabled` is true.
> - `awaitReadyConversationId` now throws immediately on `.error` state instead of exhausting the full polling budget, and the polling budget is extended to ~2 minutes (600 attempts).
> - Risk: callers of `commitClaimedConversation` that previously ignored the return value now need to handle `false` as a failure signal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6b2fec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->