### PR TITLE
fix(lint): extract Firebase setup so ConvosApp.init clears the length limit

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -82,27 +82,7 @@ struct ConvosApp: App {
         QAEvent.emit(.app, "launched", ["environment": environment.name])
         QALaunchHooks.run(environment: environment)
 
-        // Firebase must be configured before ConvosClient is created so AppCheck is ready when auth begins
-        switch environment {
-        case .tests:
-            Log.info("Running in test environment, skipping Firebase config...")
-        default:
-            let configManager = ConfigManager.shared
-            let overrideURL: URL? = configManager.firebaseConfigOverride.flatMap {
-                Bundle.main.url(forResource: $0, withExtension: "plist")
-            }
-            if let url = overrideURL ?? configManager.currentEnvironment.firebaseConfigURL {
-                let debugToken: String? = environment.isProduction ? nil : Secrets.FIREBASE_APP_CHECK_DEBUG_TOKEN
-                FirebaseHelperCore.configure(with: url, debugToken: debugToken)
-                // Extensions can't App Attest, so the main app hands them its
-                // current App Check token via the shared app group (refreshed
-                // again on every foreground in handleScenePhaseActive).
-                let appGroupIdentifier = environment.appGroupIdentifier
-                Task { await FirebaseHelperCore.mirrorTokenToAppGroup(appGroupIdentifier) }
-            } else {
-                Log.error("Missing Firebase plist URL for current environment")
-            }
-        }
+        Self.configureFirebase(environment: environment)
 
         #if DEBUG
         let debugFallbackKey = DebugAgentKeysetOverride.parse(jwksJSON: Secrets.AGENT_DEBUG_JWKS)
@@ -201,6 +181,30 @@ struct ConvosApp: App {
         }
 
         Self.configureTabBarItemColors()
+    }
+
+    /// Configures Firebase before ConvosClient is created, so AppCheck is
+    /// ready by the time auth begins.
+    private static func configureFirebase(environment: AppEnvironment) {
+        if case .tests = environment {
+            Log.info("Running in test environment, skipping Firebase config...")
+            return
+        }
+        let configManager = ConfigManager.shared
+        let overrideURL: URL? = configManager.firebaseConfigOverride.flatMap {
+            Bundle.main.url(forResource: $0, withExtension: "plist")
+        }
+        guard let url = overrideURL ?? configManager.currentEnvironment.firebaseConfigURL else {
+            Log.error("Missing Firebase plist URL for current environment")
+            return
+        }
+        let debugToken: String? = environment.isProduction ? nil : Secrets.FIREBASE_APP_CHECK_DEBUG_TOKEN
+        FirebaseHelperCore.configure(with: url, debugToken: debugToken)
+        // Extensions can't App Attest, so the main app hands them its current
+        // App Check token via the shared app group (refreshed again on every
+        // foreground in handleScenePhaseActive).
+        let appGroupIdentifier = environment.appGroupIdentifier
+        Task { await FirebaseHelperCore.mirrorTokenToAppGroup(appGroupIdentifier) }
     }
 
     /// Wires the live abilities service (mock/live selection happens per


### PR DESCRIPTION
## Why

`ConvosApp.init()` is at **126 lines** against SwiftLint's 125-line `function_body_length` limit, so the **SwiftLint job fails on every PR opened against `dev`** — currently including #1277 and #1278. It is not caused by any of those PRs; it landed with Abilities v2 (#1259) and is reproducible on a clean `dev` checkout.

```
Convos/ConvosApp.swift:24:5: error: Function Body Length Violation:
Initializer body should span 125 lines or less excluding comments and
whitespace: currently spans 126 lines (function_body_length)
```

## What

Moves the Firebase configuration block out of `init()` into a private `static func configureFirebase(environment:)`, placed next to the existing `configureAbilities(session:environment:)` it mirrors.

The `switch environment { case .tests: ... default: ... }` becomes an early return. Note it uses `if case .tests = environment` rather than `!=` — `AppEnvironment` carries associated values on its other cases and does not conform to `Equatable`.

**Behavior is unchanged.** Same calls, same order, same early-exit paths.

## Testing

- `swiftlint --strict` full tree: **clean**, 0 violations across 973 files
- `Convos (Dev)` builds successfully for the simulator
- No test changes; this is a pure extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788456361&installation_model_id=20076&pr_number=1279&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1279&signature=6561743b13519d7834355d83b6166b450d5a6c4e951aca82de44ef2e5ea3a336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract Firebase setup into `ConvosApp.configureFirebase` to reduce `init` length
> Moves the inline Firebase configuration logic from `ConvosApp.init` into a new private static method `configureFirebase(environment:)` in [ConvosApp.swift](https://github.com/xmtplabs/convos-ios/pull/1279/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014). The behavior is unchanged — the method skips setup for the `.tests` environment, resolves the Firebase plist, configures Firebase with an optional debug token, and mirrors the App Check token to the app group asynchronously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d0a76a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->