### PR TITLE
Abilities v2: escalation consent UI - prompt card, approval sheet, delegations (mock-first, flag-gated)

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -12,16 +12,20 @@ import SwiftUI
 /// replacement).
 struct AbilitiesListScreen: View {
     @State private var viewModel: AbilitiesListViewModel
+    /// Kept so entitled rows can hand the whole latched pair down to the
+    /// ability detail push (see `AbilitiesSelection`).
+    private let selection: AbilitiesSelection
 
     /// Takes the whole selection so the service and its authorizer are
     /// latched together for the screen's lifetime -- the halves must never
     /// be resolved at different times (see `AbilitiesSelection`).
     init(selection: AbilitiesSelection) {
+        self.selection = selection
         _viewModel = State(initialValue: AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer))
     }
 
     var body: some View {
-        AbilitiesListView(viewModel: viewModel)
+        AbilitiesListView(viewModel: viewModel, selection: selection)
     }
 }
 
@@ -38,8 +42,14 @@ struct AbilitiesListScreen: View {
 /// A conversation toggle that needs an entitlement no longer deep-links
 /// here: it presents the scoped `AbilityConnectSheet` instead, which reuses
 /// this screen's view model for the connect machinery.
+///
+/// Entitled rows push `AbilityDetailScreen` (delegations list) inside the
+/// App Settings `NavigationStack`. Available and state-unknown rows stay
+/// non-navigable: delegations only exist against an entitlement.
 struct AbilitiesListView: View {
     @Bindable var viewModel: AbilitiesListViewModel
+    /// Latched pair handed down to ability detail pushes.
+    let selection: AbilitiesSelection
 
     var body: some View {
         catalogList
@@ -177,8 +187,12 @@ struct AbilitiesListView: View {
     // MARK: - Rows
 
     private func entitledRow(_ ability: AbilitiesAPI.Ability) -> some View {
-        abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
-            entitledAccessory(ability)
+        NavigationLink {
+            AbilityDetailScreen(ability: ability, selection: selection)
+        } label: {
+            abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
+                entitledAccessory(ability)
+            }
         }
     }
 

--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -13,10 +13,20 @@ struct AbilitiesSelection {
     /// Nil in mock mode: the stub authorization sheet stands in, and a
     /// mock connect never opens a real browser.
     let authorizer: (any AbilityAuthorizing)?
+    /// The consent-flow seam. Escalation has no live transport, so the
+    /// mock is the only implementation in both modes; app code must pass
+    /// `AbilitiesServices`' shared instance so grants carry across
+    /// surfaces. The default (a fresh, isolated mock) is for previews.
+    let escalation: any AbilityEscalationServiceProtocol
 
-    init(service: any AbilitiesServiceProtocol, authorizer: (any AbilityAuthorizing)? = nil) {
+    init(
+        service: any AbilitiesServiceProtocol,
+        authorizer: (any AbilityAuthorizing)? = nil,
+        escalation: (any AbilityEscalationServiceProtocol)? = nil
+    ) {
         self.service = service
         self.authorizer = authorizer
+        self.escalation = escalation ?? MockAbilityEscalationService()
     }
 }
 
@@ -36,17 +46,26 @@ enum AbilitiesServices {
     nonisolated(unsafe) private static var liveService: LiveAbilitiesService?
     nonisolated(unsafe) private static var catalogCache: AbilitiesCatalogDiskCache?
     private static let mockService: MockAbilitiesService = MockAbilitiesService()
+    /// One escalation mock app-wide so grants made in a conversation are
+    /// visible in the ability detail's delegations list. Both selection
+    /// branches carry it: escalation has no live transport, so the mock is
+    /// the only source either way; the `isActive` gate decides whether it
+    /// serves anything.
+    private static let escalationService: MockAbilityEscalationService = MockAbilityEscalationService(
+        isActive: { AbilitiesServices.isEscalationMockEnabled }
+    )
 
     /// The atomic (service, authorizer) pair for the current mode. Resolve
     /// once per screen/view-model lifetime and pass the whole value down;
     /// never read the halves at different times.
     static var selection: AbilitiesSelection {
         guard let liveService, useLiveBackend else {
-            return AbilitiesSelection(service: mockService)
+            return AbilitiesSelection(service: mockService, escalation: escalationService)
         }
         return AbilitiesSelection(
             service: liveService,
-            authorizer: AbilityOAuthAuthorizer(callbackURLScheme: ConfigManager.shared.appUrlScheme)
+            authorizer: AbilityOAuthAuthorizer(callbackURLScheme: ConfigManager.shared.appUrlScheme),
+            escalation: escalationService
         )
     }
 
@@ -130,8 +149,26 @@ enum AbilitiesServices {
         UserDefaults.standard.set(value, forKey: Constant.v1AwarenessShimEnabledKey)
     }
 
+    /// Debug sub-toggle for the mock consent flow (agent ability-use
+    /// requests and delegations). Default on in non-production so enabling
+    /// the abilities flag is the only step needed to demo the full consent
+    /// flow; production always reads false.
+    static var isEscalationMockEnabled: Bool {
+        guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+        if let stored = UserDefaults.standard.object(forKey: Constant.escalationMockEnabledKey) as? Bool {
+            return stored
+        }
+        return true
+    }
+
+    static func setEscalationMockEnabled(_ value: Bool) {
+        guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+        UserDefaults.standard.set(value, forKey: Constant.escalationMockEnabledKey)
+    }
+
     private enum Constant {
         static let useLiveBackendKey: String = "abilitiesServices.useLiveBackend"
         static let v1AwarenessShimEnabledKey: String = "abilitiesServices.v1AwarenessShimEnabled"
+        static let escalationMockEnabledKey: String = "abilitiesServices.escalationMockEnabled"
     }
 }

--- a/Convos/Abilities/AbilityDetailView.swift
+++ b/Convos/Abilities/AbilityDetailView.swift
@@ -1,0 +1,207 @@
+import ConvosCore
+import SwiftUI
+
+/// Owns the ability detail view model via `@State`, so it is created once
+/// per navigation push and survives re-evaluation of the presenting
+/// builder. Entry points must push this wrapper: constructing
+/// `AbilityDetailViewModel` inline in a navigation destination would hand
+/// `AbilityDetailView` a fresh model on every parent invalidation,
+/// silently dropping loaded delegations (and the list's `.task`, keyed to
+/// view identity, would not re-fire for the replacement). Same rationale
+/// as `AbilitiesListScreen`.
+struct AbilityDetailScreen: View {
+    @State private var viewModel: AbilityDetailViewModel
+
+    init(ability: AbilitiesAPI.Ability, selection: AbilitiesSelection) {
+        _viewModel = State(initialValue: AbilityDetailViewModel(ability: ability, selection: selection))
+    }
+
+    var body: some View {
+        AbilityDetailView(viewModel: viewModel)
+    }
+}
+
+/// One ability's detail: identity header plus every delegation granted
+/// against it, split into active and earlier, with owner-initiated
+/// revocation on active rows.
+///
+/// Reachable only from `AbilitiesListView`'s entitled rows, which are
+/// themselves only reachable from surfaces already gated by the Abilities
+/// V2 flag -- no extra flag check needed here.
+struct AbilityDetailView: View {
+    @Bindable var viewModel: AbilityDetailViewModel
+
+    var body: some View {
+        List {
+            headerSection
+            if let errorMessage = viewModel.errorMessage {
+                errorBanner(errorMessage)
+            }
+            delegationsSection
+            earlierSection
+        }
+        .scrollContentBackground(.hidden)
+        .background(.colorBackgroundRaisedSecondary)
+        .navigationTitle(viewModel.ability.displayName.resolved())
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay { emptyStateOverlay }
+        .task { await viewModel.refresh() }
+        .accessibilityIdentifier("ability-detail-\(viewModel.ability.id)")
+    }
+
+    // MARK: - Sections
+
+    private var headerSection: some View {
+        Section {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                AbilityIconView(ability: viewModel.ability)
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                    Text(viewModel.ability.displayName.resolved())
+                        .font(.body)
+                        .foregroundStyle(.colorTextPrimary)
+                    Text(viewModel.ability.subtitle.resolved())
+                        .font(.footnote)
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(2)
+                }
+                Spacer()
+                if let entitlement = viewModel.ability.entitlement {
+                    AbilityStatusBadge(status: entitlement.status)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var delegationsSection: some View {
+        if !viewModel.activeDelegations.isEmpty {
+            Section {
+                ForEach(viewModel.activeDelegations) { delegation in
+                    activeDelegationRow(delegation)
+                }
+            } header: {
+                sectionHeader("Delegations")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var earlierSection: some View {
+        if !viewModel.pastDelegations.isEmpty {
+            Section {
+                ForEach(viewModel.pastDelegations) { delegation in
+                    delegationRow(delegation)
+                }
+            } header: {
+                sectionHeader("Earlier")
+            }
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.footnote.weight(.medium))
+            .foregroundStyle(.colorTextSecondary)
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        Section {
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.colorCaution)
+        }
+    }
+
+    @ViewBuilder
+    private var emptyStateOverlay: some View {
+        if viewModel.delegations.isEmpty, !viewModel.isLoading {
+            ContentUnavailableView(
+                "No delegations",
+                systemImage: "person.badge.key",
+                description: Text("When an agent asks to use \(viewModel.ability.displayName.resolved()), what you allow shows up here.")
+            )
+        }
+    }
+
+    // MARK: - Rows
+
+    /// Active rows carry the revoke affordances (swipe + context menu);
+    /// past rows are inert.
+    private func activeDelegationRow(_ delegation: AbilityDelegation) -> some View {
+        let revokeAction = { viewModel.revoke(delegation) }
+        return delegationRow(delegation)
+            .swipeActions(edge: .trailing) {
+                Button("Revoke", role: .destructive, action: revokeAction)
+                    .accessibilityIdentifier("delegation-revoke-\(delegation.id)")
+            }
+            .contextMenu {
+                Button("Revoke", role: .destructive, action: revokeAction)
+            }
+    }
+
+    private func delegationRow(_ delegation: AbilityDelegation) -> some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            delegationRowTitles(delegation)
+            Spacer()
+            AbilityDelegationStateChip(state: delegation.effectiveState())
+        }
+        .accessibilityIdentifier("delegation-row-\(delegation.id)")
+    }
+
+    private func delegationRowTitles(_ delegation: AbilityDelegation) -> some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+            Text(delegation.conversationName)
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+            Text("\(delegation.agentDisplayName) - \(viewModel.bundlesSummary(for: delegation))")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .lineLimit(1)
+            Text(scopeLine(delegation))
+                .font(.footnote)
+                .foregroundStyle(.colorTextTertiary)
+        }
+    }
+
+    private func scopeLine(_ delegation: AbilityDelegation) -> String {
+        switch delegation.scope {
+        case .oneShot:
+            return "Just once"
+        case .expiring(let expiry):
+            let formatted: String = expiry.formatted(date: .abbreviated, time: .omitted)
+            return "Until \(formatted)"
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Populated") {
+    let gcal = MockAbilitiesService.standardCatalog().first { $0.id == "googlecalendar" }
+    if let gcal {
+        NavigationStack {
+            AbilityDetailScreen(
+                ability: gcal,
+                selection: AbilitiesSelection(
+                    service: MockAbilitiesService(),
+                    escalation: MockAbilityEscalationService(scenario: .populated)
+                )
+            )
+        }
+    }
+}
+
+#Preview("Empty") {
+    let youtube = MockAbilitiesService.standardCatalog().first { $0.id == "youtube" }
+    if let youtube {
+        NavigationStack {
+            AbilityDetailScreen(
+                ability: youtube,
+                selection: AbilitiesSelection(
+                    service: MockAbilitiesService(),
+                    escalation: MockAbilityEscalationService(scenario: .quiet)
+                )
+            )
+        }
+    }
+}

--- a/Convos/Abilities/AbilityDetailViewModel.swift
+++ b/Convos/Abilities/AbilityDetailViewModel.swift
@@ -1,0 +1,76 @@
+import ConvosCore
+import Foundation
+import Observation
+
+/// Drives the ability detail screen: the delegations granted against one
+/// ability across conversations, with owner-initiated revocation.
+/// Pull-only: the list refreshes on appear and after its own mutations,
+/// matching how `ConversationAbilitiesViewModel.refresh()` works.
+@MainActor @Observable
+final class AbilityDetailViewModel {
+    let ability: AbilitiesAPI.Ability
+
+    private(set) var delegations: [AbilityDelegation] = []
+    private(set) var isLoading: Bool = false
+    private(set) var errorMessage: String?
+    private var isMutating: Bool = false
+
+    private let selection: AbilitiesSelection
+
+    init(ability: AbilitiesAPI.Ability, selection: AbilitiesSelection) {
+        self.ability = ability
+        self.selection = selection
+    }
+
+    /// Delegations whose derived state is active, newest first.
+    var activeDelegations: [AbilityDelegation] {
+        let now = Date()
+        return delegations
+            .filter { (delegation: AbilityDelegation) -> Bool in delegation.effectiveState(at: now) == .active }
+            .sorted { (lhs: AbilityDelegation, rhs: AbilityDelegation) -> Bool in lhs.grantedAt > rhs.grantedAt }
+    }
+
+    /// Everything consumed, expired, or revoked, newest first.
+    var pastDelegations: [AbilityDelegation] {
+        let now = Date()
+        return delegations
+            .filter { (delegation: AbilityDelegation) -> Bool in delegation.effectiveState(at: now) != .active }
+            .sorted { (lhs: AbilityDelegation, rhs: AbilityDelegation) -> Bool in lhs.grantedAt > rhs.grantedAt }
+    }
+
+    func refresh() async {
+        isLoading = true
+        delegations = await selection.escalation.delegations(abilityId: ability.id)
+        isLoading = false
+    }
+
+    /// Mutate-then-refresh, copying `ConversationAbilitiesViewModel`'s
+    /// withdraw shape: the service is the source of truth for the row's
+    /// new state.
+    func revoke(_ delegation: AbilityDelegation) {
+        guard !isMutating else { return }
+        isMutating = true
+        errorMessage = nil
+        Task {
+            do {
+                try await selection.escalation.revoke(delegationId: delegation.id)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isMutating = false
+            await refresh()
+        }
+    }
+
+    /// Resolves bundle ids against the ability's bundle metadata, falling
+    /// back to the raw id for anything the manifest no longer lists.
+    func bundlesSummary(for delegation: AbilityDelegation) -> String {
+        let titlesById: [String: String] = ability.bundles.reduce(into: [:]) { partial, bundle in
+            partial[bundle.id] = bundle.title.resolved()
+        }
+        let titles: [String] = delegation.bundleIds.map { (bundleId: String) -> String in
+            titlesById[bundleId] ?? bundleId
+        }
+        return titles.joined(separator: ", ")
+    }
+}

--- a/Convos/Abilities/AbilityEscalationApprovalSheet.swift
+++ b/Convos/Abilities/AbilityEscalationApprovalSheet.swift
@@ -1,0 +1,212 @@
+import ConvosCore
+import SwiftUI
+
+/// Approval sheet for an agent's ability-use ask: the owner narrows the
+/// requested permission bundles (never widens -- bundles the agent did
+/// not ask for are not offered), picks a scope, and allows or declines.
+/// Layout mirrors `AbilityBundleSelectionSheet` (header / rows / actions).
+///
+/// A swipe-down is neither answer: the request stays pending and the
+/// prompt card stays up. Deliberate -- consent must be explicit, so only
+/// Allow and Don't allow resolve the ask; the sheet is closed by the view
+/// model once the service call lands.
+struct AbilityEscalationApprovalSheet: View {
+    let context: AbilityEscalationApprovalContext
+    let isResolving: Bool
+    let onAllow: ([String], AbilityDelegationScope) -> Void
+    let onDecline: () -> Void
+
+    @State private var enabledBundleIds: Set<String> = []
+    @State private var didSeedSelection: Bool = false
+    @State private var scopeChoice: ScopeChoice = .once
+
+    /// Owner-facing scope choices; maps onto `AbilityDelegationScope` at
+    /// grant. Defaults to `.once` (least privilege).
+    private enum ScopeChoice: String, CaseIterable, Identifiable {
+        case once = "Just once"
+        case day = "1 day"
+        case week = "1 week"
+
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step4x) {
+            header
+            permissionRows
+            scopePicker
+            actionButtons
+        }
+        .padding(.vertical, DesignConstants.Spacing.step6x)
+        .presentationDetents([.medium, .large])
+        .onAppear { seedSelectionIfNeeded() }
+    }
+
+    private var header: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            AbilityIconView(ability: context.ability)
+            Text("Let \(context.request.agentDisplayName) use \(context.ability.displayName.resolved())?")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.colorTextPrimary)
+                .multilineTextAlignment(.center)
+            Text(context.request.reason)
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.center)
+            Text("Asked by \(context.request.agentDisplayName) in this convo")
+                .font(.caption)
+                .foregroundStyle(.colorTextTertiary)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    /// One toggle per requested bundle, seeded on. Row layout copies
+    /// `AbilityBundleSelectionSheet.bundleRow`'s pattern (not extracted:
+    /// the two sheets may diverge).
+    private var permissionRows: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("Permissions")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+
+            VStack(spacing: Constant.rowGap) {
+                ForEach(requestedBundles) { bundle in
+                    bundleRow(bundle)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge))
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+        }
+    }
+
+    private func bundleRow(_ bundle: AbilitiesAPI.AbilityBundle) -> some View {
+        let binding: Binding<Bool> = bundleBinding(bundleId: bundle.id)
+        let description: String = bundle.description.resolved()
+        return HStack(spacing: DesignConstants.Spacing.step2x) {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                Text(bundle.title.resolved())
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                if !description.isEmpty {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+            }
+            Spacer(minLength: 0)
+            Toggle(bundle.title.resolved(), isOn: binding)
+                .labelsHidden()
+        }
+        .padding(DesignConstants.Spacing.step4x)
+        .background(Color.colorBackgroundSurfaceless)
+    }
+
+    private var scopePicker: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            Text("How long")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+
+            Picker("How long", selection: $scopeChoice) {
+                ForEach(ScopeChoice.allCases) { choice in
+                    Text(choice.rawValue).tag(choice)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, DesignConstants.Spacing.step4x)
+            .accessibilityIdentifier("escalation-scope-picker")
+        }
+    }
+
+    private var actionButtons: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            allowButton
+            declineButton
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+    }
+
+    private var allowButton: some View {
+        let allowAction = {
+            onAllow(enabledBundleIds.sorted(), delegationScope())
+        }
+        return Button("Allow", action: allowAction)
+            .convosButtonStyle(.rounded(fullWidth: true))
+            .disabled(enabledBundleIds.isEmpty || isResolving)
+            .accessibilityIdentifier("escalation-allow-button")
+    }
+
+    /// An explicit negative resolution, not a dismissal: styled like the
+    /// sheets' cancel buttons but it resolves the request.
+    private var declineButton: some View {
+        let declineAction = onDecline
+        return Button(action: declineAction) {
+            Text("Don't allow")
+                .font(.body)
+                .foregroundStyle(.colorTextSecondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, DesignConstants.Spacing.step3x)
+        }
+        .disabled(isResolving)
+        .accessibilityIdentifier("escalation-decline-button")
+    }
+
+    /// The requested bundles resolved against the catalog ability's
+    /// metadata; the owner can narrow this set, not widen it.
+    private var requestedBundles: [AbilitiesAPI.AbilityBundle] {
+        let requested = Set(context.request.requestedBundleIds)
+        return context.ability.bundles.filter { (bundle: AbilitiesAPI.AbilityBundle) -> Bool in
+            requested.contains(bundle.id)
+        }
+    }
+
+    private func delegationScope(now: Date = Date()) -> AbilityDelegationScope {
+        switch scopeChoice {
+        case .once: .oneShot
+        case .day: .expiring(now.addingTimeInterval(Constant.dayInterval))
+        case .week: .expiring(now.addingTimeInterval(Constant.weekInterval))
+        }
+    }
+
+    private func bundleBinding(bundleId: String) -> Binding<Bool> {
+        Binding(
+            get: { enabledBundleIds.contains(bundleId) },
+            set: { isOn in
+                if isOn {
+                    enabledBundleIds.insert(bundleId)
+                } else {
+                    enabledBundleIds.remove(bundleId)
+                }
+            }
+        )
+    }
+
+    private func seedSelectionIfNeeded() {
+        guard !didSeedSelection else { return }
+        didSeedSelection = true
+        enabledBundleIds = Set(context.request.requestedBundleIds)
+    }
+
+    private enum Constant {
+        static let rowGap: CGFloat = 1.0
+        static let dayInterval: TimeInterval = 86_400
+        static let weekInterval: TimeInterval = 604_800
+    }
+}
+
+#Preview("Approval sheet") {
+    let gcal = MockAbilitiesService.standardCatalog().first { $0.id == "googlecalendar" }
+    if let gcal {
+        AbilityEscalationApprovalSheet(
+            context: AbilityEscalationApprovalContext(
+                request: MockAbilityEscalationService.scriptedRequest(conversationId: "mock-conversation-1"),
+                ability: gcal
+            ),
+            isResolving: false,
+            onAllow: { _, _ in },
+            onDecline: {}
+        )
+    }
+}

--- a/Convos/Abilities/AbilityEscalationApprovalSheet.swift
+++ b/Convos/Abilities/AbilityEscalationApprovalSheet.swift
@@ -188,10 +188,13 @@ struct AbilityEscalationApprovalSheet: View {
         )
     }
 
+    /// Seeds from the resolved `requestedBundles`, not the raw request ids:
+    /// an id the catalog ability doesn't carry never renders a toggle, so it
+    /// must not ride the seed set into `onAllow` unseen.
     private func seedSelectionIfNeeded() {
         guard !didSeedSelection else { return }
         didSeedSelection = true
-        enabledBundleIds = Set(context.request.requestedBundleIds)
+        enabledBundleIds = Set(requestedBundles.map(\.id))
     }
 
     private enum Constant {

--- a/Convos/Abilities/AbilityEscalationApprovalSheet.swift
+++ b/Convos/Abilities/AbilityEscalationApprovalSheet.swift
@@ -30,14 +30,19 @@ struct AbilityEscalationApprovalSheet: View {
         var id: String { rawValue }
     }
 
+    /// Scrollable so the header is never clipped at the medium detent and
+    /// large Dynamic Type sizes scroll instead of overflowing.
     var body: some View {
-        VStack(spacing: DesignConstants.Spacing.step4x) {
-            header
-            permissionRows
-            scopePicker
-            actionButtons
+        ScrollView {
+            VStack(spacing: DesignConstants.Spacing.step4x) {
+                header
+                permissionRows
+                scopePicker
+                actionButtons
+            }
+            .padding(.vertical, DesignConstants.Spacing.step6x)
         }
-        .padding(.vertical, DesignConstants.Spacing.step6x)
+        .scrollBounceBehavior(.basedOnSize)
         .presentationDetents([.medium, .large])
         .onAppear { seedSelectionIfNeeded() }
     }

--- a/Convos/Abilities/AbilityEscalationPromptCard.swift
+++ b/Convos/Abilities/AbilityEscalationPromptCard.swift
@@ -1,0 +1,135 @@
+import ConvosCore
+import SwiftUI
+
+/// Consent prompt for an agent's ability-use ask: centered caption above
+/// a tappable ability pill, one reason line underneath. Borrows
+/// `CapabilityConnectPromptView`'s layout language (caption + pill), but
+/// lives on an app surface, not in the transcript.
+///
+/// Entry points: exactly one today -- the conversation bottom bar's
+/// status slot, via `AbilityEscalationPromptSurface`. The approval sheet
+/// is reachable from nowhere else. Behavior is single-entry, so no mode
+/// enum is warranted (the `ContactDetailMode` convention kicks in only
+/// once a second entry point branches behavior).
+struct AbilityEscalationPromptCard: View {
+    let request: AbilityDelegationRequest
+    /// Display name resolved from the catalog; falls back to the raw
+    /// ability id only if the fixture and catalog ever diverge.
+    let abilityDisplayName: String
+    let onTap: () -> Void
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step2x) {
+            Text("\(request.agentDisplayName) asked to use")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .lineLimit(1)
+
+            let action = onTap
+            Button(action: action) {
+                pillContent
+            }
+            .buttonStyle(.plain)
+
+            Text(request.reason)
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(request.agentDisplayName) asked to use \(abilityDisplayName). \(request.reason)")
+        .accessibilityIdentifier("escalation-prompt-card")
+    }
+
+    private var pillContent: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            Image(systemName: AbilityIconView.symbolName(for: request.abilityId))
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+                .frame(width: Constant.iconSize, height: Constant.iconSize)
+
+            Text(abilityDisplayName)
+                .font(.callout)
+                .foregroundStyle(.colorTextPrimary)
+                .lineLimit(1)
+
+            Image(systemName: "chevron.right")
+                .font(.footnote)
+                .foregroundStyle(.colorTextTertiary)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .frame(height: Constant.pillHeight)
+        .background(
+            RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.mediumLarge)
+                .fill(Color.colorFillMinimal)
+        )
+        .contentShape(.rect)
+    }
+
+    private enum Constant {
+        static let pillHeight: CGFloat = 44.0
+        static let iconSize: CGFloat = 24.0
+    }
+}
+
+/// Thin wrapper the conversation bottom bar embeds: renders the card for
+/// the view model's pending ask and owns the approval sheet presentation,
+/// so `ConversationView` adds exactly one view expression and zero new
+/// modifiers to its already-heavy body.
+struct AbilityEscalationPromptSurface: View {
+    @Bindable var viewModel: ConversationEscalationViewModel
+
+    var body: some View {
+        Group {
+            if let request = viewModel.pendingRequest {
+                AbilityEscalationPromptCard(
+                    request: request,
+                    abilityDisplayName: abilityDisplayName(for: request),
+                    onTap: handleCardTap
+                )
+            }
+        }
+        .sheet(item: $viewModel.approvalContext) { context in
+            approvalSheet(context)
+        }
+    }
+
+    private func abilityDisplayName(for request: AbilityDelegationRequest) -> String {
+        guard let ability = viewModel.pendingAbility, ability.id == request.abilityId else {
+            return request.abilityId
+        }
+        return ability.displayName.resolved()
+    }
+
+    private func handleCardTap() {
+        viewModel.presentApproval()
+    }
+
+    private func approvalSheet(_ context: AbilityEscalationApprovalContext) -> some View {
+        AbilityEscalationApprovalSheet(
+            context: context,
+            isResolving: viewModel.isResolving,
+            onAllow: handleAllow,
+            onDecline: handleDecline
+        )
+    }
+
+    private func handleAllow(bundleIds: [String], scope: AbilityDelegationScope) {
+        viewModel.grant(bundleIds: bundleIds, scope: scope)
+    }
+
+    private func handleDecline() {
+        viewModel.decline()
+    }
+}
+
+#Preview("Prompt card") {
+    AbilityEscalationPromptCard(
+        request: MockAbilityEscalationService.scriptedRequest(conversationId: "mock-conversation-1"),
+        abilityDisplayName: "Google Calendar",
+        onTap: {}
+    )
+    .padding(DesignConstants.Spacing.step4x)
+}

--- a/Convos/Abilities/AbilityRowComponents.swift
+++ b/Convos/Abilities/AbilityRowComponents.swift
@@ -107,6 +107,40 @@ struct AbilityNeutralBadge: View {
     }
 }
 
+/// Capsule chip for a delegation's derived lifecycle state. Sibling of
+/// `AbilityStatusBadge`: delegation states are client-vocabulary, so they
+/// never borrow the entitlement badge's server-owned labels.
+struct AbilityDelegationStateChip: View {
+    let state: AbilityDelegationState
+
+    var body: some View {
+        Text(label)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(labelColor)
+            .padding(.horizontal, DesignConstants.Spacing.step2x)
+            .padding(.vertical, DesignConstants.Spacing.stepHalf)
+            .background(Capsule().fill(Color.colorFillMinimal))
+            .accessibilityLabel("Status: \(label)")
+    }
+
+    private var label: String {
+        switch state {
+        case .active: "Active"
+        case .consumed: "Used"
+        case .expired: "Expired"
+        case .revoked: "Revoked"
+        }
+    }
+
+    private var labelColor: Color {
+        switch state {
+        case .active: .colorGreen
+        case .consumed: .colorTextSecondary
+        case .expired, .revoked: .colorCaution
+        }
+    }
+}
+
 #Preview("Badges") {
     VStack(spacing: DesignConstants.Spacing.step2x) {
         AbilityStatusBadge(status: .active)
@@ -115,6 +149,10 @@ struct AbilityNeutralBadge: View {
         AbilityStatusBadge(status: .expired)
         AbilityStatusBadge(status: .revoked)
         AbilityNeutralBadge(label: "Not connected")
+        AbilityDelegationStateChip(state: .active)
+        AbilityDelegationStateChip(state: .consumed)
+        AbilityDelegationStateChip(state: .expired)
+        AbilityDelegationStateChip(state: .revoked)
     }
     .padding(DesignConstants.Spacing.step4x)
 }

--- a/Convos/Abilities/ConversationEscalationViewModel.swift
+++ b/Convos/Abilities/ConversationEscalationViewModel.swift
@@ -29,7 +29,9 @@ final class ConversationEscalationViewModel {
     /// Non-nil presents the approval sheet.
     var approvalContext: AbilityEscalationApprovalContext?
 
-    private let conversationId: String
+    /// Read by the owning view to detect that it now shows a different
+    /// conversation and this model must be rebuilt for the new stream.
+    let conversationId: String
     /// The pair latched at construction, same posture as the abilities VMs.
     private let selection: AbilitiesSelection
     @ObservationIgnored private var observationTask: Task<Void, Never>?

--- a/Convos/Abilities/ConversationEscalationViewModel.swift
+++ b/Convos/Abilities/ConversationEscalationViewModel.swift
@@ -1,0 +1,129 @@
+import ConvosCore
+import Foundation
+import Observation
+
+/// Sheet context: the request under review plus the resolved ability
+/// (icon, name, and bundle titles come from the catalog entry).
+struct AbilityEscalationApprovalContext: Identifiable, Hashable {
+    let request: AbilityDelegationRequest
+    let ability: AbilitiesAPI.Ability
+
+    var id: String { request.id }
+}
+
+/// Drives the conversation consent surfaces: observes the escalation
+/// seam's pending-request stream, exposes the single actionable ask, and
+/// resolves it through grant or decline. Self-contained: talks only to
+/// the latched `AbilitiesSelection`, never to `ConversationViewModel`.
+@MainActor @Observable
+final class ConversationEscalationViewModel {
+    /// The newest pending ask (single-actionable-ask semantics, mirroring
+    /// V1's latest-pending-request derivation: older unresolved asks stay
+    /// hidden until the newest resolves).
+    private(set) var pendingRequest: AbilityDelegationRequest?
+    /// The catalog entry backing `pendingRequest`, resolved when the ask
+    /// arrives so the prompt card can render the ability's display name.
+    private(set) var pendingAbility: AbilitiesAPI.Ability?
+    private(set) var isResolving: Bool = false
+    private(set) var errorMessage: String?
+    /// Non-nil presents the approval sheet.
+    var approvalContext: AbilityEscalationApprovalContext?
+
+    private let conversationId: String
+    /// The pair latched at construction, same posture as the abilities VMs.
+    private let selection: AbilitiesSelection
+    @ObservationIgnored private var observationTask: Task<Void, Never>?
+
+    init(conversationId: String, selection: AbilitiesSelection) {
+        self.conversationId = conversationId
+        self.selection = selection
+    }
+
+    /// Spawns the stream task; idempotent while one is live.
+    func startObserving() {
+        guard observationTask == nil else { return }
+        let escalation = selection.escalation
+        let conversationId = conversationId
+        observationTask = Task { [weak self] in
+            let stream = await escalation.pendingRequestsStream(conversationId: conversationId)
+            for await requests in stream {
+                guard !Task.isCancelled else { return }
+                await self?.handlePendingRequests(requests)
+            }
+        }
+    }
+
+    /// Cancels the stream task (view disappeared). A later
+    /// `startObserving` re-subscribes and re-syncs from the first emission.
+    func stopObserving() {
+        observationTask?.cancel()
+        observationTask = nil
+    }
+
+    /// Resolves the catalog entry for the pending ask and presents the
+    /// approval sheet. An unresolvable ability id leaves the card up and
+    /// surfaces an error (should not happen with consistent fixtures).
+    func presentApproval() {
+        guard let request = pendingRequest else { return }
+        Task {
+            let ability = await resolvedAbility(for: request)
+            guard let ability else {
+                errorMessage = AbilitiesServiceError.unknownAbility(abilityId: request.abilityId).localizedDescription
+                return
+            }
+            pendingAbility = ability
+            approvalContext = AbilityEscalationApprovalContext(request: request, ability: ability)
+        }
+    }
+
+    func grant(bundleIds: [String], scope: AbilityDelegationScope) {
+        resolve { escalation, requestId in
+            try await escalation.grant(requestId: requestId, bundleIds: bundleIds, scope: scope)
+        }
+    }
+
+    func decline() {
+        resolve { escalation, requestId in
+            try await escalation.decline(requestId: requestId)
+        }
+    }
+
+    /// Shared resolution path: the service is the source of truth, so the
+    /// stream emission (not optimistic local state) is what clears the
+    /// card; this only closes the sheet and surfaces failures.
+    private func resolve(_ operation: @escaping (any AbilityEscalationServiceProtocol, String) async throws -> Void) {
+        guard let request = pendingRequest, !isResolving else { return }
+        isResolving = true
+        errorMessage = nil
+        let escalation = selection.escalation
+        Task {
+            do {
+                try await operation(escalation, request.id)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isResolving = false
+            approvalContext = nil
+        }
+    }
+
+    private func handlePendingRequests(_ requests: [AbilityDelegationRequest]) async {
+        let newest = requests.last
+        pendingRequest = newest
+        guard let newest else {
+            pendingAbility = nil
+            return
+        }
+        if pendingAbility?.id != newest.abilityId {
+            pendingAbility = await resolvedAbility(for: newest)
+        }
+    }
+
+    private func resolvedAbility(for request: AbilityDelegationRequest) async -> AbilitiesAPI.Ability? {
+        if let pendingAbility, pendingAbility.id == request.abilityId {
+            return pendingAbility
+        }
+        let catalog = try? await selection.service.fetchCatalog()
+        return catalog?.abilities.first { $0.id == request.abilityId }
+    }
+}

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -70,6 +70,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// presented.
     @State private var contextMenuState: MessageContextMenuState = .init()
     @State private var showingDebugInjector: Bool = false
+    /// Consent surface for agent ability-use asks, latched once per view
+    /// lifetime by `prepareEscalationIfNeeded` (nil while the abilities
+    /// flag is off or the conversation has no agent).
+    @State private var escalationViewModel: ConversationEscalationViewModel?
     @State private var presentingAddFromContactsPicker: Bool = false
     @State private var navState: ConversationNavigatorImpl = .init()
     @State private var navigator: ConversationCollector?
@@ -232,25 +236,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             bottomBarContent: {
                 VStack(spacing: DesignConstants.Spacing.step3x) {
                     bottomBarContent()
-
-                    // Capability requests no longer auto-present a card here:
-                    // the transcript's connect pill is the single entry point
-                    // and opens the approval sheet. The slot keeps the
-                    // post-approval toast and the onboarding view.
-                    Group {
-                        if viewModel.showsCapabilityApprovedToast {
-                            CapabilityApprovedToastView()
-                                .transition(.blurReplace)
-                        } else {
-                            ConversationOnboardingView(
-                                coordinator: onboardingCoordinator,
-                                focusCoordinator: focusCoordinator,
-                                coreActions: viewModel.coreActions
-                            )
-                            .transition(.blurReplace)
-                        }
-                    }
-                    .animation(.spring(duration: 0.4, bounce: 0.2), value: viewModel.showsCapabilityApprovedToast)
+                    bottomBarStatusSlot
                 }
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
             }
@@ -557,6 +543,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             navState.markScreenAppeared()
             viewModel.onConversationAppeared()
             seedInitialPageIfNeeded()
+            prepareEscalationIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .selectAgentDmPageRequested)) { note in
             handleSelectAgentDmPageRequest(note)
@@ -565,6 +552,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             focusCoordinator.dismissThingsSearchIfNeeded()
             viewModel.onConversationDisappeared()
             navigator?.closed(context: navState.closeContext())
+            escalationViewModel?.stopObserving()
         }
         .modifier(metricsObserversPart1)
         .modifier(metricsObserversPart2)
@@ -1072,5 +1060,80 @@ private extension ConversationView {
         )
         store.apply(syncedLevel: AgentParticipationLevel(mode: mode))
         participation = store
+    }
+}
+
+/// Which view occupies the status slot under the composer; also the
+/// animation value for the slot's transitions, so the whole slot animates
+/// on one Equatable instead of stacking per-branch `.animation` modifiers.
+private enum ConversationBottomBarSlot: Equatable {
+    case capabilityApprovedToast
+    case escalationPrompt(requestId: String)
+    case onboarding
+}
+
+// MARK: - Bottom bar status slot
+
+private extension ConversationView {
+    /// Toast wins, then a pending agent ability-use ask, then onboarding.
+    var bottomBarSlot: ConversationBottomBarSlot {
+        if viewModel.showsCapabilityApprovedToast {
+            return .capabilityApprovedToast
+        }
+        if let request = escalationViewModel?.pendingRequest {
+            return .escalationPrompt(requestId: request.id)
+        }
+        return .onboarding
+    }
+
+    /// The status slot under the composer. Capability requests no longer
+    /// auto-present a card here: the transcript's connect pill is the
+    /// single entry point for those and opens the approval sheet. The slot
+    /// keeps the post-approval toast, the agent ability-use consent card,
+    /// and the onboarding view.
+    var bottomBarStatusSlot: some View {
+        @Bindable var onboardingCoordinator = viewModel.onboardingCoordinator
+        return Group {
+            switch bottomBarSlot {
+            case .capabilityApprovedToast:
+                CapabilityApprovedToastView()
+                    .transition(.blurReplace)
+            case .escalationPrompt:
+                if let escalationViewModel {
+                    AbilityEscalationPromptSurface(viewModel: escalationViewModel)
+                        .transition(.blurReplace)
+                }
+            case .onboarding:
+                ConversationOnboardingView(
+                    coordinator: onboardingCoordinator,
+                    focusCoordinator: focusCoordinator,
+                    coreActions: viewModel.coreActions
+                )
+                .transition(.blurReplace)
+            }
+        }
+        .animation(.spring(duration: 0.4, bounce: 0.2), value: bottomBarSlot)
+    }
+
+    /// Builds the escalation view model once per view lifetime: only when
+    /// the Abilities V2 flag is on and the conversation has an agent. The
+    /// flag is read once and latched -- same posture as
+    /// `ConversationInfoView.AgentAccessMode`. Re-appearance restarts the
+    /// stream observation on the latched model.
+    func prepareEscalationIfNeeded() {
+        if let escalationViewModel {
+            escalationViewModel.startObserving()
+            return
+        }
+        guard FeatureFlags.shared.isAbilitiesV2Enabled,
+              viewModel.conversation.hasAgent else {
+            return
+        }
+        let escalation = ConversationEscalationViewModel(
+            conversationId: viewModel.conversation.id,
+            selection: AbilitiesServices.selection
+        )
+        escalation.startObserving()
+        escalationViewModel = escalation
     }
 }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -70,9 +70,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// presented.
     @State private var contextMenuState: MessageContextMenuState = .init()
     @State private var showingDebugInjector: Bool = false
-    /// Consent surface for agent ability-use asks, latched once per view
-    /// lifetime by `prepareEscalationIfNeeded` (nil while the abilities
-    /// flag is off or the conversation has no agent).
+    /// Consent surface for agent ability-use asks, managed by
+    /// `prepareEscalationIfNeeded` keyed on `escalationTaskKey` (nil while
+    /// the abilities flag is off or the conversation has no agent; rebuilt
+    /// when the shown conversation changes).
     @State private var escalationViewModel: ConversationEscalationViewModel?
     @State private var presentingAddFromContactsPicker: Bool = false
     @State private var navState: ConversationNavigatorImpl = .init()
@@ -245,6 +246,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
         // flag is on. Absent, the composer draws no bubble at all.
         .environment(\.agentParticipation, participationContext)
         .task(id: participationTaskKey) { await prepareParticipation() }
+        .task(id: escalationTaskKey) { prepareEscalationIfNeeded() }
         // The mode rides the group's appData, so another member's change lands
         // as a change to this conversation's synced row and the bubble follows
         // it - nothing here polls.
@@ -543,7 +545,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
             navState.markScreenAppeared()
             viewModel.onConversationAppeared()
             seedInitialPageIfNeeded()
-            prepareEscalationIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .selectAgentDmPageRequested)) { note in
             handleSelectAgentDmPageRequest(note)
@@ -1115,12 +1116,25 @@ private extension ConversationView {
         .animation(.spring(duration: 0.4, bounce: 0.2), value: bottomBarSlot)
     }
 
-    /// Builds the escalation view model once per view lifetime: only when
-    /// the Abilities V2 flag is on and the conversation has an agent. The
-    /// flag is read once and latched -- same posture as
-    /// `ConversationInfoView.AgentAccessMode`. Re-appearance restarts the
-    /// stream observation on the latched model.
+    /// Keys the escalation `.task` on the conversation AND on whether it
+    /// has an agent, mirroring `participationTaskKey`: a view instance that
+    /// pages to another conversation rebuilds the model for the new stream,
+    /// and an agent that joins an already-open conversation starts
+    /// observation without needing a re-appear.
+    var escalationTaskKey: String {
+        "\(viewModel.conversation.id)-\(viewModel.conversation.hasAgent)"
+    }
+
+    /// Builds the escalation view model when the Abilities V2 flag is on
+    /// and the conversation has an agent. The flag is read once and latched
+    /// -- same posture as `ConversationInfoView.AgentAccessMode`. Runs from
+    /// a `.task` keyed on `escalationTaskKey`, so re-appearance restarts
+    /// stream observation and a conversation change rebuilds the model.
     func prepareEscalationIfNeeded() {
+        if let escalationViewModel, escalationViewModel.conversationId != viewModel.conversation.id {
+            escalationViewModel.stopObserving()
+            self.escalationViewModel = nil
+        }
         if let escalationViewModel {
             escalationViewModel.startObserving()
             return

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -51,6 +51,7 @@ struct DebugViewSection: View {
     @State private var useRealCredits: Bool = CreditsServices.useRealBackend
     @State private var useLiveAbilities: Bool = AbilitiesServices.useLiveBackend
     @State private var abilitiesV1ShimEnabled: Bool = AbilitiesServices.isV1AwarenessShimEnabled
+    @State private var abilitiesEscalationMockEnabled: Bool = AbilitiesServices.isEscalationMockEnabled
     @State private var identity: DeviceIdentitySnapshot?
 
     var body: some View {
@@ -103,9 +104,10 @@ struct DebugViewSection: View {
     }
 
     /// The Abilities V2 flag with its sub-toggles: mock/live backend
-    /// selection (default live) and the V1 awareness shim (default off).
-    /// Sub-toggles only render while the flag is on; both take effect on
-    /// the next read (no relaunch needed).
+    /// selection (default live), the V1 awareness shim (default off), and
+    /// the mock consent flow (default on). Sub-toggles only render while
+    /// the flag is on; all take effect on the next read (no relaunch
+    /// needed).
     @ViewBuilder
     private var abilitiesFeatureToggles: some View {
         Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
@@ -117,6 +119,10 @@ struct DebugViewSection: View {
             Toggle("Abilities: v1 awareness shim", isOn: $abilitiesV1ShimEnabled)
                 .onChange(of: abilitiesV1ShimEnabled) { _, newValue in
                     AbilitiesServices.setV1AwarenessShimEnabled(newValue)
+                }
+            Toggle("Abilities: consent flow (mock)", isOn: $abilitiesEscalationMockEnabled)
+                .onChange(of: abilitiesEscalationMockEnabled) { _, newValue in
+                    AbilitiesServices.setEscalationMockEnabled(newValue)
                 }
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilityDelegation.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilityDelegation.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// An agent's pending ask to use the owner's ability in a conversation.
+public struct AbilityDelegationRequest: Sendable, Hashable, Identifiable {
+    public let id: String
+    public let conversationId: String
+    public let agentInboxId: String
+    /// Display name supplied by the serving layer; the mock seeds it
+    /// directly, a future live path resolves it from members.
+    public let agentDisplayName: String
+    public let abilityId: String
+    public let requestedBundleIds: [String]
+    /// One human sentence of agent-supplied context ("Alex asked me to
+    /// add the team dinner to your calendar").
+    public let reason: String
+    public let requestedAt: Date
+
+    public init(
+        id: String,
+        conversationId: String,
+        agentInboxId: String,
+        agentDisplayName: String,
+        abilityId: String,
+        requestedBundleIds: [String],
+        reason: String,
+        requestedAt: Date
+    ) {
+        self.id = id
+        self.conversationId = conversationId
+        self.agentInboxId = agentInboxId
+        self.agentDisplayName = agentDisplayName
+        self.abilityId = abilityId
+        self.requestedBundleIds = requestedBundleIds
+        self.reason = reason
+        self.requestedAt = requestedAt
+    }
+}
+
+/// The bound the owner chose at grant time.
+public enum AbilityDelegationScope: Sendable, Hashable {
+    case oneShot
+    case expiring(Date)
+}
+
+/// Stored lifecycle state of a granted delegation.
+public enum AbilityDelegationState: String, Sendable, Hashable {
+    case active
+    /// One-shot, used.
+    case consumed
+    case expired
+    case revoked
+}
+
+/// A bounded grant: this conversation, this agent, these bundles, this
+/// scope. Requests that were declined never materialize as delegations.
+public struct AbilityDelegation: Sendable, Hashable, Identifiable {
+    public let id: String
+    public let conversationId: String
+    /// Display label for the delegations list; mock-seeded.
+    public let conversationName: String
+    public let agentInboxId: String
+    public let agentDisplayName: String
+    public let abilityId: String
+    public let bundleIds: [String]
+    public let scope: AbilityDelegationScope
+    public let grantedAt: Date
+    public let state: AbilityDelegationState
+
+    public init(
+        id: String,
+        conversationId: String,
+        conversationName: String,
+        agentInboxId: String,
+        agentDisplayName: String,
+        abilityId: String,
+        bundleIds: [String],
+        scope: AbilityDelegationScope,
+        grantedAt: Date,
+        state: AbilityDelegationState
+    ) {
+        self.id = id
+        self.conversationId = conversationId
+        self.conversationName = conversationName
+        self.agentInboxId = agentInboxId
+        self.agentDisplayName = agentDisplayName
+        self.abilityId = abilityId
+        self.bundleIds = bundleIds
+        self.scope = scope
+        self.grantedAt = grantedAt
+        self.state = state
+    }
+
+    /// Expiry is derived, never stored: an active expiring delegation
+    /// whose instant has passed reads as expired everywhere.
+    public func effectiveState(at now: Date = Date()) -> AbilityDelegationState {
+        guard state == .active, case .expiring(let expiry) = scope, expiry <= now else {
+            return state
+        }
+        return .expired
+    }
+
+    /// A copy of this delegation with `state` replaced, mirroring
+    /// `AbilitiesAPI.Ability.withEntitlementState`.
+    public func withState(_ state: AbilityDelegationState) -> AbilityDelegation {
+        AbilityDelegation(
+            id: id,
+            conversationId: conversationId,
+            conversationName: conversationName,
+            agentInboxId: agentInboxId,
+            agentDisplayName: agentDisplayName,
+            abilityId: abilityId,
+            bundleIds: bundleIds,
+            scope: scope,
+            grantedAt: grantedAt,
+            state: state
+        )
+    }
+}
+
+/// Typed failures for the escalation seam, mirroring
+/// `AbilitiesServiceError`'s style.
+public enum AbilityEscalationServiceError: Error, Sendable, Equatable {
+    case unknownRequest(requestId: String)
+    case requestAlreadyResolved(requestId: String)
+    case unknownDelegation(delegationId: String)
+    case delegationNotActive(delegationId: String)
+}
+
+extension AbilityEscalationServiceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unknownRequest:
+            "This request is no longer available."
+        case .requestAlreadyResolved:
+            "This request was already answered."
+        case .unknownDelegation:
+            "This delegation is no longer available."
+        case .delegationNotActive:
+            "This delegation is not active."
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilityEscalationServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilityEscalationServiceProtocol.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Client-side seam for agent-initiated ability-use requests and the
+/// delegations they produce. Deliberately transport-free: the
+/// authorization semantics (who may ask, how the ask travels, where
+/// grants are stored) are still being decided server-side, so the only
+/// implementation is the in-memory mock. When the real transport lands it
+/// conforms here; every surface upstream of this protocol is already
+/// final. Nothing in this contract implies a wire format.
+///
+/// Deliberately a sibling of `AbilitiesServiceProtocol`, not an extension
+/// of it: extending would force `LiveAbilitiesService` to grow throwing
+/// stubs for a flow that has no wire, and would smear the seam across two
+/// files.
+public protocol AbilityEscalationServiceProtocol: Sendable {
+    /// Pending asks for one conversation, newest last.
+    func pendingRequests(conversationId: String) async -> [AbilityDelegationRequest]
+
+    /// Live view of the same: emits the full pending set on every change.
+    /// The first emission is the current state.
+    func pendingRequestsStream(conversationId: String) async -> AsyncStream<[AbilityDelegationRequest]>
+
+    /// Every delegation ever granted for one ability, newest first,
+    /// across conversations (the ability-detail list).
+    func delegations(abilityId: String) async -> [AbilityDelegation]
+
+    /// Resolves a pending request into a bounded delegation.
+    /// Throws `requestAlreadyResolved` on a second resolution.
+    @discardableResult
+    func grant(requestId: String, bundleIds: [String], scope: AbilityDelegationScope) async throws -> AbilityDelegation
+
+    /// Resolves a pending request negatively. No delegation is created.
+    func decline(requestId: String) async throws
+
+    /// Owner-initiated revocation of an active delegation.
+    func revoke(delegationId: String) async throws
+}

--- a/ConvosCore/Sources/ConvosCore/Abilities/MockAbilityEscalationService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/MockAbilityEscalationService.swift
@@ -121,7 +121,7 @@ public actor MockAbilityEscalationService: AbilityEscalationServiceProtocol {
         guard let delegation = delegationsById[delegationId] else {
             throw AbilityEscalationServiceError.unknownDelegation(delegationId: delegationId)
         }
-        guard delegation.state == .active else {
+        guard delegation.effectiveState() == .active else {
             throw AbilityEscalationServiceError.delegationNotActive(delegationId: delegationId)
         }
         delegationsById[delegationId] = delegation.withState(.revoked)
@@ -176,7 +176,12 @@ public actor MockAbilityEscalationService: AbilityEscalationServiceProtocol {
     }
 
     private func fireScriptedRequest(conversationId: String) {
-        guard isActive() else { return }
+        guard isActive() else {
+            // The toggle went off during the delay; re-arm so the scripted
+            // ask fires on the next subscribe after re-enable.
+            firedConversations.remove(conversationId)
+            return
+        }
         let request = Self.scriptedRequest(conversationId: conversationId)
         pendingByConversation[conversationId, default: []].append(request)
         emitPending(conversationId: conversationId)

--- a/ConvosCore/Sources/ConvosCore/Abilities/MockAbilityEscalationService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/MockAbilityEscalationService.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// In-memory `AbilityEscalationServiceProtocol` driving the consent-flow
+/// surfaces until the real transport lands. Simulates the whole request
+/// lifecycle: a scripted incoming ask, grant and decline resolution,
+/// one-shot consumption, revocation, and derived expiry. Fixture ids match
+/// `MockAbilitiesService.standardCatalog()` so icons and names resolve.
+public actor MockAbilityEscalationService: AbilityEscalationServiceProtocol {
+    /// Seed states for the app, previews, and tests.
+    public enum Scenario: Sendable {
+        /// Seeded delegations in every display state plus a scripted
+        /// incoming calendar request that fires shortly after a
+        /// conversation's pending stream is first observed. The default
+        /// for the app and for lifecycle previews.
+        case scripted
+        /// Seeded delegations, no auto-fire (delegations-list previews).
+        case populated
+        /// Nothing pending, nothing granted (empty states).
+        case quiet
+    }
+
+    private let scenario: Scenario
+    private let artificialDelay: Duration
+    private let autoFireDelay: Duration
+    private let oneShotConsumptionDelay: Duration
+    /// Read at call time so the Debug toggle is live without a relaunch:
+    /// when false, every read serves empty, streams emit only the empty
+    /// set, and the scripted auto-fire never schedules.
+    private let isActive: @Sendable () -> Bool
+
+    private var pendingByConversation: [String: [AbilityDelegationRequest]] = [:]
+    private var delegationsById: [String: AbilityDelegation] = [:]
+    private var resolvedRequestIds: Set<String> = []
+    private var continuationsByConversation: [String: [UUID: AsyncStream<[AbilityDelegationRequest]>.Continuation]] = [:]
+    /// The scripted request fires once per conversation per process.
+    private var firedConversations: Set<String> = []
+
+    public init(
+        scenario: Scenario = .scripted,
+        artificialDelay: Duration = .milliseconds(150),
+        autoFireDelay: Duration = .seconds(3),
+        oneShotConsumptionDelay: Duration = .seconds(8),
+        isActive: @escaping @Sendable () -> Bool = { true }
+    ) {
+        self.scenario = scenario
+        self.artificialDelay = artificialDelay
+        self.autoFireDelay = autoFireDelay
+        self.oneShotConsumptionDelay = oneShotConsumptionDelay
+        self.isActive = isActive
+        switch scenario {
+        case .scripted, .populated:
+            for delegation in Self.standardDelegations() {
+                delegationsById[delegation.id] = delegation
+            }
+        case .quiet:
+            break
+        }
+    }
+
+    // MARK: - AbilityEscalationServiceProtocol
+
+    public func pendingRequests(conversationId: String) async -> [AbilityDelegationRequest] {
+        await simulateLatency()
+        return servedPendingRequests(conversationId: conversationId)
+    }
+
+    public func pendingRequestsStream(conversationId: String) async -> AsyncStream<[AbilityDelegationRequest]> {
+        let (stream, continuation) = AsyncStream<[AbilityDelegationRequest]>.makeStream()
+        let id = UUID()
+        continuation.onTermination = { [weak self] _ in
+            Task { [weak self] in
+                await self?.removeContinuation(id: id, conversationId: conversationId)
+            }
+        }
+        continuationsByConversation[conversationId, default: [:]][id] = continuation
+        continuation.yield(servedPendingRequests(conversationId: conversationId))
+        scheduleAutoFireIfNeeded(conversationId: conversationId)
+        return stream
+    }
+
+    public func delegations(abilityId: String) async -> [AbilityDelegation] {
+        await simulateLatency()
+        guard isActive() else { return [] }
+        return delegationsById.values
+            .filter { (delegation: AbilityDelegation) -> Bool in delegation.abilityId == abilityId }
+            .sorted { (lhs: AbilityDelegation, rhs: AbilityDelegation) -> Bool in lhs.grantedAt > rhs.grantedAt }
+    }
+
+    @discardableResult
+    public func grant(requestId: String, bundleIds: [String], scope: AbilityDelegationScope) async throws -> AbilityDelegation {
+        await simulateLatency()
+        let request = try takePendingRequest(requestId: requestId)
+        let delegation = AbilityDelegation(
+            id: "delegation-\(UUID().uuidString)",
+            conversationId: request.conversationId,
+            conversationName: Self.conversationName(for: request.conversationId),
+            agentInboxId: request.agentInboxId,
+            agentDisplayName: request.agentDisplayName,
+            abilityId: request.abilityId,
+            bundleIds: bundleIds,
+            scope: scope,
+            grantedAt: Date(),
+            state: .active
+        )
+        delegationsById[delegation.id] = delegation
+        emitPending(conversationId: request.conversationId)
+        if scenario == .scripted, scope == .oneShot {
+            scheduleOneShotConsumption(delegationId: delegation.id)
+        }
+        return delegation
+    }
+
+    public func decline(requestId: String) async throws {
+        await simulateLatency()
+        let request = try takePendingRequest(requestId: requestId)
+        emitPending(conversationId: request.conversationId)
+    }
+
+    public func revoke(delegationId: String) async throws {
+        await simulateLatency()
+        guard let delegation = delegationsById[delegationId] else {
+            throw AbilityEscalationServiceError.unknownDelegation(delegationId: delegationId)
+        }
+        guard delegation.state == .active else {
+            throw AbilityEscalationServiceError.delegationNotActive(delegationId: delegationId)
+        }
+        delegationsById[delegationId] = delegation.withState(.revoked)
+    }
+
+    // MARK: - Lifecycle helpers
+
+    private func simulateLatency() async {
+        guard artificialDelay > .zero else { return }
+        try? await Task.sleep(for: artificialDelay)
+    }
+
+    private func servedPendingRequests(conversationId: String) -> [AbilityDelegationRequest] {
+        guard isActive() else { return [] }
+        return pendingByConversation[conversationId] ?? []
+    }
+
+    /// Removes and returns the pending request, recording it as resolved.
+    /// A second resolution throws `requestAlreadyResolved`; an id that was
+    /// never pending throws `unknownRequest`.
+    private func takePendingRequest(requestId: String) throws -> AbilityDelegationRequest {
+        guard !resolvedRequestIds.contains(requestId) else {
+            throw AbilityEscalationServiceError.requestAlreadyResolved(requestId: requestId)
+        }
+        for (conversationId, requests) in pendingByConversation {
+            guard let request = requests.first(where: { $0.id == requestId }) else { continue }
+            pendingByConversation[conversationId] = requests.filter { $0.id != requestId }
+            resolvedRequestIds.insert(requestId)
+            return request
+        }
+        throw AbilityEscalationServiceError.unknownRequest(requestId: requestId)
+    }
+
+    private func emitPending(conversationId: String) {
+        let served: [AbilityDelegationRequest] = servedPendingRequests(conversationId: conversationId)
+        for continuation in (continuationsByConversation[conversationId] ?? [:]).values {
+            continuation.yield(served)
+        }
+    }
+
+    private func removeContinuation(id: UUID, conversationId: String) {
+        continuationsByConversation[conversationId]?.removeValue(forKey: id)
+    }
+
+    private func scheduleAutoFireIfNeeded(conversationId: String) {
+        guard scenario == .scripted, isActive(), !firedConversations.contains(conversationId) else { return }
+        firedConversations.insert(conversationId)
+        Task { [autoFireDelay] in
+            try? await Task.sleep(for: autoFireDelay)
+            await self.fireScriptedRequest(conversationId: conversationId)
+        }
+    }
+
+    private func fireScriptedRequest(conversationId: String) {
+        guard isActive() else { return }
+        let request = Self.scriptedRequest(conversationId: conversationId)
+        pendingByConversation[conversationId, default: []].append(request)
+        emitPending(conversationId: conversationId)
+    }
+
+    /// Simulates the agent using its single shot: the granted one-shot
+    /// delegation flips to consumed after the consumption delay.
+    private func scheduleOneShotConsumption(delegationId: String) {
+        Task { [oneShotConsumptionDelay] in
+            try? await Task.sleep(for: oneShotConsumptionDelay)
+            await self.consumeOneShot(delegationId: delegationId)
+        }
+    }
+
+    private func consumeOneShot(delegationId: String) {
+        guard let delegation = delegationsById[delegationId], delegation.state == .active else { return }
+        delegationsById[delegationId] = delegation.withState(.consumed)
+    }
+
+    // MARK: - Fixtures
+
+    /// The scripted incoming ask: Caley wants Google Calendar in whatever
+    /// conversation first observes the pending stream. Asks for both
+    /// calendar bundles so the approval sheet's narrowing interaction is
+    /// exercisable (a single-bundle ask could only be granted whole or
+    /// not at all).
+    public static func scriptedRequest(conversationId: String, requestedAt: Date = Date()) -> AbilityDelegationRequest {
+        AbilityDelegationRequest(
+            id: "request-scripted-\(conversationId)",
+            conversationId: conversationId,
+            agentInboxId: Constant.mockAgentInboxId,
+            agentDisplayName: Constant.mockAgentDisplayName,
+            abilityId: "googlecalendar",
+            requestedBundleIds: ["calendar.events", "calendar.availability"],
+            reason: "Alex asked me to add the team dinner to your calendar.",
+            requestedAt: requestedAt
+        )
+    }
+
+    /// Seeded delegations covering every display state, consistent with
+    /// `MockAbilitiesService.standardCatalog()` ability and bundle ids.
+    /// The gmail entry is stored active with a past expiry, proving the
+    /// derived-expiry read end to end.
+    public static func standardDelegations(now: Date = Date()) -> [AbilityDelegation] {
+        [
+            AbilityDelegation(
+                id: "delegation-gcal-active",
+                conversationId: Constant.mockConversationOneId,
+                conversationName: Constant.mockConversationOneName,
+                agentInboxId: Constant.mockAgentInboxId,
+                agentDisplayName: Constant.mockAgentDisplayName,
+                abilityId: "googlecalendar",
+                bundleIds: ["calendar.events"],
+                scope: .expiring(now.addingTimeInterval(Constant.sixDays)),
+                grantedAt: now.addingTimeInterval(-Constant.oneDay),
+                state: .active
+            ),
+            AbilityDelegation(
+                id: "delegation-gcal-consumed",
+                conversationId: Constant.mockConversationTwoId,
+                conversationName: Constant.mockConversationTwoName,
+                agentInboxId: Constant.mockAgentInboxId,
+                agentDisplayName: Constant.mockAgentDisplayName,
+                abilityId: "googlecalendar",
+                bundleIds: ["calendar.events", "calendar.availability"],
+                scope: .oneShot,
+                grantedAt: now.addingTimeInterval(-Constant.twoDays),
+                state: .consumed
+            ),
+            AbilityDelegation(
+                id: "delegation-gmail-expired",
+                conversationId: Constant.mockConversationOneId,
+                conversationName: Constant.mockConversationOneName,
+                agentInboxId: Constant.mockAgentInboxId,
+                agentDisplayName: Constant.mockAgentDisplayName,
+                abilityId: "gmail",
+                bundleIds: ["gmail.read"],
+                scope: .expiring(now.addingTimeInterval(-Constant.twoDays)),
+                grantedAt: now.addingTimeInterval(-Constant.nineDays),
+                state: .active
+            ),
+            AbilityDelegation(
+                id: "delegation-coinbase-revoked",
+                conversationId: Constant.mockConversationOneId,
+                conversationName: Constant.mockConversationOneName,
+                agentInboxId: Constant.mockAgentInboxId,
+                agentDisplayName: Constant.mockAgentDisplayName,
+                abilityId: "coinbase",
+                bundleIds: ["coinbase.prices"],
+                scope: .expiring(now.addingTimeInterval(Constant.threeDays)),
+                grantedAt: now.addingTimeInterval(-Constant.threeDays),
+                state: .revoked
+            ),
+        ]
+    }
+
+    /// Display label for a delegation's conversation: fixture names for
+    /// the mock conversations, a neutral label for real conversation ids
+    /// the mock cannot resolve.
+    private static func conversationName(for conversationId: String) -> String {
+        switch conversationId {
+        case Constant.mockConversationOneId: Constant.mockConversationOneName
+        case Constant.mockConversationTwoId: Constant.mockConversationTwoName
+        default: "This convo"
+        }
+    }
+
+    private enum Constant {
+        static let mockConversationOneId: String = "mock-conversation-1"
+        static let mockConversationTwoId: String = "mock-conversation-2"
+        static let mockConversationOneName: String = "Weekend planning"
+        static let mockConversationTwoName: String = "Family"
+        static let mockAgentInboxId: String = "mock-agent-inbox-1"
+        static let mockAgentDisplayName: String = "Caley"
+        static let oneDay: TimeInterval = 86_400
+        static let twoDays: TimeInterval = 172_800
+        static let threeDays: TimeInterval = 259_200
+        static let sixDays: TimeInterval = 518_400
+        static let nineDays: TimeInterval = 777_600
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AbilityEscalationMockTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilityEscalationMockTests.swift
@@ -1,0 +1,225 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Mutable flag captured by the mock's `isActive` closure; tests flip it
+/// mid-run to prove the gate is read at call time. Reads and writes are
+/// sequenced by the test body itself.
+private final class ActiveFlagBox: @unchecked Sendable {
+    var isActive: Bool
+
+    init(isActive: Bool) {
+        self.isActive = isActive
+    }
+}
+
+@Suite("MockAbilityEscalationService")
+struct AbilityEscalationMockTests {
+    private func makeService(
+        scenario: MockAbilityEscalationService.Scenario = .scripted,
+        isActive: @escaping @Sendable () -> Bool = { true }
+    ) -> MockAbilityEscalationService {
+        MockAbilityEscalationService(
+            scenario: scenario,
+            artificialDelay: .zero,
+            autoFireDelay: .milliseconds(10),
+            oneShotConsumptionDelay: .milliseconds(10),
+            isActive: isActive
+        )
+    }
+
+    /// Waits for the scripted request through a fresh stream: first
+    /// emission is the current (empty) set, the next carries the ask.
+    private func awaitScriptedRequest(
+        from service: MockAbilityEscalationService,
+        conversationId: String
+    ) async throws -> (request: AbilityDelegationRequest, iterator: AsyncStream<[AbilityDelegationRequest]>.AsyncIterator) {
+        let stream = await service.pendingRequestsStream(conversationId: conversationId)
+        var iterator = stream.makeAsyncIterator()
+        let first = await iterator.next()
+        #expect(first == [])
+        let second = await iterator.next()
+        let request = try #require(second?.last)
+        return (request, iterator)
+    }
+
+    @Test("Scripted stream emits current state, then the scripted request with catalog-consistent ids")
+    func scriptedStreamLifecycle() async throws {
+        let service = makeService()
+        let (request, _) = try await awaitScriptedRequest(from: service, conversationId: "convo-a")
+
+        let catalog = MockAbilitiesService.standardCatalog()
+        let ability = try #require(catalog.first { $0.id == request.abilityId })
+        #expect(request.agentInboxId == "mock-agent-inbox-1")
+        let bundleIds = Set(ability.bundles.map(\.id))
+        #expect(Set(request.requestedBundleIds).isSubset(of: bundleIds))
+        #expect(!request.requestedBundleIds.isEmpty)
+        #expect(!request.reason.isEmpty)
+    }
+
+    @Test("Grant empties the pending set, returns an active delegation, and lists it")
+    func grantResolvesRequest() async throws {
+        let service = makeService()
+        let arrival = try await awaitScriptedRequest(from: service, conversationId: "convo-b")
+        let request = arrival.request
+        var iterator = arrival.iterator
+
+        let scope = AbilityDelegationScope.oneShot
+        let delegation = try await service.grant(requestId: request.id, bundleIds: ["calendar.events"], scope: scope)
+        #expect(delegation.state == .active)
+        #expect(delegation.bundleIds == ["calendar.events"])
+        #expect(delegation.scope == scope)
+        #expect(delegation.conversationId == "convo-b")
+
+        let afterGrant = await iterator.next()
+        #expect(afterGrant == [])
+
+        let listed = await service.delegations(abilityId: request.abilityId)
+        #expect(listed.contains { $0.id == delegation.id })
+    }
+
+    @Test("Second resolution throws requestAlreadyResolved; unknown ids throw unknownRequest")
+    func grantIdempotency() async throws {
+        let service = makeService()
+        let (request, _) = try await awaitScriptedRequest(from: service, conversationId: "convo-c")
+
+        try await service.grant(requestId: request.id, bundleIds: ["calendar.events"], scope: .oneShot)
+
+        await #expect(throws: AbilityEscalationServiceError.requestAlreadyResolved(requestId: request.id)) {
+            try await service.grant(requestId: request.id, bundleIds: ["calendar.events"], scope: .oneShot)
+        }
+        await #expect(throws: AbilityEscalationServiceError.requestAlreadyResolved(requestId: request.id)) {
+            try await service.decline(requestId: request.id)
+        }
+        await #expect(throws: AbilityEscalationServiceError.unknownRequest(requestId: "nope")) {
+            try await service.grant(requestId: "nope", bundleIds: [], scope: .oneShot)
+        }
+    }
+
+    @Test("Decline empties the pending set and creates no delegation")
+    func declineCreatesNothing() async throws {
+        let service = makeService()
+        let arrival = try await awaitScriptedRequest(from: service, conversationId: "convo-d")
+        let request = arrival.request
+        var iterator = arrival.iterator
+
+        let before = await service.delegations(abilityId: request.abilityId)
+        try await service.decline(requestId: request.id)
+        let afterDecline = await iterator.next()
+        #expect(afterDecline == [])
+        let after = await service.delegations(abilityId: request.abilityId)
+        #expect(after == before)
+    }
+
+    @Test("Revoke flips active to revoked; repeat and unknown ids throw")
+    func revokeLifecycle() async throws {
+        let service = makeService(scenario: .populated)
+        let activeId = "delegation-gcal-active"
+
+        try await service.revoke(delegationId: activeId)
+        let listed = await service.delegations(abilityId: "googlecalendar")
+        let revoked = try #require(listed.first { $0.id == activeId })
+        #expect(revoked.state == .revoked)
+
+        await #expect(throws: AbilityEscalationServiceError.delegationNotActive(delegationId: activeId)) {
+            try await service.revoke(delegationId: activeId)
+        }
+        await #expect(throws: AbilityEscalationServiceError.unknownDelegation(delegationId: "nope")) {
+            try await service.revoke(delegationId: "nope")
+        }
+    }
+
+    @Test("A granted one-shot flips to consumed after the consumption delay")
+    func oneShotConsumption() async throws {
+        let service = makeService()
+        let (request, _) = try await awaitScriptedRequest(from: service, conversationId: "convo-e")
+        let delegation = try await service.grant(requestId: request.id, bundleIds: ["calendar.events"], scope: .oneShot)
+
+        var consumed = false
+        for _ in 0..<200 where !consumed {
+            let listed = await service.delegations(abilityId: request.abilityId)
+            if listed.first(where: { $0.id == delegation.id })?.state == .consumed {
+                consumed = true
+            } else {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        #expect(consumed)
+    }
+
+    @Test("Expiry is derived from scope, never stored; revoked wins over past expiry")
+    func expiryDerivation() {
+        let now = Date()
+        let seeds = MockAbilityEscalationService.standardDelegations(now: now)
+        let expired = seeds.first { $0.id == "delegation-gmail-expired" }
+        #expect(expired?.state == .active)
+        #expect(expired?.effectiveState(at: now) == .expired)
+
+        let active = seeds.first { $0.id == "delegation-gcal-active" }
+        #expect(active?.effectiveState(at: now) == .active)
+
+        let revokedPastExpiry = AbilityDelegation(
+            id: "delegation-test-revoked",
+            conversationId: "c",
+            conversationName: "C",
+            agentInboxId: "a",
+            agentDisplayName: "A",
+            abilityId: "gmail",
+            bundleIds: ["gmail.read"],
+            scope: .expiring(now.addingTimeInterval(-60)),
+            grantedAt: now.addingTimeInterval(-120),
+            state: .revoked
+        )
+        #expect(revokedPastExpiry.effectiveState(at: now) == .revoked)
+    }
+
+    @Test("isActive gate: reads serve empty, auto-fire never lands, and the closure is read at call time")
+    func inactiveGate() async throws {
+        let flag = ActiveFlagBox(isActive: false)
+        let service = makeService(isActive: { flag.isActive })
+
+        let pending = await service.pendingRequests(conversationId: "convo-f")
+        #expect(pending.isEmpty)
+        let seeded = await service.delegations(abilityId: "googlecalendar")
+        #expect(seeded.isEmpty)
+
+        let stream = await service.pendingRequestsStream(conversationId: "convo-f")
+        var iterator = stream.makeAsyncIterator()
+        let first = await iterator.next()
+        #expect(first == [])
+
+        // Well past the 10ms auto-fire delay: nothing may have landed.
+        try await Task.sleep(for: .milliseconds(100))
+        let stillPending = await service.pendingRequests(conversationId: "convo-f")
+        #expect(stillPending.isEmpty)
+
+        // Flipping the captured flag makes the very next call serve.
+        flag.isActive = true
+        let served = await service.delegations(abilityId: "googlecalendar")
+        #expect(!served.isEmpty)
+
+        // A fresh subscription now schedules the scripted fire.
+        let (request, _) = try await awaitScriptedRequest(from: service, conversationId: "convo-f")
+        #expect(request.abilityId == "googlecalendar")
+    }
+
+    @Test("Seeded fixtures: unique ids, catalog-resolvable abilities, all four display states")
+    func fixtureSanity() {
+        let now = Date()
+        let seeds = MockAbilityEscalationService.standardDelegations(now: now)
+        let ids = seeds.map(\.id)
+        #expect(Set(ids).count == ids.count)
+
+        let catalog = MockAbilitiesService.standardCatalog()
+        let catalogIds = Set(catalog.map(\.id))
+        for seed in seeds {
+            #expect(catalogIds.contains(seed.abilityId))
+            let ability = catalog.first { $0.id == seed.abilityId }
+            let bundleIds = Set(ability?.bundles.map(\.id) ?? [])
+            #expect(Set(seed.bundleIds).isSubset(of: bundleIds))
+        }
+
+        let displayStates = Set(seeds.map { $0.effectiveState(at: now) })
+        #expect(displayStates == [.active, .consumed, .expired, .revoked])
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/AbilityEscalationMockTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilityEscalationMockTests.swift
@@ -203,6 +203,40 @@ struct AbilityEscalationMockTests {
         #expect(request.abilityId == "googlecalendar")
     }
 
+    @Test("Revoking a stored-active but expired delegation throws and leaves it expired")
+    func revokeExpiredDelegation() async throws {
+        let service = makeService()
+        let expiredId = "delegation-gmail-expired"
+
+        await #expect(throws: AbilityEscalationServiceError.delegationNotActive(delegationId: expiredId)) {
+            try await service.revoke(delegationId: expiredId)
+        }
+
+        // The stored row must not have been rewritten to revoked.
+        let delegations = await service.delegations(abilityId: "gmail")
+        let expired = try #require(delegations.first { $0.id == expiredId })
+        #expect(expired.effectiveState() == .expired)
+    }
+
+    @Test("Toggle-off during the auto-fire delay re-arms the scripted ask for the next subscribe")
+    func autoFireRearmsAfterInactiveWindow() async throws {
+        let flag = ActiveFlagBox(isActive: true)
+        let service = makeService(isActive: { flag.isActive })
+
+        // Subscribing while active schedules the fire; the toggle goes off
+        // before the delay elapses, so the fire must not land.
+        _ = await service.pendingRequestsStream(conversationId: "convo-g")
+        flag.isActive = false
+        try await Task.sleep(for: .milliseconds(100))
+        let pending = await service.pendingRequests(conversationId: "convo-g")
+        #expect(pending.isEmpty)
+
+        // Re-enabling and resubscribing schedules it again.
+        flag.isActive = true
+        let (request, _) = try await awaitScriptedRequest(from: service, conversationId: "convo-g")
+        #expect(request.abilityId == "googlecalendar")
+    }
+
     @Test("Seeded fixtures: unique ids, catalog-resolvable abilities, all four display states")
     func fixtureSanity() {
         let now = Date()

--- a/ConvosCore/Tests/ConvosCoreTests/VoiceMemoTranscriptionServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/VoiceMemoTranscriptionServiceTests.swift
@@ -26,7 +26,10 @@ struct VoiceMemoTranscriptionServiceTests {
             mimeType: "audio/m4a"
         )
 
-        try await waitUntil(timeout: .seconds(10)) { await writer.completedSnapshot().count == 1 }
+        // The service transcribes on a detached task, which can starve for
+        // several seconds while the full parallel suite spins up; this test
+        // runs first in the serialized suite, so give it extra headroom.
+        try await waitUntil(timeout: .seconds(30)) { await writer.completedSnapshot().count == 1 }
 
         let pendingCount = await writer.pendingSnapshot().count
         let completed = await writer.completedSnapshot()


### PR DESCRIPTION
Mock-first UI for the abilities escalation (authorization consent) flow, gated behind the existing Abilities v2 debug feature flag. Stacked conceptually on #1259 (now in dev); rebased onto dev so only this feature's commits ship here.

## What it ships

- **Consent prompt card** in the conversation's bottom-bar status slot: when an agent asks to use an ability it hasn't been delegated, a card surfaces the ask inline (toast > pending ask > onboarding priority, one animated slot).
- **Approval sheet** with bundle narrowing (approve the whole bundle or narrow to individual abilities) and scope choice: one-shot or expiring grants. Medium detent, scrollable so nothing clips.
- **Delegations list** on the ability detail screen showing granted delegations across display states (active, one-shot pending/consumed, expiring, expired, revoked) with revoke.
- **Mock lifecycle service** behind the existing Abilities v2 flag plus a new Debug sub-toggle ("Abilities: consent flow (mock)", default on) with a scripted scenario: seeded delegations and an incoming calendar ask that fires shortly after a conversation's pending stream is first observed. One shared mock instance app-wide so grants made in a conversation are visible in the delegations list.

## The seam

`AbilityEscalationServiceProtocol` is the stub seam: the UI consumes only the protocol (pending-request stream, resolve, delegations, revoke). The real transport plugs in when the actor model lands - nothing here pre-empts that decision; the mock is the only implementation in both mock and live service modes.

## Verification

- 9 unit tests on the mock lifecycle (grant, decline, narrowing, one-shot consumption, revocation, derived expiry, inactive gate); full ConvosCore suite green (1825 tests).
- QA: 19 screenshots (name-prefix `qa-escalation`) in the session records covering the prompt card, approval sheet variants, and delegations states.
- SwiftLint strict clean on changed files; Dev-configuration simulator build green.
- One drive-by: the voice-memo transcription happy-path test needed a larger wait ceiling - it runs first in its serialized suite and its detached-task work starves during full-suite spin-up once this new suite joins the run; the ceiling only matters when red.

## Design review

Louis reviewed the flow and approved opening this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788457543&installation_model_id=20076&pr_number=1280&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1280&signature=2f8b4b99a2d66c7d5342d95764e43cfbc949236fa1d844d47e5e6c2eba28b06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add escalation consent UI for agent ability-use requests behind a feature flag
> - Adds a full escalation consent flow (mock-first, flag-gated) for agent ability-use requests in conversations: a prompt card appears under the composer when a pending request exists, and tapping it opens an approval sheet where owners can narrow permission bundles, choose scope (once/1 day/1 week), and allow or decline.
> - Introduces `AbilityEscalationServiceProtocol` and `MockAbilityEscalationService` (three scenarios: scripted, populated, quiet) in `ConvosCore`, plus new `AbilityDelegation`, `AbilityDelegationRequest`, and related models.
> - Adds `AbilityDetailView` and `AbilityDetailViewModel` so entitled ability rows in the abilities list push a detail screen showing active and past delegations with swipe-to-revoke support.
> - Wires `ConversationEscalationViewModel` into `ConversationView` with lifecycle-managed observation that starts/stops based on conversation ID and agent presence.
> - A new debug toggle
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 234a092.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->