### PR TITLE
test: scale polled waits on CI so timing flakes stop failing PRs

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/AgentDmReconcilerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentDmReconcilerTests.swift
@@ -39,9 +39,10 @@ struct AgentDmReconcilerTests {
     }
 
     private func waitUntil(_ condition: @escaping () -> Bool) async throws {
-        for _ in 0..<200 {
+        let deadline = ContinuousClock.now + .seconds(2) * testTimeoutScale
+        while ContinuousClock.now < deadline {
             if condition() { return }
-            try await Task.sleep(nanoseconds: 10_000_000)
+            try await Task.sleep(for: .milliseconds(10))
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateCacheCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateCacheCoordinatorTests.swift
@@ -45,7 +45,7 @@ struct AgentTemplateCacheCoordinatorTests {
 
     /// Returns true as soon as `condition` holds, or false at `timeout`.
     private func waitUntil(_ timeout: Duration, _ condition: () -> Bool) async -> Bool {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
+        let deadline = ContinuousClock.now.advanced(by: timeout * testTimeoutScale)
         while ContinuousClock.now < deadline {
             if condition() { return true }
             try? await Task.sleep(for: .milliseconds(25))

--- a/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
@@ -638,12 +638,17 @@ private final class ThrowingExplosionWriter: ConversationExplosionWriterProtocol
     }
 }
 
+/// Polls until the condition holds. The deadline is scaled by
+/// `testTimeoutScale` so a loaded CI runner doesn't lose the race, and running
+/// out of time throws rather than returning quietly - a silent return surfaced
+/// as whichever `#expect` came next, which hid that the wait was the problem.
 private func waitForCondition(timeout: TimeInterval, condition: () -> Bool) async throws {
-    let deadline = Date().addingTimeInterval(timeout)
+    let deadline = Date().addingTimeInterval(timeout * testTimeoutScale)
     while Date() < deadline {
         if condition() {
             return
         }
         try await Task.sleep(for: .milliseconds(50))
     }
+    throw TimeoutError()
 }

--- a/ConvosCore/Tests/ConvosCoreTests/NetworkMonitorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/NetworkMonitorTests.swift
@@ -23,7 +23,7 @@ struct NetworkMonitorTests {
         interval: Duration = .milliseconds(10),
         condition: () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + timeout
+        let deadline = ContinuousClock.now + timeout * testTimeoutScale
         while ContinuousClock.now < deadline {
             if await condition() {
                 return

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -219,7 +219,7 @@ struct SyncingManagerPushReconciliationTests {
         interval: Duration = .milliseconds(50),
         condition: () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + timeout
+        let deadline = ContinuousClock.now + timeout * testTimeoutScale
         while ContinuousClock.now < deadline {
             if await condition() { return }
             try await Task.sleep(for: interval)

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -459,7 +459,7 @@ struct SyncingManagerTests {
         interval: Duration = .milliseconds(50),
         condition: () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + timeout
+        let deadline = ContinuousClock.now + timeout * testTimeoutScale
         while ContinuousClock.now < deadline {
             if await condition() {
                 return

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -50,9 +50,21 @@ private let _configureXMTPLogging: Void = {
     print("libxmtp log writer activated at \(directoryURL.path) (level=\(levelString))")
 }()
 
+/// Stretches every polled wait on CI. The timeouts callers pass are picked
+/// against a developer machine, where these conditions settle in well under a
+/// second; a loaded shared runner can take an order of magnitude longer for the
+/// same work, and the tests then fail on the clock rather than on behavior.
+/// Scaling the deadline keeps a real hang bounded while removing the race.
+let testTimeoutScale: Double = {
+    let env = ProcessInfo.processInfo.environment
+    let isCI = env["CI"] != nil || env["GITHUB_ACTIONS"] != nil
+    return isCI ? 6.0 : 1.0
+}()
+
 /// Waits until a condition becomes true, polling at a specified interval
 /// - Parameters:
-///   - timeout: Maximum time to wait (default: 10 seconds)
+///   - timeout: Maximum time to wait (default: 10 seconds), scaled by
+///     `testTimeoutScale` on CI
 ///   - interval: Polling interval (default: 50ms)
 ///   - condition: Async closure that returns true when condition is met
 /// - Throws: TimeoutError if condition not met within timeout
@@ -61,7 +73,7 @@ func waitUntil(
     interval: Duration = .milliseconds(50),
     condition: () async -> Bool
 ) async throws {
-    let deadline = ContinuousClock.now + timeout
+    let deadline = ContinuousClock.now + timeout * testTimeoutScale
     while ContinuousClock.now < deadline {
         if await condition() {
             return

--- a/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
@@ -106,7 +106,7 @@ private func makeContacts(count: Int) -> [Contact] {
 struct UserPropertiesBuilderTests {
     /// Returns true as soon as `condition` holds, or false at `timeout`.
     private func waitUntil(_ timeout: Duration, _ condition: () -> Bool) async -> Bool {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
+        let deadline = ContinuousClock.now.advanced(by: timeout * testTimeoutScale)
         while ContinuousClock.now < deadline {
             if condition() { return true }
             try? await Task.sleep(for: .milliseconds(25))


### PR DESCRIPTION
## Why

Integration Tests has been failing on PRs with a rotating cast of tests — `VoiceMemoTranscriptionService` ("happy path"), `ExpiredConversationsWorker` (two different tests on different runs), `SyncingManager` ("isSyncReady is false before start completes"). **A different test each run is the signature of a race against the clock, not a defect.**

The cause: the suite's wait helpers poll a condition against a deadline chosen on a developer machine.

| | local | CI |
|---|---|---|
| `VoiceMemoTranscriptionService` (10s budget) | 0.7s | timed out at 13–17s |
| `ExpiredConversationsWorker` (2s / 5s budgets) | 6.3s | failed at 8–13s |

A loaded shared runner takes an order of magnitude longer for identical work, so the wait expires and the test fails on time rather than behavior. Measured across recent runs, it hits multiple branches — `devin/…participation-mode-appdata-sync` took one too, not just mine.

## What

`testTimeoutScale` in `TestHelpers.swift` — **6× when `CI` or `GITHUB_ACTIONS` is set, 1× locally** — applied to every polled wait in the suite:

- `TestHelpers.waitUntil` (the shared one)
- `ExpiredConversationsWorkerTests`, `SyncingManagerTests`, `SyncingManagerPushReconciliationTests`, `NetworkMonitorTests`, `AgentTemplateCacheCoordinatorTests`, `UserPropertiesBuilderTests`
- `AgentDmReconcilerTests` — was a fixed 200-iteration loop, now a scaled deadline

**Only the deadline grows.** The helpers still return the instant the condition holds, so nothing waits longer than it does today when things are healthy. Full suite: 73s with scaling on, 73s without.

### Also: a silent timeout

`ExpiredConversationsWorkerTests.waitForCondition` returned quietly when it ran out of time, so the failure surfaced as whichever `#expect` came next — `Expectation failed: matched` — with no hint that the wait was the problem. That's what made this take a while to pin down. It now throws `TimeoutError`.

## What this does not do

It doesn't make a genuinely hung test run forever — the deadline is still bounded, just generously. And it doesn't touch the tests' logic or assertions, only how long they're willing to wait.

## Verification

- `swift test --package-path ConvosCore` — 1816 tests / 248 suites passing
- `CI=1 swift test --package-path ConvosCore` — same 1816 passing, same 73s, with scaling active
- Affected suites run individually under `CI=1`: 62 tests, 6 suites, green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788545476&installation_model_id=20076&pr_number=1288&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1288&signature=b973e7f440e79441afa0ebe03e0577e68b5daccc859508f0b92d62771fc6349a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scale polled wait timeouts by 6x on CI to reduce timing flakes
> Introduces a `testTimeoutScale` constant in [TestHelpers.swift](https://github.com/xmtplabs/convos-ios/pull/1288/files#diff-30cc9de0f0791e7a8631762f4a7590db2b113ca47cb39aab76befa02b71b3eb8) that returns `6.0` when the `CI` or `GITHUB_ACTIONS` environment variable is set, and `1.0` otherwise. All `waitUntil` and `waitForCondition` helpers across the test suite multiply their deadlines by this factor, giving async conditions more time to resolve on slower CI runners. `waitForCondition` in [ExpiredConversationsWorkerTests.swift](https://github.com/xmtplabs/convos-ios/pull/1288/files#diff-0e6188c07d8d016f54b6fa53893cfd3ab6c707458de437a2a701f0373d2930ae) also gains throwing behavior on timeout instead of silently returning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdd47ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->