### PR TITLE
ci: stop the SPM cache thrash behind sporadic 40-min integration runs

### DIFF
--- a/.github/workflows/convoscore-tests.yml
+++ b/.github/workflows/convoscore-tests.yml
@@ -16,7 +16,10 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: warp-macos-26-arm64-12x
-    timeout-minutes: 15
+    # Generous enough to survive a cold SwiftPM fetch: the libxmtp clone
+    # alone has been observed at 44 minutes under GitHub throttling, and a
+    # timeout kill also skips the cache save that would spare the next run.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -29,20 +32,31 @@ jobs:
           swift --version
           xcodebuild -version
 
-      - name: Cache Swift Package dependencies
-        uses: actions/cache@v4
+      # Cache only SwiftPM's repository/artifact cache, not .build: the bare
+      # git mirrors (libxmtp's full clone is the expensive part, 92s-2650s
+      # observed) and downloaded binary artifacts are what make a run fast,
+      # while .build products pushed entries to 6-8GB - blowing the repo's
+      # 10GB cache quota and evicting every other cache within hours.
+      - name: Restore Swift Package cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ConvosCore/.build
-            ConvosAppData/.build
-            ConvosInvites/.build
-            ~/Library/Caches/org.swift.swiftpm
+          path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-spm-${{ hashFiles('ConvosCore/Package.resolved', 'ConvosAppData/Package.resolved', 'ConvosInvites/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
 
       - name: Run unit tests
         run: ./ci/run-tests.sh --unit
+
+      # Save only from dev: caches saved during pull_request runs land on
+      # refs/pull/N/merge, which no other PR can restore - they just evict
+      # the shared entry. One dev-scoped cache is inherited by every PR.
+      - name: Save Swift Package cache
+        if: always() && github.ref == 'refs/heads/dev'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('ConvosCore/Package.resolved', 'ConvosAppData/Package.resolved', 'ConvosInvites/Package.resolved') }}
 
       - name: Upload unit test logs
         if: always()
@@ -95,13 +109,15 @@ jobs:
           swift --version
           xcodebuild -version
 
-      - name: Cache Swift Package dependencies
-        uses: actions/cache@v4
+      # Same path and key as the unit job so both restore the one dev-saved
+      # entry (they previously hashed different Package.resolved sets, so
+      # each job stored its own multi-GB cache). Restore-only: dev's unit
+      # job owns the save.
+      - name: Restore Swift Package cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ConvosCore/.build
-            ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-spm-${{ hashFiles('ConvosCore/Package.resolved') }}
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('ConvosCore/Package.resolved', 'ConvosAppData/Package.resolved', 'ConvosInvites/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
 


### PR DESCRIPTION
## Symptom

Integration Tests (and occasionally Unit Tests) randomly take **17–50 minutes** across PRs vs a ~6 minute norm. Observed on `dev` itself (41.7m on 30919992848), #1274 (48.2m Aug 3, 40m+ today), and others — no correlation with the diffs.

## Root cause

The entire variance is one operation: a **cold SwiftPM clone of `xmtp/libxmtp`**. SwiftPM can't shallow-clone, and the clone's duration swings with GitHub's git-endpoint throttling — the same fetch was `92.42s` in one run and `2,653.10s` in another (SwiftPM's own `Fetched … from cache (Ns)` lines, buffered inside the `Build tests` step).

Every run is cold because the actions cache **never survives**:

1. **Entries are 6–8GB** — the cache paths included whole `.build` dirs (arch/toolchain-sensitive build products), not just the SPM mirrors. The repo sat at **15.5GB active against the 10GB quota** when investigated, so LRU eviction ran constantly (the dev-scoped entry saved at 15:25 was gone by 17:31 the same day).
2. **Saves land on `refs/pull/N/merge`** — pull_request-run saves are scoped to the PR's merge ref, which no other PR can restore. Each PR's save just evicted the shared entries.
3. **Unit and integration used different keys** (different `hashFiles` sets), doubling storage pressure.

## Fix

- Cache **only `~/Library/Caches/org.swift.swiftpm`** — the bare git mirrors + downloaded binary artifacts, i.e. exactly what prevents the libxmtp clone, at ~1–2GB instead of 8.
- **One key for both jobs** (union `hashFiles` of all three `Package.resolved` files; ConvosCore's deps are a subset).
- **Split `actions/cache/restore` / `actions/cache/save`, saving only on `dev` pushes** (`if: always() && github.ref == 'refs/heads/dev'`) — one canonical base-scoped entry that every PR inherits; PRs stop minting evicting duplicates.
- **Unit job timeout 15 → 60**: a cold run under throttling could exceed 15m, and the timeout kill also skipped the cache save — restarting the cold-start spiral for the next run.

## Expected behavior after merge

First `dev` push saves the canonical cache; from then on every PR restores it and skips the libxmtp clone entirely. Cold runs still happen when `Package.resolved` changes ahead of dev (prefix `restore-keys` soften this — most mirrors are still reusable), but they no longer poison the cache pool for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788463383&installation_model_id=20076&pr_number=1282&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1282&signature=6806cec0946f2f74ba7ff04adc06649f8da4782d4f24b8fd3b8d362c44377452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SPM cache thrashing causing sporadic 40-minute integration runs in CI
> - Replaces broad `.build` directory caching with a targeted restore/save strategy that only caches the SwiftPM repository/artifact cache directory.
> - Cache saves now run only on the `dev` branch; all other branches (including PRs) restore-only, preventing cache key collisions.
> - Unifies the cache key across unit and deploy-backend jobs by hashing `Package.resolved` files for ConvosCore, ConvosAppData, and ConvosInvites.
> - Increases the unit test job timeout from 15 to 60 minutes to handle legitimate long runs without false failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bdd9a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->