### PR TITLE
fix(composer): stop the participation glyph flickering, rename the middle level to Listen mode

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -66,7 +66,7 @@ final class FeatureFlags {
     }
 
     /// Gates the per-conversation agent participation control ("Listen"):
-    /// Speak freely / Mentions only / Paused. Toggle from App Settings -> Debug
+    /// Speak freely / Listen mode / Paused. Toggle from App Settings -> Debug
     /// in non-production builds, or from the curated prod debug menu in
     /// production. Deliberately not prod-locked like the flags above: the
     /// control is reachable everywhere so Listen can be dogfooded in TestFlight.

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -20,7 +20,7 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
-        case .mentionsOnly: "Mentions only"
+        case .mentionsOnly: "Listen mode"
         case .paused: "Pause"
         }
     }
@@ -28,7 +28,7 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     public var caption: String {
         switch self {
         case .speakFreely: "Chime in any time"
-        case .mentionsOnly: "Speak when you see your name"
+        case .mentionsOnly: "Only speaks if you @mention or say name"
         case .paused: "Go offline, use no credits"
         }
     }

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -477,22 +477,36 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             let label: String = isLoading
                 ? "Agent participation, loading"
                 : "Agent participation: \(participation.level.title)"
-            ParticipationMenuControl(
-                level: participation.level,
-                isLoading: isLoading,
-                onSelect: participation.onSelect
-            )
-            .equatable()
-            .disabled(isLoading)
-            .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
-            .frame(width: bubbleSize, height: bubbleSize)
-            .clipShape(.circle)
-            .glassEffect(.regular.interactive(), in: .circle)
-            .transition(.scale.combined(with: .opacity))
-            .animation(.easeInOut(duration: 0.2), value: isLoading)
-            .accessibilityLabel(label)
-            .accessibilityHint("Change how much the agents speak here")
-            .accessibilityIdentifier("agent-participation-button")
+            // The glyph is drawn inert on the glass, with an invisible menu
+            // hit-target over it - the same split the attachments `+` uses.
+            // iOS opens a menu by morphing the glass that holds its label, so a
+            // label that is the glyph gets lifted into that morph. On its own
+            // that is invisible; it shows when this menu and the attachments
+            // menu are worked in quick succession, because the second morph
+            // starts while the first is still unwinding and the glyph jumps
+            // between them. Leaving a beat between the two hid it, which is
+            // what identified the overlap. Out of the menu, the glyph takes
+            // part in neither morph and overlapping presentations can't move
+            // it.
+            ParticipationGlyph(level: participation.level, isLoading: isLoading)
+                .frame(width: bubbleSize, height: bubbleSize)
+                .clipShape(.circle)
+                .glassEffect(.regular.interactive(), in: .circle)
+                .overlay {
+                    ParticipationMenuControl(
+                        level: participation.level,
+                        isLoading: isLoading,
+                        onSelect: participation.onSelect
+                    )
+                    .equatable()
+                }
+                .disabled(isLoading)
+                .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
+                .transition(.scale.combined(with: .opacity))
+                .animation(.easeInOut(duration: 0.2), value: isLoading)
+                .accessibilityLabel(label)
+                .accessibilityHint("Change how much the agents speak here")
+                .accessibilityIdentifier("agent-participation-button")
         }
     }
 
@@ -693,7 +707,9 @@ private struct ParticipationMenuControl: View, Equatable {
                 }
             }
         } label: {
-            glyph
+            Color.clear
+                .frame(width: 32, height: 32)
+                .contentShape(.circle)
         }
         .menuOrder(.fixed)
     }
@@ -716,13 +732,20 @@ private struct ParticipationMenuControl: View, Equatable {
         }
         .accessibilityIdentifier("participation-\(option.rawValue)-row")
     }
+}
 
-    /// The icon, or the resting dot that stands in for it. The level starts at a
-    /// product default the conversation may not actually be in, so showing an
-    /// icon before the read lands would state something that can change a moment
-    /// later — the dot says "not known yet" instead.
+/// The icon, or the resting dot that stands in for it. The level starts at a
+/// product default the conversation may not actually be in, so showing an
+/// icon before the read lands would state something that can change a moment
+/// later - the dot says "not known yet" instead.
+///
+/// Drawn outside the menu so opening the menu never lifts it into the morph.
+private struct ParticipationGlyph: View {
+    let level: AgentParticipationLevel
+    let isLoading: Bool
+
     @ViewBuilder
-    private var glyph: some View {
+    var body: some View {
         if isLoading {
             ParticipationLoadingDot()
                 .frame(width: 32, height: 32)
@@ -731,8 +754,8 @@ private struct ParticipationMenuControl: View, Equatable {
                 .font(.system(size: 16.0, weight: .medium))
                 .foregroundStyle(Color.colorTextPrimary)
                 .frame(width: 32, height: 32)
-                .contentShape(.circle)
-                .transition(.opacity)
+                .contentTransition(.symbolEffect(.replace))
+                .animation(.easeInOut(duration: 0.2), value: level)
         }
     }
 }


### PR DESCRIPTION
## The flicker

Working the participation bubble and the attachments `+` in quick succession made the bubble's icon flicker.

iOS opens a menu by morphing the glass element that holds the menu's **label**. The bubble's label *was* the glyph, so the icon got lifted into that morph. On its own that's invisible — it only shows when one menu closes and the other opens back-to-back, because the second morph starts while the first is still unwinding and the glyph jumps between them.

The tell: **leaving a beat between the two menus made it disappear.** That's what identified this as overlapping presentations rather than anything about the icon itself (credit to @fguespe for spotting it — it reframed the whole investigation).

## The fix

Split the glyph out of the menu, mirroring what the attachments `+` already does (#1255: *"the visible glyph stays inert inside the glass while an invisible `Menu` hit-target overlays the same spot"*):

- `ParticipationGlyph` draws the icon inert on the glass circle
- The `Menu`'s label is now `Color.clear`, overlaid on top, carrying only the hit target

The glyph takes part in neither morph, so overlapping presentations can't move it. The bubble and the `+` are now built the same way.

Now that the glyph lives outside the menu, the level change animates with `.contentTransition(.symbolEffect(.replace))`. The `.transition(.opacity)` it used to carry never actually ran — `transition` only fires on insertion/removal, and the view's identity never changed when only the symbol did.

## The copy

`.mentionsOnly` is now **Listen mode** — *"Only speaks if you @mention or say name"* (was "Mentions only" / "Speak when you see your name"). Also fixes a comment in `FeatureFlags.swift` naming the old label.

The `rawValue` stays `mention`: it's persisted and sent to the backend, so renaming it would break stored state.

## Verification

- `swift test --package-path ConvosCore` — 1816 tests / 248 suites passing
- `swiftlint --strict` clean
- Built and installed on a physical iPhone; flicker confirmed gone in the fast back-to-back case that reproduced it

## Note

The separate report that these menus **open low** is not addressed here — @yewreeka confirmed that's native `Menu` placement, not a bug. No API exists to reposition a system menu, so nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788536558&installation_model_id=20076&pr_number=1286&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1286&signature=64c1a8bcf225e3d805b343847067f0be752455bb928273dfce19aa2e6e3ef2a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix participation glyph flickering and rename middle participation level to 'Listen mode'
> - Decouples the visible participation glyph from the `Menu` label in `MessagesBottomBar` by introducing a new `ParticipationGlyph` view and overlaying an invisible `ParticipationMenuControl` hit target on top, preventing the icon from morphing when the menu opens.
> - `ParticipationGlyph` animates with a symbol replace transition when the level changes and shows a loading dot while loading.
> - Renames the `mentionsOnly` participation level from 'Mentions only' to 'Listen mode' with updated caption text ('Only speaks if you @mention or say name').
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9434ad6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->