### PR TITLE
test(pairing): cross-platform interop vectors

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/PairingInteropVectorsTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PairingInteropVectorsTests.swift
@@ -1,0 +1,402 @@
+import CryptoSwift
+import Foundation
+import Testing
+@testable import ConvosCore
+import XMTPiOS
+
+/// Golden cross-platform test vectors for Linked Device Sync.
+///
+/// The Android joiner (`convos-client/android`, `core/pairing/`) has to be
+/// byte-compatible with this implementation: a slug minted by an iPhone must
+/// verify on a Pixel, and the emoji fingerprint both devices render has to
+/// match exactly or the user aborts a legitimate pairing.
+///
+/// `generatePairingVectors` writes `Tests/Fixtures/pairing-vectors.json` from
+/// the *real* production code paths (`PairingInvite.signingPayload`,
+/// `toURLSafeSlug`, `PairingCoordinator.emojiFingerprint`, the four codecs).
+/// That file is committed into both repos; Android's `commonTest` pins every
+/// interop assertion against it.
+///
+/// `iosStillMatchesCommittedVectors` is the guard in the other direction: any
+/// future iOS change that would break the Android joiner fails here first.
+@Suite("Pairing interop vectors")
+struct PairingInteropVectorsTests {
+    // MARK: - Fixed inputs (never change these; Android pins them)
+
+    /// Same convention as `SIWESignerTests` — a fixed key so the vectors are
+    /// reproducible.
+    private static let privateKeyBytes: Data = Data(repeating: 0x11, count: 32)
+
+    /// Opaque to the wire protocol: the inbox id is carried as a UTF-8 string
+    /// in the signing payload and hashed as a string in the fingerprint, so a
+    /// fixed literal exercises the same bytes a real libxmtp inbox id would
+    /// (deriving one needs the FFI's `generateInboxId`, which isn't reachable
+    /// from this test target).
+    private static let initiatorInboxId: String =
+        "3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682"
+    private static let joinerInboxId: String =
+        "8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73"
+
+    private static let nonce: Data = Data((0 ..< 16).map { UInt8($0 &* 17) })
+    private static let issuedAt: Int64 = 1_750_000_000
+    private static let expiresAt: Int64 = 1_750_000_120
+    private static let pin: String = "123456"
+
+    /// Standalone EIP-191 messages, so the Android `Eip191` + secp256k1
+    /// recovery work can be pinned before any pairing types exist. The
+    /// non-ASCII case is deliberate: the prefix length is the message's
+    /// **UTF-8 byte count**, which differs from Kotlin's `String.length`
+    /// (UTF-16 units) for anything outside the BMP-ASCII range.
+    private static let eip191Messages: [String] = [
+        "",
+        "Hello, Convos!",
+        "héllo 🌍 wörld",
+    ]
+
+    private static let identityShareKey: Data = Data(repeating: 0x22, count: 32)
+    private static let identityShareIssuedAt: Int64 = 1_750_000_100
+    private static let deviceRemovedAt: Int64 = 1_750_000_200
+
+    // MARK: - Generation
+
+    @Test("Generate pairing-vectors.json from the production code paths")
+    func generatePairingVectors() async throws {
+        let vectors = try await Self.buildVectors()
+        let json = try JSONSerialization.data(
+            withJSONObject: vectors,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        let url = Self.fixtureURL
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try json.write(to: url)
+        print("[pairing-vectors] wrote \(json.count) bytes to \(url.path)")
+    }
+
+    // MARK: - Mirror assertion (drift guard)
+
+    @Test("iOS still produces and accepts the committed vectors")
+    func iosStillMatchesCommittedVectors() async throws {
+        let data = try Data(contentsOf: Self.fixtureURL)
+        guard let committed = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Issue.record("pairing-vectors.json is not a JSON object")
+            return
+        }
+
+        // 0. EIP-191 digests and signatures still recover the same address.
+        let identity = try #require(committed["identity"] as? [String: Any])
+        let address = try #require(identity["address"] as? String)
+        for vector in try #require(committed["eip191"] as? [[String: Any]]) {
+            let message = try #require(vector["message"] as? String)
+            #expect(Self.hex(Self.personalSignDigest(message)) == vector["digestHex"] as? String)
+            let signature = try #require((vector["signatureBase64"] as? String).flatMap {
+                Data(base64Encoded: $0)
+            })
+            let recovered = try EthereumSignatureRecovery.recoverAddress(
+                message: message,
+                signature: signature
+            )
+            #expect(recovered == address.lowercased())
+        }
+
+        // 1. Signing payload bytes are unchanged.
+        let invite = try #require(committed["invite"] as? [String: Any])
+        let payload = PairingInvite.signingPayload(
+            initiatorInboxId: Self.initiatorInboxId,
+            initiatorAddress: try #require(invite["initiatorAddress"] as? String),
+            nonce: Self.nonce,
+            issuedAt: Self.issuedAt,
+            expiresAt: Self.expiresAt
+        )
+        #expect(Self.hex(payload) == invite["signingPayloadHex"] as? String)
+        // The interop trap: the signed *message* is the lowercase hex string
+        // of the payload, not the payload bytes.
+        #expect(invite["signedMessage"] as? String == Self.hex(payload))
+
+        // 2. The committed slug still decodes and its signature still verifies.
+        let slug = try #require(invite["slug"] as? String)
+        let decoded = try #require(Self.base64URLDecode(slug))
+        let parsed = try JSONDecoder().decode(PairingInvite.self, from: decoded)
+        #expect(parsed.initiatorInboxId == Self.initiatorInboxId)
+        #expect(parsed.nonce == Self.nonce)
+        #expect(parsed.issuedAt == Self.issuedAt)
+        #expect(parsed.expiresAt == Self.expiresAt)
+        #expect(parsed.signature.count == 65)
+        // Deliberately not `fromURLSafeSlug` — that enforces expiry and the
+        // fixture's window is long past.
+        try parsed.verifySignature()
+
+        // 3. Emoji pool and fingerprints are unchanged.
+        let emoji = try #require(committed["emoji"] as? [String: Any])
+        #expect(emoji["poolCount"] as? Int == EmojiSelector.emojis.count)
+        #expect(emoji["pool"] as? [String] == EmojiSelector.emojis)
+        for testCase in try #require(emoji["cases"] as? [[String: Any]]) {
+            let produced = PairingCoordinator.emojiFingerprint(
+                inboxA: try #require(testCase["inboxA"] as? String),
+                inboxB: try #require(testCase["inboxB"] as? String),
+                pin: try #require(testCase["pin"] as? String)
+            )
+            #expect(produced == testCase["emojis"] as? [String])
+        }
+
+        // 4. Every codec still decodes its committed bytes back to the same
+        //    content.
+        //
+        //    Deliberately not a byte comparison of re-encoded output:
+        //    Swift's `JSONEncoder` emits object keys in a per-process
+        //    randomized order, so the committed bytes are only one of many
+        //    valid encodings. Decoding is the property that actually has to
+        //    hold cross-platform — Android's encoder orders keys differently
+        //    again, and both sides must accept either.
+        let codecs = try #require(committed["codecs"] as? [String: Any])
+        func contentBytes(_ key: String) throws -> Data {
+            let vector = try #require(codecs[key] as? [String: Any])
+            return try #require((vector["contentBase64"] as? String).flatMap { Data(base64Encoded: $0) })
+        }
+        func encoded(_ key: String, _ type: ContentTypeID) throws -> EncodedContent {
+            var encoded = EncodedContent()
+            encoded.type = type
+            encoded.content = try contentBytes(key)
+            return encoded
+        }
+
+        let joinRequest = try PairingJoinRequestCodec().decode(
+            content: encoded("pairing_join_request", ContentTypePairingJoinRequest)
+        )
+        #expect(joinRequest.schemaVersion == 1)
+        #expect(joinRequest.slug == slug)
+        #expect(joinRequest.joinerInboxId == Self.joinerInboxId)
+        #expect(joinRequest.deviceName == "Pixel 9 Pro")
+
+        let pinMessage = try PairingMessageCodec().decode(
+            content: encoded("pairing_message_pin", ContentTypePairingMessage)
+        )
+        #expect(pinMessage == .pin(Self.pin))
+        let pinEcho = try PairingMessageCodec().decode(
+            content: encoded("pairing_message_pin_echo", ContentTypePairingMessage)
+        )
+        #expect(pinEcho == .pinEcho(Self.pin))
+        #expect(pinEcho.type.rawValue == "pin_echo")
+        let errorMessage = try PairingMessageCodec().decode(
+            content: encoded("pairing_message_error", ContentTypePairingMessage)
+        )
+        #expect(errorMessage == .error("Pairing failed"))
+
+        let identityShare = try IdentityShareCodec().decode(
+            content: encoded("identity_share", ContentTypeIdentityShare)
+        )
+        #expect(identityShare.schemaVersion == 1)
+        #expect(identityShare.privateKeyData == Self.identityShareKey)
+        #expect(identityShare.inboxId == Self.initiatorInboxId)
+        #expect(identityShare.issuedAt == Self.identityShareIssuedAt)
+        #expect(identityShare.initiatorDeviceName == "Cameron's iPhone")
+        #expect(identityShare.displayName == "Cameron")
+        #expect(identityShare.imageAssetIdentifier == "https://assets.convos.org/avatar/abc123.jpg")
+
+        let deviceRemoved = try DeviceRemovedCodec().decode(
+            content: encoded("device_removed", ContentTypeDeviceRemoved)
+        )
+        #expect(deviceRemoved.schemaVersion == 1)
+        #expect(deviceRemoved.revokedInstallationId == "b1946ac92492d2347c6235b4d2611184")
+        #expect(deviceRemoved.removedAt == Self.deviceRemovedAt)
+    }
+
+    // MARK: - Builders
+
+    private static func buildVectors() async throws -> [String: Any] {
+        let privateKey = try PrivateKey(privateKeyBytes)
+        let address = privateKey.walletAddress
+
+        let payload = PairingInvite.signingPayload(
+            initiatorInboxId: initiatorInboxId,
+            initiatorAddress: address,
+            nonce: nonce,
+            issuedAt: issuedAt,
+            expiresAt: expiresAt
+        )
+        let signedMessage = hex(payload)
+        let signature = try await privateKey.sign(signedMessage)
+        let invite = PairingInvite(
+            initiatorInboxId: initiatorInboxId,
+            initiatorAddress: address,
+            nonce: nonce,
+            issuedAt: issuedAt,
+            expiresAt: expiresAt,
+            signature: signature.rawData
+        )
+        // Closes the loop on our local hex helper: if it disagreed with the
+        // production `toHexString()` that `verifySignature` re-derives, this
+        // would throw.
+        try invite.verifySignature()
+        let slug = try invite.toURLSafeSlug()
+
+        return [
+            "schema": 1,
+            "generatedBy": "ConvosCore PairingInteropVectorsTests",
+            "eip191": try await eip191Vectors(privateKey: privateKey),
+            "note": "Golden cross-platform vectors for Linked Device Sync. "
+                + "Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. "
+                + "JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's "
+                + "JSONEncoder emitted — it is randomized per process and is NOT part of the contract. "
+                + "Consumers must decode order-insensitively and tolerate unknown keys.",
+            "identity": [
+                "privateKeyHex": hex(privateKeyBytes),
+                "address": address,
+                "addressLowercased": address.lowercased(),
+                "inboxId": initiatorInboxId,
+            ],
+            "invite": [
+                "schemaVersion": 1,
+                "initiatorInboxId": initiatorInboxId,
+                "initiatorAddress": address,
+                "nonceBase64": nonce.base64EncodedString(),
+                "nonceHex": hex(nonce),
+                "issuedAt": issuedAt,
+                "expiresAt": expiresAt,
+                "signingPayloadHex": hex(payload),
+                "signedMessage": signedMessage,
+                "signatureBase64": signature.rawData.base64EncodedString(),
+                "signatureHex": hex(signature.rawData),
+                "signatureRecoveryByte": Int(signature.rawData[64]),
+                "slug": slug,
+                "verifyAtUnixSeconds": issuedAt + 1,
+            ],
+            "emoji": [
+                "poolCount": EmojiSelector.emojis.count,
+                "pool": EmojiSelector.emojis,
+                "cases": [
+                    emojiCase(inboxA: initiatorInboxId, inboxB: joinerInboxId, pin: pin),
+                    // Same pair, arguments swapped: the fingerprint sorts its
+                    // inputs, so Android must produce the identical triple.
+                    emojiCase(inboxA: joinerInboxId, inboxB: initiatorInboxId, pin: pin),
+                    emojiCase(inboxA: "alpha", inboxB: "bravo", pin: "000000"),
+                    emojiCase(inboxA: "alpha", inboxB: "bravo", pin: "999999"),
+                ],
+            ],
+            "pin": [
+                "raw": pin,
+                "formatted": PairingCoordinator.formatPin(pin),
+            ],
+            "codecs": try codecVectors(slug: slug),
+        ]
+    }
+
+    private static func eip191Vectors(privateKey: PrivateKey) async throws -> [[String: Any]] {
+        var vectors: [[String: Any]] = []
+        for message in eip191Messages {
+            let signature = try await privateKey.sign(message)
+            vectors.append([
+                "message": message,
+                "messageUtf8ByteCount": Array(message.utf8).count,
+                "digestHex": hex(personalSignDigest(message)),
+                "signatureHex": hex(signature.rawData),
+                "signatureBase64": signature.rawData.base64EncodedString(),
+                "recoveryByte": Int(signature.rawData[64]),
+                "recoveredAddress": try EthereumSignatureRecovery.recoverAddress(
+                    message: message,
+                    signature: signature.rawData
+                ),
+            ])
+        }
+        return vectors
+    }
+
+    /// Mirror of `EthereumSignatureRecovery.personalSignDigest` (which is
+    /// private). Verified against it indirectly: `recoverAddress` re-derives
+    /// the digest and must recover the same address we record.
+    private static func personalSignDigest(_ message: String) -> Data {
+        let utf8 = Array(message.utf8)
+        var bytes: [UInt8] = Array("\u{19}Ethereum Signed Message:\n\(utf8.count)".utf8)
+        bytes.append(contentsOf: utf8)
+        return Data(SHA3(variant: .keccak256).calculate(for: bytes))
+    }
+
+    private static func emojiCase(inboxA: String, inboxB: String, pin: String) -> [String: Any] {
+        [
+            "inboxA": inboxA,
+            "inboxB": inboxB,
+            "pin": pin,
+            "emojis": PairingCoordinator.emojiFingerprint(inboxA: inboxA, inboxB: inboxB, pin: pin),
+        ]
+    }
+
+    private static func codecVectors(slug: String) throws -> [String: Any] {
+        let joinRequest = try PairingJoinRequestCodec().encode(
+            content: PairingJoinRequestContent(
+                slug: slug,
+                joinerInboxId: joinerInboxId,
+                deviceName: "Pixel 9 Pro"
+            )
+        )
+        let pinMessage = try PairingMessageCodec().encode(content: .pin(pin))
+        let pinEcho = try PairingMessageCodec().encode(content: .pinEcho(pin))
+        let errorMessage = try PairingMessageCodec().encode(content: .error("Pairing failed"))
+        let identityShare = try IdentityShareCodec().encode(
+            content: IdentityShareContent(
+                privateKeyData: identityShareKey,
+                inboxId: initiatorInboxId,
+                issuedAt: identityShareIssuedAt,
+                initiatorDeviceName: "Cameron's iPhone",
+                displayName: "Cameron",
+                imageAssetIdentifier: "https://assets.convos.org/avatar/abc123.jpg"
+            )
+        )
+        let deviceRemoved = try DeviceRemovedCodec().encode(
+            content: DeviceRemovedContent(
+                revokedInstallationId: "b1946ac92492d2347c6235b4d2611184",
+                removedAt: deviceRemovedAt
+            )
+        )
+        return [
+            "pairing_join_request": describe(joinRequest),
+            "pairing_message_pin": describe(pinMessage),
+            "pairing_message_pin_echo": describe(pinEcho),
+            "pairing_message_error": describe(errorMessage),
+            "identity_share": describe(identityShare),
+            "device_removed": describe(deviceRemoved),
+        ]
+    }
+
+    private static func describe(_ encoded: EncodedContent) -> [String: Any] {
+        [
+            "authorityId": encoded.type.authorityID,
+            "typeId": encoded.type.typeID,
+            "versionMajor": Int(encoded.type.versionMajor),
+            "versionMinor": Int(encoded.type.versionMinor),
+            "contentType": "\(encoded.type.authorityID)/\(encoded.type.typeID):"
+                + "\(encoded.type.versionMajor).\(encoded.type.versionMinor)",
+            "contentBase64": encoded.content.base64EncodedString(),
+            "contentJSON": String(data: encoded.content, encoding: .utf8) ?? "",
+        ]
+    }
+
+    // MARK: - Helpers
+
+    /// `Tests/Fixtures/pairing-vectors.json`, resolved from this file's own
+    /// location so the test works from any working directory.
+    private static var fixtureURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // ConvosCoreTests
+            .deletingLastPathComponent() // Tests
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("pairing-vectors.json")
+    }
+
+    /// Lowercase, unprefixed — the same shape `Data.toHexString()` produces.
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func base64URLDecode(_ slug: String) -> Data? {
+        var padded = slug
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = padded.count % 4
+        if remainder > 0 {
+            padded.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: padded)
+    }
+}

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -1,0 +1,253 @@
+{
+  "codecs" : {
+    "device_removed" : {
+      "authorityId" : "convos.org",
+      "contentBase64" : "eyJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInNjaGVtYVZlcnNpb24iOjEsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
+      "contentJSON" : "{\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"schemaVersion\":1,\"removedAt\":1750000200}",
+      "contentType" : "convos.org/device_removed:1.0",
+      "typeId" : "device_removed",
+      "versionMajor" : 1,
+      "versionMinor" : 0
+    },
+    "identity_share" : {
+      "authorityId" : "convos.org",
+      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaW5ib3hJZCI6IjNmOWExYzBlNWI3ZDI4NDZhMWYzMGM5ZTRkOGI2NzUyZTBhNGM5MTM3ZmI1NjI4ZDBlM2E3YzE0YjlkNWY2ODIiLCJwcml2YXRlS2V5RGF0YSI6IklpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUk9IiwiaW5pdGlhdG9yRGV2aWNlTmFtZSI6IkNhbWVyb24ncyBpUGhvbmUiLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpc3N1ZWRBdCI6MTc1MDAwMDEwMCwic2NoZW1hVmVyc2lvbiI6MX0=",
+      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"displayName\":\"Cameron\",\"issuedAt\":1750000100,\"schemaVersion\":1}",
+      "contentType" : "convos.org/identity_share:1.0",
+      "typeId" : "identity_share",
+      "versionMajor" : 1,
+      "versionMinor" : 0
+    },
+    "pairing_join_request" : {
+      "authorityId" : "convos.org",
+      "contentBase64" : "eyJzbHVnIjoiZXlKelkyaGxiV0ZXWlhKemFXOXVJam94TENKcGJtbDBhV0YwYjNKSmJtSnZlRWxrSWpvaU0yWTVZVEZqTUdVMVlqZGtNamcwTm1FeFpqTXdZemxsTkdRNFlqWTNOVEpsTUdFMFl6a3hNemRtWWpVMk1qaGtNR1V6WVRkak1UUmlPV1ExWmpZNE1pSXNJbk5wWjI1aGRIVnlaU0k2SWl0WVptTTVVREZ0UnpsT1lURmNMMkowVTBoVldWcFZiMDg1TmxoM00wUmlVRGxvYTFocFJsZ3pkVkZqVGs1Y0wxZE5TamhjTHpKdmNFTk9ibE5aWTNCRVIxQkJTbk51T0VOSWFIUkRhMmd3WnpGak16TnJOSFpvZHowaUxDSnBibWwwYVdGMGIzSkJaR1J5WlhOeklqb2lNSGd4T1dVM1pUTTNObVUzWXpJeE0ySTNaVGRsTjJVME5tTmpOekJoTldSa01EZzJaR0ZtWmpKaElpd2laWGh3YVhKbGMwRjBJam94TnpVd01EQXdNVEl3TENKdWIyNWpaU0k2SWtGQ1JXbE5NRkpXV201bFNXMWhjVGQ2VGpOMVhDOTNQVDBpTENKcGMzTjFaV1JCZENJNk1UYzFNREF3TURBd01IMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIiwic2NoZW1hVmVyc2lvbiI6MX0=",
+      "contentJSON" : "{\"slug\":\"eyJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIiwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJpc3N1ZWRBdCI6MTc1MDAwMDAwMH0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\",\"schemaVersion\":1}",
+      "contentType" : "convos.org/pairing_join_request:1.0",
+      "typeId" : "pairing_join_request",
+      "versionMajor" : 1,
+      "versionMinor" : 0
+    },
+    "pairing_message_error" : {
+      "authorityId" : "convos.org",
+      "contentBase64" : "eyJwYXlsb2FkIjoiUGFpcmluZyBmYWlsZWQiLCJ0eXBlIjoiZXJyb3IifQ==",
+      "contentJSON" : "{\"payload\":\"Pairing failed\",\"type\":\"error\"}",
+      "contentType" : "convos.org/pairing_message:1.0",
+      "typeId" : "pairing_message",
+      "versionMajor" : 1,
+      "versionMinor" : 0
+    },
+    "pairing_message_pin" : {
+      "authorityId" : "convos.org",
+      "contentBase64" : "eyJ0eXBlIjoicGluIiwicGF5bG9hZCI6IjEyMzQ1NiJ9",
+      "contentJSON" : "{\"type\":\"pin\",\"payload\":\"123456\"}",
+      "contentType" : "convos.org/pairing_message:1.0",
+      "typeId" : "pairing_message",
+      "versionMajor" : 1,
+      "versionMinor" : 0
+    },
+    "pairing_message_pin_echo" : {
+      "authorityId" : "convos.org",
+      "contentBase64" : "eyJ0eXBlIjoicGluX2VjaG8iLCJwYXlsb2FkIjoiMTIzNDU2In0=",
+      "contentJSON" : "{\"type\":\"pin_echo\",\"payload\":\"123456\"}",
+      "contentType" : "convos.org/pairing_message:1.0",
+      "typeId" : "pairing_message",
+      "versionMajor" : 1,
+      "versionMinor" : 0
+    }
+  },
+  "eip191" : [
+    {
+      "digestHex" : "5f35dce98ba4fba25530a026ed80b2cecdaa31091ba4958b99b52ea1d068adad",
+      "message" : "",
+      "messageUtf8ByteCount" : 0,
+      "recoveredAddress" : "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+      "recoveryByte" : 27,
+      "signatureBase64" : "KnjMqOPHZTy3lDiYgGs7nXSBGib6n522xLoHv3FGZMsvhBsIT1Jk3xRxGizHemzwwM7LZpGhMqKoxukyHyPVXRs=",
+      "signatureHex" : "2a78cca8e3c7653cb7943898806b3b9d74811a26fa9f9db6c4ba07bf714664cb2f841b084f5264df14711a2cc77a6cf0c0cecb6691a132a2a8c6e9321f23d55d1b"
+    },
+    {
+      "digestHex" : "00b2d511a3411a5358833cc6bd7598e7e1aab1705181548b1e8c8bd9801eb72b",
+      "message" : "Hello, Convos!",
+      "messageUtf8ByteCount" : 14,
+      "recoveredAddress" : "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+      "recoveryByte" : 28,
+      "signatureBase64" : "ICiPx/tFfKNhPg/iK0RCioI/Yl4cBSMmusGbCJRHBPEdKfyNnRrWQTZO9tuNIJt6VAM5ikL1aqHh7MBUm7IiFRw=",
+      "signatureHex" : "20288fc7fb457ca3613e0fe22b44428a823f625e1c052326bac19b08944704f11d29fc8d9d1ad641364ef6db8d209b7a5403398a42f56aa1e1ecc0549bb222151c"
+    },
+    {
+      "digestHex" : "57189da2cc2bb20596604aea9cfa5573cd2cc4ee37bf3579a1142d09d9b496d6",
+      "message" : "héllo 🌍 wörld",
+      "messageUtf8ByteCount" : 18,
+      "recoveredAddress" : "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+      "recoveryByte" : 28,
+      "signatureBase64" : "69s0oOXiuwbCItRrILGCqjheT/6/V5WpdR5zDw339NEiF18fMMxtC4Z1ABdaibNZDTrA+P+nPDm2RsI/PHEfEhw=",
+      "signatureHex" : "ebdb34a0e5e2bb06c222d46b20b182aa385e4ffebf5795a9751e730f0df7f4d122175f1f30cc6d0b867500175a89b3590d3ac0f8ffa73c39b646c23f3c711f121c"
+    }
+  ],
+  "emoji" : {
+    "cases" : [
+      {
+        "emojis" : [
+          "🪆",
+          "🎸",
+          "🪁"
+        ],
+        "inboxA" : "3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682",
+        "inboxB" : "8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73",
+        "pin" : "123456"
+      },
+      {
+        "emojis" : [
+          "🪆",
+          "🎸",
+          "🪁"
+        ],
+        "inboxA" : "8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73",
+        "inboxB" : "3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682",
+        "pin" : "123456"
+      },
+      {
+        "emojis" : [
+          "🪻",
+          "🦕",
+          "🦊"
+        ],
+        "inboxA" : "alpha",
+        "inboxB" : "bravo",
+        "pin" : "000000"
+      },
+      {
+        "emojis" : [
+          "🪁",
+          "🦋",
+          "🌸"
+        ],
+        "inboxA" : "alpha",
+        "inboxB" : "bravo",
+        "pin" : "999999"
+      }
+    ],
+    "pool" : [
+      "🥫",
+      "🎸",
+      "🎨",
+      "🎯",
+      "🎪",
+      "🎭",
+      "🎬",
+      "🎤",
+      "🎧",
+      "🎹",
+      "🎺",
+      "🎻",
+      "🪘",
+      "🪗",
+      "🎲",
+      "🎮",
+      "🧩",
+      "🪀",
+      "🪁",
+      "🧸",
+      "🪆",
+      "🔮",
+      "🧿",
+      "🪬",
+      "🎰",
+      "🛸",
+      "🚀",
+      "⚓️",
+      "🧲",
+      "💎",
+      "🌵",
+      "🌊",
+      "🍄",
+      "🌸",
+      "🌈",
+      "🌻",
+      "🌴",
+      "🌲",
+      "🍀",
+      "🌾",
+      "🪻",
+      "🪷",
+      "🪹",
+      "🪺",
+      "🌙",
+      "⭐️",
+      "🌍",
+      "🔥",
+      "💧",
+      "🌪️",
+      "🦊",
+      "🐙",
+      "🦋",
+      "🐢",
+      "🦩",
+      "🦄",
+      "🐋",
+      "🦈",
+      "🦑",
+      "🐠",
+      "🦜",
+      "🦚",
+      "🦢",
+      "🦉",
+      "🦇",
+      "🐝",
+      "🐌",
+      "🦎",
+      "🐲",
+      "🦕",
+      "🍕",
+      "🌮",
+      "🍩",
+      "🍦",
+      "🥑",
+      "🍎",
+      "🍋",
+      "🍇",
+      "🥝",
+      "🍒",
+      "🧁",
+      "🍰",
+      "🍪",
+      "🥨",
+      "🥐",
+      "🧀",
+      "🥗",
+      "🍜",
+      "🍣",
+      "🥟"
+    ],
+    "poolCount" : 90
+  },
+  "generatedBy" : "ConvosCore PairingInteropVectorsTests",
+  "identity" : {
+    "address" : "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+    "addressLowercased" : "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+    "inboxId" : "3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682",
+    "privateKeyHex" : "1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "invite" : {
+    "expiresAt" : 1750000120,
+    "initiatorAddress" : "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
+    "initiatorInboxId" : "3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682",
+    "issuedAt" : 1750000000,
+    "nonceBase64" : "ABEiM0RVZneImaq7zN3u/w==",
+    "nonceHex" : "00112233445566778899aabbccddeeff",
+    "schemaVersion" : 1,
+    "signatureBase64" : "+Xfc9P1mG9Na1/btSHUYZUoO96Xw3DbP9hkXiFX3uQcNN/WMJ8/2opCNnSYcpDGPAJsn8CHhtCkh0g1c33k4vhw=",
+    "signatureHex" : "f977dcf4fd661bd35ad7f6ed487518654a0ef7a5f0dc36cff619178855f7b9070d37f58c27cff6a2908d9d261ca4318f009b27f021e1b42921d20d5cdf7938be1c",
+    "signatureRecoveryByte" : 28,
+    "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
+    "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
+    "slug" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIiwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJpc3N1ZWRBdCI6MTc1MDAwMDAwMH0",
+    "verifyAtUnixSeconds" : 1750000001
+  },
+  "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",
+  "pin" : {
+    "formatted" : "123 456",
+    "raw" : "123456"
+  },
+  "schema" : 1
+}


### PR DESCRIPTION
Generates Tests/Fixtures/pairing-vectors.json from the production pairing code paths (PairingInvite.signingPayload / toURLSafeSlug, EmojiSelector, PairingCoordinator.emojiFingerprint, the four content-type codecs) and mirrors it back as a drift guard: any future iOS change that would break the Android joiner fails here first.

The same fixture is committed into convos-client/android, where the joiner's commonTest pins every wire-format assertion against it.

Two things the vectors pinned down that the written spec had wrong or left implicit:

- PrivateKey.sign() emits v = 27/28, not v ∈ {0,1}. Accepting and normalizing 27/28 on the verifying side is mandatory for real slugs, not just defensive.
- JSONEncoder's object key order is randomized per process, so encoded bytes are not reproducible. The mirror test asserts on decode, and the fixture says so explicitly, so neither platform pins byte-equality of re-encoded JSON.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788460666&installation_model_id=20076&pr_number=1281&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1281&signature=d2ecbc3b1e945bdc8a0e031ae8cd6b2734c0c86d51e41aca15d999587959a233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-platform pairing interop test vectors for EIP-191 and codec validation
> - Adds [PairingInteropVectorsTests.swift](https://github.com/xmtplabs/convos-ios/pull/1281/files#diff-f022e0957f3b3900cad80be255b0b2551a631681c11a0220509070c1a976f8c4) with two tests: one generates [pairing-vectors.json](https://github.com/xmtplabs/convos-ios/pull/1281/files#diff-afbf2b141844bd115cc5719a0d2dc9cb46335e6992e766e2a9a5a6f98d867a31) from current production code, and one verifies current behavior matches the committed fixture.
> - The fixture captures golden vectors for EIP-191 personal sign digests/signatures, pairing invite signing payloads and slug encoding, emoji fingerprints, and codec payloads for `PairingJoinRequest`, `PairingMessage`, `IdentityShare`, and `DeviceRemoved`.
> - The verification test fails if any production behavior diverges from the committed vectors, providing a cross-platform regression signal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d56c51.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->