### PR TITLE
fix(composer): keep the agent participation control visible while typing

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -34,35 +34,6 @@ private struct FilePickerModifier: ViewModifier {
     }
 }
 
-/// Tracks whether the keyboard is on screen. The composer's stored focus is not
-/// a reliable stand-in: the coordinator stops syncing while a focus transition
-/// is open, and an interactive dismissal leaves `@FocusState` set with the
-/// keyboard already gone (see `FocusCoordinator.refocusNonce`), so each signal
-/// lies in one direction. The keyboard itself is the honest one.
-private struct KeyboardVisibilityModifier: ViewModifier {
-    @Binding var isKeyboardVisible: Bool
-
-    func body(content: Content) -> some View {
-        content
-            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
-                setVisible(true, matching: notification)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { notification in
-                setVisible(false, matching: notification)
-            }
-    }
-
-    /// Carries the keyboard's own duration into the change, so whatever moves
-    /// with it travels at the keyboard's pace instead of a spring of its own.
-    private func setVisible(_ visible: Bool, matching notification: Notification) {
-        let key: String = UIResponder.keyboardAnimationDurationUserInfoKey
-        let duration: Double = notification.userInfo?[key] as? Double ?? 0.25
-        withAnimation(.easeOut(duration: duration)) {
-            isKeyboardVisible = visible
-        }
-    }
-}
-
 /// A single dot breathing in place, holding the participation bubble while the
 /// conversation's level is read. It rests at a visible opacity, so if the
 /// animation never runs the bubble still reads as occupied rather than empty.
@@ -146,7 +117,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     @State private var previousFocus: MessagesViewInputFocus?
     @State private var voiceMemoReturnFocus: MessagesViewInputFocus?
     @State private var didSelectPhotoThisSession: Bool = false
-    @State private var isKeyboardVisible: Bool = false
     @Namespace private var namespace: Namespace.ID
     // Injected by the host on conversations that hold an agent; nil elsewhere,
     // and the bubble simply isn't drawn.
@@ -243,7 +213,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     public var body: some View {
         bodyContent
             .modifier(filePickerModifier)
-            .modifier(KeyboardVisibilityModifier(isKeyboardVisible: $isKeyboardVisible))
     }
 
     @ViewBuilder
@@ -496,21 +465,13 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         }
     }
 
-    /// Whether the participation bubble stands aside: it does while the keyboard
-    /// is up, so the member typing gets that width back, and comes back the
-    /// moment it goes down. Keyed to the keyboard rather than to focus, which
-    /// desyncs in both directions - see `KeyboardVisibilityModifier`.
-    private var showsParticipationBubble: Bool {
-        !isKeyboardVisible
-    }
-
     /// The agent-participation control: how much the agents speak in this
     /// conversation. It leads the composer row, outside the input field, since
-    /// it governs the room rather than the message being written — and it steps
-    /// aside entirely once someone starts typing.
+    /// it governs the room rather than the message being written, and stays put
+    /// while someone types so the level is always readable and reachable.
     @ViewBuilder
     private var participationBubble: some View {
-        if let participation = agentParticipation, showsParticipationBubble {
+        if let participation = agentParticipation {
             let bubbleSize: CGFloat = DesignConstants.Spacing.step12x
             let isLoading: Bool = participation.isLoading
             let label: String = isLoading


### PR DESCRIPTION
## What

The agent participation ("Listen") bubble now stays in the composer row at all times. Previously it stepped aside whenever the keyboard came up, giving its width back to the text field.

New requirement: always show it, so the current participation level is readable and changeable without dismissing the keyboard first.

## How

- Dropped the `showsParticipationBubble` gate — `participationBubble` now draws whenever an `AgentParticipationContext` is injected.
- Removed `KeyboardVisibilityModifier`, the `isKeyboardVisible` state, and its `.modifier(...)` application. That plumbing existed solely to feed the gate.

One file, `ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift`.

## Notes for review

- **The deleted modifier encoded a real lesson** — that `@FocusState` and keyboard visibility desync in both directions, so the keyboard notifications are the honest signal. It's gone from this file, but `ConversationView` has its own independent copy of that tracking for page dots and spacing, so the technique is still present in the codebase if it's needed again.
- **Tradeoff:** the bubble now holds its 48pt slot while typing, so the input field is correspondingly narrower. That's the width the old gate was buying back. If it reads as cramped on smaller devices, the follow-up is a layout change rather than restoring the gate.
- **Agent DMs are unaffected.** `AgentDmPageView` clears the participation context entirely, so no bubble is drawn there — unchanged by this PR.
- The control remains behind the Listen debug feature flag.

## Testing

- `swift test --package-path ConvosCore` — 1816 tests across 248 suites passed.
- Built and manually exercised on the `convos-dev` simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788456059&installation_model_id=20076&pr_number=1278&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1278&signature=1c677ef98369dbe8a4f6b9ba871c9090685faa7ef69fd66723c2c190ac291452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep agent participation bubble visible while the keyboard is open in `MessagesBottomBar`
> Previously, the agent participation bubble was hidden whenever the keyboard appeared, using a `KeyboardVisibilityModifier` that tracked show/hide notifications. This modifier and its associated state have been removed, so the bubble now renders whenever an `agentParticipation` context exists, regardless of keyboard state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 497241c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->