### PR TITLE
fix: inline ability connect from the conversation toggle, flag-gated Abilities settings title

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -32,9 +32,12 @@ struct AbilitiesListScreen: View {
 /// Entry points (all flag-gated behind Abilities V2, all via
 /// `AbilitiesListScreen`, which owns the view model):
 /// - App Settings connections row (`AppSettingsView.connectionsDestination`)
-///   pushes it in place of the V1 `ConnectionsListView`.
-/// - The conversation abilities section presents it as a sheet when a
-///   toggle needs an entitlement (`ConversationAbilitiesSection`).
+///   pushes it in place of the V1 `ConnectionsListView`; the row is titled
+///   "Abilities" under the flag.
+///
+/// A conversation toggle that needs an entitlement no longer deep-links
+/// here: it presents the scoped `AbilityConnectSheet` instead, which reuses
+/// this screen's view model for the connect machinery.
 struct AbilitiesListView: View {
     @Bindable var viewModel: AbilitiesListViewModel
 

--- a/Convos/Abilities/AbilityAuthorizationSheet.swift
+++ b/Convos/Abilities/AbilityAuthorizationSheet.swift
@@ -2,11 +2,13 @@ import ConvosCore
 import SwiftUI
 
 /// Stubbed stand-in for the OAuth browser session between
-/// `beginEntitlement` and `completeEntitlement`, presented only in mock
-/// mode (no `AbilityAuthorizing` injected): the redirect URL is shown and
-/// approval is a tap. With the live transport, the same redirect URL
-/// drives `AbilityOAuthAuthorizer`'s `ASWebAuthenticationSession` instead,
-/// feeding the same approve/cancel lifecycle in the view model.
+/// `beginEntitlement` and `completeEntitlement`, shown only in mock mode
+/// (no `AbilityAuthorizing` injected): the redirect URL is shown and
+/// approval is a tap. The abilities list presents it as a sheet;
+/// `AbilityConnectSheet` embeds the same content inline. With the live
+/// transport, the same redirect URL drives `AbilityOAuthAuthorizer`'s
+/// `ASWebAuthenticationSession` instead, feeding the same approve/cancel
+/// lifecycle in the view model.
 struct AbilityAuthorizationSheet: View {
     let context: AbilityAuthorizationContext
     let onAuthorize: () -> Void

--- a/Convos/Abilities/AbilityConnectSheet.swift
+++ b/Convos/Abilities/AbilityConnectSheet.swift
@@ -1,0 +1,178 @@
+import ConvosCore
+import SwiftUI
+
+/// Inline connect flow for a single ability, so a toggle that needs an
+/// entitlement resolves right where it was tapped.
+///
+/// Entry points:
+/// - `ConversationAbilitiesSection` presents it as a sheet when a toggle
+///   (or a needs-attention row) has no active entitlement; on success the
+///   section's view model continues into the extension
+///   (`ConversationAbilitiesViewModel.handleConnected`).
+///
+/// The flow reuses the account-level connect machinery via
+/// `AbilitiesListViewModel` (begin, browser or stub authorization,
+/// completion retries), scoped to one ability. In live mode the Connect
+/// button opens the `ASWebAuthenticationSession` browser; in mock mode the
+/// stub `AbilityAuthorizationSheet` content swaps in inline -- nesting
+/// another sheet inside this one is exactly the presentation shape this
+/// flow exists to avoid. Success is observed on the refreshed catalog and
+/// reported through `onConnected`; cancel and failure leave the presenting
+/// surface untouched.
+struct AbilityConnectSheet: View {
+    let ability: AbilitiesAPI.Ability
+    /// Called with the refreshed ability (entitlement now active); the
+    /// presenter dismisses and continues.
+    let onConnected: (AbilitiesAPI.Ability) -> Void
+
+    @Environment(\.dismiss) private var dismiss: DismissAction
+    @State private var viewModel: AbilitiesListViewModel
+
+    /// Takes the whole selection so the service and its authorizer are
+    /// latched together for the sheet's lifetime (see `AbilitiesSelection`).
+    init(
+        ability: AbilitiesAPI.Ability,
+        selection: AbilitiesSelection,
+        onConnected: @escaping (AbilitiesAPI.Ability) -> Void
+    ) {
+        self.ability = ability
+        self.onConnected = onConnected
+        _viewModel = State(initialValue: AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer))
+    }
+
+    var body: some View {
+        content
+            .presentationDetents([.medium])
+            .task { await viewModel.refresh() }
+            .onChange(of: connectedAbility) { _, newValue in
+                guard let newValue else { return }
+                onConnected(newValue)
+            }
+    }
+
+    /// The ability as served by the freshest catalog once its entitlement
+    /// is active; nil until then. Flipping non-nil is the success signal,
+    /// which also covers an ability that went active elsewhere while this
+    /// sheet was opening.
+    private var connectedAbility: AbilitiesAPI.Ability? {
+        guard let refreshed = viewModel.catalog?.abilities.first(where: { $0.id == ability.id }),
+              refreshed.entitlement?.status == .active else { return nil }
+        return refreshed
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let pending = viewModel.pendingAuthorization {
+            mockAuthorizationContent(pending)
+        } else {
+            connectContent
+        }
+    }
+
+    /// Mock mode's stand-in for the provider consent page, embedded inline
+    /// in place of the confirm content. Approve runs the same completion
+    /// lifecycle the abilities list drives; cancel abandons the whole flow.
+    private func mockAuthorizationContent(_ context: AbilityAuthorizationContext) -> some View {
+        AbilityAuthorizationSheet(
+            context: context,
+            onAuthorize: { viewModel.completeAuthorization(context) },
+            onCancel: handleAuthorizationCancelled
+        )
+    }
+
+    private var connectContent: some View {
+        VStack(spacing: DesignConstants.Spacing.step4x) {
+            header
+            if let errorMessage = viewModel.errorMessage {
+                errorLabel(errorMessage)
+            }
+            actionButtons
+        }
+        .padding(.vertical, DesignConstants.Spacing.step6x)
+        .accessibilityIdentifier("ability-connect-sheet")
+    }
+
+    private var header: some View {
+        let displayName: String = ability.displayName.resolved()
+        return VStack(spacing: DesignConstants.Spacing.step2x) {
+            AbilityIconView(ability: ability)
+            Text("Connect \(displayName)?")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.colorTextPrimary)
+                .multilineTextAlignment(.center)
+            Text("You'll sign in with \(displayName), then pick what to share in this convo.")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    private func errorLabel(_ message: String) -> some View {
+        Text(message)
+            .font(.footnote)
+            .foregroundStyle(.colorCaution)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    private var actionButtons: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            connectButton
+            cancelButton
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    private var connectButton: some View {
+        let isBusy: Bool = viewModel.isBusy(ability)
+        let title: String = viewModel.errorMessage == nil ? "Connect" : "Try Again"
+        let connectAction = { viewModel.connect(ability) }
+        return Button(action: connectAction) {
+            connectButtonLabel(title: title, isBusy: isBusy)
+        }
+        .convosButtonStyle(.rounded(fullWidth: true))
+        .disabled(isBusy)
+        .accessibilityIdentifier("ability-connect-confirm-button")
+    }
+
+    @ViewBuilder
+    private func connectButtonLabel(title: String, isBusy: Bool) -> some View {
+        if isBusy {
+            ProgressView()
+        } else {
+            Text(title)
+        }
+    }
+
+    private var cancelButton: some View {
+        let cancelAction = { dismiss() }
+        return Button(action: cancelAction) {
+            Text("Cancel")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, DesignConstants.Spacing.step3x)
+        }
+        .accessibilityIdentifier("ability-connect-cancel-button")
+    }
+
+    /// Cancel from the mock authorization step: same outcome as Cancel on
+    /// the confirm step. The entitlement stays pending server-side, so the
+    /// presenting row keeps offering the connect path.
+    private func handleAuthorizationCancelled() {
+        viewModel.cancelAuthorization()
+        dismiss()
+    }
+}
+
+#Preview("Connect") {
+    let youtube = MockAbilitiesService.standardCatalog().first { $0.id == "youtube" }
+    if let youtube {
+        AbilityConnectSheet(
+            ability: youtube,
+            selection: AbilitiesSelection(service: MockAbilitiesService()),
+            onConnected: { _ in }
+        )
+    }
+}

--- a/Convos/Abilities/ConversationAbilitiesSection.swift
+++ b/Convos/Abilities/ConversationAbilitiesSection.swift
@@ -9,10 +9,17 @@ import SwiftUI
 /// plain toggle per ability, multi-agent conversations label each row with
 /// the agent it extends to. Rows honor the entitlement lifecycle: an
 /// opt-in backed by a non-active entitlement renders its status badge and
-/// deep-links to the abilities list instead of presenting a usable toggle.
+/// opens the inline connect sheet instead of presenting a usable toggle.
 /// Toggling on a multi-bundle ability opens the bundle picker; toggling an
-/// ability without an active entitlement opens the abilities list to
-/// connect it first.
+/// ability without an active entitlement opens the inline connect sheet
+/// (`AbilityConnectSheet`) and, once connected, continues into the
+/// extension without leaving the conversation.
+/// The section renders rows only; its bundle and connect sheets are hosted
+/// by `ConversationAbilitiesSheetsModifier`, which the presenting screen
+/// applies at its list level. Sheet modifiers attached to the `Section`
+/// itself resolve the wrong presentation context from inside the
+/// already-presented info sheet: the toggle's sheet then dismisses the
+/// info sheet instead of presenting, dead-ending the flow.
 struct ConversationAbilitiesSection: View {
     @Bindable var viewModel: ConversationAbilitiesViewModel
 
@@ -30,12 +37,6 @@ struct ConversationAbilitiesSection: View {
             Text("Abilities")
                 .font(.footnote.weight(.medium))
                 .foregroundStyle(.colorTextSecondary)
-        }
-        .sheet(item: $viewModel.bundleSelection) { context in
-            bundleSelectionSheet(context)
-        }
-        .sheet(item: $viewModel.needsEntitlementAbility, onDismiss: handleSheetDismissed) { ability in
-            needsEntitlementSheet(ability)
         }
     }
 
@@ -65,13 +66,13 @@ struct ConversationAbilitiesSection: View {
     }
 
     /// An opt-in whose entitlement is no longer active: no usable toggle,
-    /// a badge, and the whole row deep-links to the abilities list to
+    /// a badge, and the whole row opens the inline connect sheet to
     /// reconnect.
     private func needsAttentionRow(
         _ row: ConversationAbilitiesViewModel.Row,
         status: AbilitiesAPI.EntitlementStatus?
     ) -> some View {
-        let reconnectAction = { viewModel.needsEntitlementAbility = row.ability }
+        let reconnectAction = { viewModel.presentConnect(for: row) }
         return Button(action: reconnectAction) {
             featureRow(row) {
                 attentionBadge(status: status)
@@ -138,8 +139,43 @@ struct ConversationAbilitiesSection: View {
         case .active: ""
         }
     }
+}
 
-    // MARK: - Sheets
+/// Hosts the abilities section's two sheets (bundle picker and inline
+/// connect) for a presenting screen. Applied to `ConversationInfoView`'s
+/// list, next to its other working sheet attachments -- never to the
+/// `Section` (see `ConversationAbilitiesSection`).
+struct ConversationAbilitiesSheetsModifier: ViewModifier {
+    /// Nil when the conversation renders the V1 connections section or has
+    /// no agent; both sheets then simply never present.
+    let viewModel: ConversationAbilitiesViewModel?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let viewModel {
+            content.modifier(ConversationAbilitiesActiveSheetsModifier(viewModel: viewModel))
+        } else {
+            content
+        }
+    }
+}
+
+/// The non-nil half of `ConversationAbilitiesSheetsModifier`. `@Bindable`
+/// projects the view model's sheet contexts as observation-tracked
+/// bindings; a hand-rolled `Binding(get:set:)` pair is not tracked, so the
+/// sheets would never present when the view model publishes a context.
+private struct ConversationAbilitiesActiveSheetsModifier: ViewModifier {
+    @Bindable var viewModel: ConversationAbilitiesViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: $viewModel.bundleSelection) { context in
+                bundleSelectionSheet(context)
+            }
+            .sheet(item: $viewModel.connectContext, onDismiss: handleConnectSheetDismissed) { context in
+                connectSheet(context)
+            }
+    }
 
     private func bundleSelectionSheet(_ context: AbilityBundleSelectionContext) -> some View {
         AbilityBundleSelectionSheet(context: context) { bundleIds in
@@ -147,79 +183,79 @@ struct ConversationAbilitiesSection: View {
         }
     }
 
-    /// The needs-entitlement deep link: the account-level abilities list on
-    /// the same service, so connecting here is reflected in the toggles
-    /// after dismissal (`handleSheetDismissed` refreshes). The screen
-    /// wrapper owns the list view model via `@State`, so re-evaluations of
-    /// this sheet-content builder cannot replace it mid-presentation.
-    private func needsEntitlementSheet(_ ability: AbilitiesAPI.Ability) -> some View {
-        NavigationStack {
-            AbilitiesListScreen(selection: viewModel.abilitiesSelection)
-                .navigationTitle("Connect \(ability.displayName.resolved())")
-                .navigationBarTitleDisplayMode(.inline)
-        }
+    /// The no-entitlement path: an inline connect flow for the tapped
+    /// ability on the same service selection as the rows, so a successful
+    /// connect continues straight into the extension
+    /// (`ConversationAbilitiesViewModel.handleConnected`). Replaces the old
+    /// abilities-list deep link, which dead-ended the toggle.
+    private func connectSheet(_ context: ConversationAbilityConnectContext) -> some View {
+        AbilityConnectSheet(
+            ability: context.ability,
+            selection: viewModel.abilitiesSelection,
+            onConnected: { viewModel.handleConnected($0) }
+        )
     }
 
-    private func handleSheetDismissed() {
-        viewModel.refreshSoon()
+    private func handleConnectSheetDismissed() {
+        viewModel.handleConnectSheetDismissed()
     }
 }
 
 // MARK: - Previews
 
 #Preview("Single agent") {
+    let viewModel = ConversationAbilitiesViewModel(
+        conversationId: "mock-conversation-1",
+        agents: [
+            ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
+        ],
+        selection: AbilitiesSelection(service: MockAbilitiesService())
+    )
     List {
-        ConversationAbilitiesSection(
-            viewModel: ConversationAbilitiesViewModel(
-                conversationId: "mock-conversation-1",
-                agents: [
-                    ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
-                ],
-                selection: AbilitiesSelection(service: MockAbilitiesService())
-            )
-        )
+        ConversationAbilitiesSection(viewModel: viewModel)
     }
+    .modifier(ConversationAbilitiesSheetsModifier(viewModel: viewModel))
 }
 
 #Preview("Two agents") {
+    let viewModel = ConversationAbilitiesViewModel(
+        conversationId: "mock-conversation-1",
+        agents: [
+            ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
+            ConversationAgentDescriptor(inboxId: "mock-agent-inbox-2", displayName: "Scout"),
+        ],
+        selection: AbilitiesSelection(service: MockAbilitiesService())
+    )
     List {
-        ConversationAbilitiesSection(
-            viewModel: ConversationAbilitiesViewModel(
-                conversationId: "mock-conversation-1",
-                agents: [
-                    ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
-                    ConversationAgentDescriptor(inboxId: "mock-agent-inbox-2", displayName: "Scout"),
-                ],
-                selection: AbilitiesSelection(service: MockAbilitiesService())
-            )
-        )
+        ConversationAbilitiesSection(viewModel: viewModel)
     }
+    .modifier(ConversationAbilitiesSheetsModifier(viewModel: viewModel))
 }
 
 #Preview("Entitlements unavailable") {
+    let viewModel = ConversationAbilitiesViewModel(
+        conversationId: "mock-conversation-1",
+        agents: [
+            ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
+        ],
+        selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailable))
+    )
     List {
-        ConversationAbilitiesSection(
-            viewModel: ConversationAbilitiesViewModel(
-                conversationId: "mock-conversation-1",
-                agents: [
-                    ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
-                ],
-                selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailable))
-            )
-        )
+        ConversationAbilitiesSection(viewModel: viewModel)
     }
+    .modifier(ConversationAbilitiesSheetsModifier(viewModel: viewModel))
 }
 
 #Preview("Cold-start outage") {
+    let viewModel = ConversationAbilitiesViewModel(
+        conversationId: "mock-conversation-1",
+        agents: [
+            ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
+        ],
+        selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart))
+    )
     List {
-        ConversationAbilitiesSection(
-            viewModel: ConversationAbilitiesViewModel(
-                conversationId: "mock-conversation-1",
-                agents: [
-                    ConversationAgentDescriptor(inboxId: "mock-agent-inbox-1", displayName: "Caley"),
-                ],
-                selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart))
-            )
-        )
+        ConversationAbilitiesSection(viewModel: viewModel)
     }
+    .modifier(ConversationAbilitiesSheetsModifier(viewModel: viewModel))
 }

--- a/Convos/Abilities/ConversationAbilitiesViewModel.swift
+++ b/Convos/Abilities/ConversationAbilitiesViewModel.swift
@@ -23,6 +23,29 @@ struct AbilityBundleSelectionContext: Identifiable, Hashable {
     }
 }
 
+/// Sheet context for connecting an ability inline from the conversation
+/// abilities section: the tapped ability, the agent whose row started the
+/// flow, and how to continue once the connect succeeds. Mirrors
+/// `AbilityBundleSelectionContext`'s shape for the sibling sheet.
+struct ConversationAbilityConnectContext: Identifiable, Hashable {
+    let ability: AbilitiesAPI.Ability
+    let agent: ConversationAgentDescriptor
+    /// True when a successful connect flows straight into extending the
+    /// ability to the agent (the toggle-on path). False when an opt-in
+    /// already exists and only the entitlement needed repair -- the opt-in
+    /// and its bundle selection already stand and must not be overwritten.
+    let continuesToExtension: Bool
+    /// Bundles already chosen before a connect interrupted an extension
+    /// (the extend call bounced with `needsEntitlement`); nil derives the
+    /// selection after connect instead (bundle picker for multi-bundle
+    /// abilities, manifest defaults otherwise).
+    let preselectedBundleIds: [String]?
+
+    var id: ConversationAbilityKey {
+        ConversationAbilityKey(abilityId: ability.id, agentInboxId: agent.inboxId)
+    }
+}
+
 @MainActor @Observable
 final class ConversationAbilitiesViewModel {
     /// One toggle: an ability crossed with one agent. Single-agent
@@ -63,9 +86,14 @@ final class ConversationAbilitiesViewModel {
     private(set) var errorMessage: String?
     /// Non-nil presents the bundle picker sheet.
     var bundleSelection: AbilityBundleSelectionContext?
-    /// Non-nil presents the abilities list sheet: the tapped ability has no
-    /// active entitlement, so the user connects or reconnects it there.
-    var needsEntitlementAbility: AbilitiesAPI.Ability?
+    /// Non-nil presents the inline connect sheet: the tapped ability has no
+    /// active entitlement, so the user connects (or reconnects) it right
+    /// here instead of detouring through App Settings.
+    var connectContext: ConversationAbilityConnectContext?
+    /// Parked continuation for a connect that succeeded: the connect sheet
+    /// finishes dismissing first, then `handleConnectSheetDismissed` flows
+    /// into the extension, so the bundle picker never races the dismissal.
+    private var pendingExtensionAfterConnect: ConversationAbilityConnectContext?
 
     private var catalog: AbilitiesCatalog?
     private var optIns: [ConversationAbility] = []
@@ -124,9 +152,78 @@ final class ConversationAbilitiesViewModel {
                 requestExtension(for: row)
             }
         case .needsAttention, .needsEntitlement:
-            needsEntitlementAbility = row.ability
+            presentConnect(for: row)
         case .unknown:
             break
+        }
+    }
+
+    /// Presents the inline connect sheet for a row without a usable
+    /// entitlement. Rows not yet opted in continue into the extension after
+    /// a successful connect; already-opted-in rows (needs-attention) only
+    /// repair the entitlement, since their opt-in and bundle selection
+    /// already stand.
+    func presentConnect(for row: Row) {
+        connectContext = ConversationAbilityConnectContext(
+            ability: row.ability,
+            agent: row.agent,
+            continuesToExtension: !row.isOn,
+            preselectedBundleIds: nil
+        )
+    }
+
+    /// The connect sheet reports the entitlement went active. Park the
+    /// continuation with the refreshed ability (the pre-connect copy still
+    /// carries the stale entitlement) and dismiss the sheet;
+    /// `handleConnectSheetDismissed` picks the continuation up.
+    func handleConnected(_ refreshedAbility: AbilitiesAPI.Ability) {
+        guard let context = connectContext else { return }
+        if context.continuesToExtension {
+            pendingExtensionAfterConnect = ConversationAbilityConnectContext(
+                ability: refreshedAbility,
+                agent: context.agent,
+                continuesToExtension: true,
+                preselectedBundleIds: context.preselectedBundleIds
+            )
+        }
+        connectContext = nil
+    }
+
+    /// Runs on every dismissal of the connect sheet. A parked continuation
+    /// means the connect succeeded: flow into the extension. Anything else
+    /// (cancel, swipe-down, failure) just refreshes -- the toggle was never
+    /// optimistically flipped, so it reads off again by construction.
+    func handleConnectSheetDismissed() {
+        if let pending = pendingExtensionAfterConnect {
+            pendingExtensionAfterConnect = nil
+            continueExtensionAfterConnect(pending)
+        } else {
+            refreshSoon()
+        }
+    }
+
+    private func continueExtensionAfterConnect(_ context: ConversationAbilityConnectContext) {
+        let ability = context.ability
+        guard ability.entitlement?.status == .active else {
+            refreshSoon()
+            return
+        }
+        if let bundleIds = context.preselectedBundleIds {
+            extend(ability: ability, agent: context.agent, bundleIds: bundleIds)
+            return
+        }
+        guard !ability.bundles.isEmpty else {
+            errorMessage = LiveAbilitiesServiceError.noBundlesSelected(abilityId: ability.id).localizedDescription
+            refreshSoon()
+            return
+        }
+        if ability.bundles.count > 1 {
+            // Refresh beneath the picker so the rows already show the
+            // now-active entitlement while the user chooses bundles.
+            refreshSoon()
+            bundleSelection = AbilityBundleSelectionContext(ability: ability, agent: context.agent)
+        } else {
+            extend(ability: ability, agent: context.agent, bundleIds: defaultBundleIds(for: ability))
         }
     }
 
@@ -146,7 +243,15 @@ final class ConversationAbilitiesViewModel {
                     bundleIds: bundleIds
                 )
             } catch AbilitiesServiceError.needsEntitlement {
-                needsEntitlementAbility = ability
+                // The server says the entitlement is gone mid-extend: run
+                // the connect inline and retry with the bundles the user
+                // already chose, instead of re-opening the picker.
+                connectContext = ConversationAbilityConnectContext(
+                    ability: ability,
+                    agent: agent,
+                    continuesToExtension: true,
+                    preselectedBundleIds: bundleIds
+                )
             } catch {
                 mutationError = error.localizedDescription
             }
@@ -160,16 +265,15 @@ final class ConversationAbilitiesViewModel {
         }
     }
 
-    /// The selection driving this conversation's rows. The
-    /// needs-entitlement deep link hands the whole pair to
-    /// `AbilitiesListScreen` so a connect there is visible here after
-    /// dismissal, and the sheet's authorizer always matches this service.
+    /// The selection driving this conversation's rows. The connect sheet
+    /// receives the whole pair, so a connect there mutates the same service
+    /// these rows read and its authorizer always matches this service.
     var abilitiesSelection: AbilitiesSelection { selection }
 
     private func requestExtension(for row: Row) {
         let ability = row.ability
         guard ability.entitlement?.status == .active else {
-            needsEntitlementAbility = ability
+            presentConnect(for: row)
             return
         }
         guard !ability.bundles.isEmpty else {

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -265,20 +265,27 @@ struct AppSettingsView: View {
         }
     }
 
+    /// Row title and count follow `connectionsDestination`: "Abilities"
+    /// over the V2 list under the flag, "Connections" over the V1 list
+    /// otherwise. The count is V1 connections, so it only renders alongside
+    /// the V1 title.
     @ViewBuilder
     private var connectionsRowLabel: some View {
+        let isAbilitiesV2: Bool = FeatureFlags.shared.isAbilitiesV2Enabled
+        let title: String = isAbilitiesV2 ? "Abilities" : "Connections"
         let connectionsCount: Int = viewModel.connectionsListViewModel.connections.count
+        let showsCount: Bool = !isAbilitiesV2 && connectionsCount > 0
         HStack {
             Image(systemName: "batteryblock.fill")
                 .foregroundStyle(.colorTextPrimary)
                 .frame(width: DesignConstants.Spacing.step8x, alignment: .center)
 
-            Text("Connections")
+            Text(title)
                 .foregroundStyle(.colorTextPrimary)
 
             Spacer()
 
-            if connectionsCount > 0 {
+            if showsCount {
                 Text("\(connectionsCount)")
                     .foregroundStyle(.colorTextSecondary)
                     .monospacedDigit()

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -5,6 +5,15 @@ import Foundation
 final class FeatureFlags {
     static let shared: FeatureFlags = FeatureFlags()
 
+    // Every flag here is a computed property over UserDefaults, and the
+    // Observable macro only instruments stored properties. Each accessor
+    // therefore registers with the observation registrar by hand --
+    // `access(keyPath:)` in get, `withMutation(keyPath:)` around the write
+    // -- so views whose bodies read a flag (for example the debug menu's
+    // dependent rows) re-evaluate as soon as it is toggled. Without the
+    // registrar calls a flip only shows up after the view is rebuilt for
+    // some other reason.
+
     // Reaching a flag in a production build takes two changes, not one, and
     // missing either looks identical from the device: the control just is not
     // there.
@@ -21,12 +30,15 @@ final class FeatureFlags {
     /// value somehow leaks in from a dev build with the same bundle id.
     var isDebugInjectorEnabled: Bool {
         get {
+            access(keyPath: \.isDebugInjectorEnabled)
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.debugInjectorEnabledKey)
         }
         set {
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
-            UserDefaults.standard.set(newValue, forKey: Constant.debugInjectorEnabledKey)
+            withMutation(keyPath: \.isDebugInjectorEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.debugInjectorEnabledKey)
+            }
         }
     }
 
@@ -35,12 +47,15 @@ final class FeatureFlags {
     /// locked off in production so the selector can never surface for end users.
     var isAgentVariantSelectorEnabled: Bool {
         get {
+            access(keyPath: \.isAgentVariantSelectorEnabled)
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.agentVariantSelectorEnabledKey)
         }
         set {
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
-            UserDefaults.standard.set(newValue, forKey: Constant.agentVariantSelectorEnabledKey)
+            withMutation(keyPath: \.isAgentVariantSelectorEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.agentVariantSelectorEnabledKey)
+            }
             // Clear any cached selection when the feature is turned off so a
             // stale variant can't resurface on re-enable. Reads are already
             // gated on this flag; clearing keeps the persisted state honest too.
@@ -62,13 +77,16 @@ final class FeatureFlags {
     /// remembered and wins over the default.
     var isListenParticipationEnabled: Bool {
         get {
+            access(keyPath: \.isListenParticipationEnabled)
             guard let stored = UserDefaults.standard.object(forKey: Constant.listenParticipationEnabledKey) as? Bool else {
                 return Self.listenParticipationDefault
             }
             return stored
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Constant.listenParticipationEnabledKey)
+            withMutation(keyPath: \.isListenParticipationEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.listenParticipationEnabledKey)
+            }
         }
     }
 
@@ -84,10 +102,13 @@ final class FeatureFlags {
     /// Default-off keeps everyone else on the legacy stream path.
     var isXMTPBidiStreamsEnabled: Bool {
         get {
+            access(keyPath: \.isXMTPBidiStreamsEnabled)
             return UserDefaults.standard.bool(forKey: Constant.xmtpBidiStreamsEnabledKey)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: Constant.xmtpBidiStreamsEnabledKey)
+            withMutation(keyPath: \.isXMTPBidiStreamsEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.xmtpBidiStreamsEnabledKey)
+            }
         }
     }
 
@@ -99,12 +120,15 @@ final class FeatureFlags {
     /// public enablement is a default flip in a client release.
     var isAbilitiesV2Enabled: Bool {
         get {
+            access(keyPath: \.isAbilitiesV2Enabled)
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.abilitiesV2EnabledKey)
         }
         set {
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
-            UserDefaults.standard.set(newValue, forKey: Constant.abilitiesV2EnabledKey)
+            withMutation(keyPath: \.isAbilitiesV2Enabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.abilitiesV2EnabledKey)
+            }
         }
     }
 
@@ -112,12 +136,15 @@ final class FeatureFlags {
     /// in the Debug menu. Non-production only; defaults to `.plusAmple`.
     var mockCreditsPreset: CreditsStatePreset {
         get {
+            access(keyPath: \.mockCreditsPreset)
             let raw = UserDefaults.standard.string(forKey: Constant.mockCreditsPresetKey)
                 ?? CreditsStatePreset.plusAmple.rawValue
             return CreditsStatePreset(compatibleRawValue: raw) ?? .plusAmple
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: Constant.mockCreditsPresetKey)
+            withMutation(keyPath: \.mockCreditsPreset) {
+                UserDefaults.standard.set(newValue.rawValue, forKey: Constant.mockCreditsPresetKey)
+            }
         }
     }
 
@@ -129,17 +156,20 @@ final class FeatureFlags {
     /// can never route an end user to a variant runtime.
     var selectedAgentVariant: ConvosAPI.AgentVariant? {
         get {
+            access(keyPath: \.selectedAgentVariant)
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return nil }
             guard let data = UserDefaults.standard.data(forKey: Constant.selectedAgentVariantKey) else { return nil }
             return try? JSONDecoder().decode(ConvosAPI.AgentVariant.self, from: data)
         }
         set {
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
-            guard let newValue, let data = try? JSONEncoder().encode(newValue) else {
-                UserDefaults.standard.removeObject(forKey: Constant.selectedAgentVariantKey)
-                return
+            withMutation(keyPath: \.selectedAgentVariant) {
+                guard let newValue, let data = try? JSONEncoder().encode(newValue) else {
+                    UserDefaults.standard.removeObject(forKey: Constant.selectedAgentVariantKey)
+                    return
+                }
+                UserDefaults.standard.set(data, forKey: Constant.selectedAgentVariantKey)
             }
-            UserDefaults.standard.set(data, forKey: Constant.selectedAgentVariantKey)
         }
     }
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -635,6 +635,11 @@ struct ConversationInfoView: View {
                 .task {
                     prepareAgentAccessViewModels()
                 }
+                // Hosted here rather than on the abilities Section: a sheet
+                // modifier attached to the Section resolves the wrong
+                // presentation context from inside this presented sheet and
+                // dismisses it instead of presenting.
+                .modifier(ConversationAbilitiesSheetsModifier(viewModel: abilitiesViewModel))
                 .alert("Restore invite tag", isPresented: $showingRestoreInviteTagAlert) {
                     TextField("Invite tag", text: $restoreInviteTagText)
                     Button("Cancel", role: .cancel) {

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -174,10 +174,27 @@ struct ConvosApp: App {
             profileViewModel.bind(session: profileSession)
         }
 
-        let metricsSession = convos.session
+        Self.startMetricsIdentification(
+            session: convos.session,
+            environment: environment,
+            coreMetrics: coreMetrics,
+            metricsDelegate: metricsDelegate
+        )
+
+        Self.configureTabBarItemColors()
+    }
+
+    /// Identifies the metrics stack once the inbox is ready and streams
+    /// user properties into it; runs entirely off the launch path.
+    private static func startMetricsIdentification(
+        session: any SessionManagerProtocol,
+        environment: AppEnvironment,
+        coreMetrics: CoreMetrics,
+        metricsDelegate: PostHogCollector
+    ) {
         Task {
             do {
-                let messagingService = metricsSession.messagingService()
+                let messagingService = session.messagingService()
                 let inboxReady = try await messagingService.sessionStateManager.waitForInboxReadyResult()
                 coreMetrics.identify(privateKey: Data(inboxReady.client.inboxId.utf8))
                 // The backend accountId (not the XMTP inbox id) lets product
@@ -188,7 +205,7 @@ struct ConvosApp: App {
                 let accountId = await DeviceIdentitySnapshot.current(identityStore: identityStore).accountId
                 let builder = UserPropertiesBuilder(
                     contactsRepository: messagingService.contactsRepository(),
-                    conversationsRepository: metricsSession.conversationsRepository(for: .all),
+                    conversationsRepository: session.conversationsRepository(for: .all),
                     accountId: accountId
                 )
                 metricsDelegate.userPropertiesCancellable = builder.publisher()
@@ -199,8 +216,6 @@ struct ConvosApp: App {
                 Log.warning("Metrics identify failed: \(error.localizedDescription)")
             }
         }
-
-        Self.configureTabBarItemColors()
     }
 
     /// Wires the live abilities service (mock/live selection happens per

--- a/ConvosTests/ConversationAbilitiesViewModelTests.swift
+++ b/ConvosTests/ConversationAbilitiesViewModelTests.swift
@@ -1,0 +1,182 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// Covers the inline connect flow the conversation abilities toggles drive
+/// when an ability has no active entitlement: presenting the connect
+/// sheet, the cancel path reverting cleanly, and the post-connect
+/// continuation into the extension.
+@MainActor
+final class ConversationAbilitiesViewModelTests: XCTestCase {
+    private enum TestError: Error {
+        case rowNotFound(String)
+        case abilityNotFound(String)
+    }
+
+    private let agent: ConversationAgentDescriptor = ConversationAgentDescriptor(
+        inboxId: "mock-agent-inbox-1",
+        displayName: "Caley"
+    )
+
+    private func makeViewModel(
+        service: MockAbilitiesService,
+        conversationId: String = "test-conversation"
+    ) async -> ConversationAbilitiesViewModel {
+        let viewModel = ConversationAbilitiesViewModel(
+            conversationId: conversationId,
+            agents: [agent],
+            selection: AbilitiesSelection(service: service)
+        )
+        await viewModel.refresh()
+        return viewModel
+    }
+
+    private func row(_ abilityId: String, in viewModel: ConversationAbilitiesViewModel) throws -> ConversationAbilitiesViewModel.Row {
+        guard let row = viewModel.rows.first(where: { $0.ability.id == abilityId }) else {
+            throw TestError.rowNotFound(abilityId)
+        }
+        return row
+    }
+
+    /// Connects `abilityId` directly on the mock service (begin, complete)
+    /// and returns the refreshed ability with its now-active entitlement,
+    /// the way `AbilityConnectSheet` reports success.
+    private func connectOnService(_ service: MockAbilitiesService, abilityId: String) async throws -> AbilitiesAPI.Ability {
+        _ = try await service.beginEntitlement(abilityId: abilityId)
+        try await service.completeEntitlement(abilityId: abilityId)
+        let catalog = try await service.fetchCatalog()
+        guard let refreshed = catalog.abilities.first(where: { $0.id == abilityId }) else {
+            throw TestError.abilityNotFound(abilityId)
+        }
+        XCTAssertEqual(refreshed.entitlement?.status, .active)
+        return refreshed
+    }
+
+    /// Waits for the view model's fire-and-forget extension task to land in
+    /// the service, returning the opt-ins once `predicate` passes.
+    private func waitForConversationAbilities(
+        service: MockAbilitiesService,
+        conversationId: String,
+        where predicate: ([ConversationAbility]) -> Bool
+    ) async throws -> [ConversationAbility] {
+        for _ in 0..<200 {
+            let optIns = try await service.conversationAbilities(conversationId: conversationId)
+            if predicate(optIns) {
+                return optIns
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        return try await service.conversationAbilities(conversationId: conversationId)
+    }
+
+    func testToggleWithoutEntitlementPresentsConnectSheet() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let viewModel = await makeViewModel(service: service)
+
+        let youtubeRow = try row("youtube", in: viewModel)
+        XCTAssertEqual(youtubeRow.lifecycle, .needsEntitlement)
+        XCTAssertFalse(youtubeRow.isOn)
+
+        viewModel.toggle(youtubeRow)
+
+        let context = try XCTUnwrap(viewModel.connectContext)
+        XCTAssertEqual(context.ability.id, "youtube")
+        XCTAssertEqual(context.agent, agent)
+        XCTAssertTrue(context.continuesToExtension)
+        XCTAssertNil(context.preselectedBundleIds)
+        XCTAssertNil(viewModel.bundleSelection)
+    }
+
+    func testConnectSheetCancelRevertsWithoutExtension() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let viewModel = await makeViewModel(service: service)
+
+        viewModel.toggle(try row("youtube", in: viewModel))
+        XCTAssertNotNil(viewModel.connectContext)
+
+        // Cancel: the sheet dismisses without ever reporting a connect.
+        viewModel.connectContext = nil
+        viewModel.handleConnectSheetDismissed()
+        await viewModel.refresh()
+
+        XCTAssertNil(viewModel.connectContext)
+        XCTAssertNil(viewModel.bundleSelection)
+        let youtubeRow = try row("youtube", in: viewModel)
+        XCTAssertFalse(youtubeRow.isOn)
+        let optIns = try await service.conversationAbilities(conversationId: "test-conversation")
+        XCTAssertFalse(optIns.contains { $0.abilityId == "youtube" })
+    }
+
+    func testConnectedContinuesIntoBundlePickerForMultiBundleAbility() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let viewModel = await makeViewModel(service: service)
+
+        viewModel.toggle(try row("youtube", in: viewModel))
+        let refreshed = try await connectOnService(service, abilityId: "youtube")
+
+        viewModel.handleConnected(refreshed)
+        XCTAssertNil(viewModel.connectContext, "success dismisses the connect sheet")
+
+        viewModel.handleConnectSheetDismissed()
+        let bundleSelection = try XCTUnwrap(viewModel.bundleSelection, "multi-bundle ability continues into the picker")
+        XCTAssertEqual(bundleSelection.ability.id, "youtube")
+        XCTAssertEqual(bundleSelection.ability.entitlement?.status, .active)
+        XCTAssertEqual(bundleSelection.agent, agent)
+    }
+
+    func testConnectedExtendsDirectlyWithPreselectedBundles() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let viewModel = await makeViewModel(service: service)
+
+        // The extend-bounced shape: bundles were already chosen when the
+        // server reported the missing entitlement.
+        let stale = try row("youtube", in: viewModel).ability
+        viewModel.connectContext = ConversationAbilityConnectContext(
+            ability: stale,
+            agent: agent,
+            continuesToExtension: true,
+            preselectedBundleIds: ["youtube.search"]
+        )
+        let refreshed = try await connectOnService(service, abilityId: "youtube")
+
+        viewModel.handleConnected(refreshed)
+        viewModel.handleConnectSheetDismissed()
+
+        let optIns = try await waitForConversationAbilities(service: service, conversationId: "test-conversation") { rows in
+            rows.contains { $0.abilityId == "youtube" }
+        }
+        let optIn = try XCTUnwrap(optIns.first { $0.abilityId == "youtube" })
+        XCTAssertEqual(optIn.bundleIds, ["youtube.search"])
+        XCTAssertNil(viewModel.bundleSelection, "preselected bundles skip the picker")
+
+        await viewModel.refresh()
+        XCTAssertTrue(try row("youtube", in: viewModel).isOn)
+    }
+
+    func testReconnectOfOptedInRowDoesNotOverwriteBundleSelection() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        // Standard fixture: coinbase is opted in here with an expired
+        // entitlement, so its row needs attention rather than a toggle.
+        let conversationId = "mock-conversation-1"
+        let viewModel = await makeViewModel(service: service, conversationId: conversationId)
+
+        let coinbaseRow = try row("coinbase", in: viewModel)
+        XCTAssertTrue(coinbaseRow.isOn)
+        XCTAssertEqual(coinbaseRow.lifecycle, .needsAttention(.expired))
+
+        viewModel.presentConnect(for: coinbaseRow)
+        let context = try XCTUnwrap(viewModel.connectContext)
+        XCTAssertFalse(context.continuesToExtension, "an existing opt-in only repairs the entitlement")
+
+        let refreshed = try await connectOnService(service, abilityId: "coinbase")
+        viewModel.handleConnected(refreshed)
+        viewModel.handleConnectSheetDismissed()
+        await viewModel.refresh()
+
+        XCTAssertNil(viewModel.bundleSelection)
+        let optIns = try await service.conversationAbilities(conversationId: conversationId)
+        let optIn = try XCTUnwrap(optIns.first { $0.abilityId == "coinbase" })
+        XCTAssertEqual(optIn.bundleIds, ["coinbase.prices"], "the original bundle selection survives the reconnect")
+        XCTAssertEqual(try row("coinbase", in: viewModel).lifecycle, .ready)
+    }
+}

--- a/ConvosTests/FeatureFlagsObservationTests.swift
+++ b/ConvosTests/FeatureFlagsObservationTests.swift
@@ -1,0 +1,46 @@
+@testable import Convos
+import Observation
+import XCTest
+
+/// The feature flags are computed properties over UserDefaults, so each
+/// accessor registers with the observation registrar by hand. These tests
+/// pin that wiring: a view that reads a flag in its body must be
+/// invalidated the moment the flag is toggled. The debug menu's dependent
+/// rows (for example the abilities sub-toggles) rely on this to appear
+/// without leaving and re-entering the screen.
+@MainActor
+final class FeatureFlagsObservationTests: XCTestCase {
+    func testTogglingAbilitiesV2NotifiesObservers() {
+        let flags = FeatureFlags.shared
+        let initial = flags.isAbilitiesV2Enabled
+        defer { flags.isAbilitiesV2Enabled = initial }
+
+        let changed = expectation(description: "abilities flag observation fired")
+        withObservationTracking {
+            _ = flags.isAbilitiesV2Enabled
+        } onChange: {
+            changed.fulfill()
+        }
+
+        flags.isAbilitiesV2Enabled = !initial
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertEqual(flags.isAbilitiesV2Enabled, !initial)
+    }
+
+    func testTogglingBidiStreamsNotifiesObservers() {
+        let flags = FeatureFlags.shared
+        let initial = flags.isXMTPBidiStreamsEnabled
+        defer { flags.isXMTPBidiStreamsEnabled = initial }
+
+        let changed = expectation(description: "bidi flag observation fired")
+        withObservationTracking {
+            _ = flags.isXMTPBidiStreamsEnabled
+        } onChange: {
+            changed.fulfill()
+        }
+
+        flags.isXMTPBidiStreamsEnabled = !initial
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertEqual(flags.isXMTPBidiStreamsEnabled, !initial)
+    }
+}


### PR DESCRIPTION
Two fixes from live user testing of the Abilities V2 surfaces (all behind the debug feature flag, hard-off in production).

## 1. Conversation Info: ability toggle with no entitlement dead-ended

Observed: in Conversation Info -> Abilities, toggling an ability that had no active entitlement silently dismissed the whole info modal. The sheet was attached to the abilities `Section`, which resolves the wrong presentation context from inside an already-presented sheet, so "present" turned into "dismiss".

Now the toggle presents an inline connect flow (`AbilityConnectSheet`) over the info modal, and a successful connect continues seamlessly into extending the ability - one flow, no dead end:

- toggle on (no entitlement) -> connect confirm -> OAuth (stub in mock mode, `ASWebAuthenticationSession` in live) -> bundle picker for multi-bundle abilities (manifest defaults otherwise) -> toggle lands on
- Cancel or failure at any step: the info modal stays open and the toggle reads off (it is never optimistically flipped)
- an extend that bounces with `needsEntitlement` mid-flight reruns the connect inline and retries with the bundles already chosen
- needs-attention rows (expired/revoked/pending) reconnect through the same sheet without touching their existing opt-in or bundle selection

The two sheets are hosted by `ConversationAbilitiesSheetsModifier` applied at the info list level. `@Bindable` projects the view model's sheet contexts as observation-tracked bindings; the initial hand-rolled `Binding(get:set:)` pairs were not tracked by Observation and the sheets never presented.

## 2. App Settings row renames to "Abilities" under the flag

The "Connections" row reads "Abilities" only when `FeatureFlags.shared.isAbilitiesV2Enabled` is true (the flag is hard-locked off in production). With the flag off, the row keeps "Connections" and the V1 connections count; the count is hidden under the flag since it counts V1 connections.

## Testing

- `ConversationAbilitiesViewModelTests` (5 tests): connect sheet presented on no-entitlement toggle, cancel reverts without an extension, post-connect continuation into the bundle picker, preselected-bundle retry skips the picker, reconnect preserves an existing bundle selection
- Full ConvosCore suite: 1816 tests passed
- Simulator (Dev configuration, mock abilities service): exercised toggle -> connect -> authorize -> bundle picker -> toggle on; cancel-revert; flag on/off settings row. Screenshots: `trackb-settings-abilities-row.png`, `trackb-settings-connections-flag-off.png`, `trackb-info-abilities-section.png`, `trackb-connect-sheet-presented.png`, `trackb-connect-cancel-reverted.png`, `trackb-connect-mock-auth.png`, `trackb-connect-continues-bundle-picker.png`, `trackb-connect-flow-complete.png`
- Not exercised: the live-backend OAuth leg (real `ASWebAuthenticationSession` against a provider); the mock stub drives the same approve/cancel lifecycle in the view model

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788450917&installation_model_id=20076&pr_number=1277&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1277&signature=0f6456cb086b92671f92b3887b22dc54f10b0386311e50ffe8214399509f1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline ability connect flow from conversation toggle and flag-gate Abilities settings title
> - Tapping a conversation ability row that lacks an entitlement now opens an inline `AbilityConnectSheet` instead of navigating to the abilities list; on success, the flow continues into bundle selection or directly extends the ability.
> - `ConversationAbilitiesViewModel` gains `connectContext` state and `presentConnect(for:)` / `handleConnected(_:)` methods; if the server returns `needsEntitlement` during extend, the connect sheet runs inline and retries with the previously chosen bundles automatically.
> - Sheet presentation is moved out of `ConversationAbilitiesSection` into a new `ConversationAbilitiesSheetsModifier` applied at the `NavigationStack` level in `ConversationInfoView`, preventing the info sheet from being dismissed when nested sheets appear.
> - The App Settings row label switches to "Abilities" (with no count) when the Abilities V2 feature flag is on, and `FeatureFlags` computed properties now call `access`/`withMutation` so observer-driven UI updates immediately on flag changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b11026b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->