### PR TITLE
perf(sync): fix conversation.sync stalls from background transitions

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -461,13 +461,10 @@ public actor ConversationStateMachine {
         // Publish the conversation
         try await optimisticConversation.publish()
 
-        do {
-            if let group = optimisticConversation as? XMTPiOS.Group {
-                _ = try await group.ensureConversationEmoji(seed: clientConversationId)
-            }
-        } catch {
-            Log.warning("Failed to seed conversation emoji for new conversation: \(error)")
-        }
+        // The emoji is seeded by processConversation below, which passes
+        // clientConversationId as the emoji seed into the creator-metadata
+        // commit - one commit for emoji + invite tag + image encryption key
+        // instead of one commit per field.
 
         // Process the conversation in case the syncing manager
         // has not finished starting the streams, or the streams closed

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -955,10 +955,16 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
     private func handleEnterBackground(result: InboxReadyResult) async throws {
         Log.info("App entering background, pausing sync for clientId \(initialClientId)...")
+        AppBackgroundTransitionCounter.shared.record()
 
         await stopNetworkMonitoring()
         stopRevocationObserver()
         await syncingManager?.pause()
+
+        // Give in-flight conversation syncs (the creation flow's state
+        // machine runs outside the paused streams) a bounded window to
+        // finish before the SQLCipher connection drops out from under them.
+        await ConversationSyncSingleFlight.shared.waitForInFlight()
 
         try result.client.dropLocalDatabaseConnection()
 

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -215,21 +215,24 @@ extension XMTPiOS.Group {
         let needsEmoji = emojiSeed != nil && (!current.hasEmoji || current.emoji.isEmpty)
         guard needsTag || needsKey || needsEmoji else { return }
 
-        let newTag = try generateSecureRandomString(length: 10)
+        // Generate the tag only when it's actually missing so a transient
+        // SecRandomCopyBytes failure can't abort an emoji- or key-only update.
+        let newTag: String? = needsTag ? try generateSecureRandomString(length: 10) : nil
         // Key generation failure stays non-fatal, matching how callers treat
         // `ensureImageEncryptionKey`: the key is retried on first image
         // upload, while a missing invite tag breaks joins.
-        let newKey: Data?
-        do {
-            newKey = try ImageEncryption.generateGroupKey()
-        } catch {
-            Log.warning("Failed to generate image encryption key: \(error). Will retry on first image upload.")
-            newKey = nil
+        var newKey: Data?
+        if needsKey {
+            do {
+                newKey = try ImageEncryption.generateGroupKey()
+            } catch {
+                Log.warning("Failed to generate image encryption key: \(error). Will retry on first image upload.")
+            }
         }
         let newEmoji: String? = emojiSeed.map { EmojiSelector.emoji(for: $0) }
 
         try await atomicUpdateMetadata(operation: "ensureCreatorMetadata") { metadata in
-            if metadata.tag.isEmpty {
+            if let newTag, metadata.tag.isEmpty {
                 metadata.tag = newTag
             }
             if let newKey, !metadata.hasImageEncryptionKey {

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -199,6 +199,52 @@ extension XMTPiOS.Group {
         }
     }
 
+    /// Seeds every piece of creator-authored metadata in one commit: the
+    /// invite tag, the image encryption key, and (when a seed is provided)
+    /// the conversation emoji. Each individual `ensure*` call publishes its
+    /// own MLS commit with a network round trip, so the creation path calls
+    /// this instead of chaining them. No-ops without a commit when every
+    /// field is already present.
+    ///
+    /// Only the conversation creator should call this - it authors the
+    /// invite tag (see `ensureInviteTag`).
+    public func ensureCreatorMetadata(emojiSeed: String? = nil) async throws {
+        let current = try currentCustomMetadata
+        let needsTag = current.tag.isEmpty
+        let needsKey = !current.hasImageEncryptionKey
+        let needsEmoji = emojiSeed != nil && (!current.hasEmoji || current.emoji.isEmpty)
+        guard needsTag || needsKey || needsEmoji else { return }
+
+        let newTag = try generateSecureRandomString(length: 10)
+        // Key generation failure stays non-fatal, matching how callers treat
+        // `ensureImageEncryptionKey`: the key is retried on first image
+        // upload, while a missing invite tag breaks joins.
+        let newKey: Data?
+        do {
+            newKey = try ImageEncryption.generateGroupKey()
+        } catch {
+            Log.warning("Failed to generate image encryption key: \(error). Will retry on first image upload.")
+            newKey = nil
+        }
+        let newEmoji: String? = emojiSeed.map { EmojiSelector.emoji(for: $0) }
+
+        try await atomicUpdateMetadata(operation: "ensureCreatorMetadata") { metadata in
+            if metadata.tag.isEmpty {
+                metadata.tag = newTag
+            }
+            if let newKey, !metadata.hasImageEncryptionKey {
+                metadata.imageEncryptionKey = newKey
+            }
+            if let newEmoji, !metadata.hasEmoji || metadata.emoji.isEmpty {
+                metadata.emoji = newEmoji
+            }
+        } verify: { metadata in
+            guard !metadata.tag.isEmpty else { return false }
+            guard newKey == nil || metadata.hasImageEncryptionKey else { return false }
+            return newEmoji == nil || (metadata.hasEmoji && !metadata.emoji.isEmpty)
+        }
+    }
+
     // This should only be done by the conversation creator
     // Updating the invite tag effectively expires all invites generated with that tag
     // The tag is used by the invitee to verify the conversation they've been added to

--- a/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/UnusedConversationCache.swift
@@ -286,13 +286,10 @@ public actor UnusedConversationCache: UnusedConversationCacheProtocol {
             try await optimisticConversation.publish()
             published = true
             try Task.checkCancellation()
-            try await group.ensureInviteTag()
-            try Task.checkCancellation()
-            do {
-                try await group.ensureImageEncryptionKey()
-            } catch {
-                Log.warning("Failed to generate image encryption key for unused conversation: \(error). Will retry on first image upload.")
-            }
+            // One commit for invite tag + image encryption key. Key
+            // generation failure is non-fatal inside; the key is retried
+            // on first image upload.
+            try await group.ensureCreatorMetadata()
             try Task.checkCancellation()
 
             let dbConversation = try await writeUnusedConversation(

--- a/ConvosCore/Sources/ConvosCore/Syncing/AppBackgroundTransitionCounter.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/AppBackgroundTransitionCounter.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Counts app background transitions so wall-clock perf measurements can
+/// distinguish genuinely slow work from a timer that spanned an iOS app
+/// suspension (the wall clock keeps running while the process is frozen,
+/// which once produced a 216s `conversation.sync` sample that was really
+/// ~5s of work around a 3.5 minute suspension).
+public final class AppBackgroundTransitionCounter: @unchecked Sendable {
+    public static let shared: AppBackgroundTransitionCounter = AppBackgroundTransitionCounter()
+
+    private let lock: NSLock = NSLock()
+    private var transitionCount: Int = 0
+
+    public var count: Int {
+        lock.withLock { transitionCount }
+    }
+
+    public func record() {
+        lock.withLock { transitionCount += 1 }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/ConversationSyncSingleFlight.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/ConversationSyncSingleFlight.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Coalesces concurrent syncs of the same conversation.
+///
+/// A newly created group is processed twice within the same instant: once by
+/// the `ConversationStateMachine` that created it and once by `SyncingManager`'s
+/// conversation stream echoing it back. Each owns its own `StreamProcessor`,
+/// so the coalescing lives here, shared process-wide, instead of inside either
+/// actor. The registry doubles as the "anything still in flight?" signal the
+/// backgrounding path checks before dropping the SQLCipher connection.
+actor ConversationSyncSingleFlight {
+    static let shared: ConversationSyncSingleFlight = ConversationSyncSingleFlight()
+
+    private struct InFlightSync {
+        let token: UUID
+        let clientConversationId: String?
+        let task: Task<Void, any Error>
+    }
+
+    private var inFlight: [String: InFlightSync] = [:]
+
+    /// Runs `operation` unless an equivalent sync for the same conversation is
+    /// already in flight, in which case the caller awaits that sync instead.
+    /// A caller carrying a `clientConversationId` the in-flight sync doesn't
+    /// know about still runs its own pass afterwards, so the draft-row mapping
+    /// is never dropped by coalescing.
+    func run(
+        conversationId: String,
+        clientConversationId: String?,
+        operation: @escaping @Sendable () async throws -> Void
+    ) async throws {
+        while let existing = inFlight[conversationId] {
+            if clientConversationId == nil || existing.clientConversationId == clientConversationId {
+                try await existing.task.value
+                return
+            }
+            // The in-flight sync doesn't carry this caller's client
+            // conversation id mapping; wait it out, then loop in case another
+            // sync started while we waited.
+            try? await existing.task.value
+        }
+
+        let token = UUID()
+        let task = Task { try await operation() }
+        inFlight[conversationId] = InFlightSync(
+            token: token,
+            clientConversationId: clientConversationId,
+            task: task
+        )
+        defer {
+            if inFlight[conversationId]?.token == token {
+                inFlight[conversationId] = nil
+            }
+        }
+        try await task.value
+    }
+
+    /// Waits (bounded) for in-flight syncs to finish. The backgrounding path
+    /// calls this before dropping the SQLCipher connection so in-flight work
+    /// completes instead of burning retries on "Pool needs to reconnect".
+    func waitForInFlight(timeoutSeconds: TimeInterval = 3) async {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while !inFlight.isEmpty && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        if !inFlight.isEmpty {
+            Log.warning("Continuing with \(inFlight.count) conversation sync(s) still in flight after \(timeoutSeconds)s")
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -165,6 +165,31 @@ actor StreamProcessor: StreamProcessorProtocol {
         params: SyncClientParams,
         clientConversationId: String? = nil
     ) async throws {
+        // A newly created group is processed by both the creating
+        // ConversationStateMachine and SyncingManager's conversation stream
+        // (each with its own StreamProcessor), so coalesce process-wide: the
+        // second caller awaits the in-flight sync instead of duplicating it.
+        // nonisolated(unsafe) because XMTP types are not Sendable; the group
+        // handle is only used by whichever caller wins the single-flight slot.
+        nonisolated(unsafe) let conversation = conversation
+        try await ConversationSyncSingleFlight.shared.run(
+            conversationId: conversation.id,
+            clientConversationId: clientConversationId
+        ) { [weak self] in
+            guard let self else { return }
+            try await self.runConversationSync(
+                conversation,
+                params: params,
+                clientConversationId: clientConversationId
+            )
+        }
+    }
+
+    private func runConversationSync(
+        _ conversation: XMTPiOS.Group,
+        params: SyncClientParams,
+        clientConversationId: String?
+    ) async throws {
         let decision = try await decideInboundConversation(conversation, params: params)
         switch decision {
         case .reject:
@@ -185,13 +210,10 @@ actor StreamProcessor: StreamProcessorProtocol {
     ) async throws {
         let creatorInboxId = try await conversation.creatorInboxId()
         if creatorInboxId == params.client.inboxId {
-            // we created the conversation, update permissions, set inviteTag, and generate encryption key
-            try await conversation.ensureInviteTag()
-            do {
-                try await conversation.ensureImageEncryptionKey()
-            } catch {
-                Log.warning("Failed to generate image encryption key: \(error). Will retry on first image upload.")
-            }
+            // We created the conversation: seed invite tag, image encryption
+            // key, and (when the creation flow supplies its seed) the emoji
+            // in a single metadata commit, then update permissions.
+            try await conversation.ensureCreatorMetadata(emojiSeed: clientConversationId)
             let permissions = try conversation.permissionPolicySet()
             if permissions.addMemberPolicy != .allow && permissions.addMemberPolicy != .deny {
                 try await conversation.updateAddMemberPermission(newPermissionOption: .allow)
@@ -199,6 +221,7 @@ actor StreamProcessor: StreamProcessorProtocol {
         }
 
         let perfStart = CFAbsoluteTimeGetCurrent()
+        let backgroundTransitionsBefore = AppBackgroundTransitionCounter.shared.count
         Log.info("Syncing conversation: \(conversation.id)")
         let storedConversation = try await conversationWriter.storeWithLatestMessages(
             conversation: conversation,
@@ -206,7 +229,11 @@ actor StreamProcessor: StreamProcessorProtocol {
             clientConversationId: clientConversationId
         )
         let perfElapsed = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - perfStart) * 1000)
-        Log.info("[PERF] conversation.sync: \(perfElapsed)ms id=\(conversation.id)")
+        // Wall clock keeps running across an iOS suspension, so flag samples
+        // that spanned one; they measure the suspension, not the sync.
+        let spannedBackground = AppBackgroundTransitionCounter.shared.count != backgroundTransitionsBefore
+        let backgroundSuffix = spannedBackground ? " spannedBackground=true" : ""
+        Log.info("[PERF] conversation.sync: \(perfElapsed)ms id=\(conversation.id)\(backgroundSuffix)")
 
         // The user deleted this conversation while its invite was still
         // verifying -- it arrived denied and stays hidden, so skip the

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -265,14 +265,21 @@ actor SyncingManager: SyncingManagerProtocol {
         // backgrounding path drops the SQLCipher connection right after this
         // call; returning early let it yank the pool out from under in-flight
         // stream work, which then burned retries on "Pool needs to reconnect"
-        // until foreground. Exits immediately when not in ready state (the
-        // pause action becomes a no-op there).
+        // until foreground. Waits through .starting too - a pause there only
+        // sets pauseOnComplete and lands after the startup sync finishes.
+        // Exits immediately from any other state (the pause is a no-op there).
         let maxWaitTime = 5.0
         let startTime = Date()
-        while case .ready = _state {
+        while true {
+            switch _state {
+            case .ready, .starting:
+                break
+            default:
+                return
+            }
             if Date().timeIntervalSince(startTime) > maxWaitTime {
                 Log.error("Pause timeout - state: \(_state)")
-                break
+                return
             }
             try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
         }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -261,6 +261,21 @@ actor SyncingManager: SyncingManagerProtocol {
 
     func pause() async {
         enqueueAction(.pause)
+        // Wait for the pause to actually take effect before returning. The
+        // backgrounding path drops the SQLCipher connection right after this
+        // call; returning early let it yank the pool out from under in-flight
+        // stream work, which then burned retries on "Pool needs to reconnect"
+        // until foreground. Exits immediately when not in ready state (the
+        // pause action becomes a no-op there).
+        let maxWaitTime = 5.0
+        let startTime = Date()
+        while case .ready = _state {
+            if Date().timeIntervalSince(startTime) > maxWaitTime {
+                Log.error("Pause timeout - state: \(_state)")
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
     }
 
     func resume() async {


### PR DESCRIPTION
## Summary

Log analysis of a device capture (`convos-logs-5F22B35F`) showed `conversation.sync` samples up to 216s. Root cause was not network or protocol work: app background/foreground transitions were landing mid-sync. This PR addresses all four findings.

### 1. Perf metric measured iOS suspensions, not sync work

The worst sample (216,736ms) started 2s before the app backgrounded and finished 3s after it foregrounded 3.5 minutes later - the wall clock ran through the suspension. `[PERF] conversation.sync` lines now carry ` spannedBackground=true` when a background transition happened during the measurement, so telemetry can filter these samples. (`AppBackgroundTransitionCounter`, stamped in `SessionStateMachine.handleEnterBackground`.)

### 2. Backgrounding dropped the SQLCipher pool under in-flight syncs

`SyncingManager.pause()` only enqueued the pause action and returned immediately, so `handleEnterBackground` called `dropLocalDatabaseConnection()` while syncs were still running - the log shows "Inbox backgrounded successfully" *before* "Sync paused". In-flight work then burned retries on `storage error: Pool needs to reconnect before use` until foreground (about half of every 5-13s sync sample in the capture).

- `pause()` now waits (bounded, 5s) for the paused state, mirroring `stop()`.
- `handleEnterBackground` additionally waits (bounded, 3s) for in-flight conversation syncs - the creation flow's `ConversationStateMachine` runs outside the paused streams, so cancelling streams alone doesn't cover it.

### 3. Every conversation synced twice, concurrently

Nearly every conversation id logged two `[PERF] conversation.sync` lines with near-identical timestamps: a newly created group is processed by both the creating `ConversationStateMachine` and `SyncingManager`'s conversation stream, and each owns its own `StreamProcessor`. New `ConversationSyncSingleFlight` actor coalesces process-wide: the second caller awaits the in-flight sync instead of duplicating it. A caller carrying a `clientConversationId` the in-flight sync doesn't know about still runs its own pass afterwards, so the draft-row mapping is never dropped. The registry doubles as the in-flight signal the backgrounding path waits on (item 2).

### 4. Creation published 3 sequential metadata commits

`ensureConversationEmoji` -> `ensureInviteTag` -> `ensureImageEncryptionKey` each published their own MLS commit with its own network round trip, and the log showed epoch-mismatch intent republishes stacking retries on top. New `ensureCreatorMetadata(emojiSeed:)` seeds all three fields in a single commit; used by the creation flow (via `StreamProcessor.persistDeliveredConversation`) and the prewarm cache (`UnusedConversationCache`). Key-generation failure stays non-fatal, matching the old `ensureImageEncryptionKey` behavior; a missing invite tag stays fatal. `markAsAgentDm` remains a separate commit - it runs in a different post-creation flow (`AgentDmFlow`) and only for agent DMs; folding it in would mean plumbing the flag through the creation API (possible follow-up).

## Log evidence

- 216.7s sync `1cef7e9b...`: started 13:32:17, app backgrounded 13:32:19, libxmtp silent for 3.5min (3 log lines), foreground 13:35:50, done 13:35:53.
- 13.6s sync `c137d984...`: started 13:36:17, backgrounded 13:36:18, `Pool needs to reconnect` retries to attempt 4 + post-commit failures until `db_reconnect` at 13:36:24, done 13:36:31.
- Baseline foreground syncs with no lifecycle churn: 0.5-3s.

## Testing

- `swift build --package-path ConvosCore` passes (no warnings in changed code).
- `swiftlint --strict` clean on changed files.
- `swift test --package-path ConvosCore` against the local XMTP node: 1816 tests in 248 suites, all passed (44s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix conversation sync stalls caused by app background transitions
> - Adds `ConversationSyncSingleFlight` actor to coalesce concurrent syncs of the same conversation, preventing duplicate in-flight work and ensuring draft mapping persists when `clientConversationId` differs.
> - `SessionStateMachine.handleEnterBackground` now records a background transition via `AppBackgroundTransitionCounter` and awaits `ConversationSyncSingleFlight.shared.waitForInFlight()` before dropping the SQLCipher connection, giving in-flight syncs a bounded window to complete.
> - `SyncingManager.pause()` now blocks until the pause is in effect (up to 5s) instead of returning immediately.
> - Creator metadata (invite tag, image key, emoji) is now set in a single MLS commit via `ensureCreatorMetadata`, reducing multiple commits to one; emoji is seeded from `clientConversationId` during `persistDeliveredConversation`.
> - Perf logs in `StreamProcessor.persistDeliveredConversation` now include a `spannedBackground=true` flag when the operation crossed a background transition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7f96e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->