### PR TITLE
test: floor polled waits at 30s, since suite load dwarfs the per-call budgets

### DIFF
--- a/ConvosCore/Tests/ConvosCoreTests/AgentDmReconcilerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentDmReconcilerTests.swift
@@ -39,7 +39,7 @@ struct AgentDmReconcilerTests {
     }
 
     private func waitUntil(_ condition: @escaping () -> Bool) async throws {
-        let deadline = ContinuousClock.now + .seconds(2) * testTimeoutScale
+        let deadline = ContinuousClock.now + .seconds(30) * testTimeoutScale
         while ContinuousClock.now < deadline {
             if condition() { return }
             try await Task.sleep(for: .milliseconds(10))

--- a/ConvosCore/Tests/ConvosCoreTests/AgentTemplateCacheCoordinatorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentTemplateCacheCoordinatorTests.swift
@@ -45,7 +45,7 @@ struct AgentTemplateCacheCoordinatorTests {
 
     /// Returns true as soon as `condition` holds, or false at `timeout`.
     private func waitUntil(_ timeout: Duration, _ condition: () -> Bool) async -> Bool {
-        let deadline = ContinuousClock.now.advanced(by: timeout * testTimeoutScale)
+        let deadline = ContinuousClock.now.advanced(by: max(timeout, .seconds(30)) * testTimeoutScale)
         while ContinuousClock.now < deadline {
             if condition() { return true }
             try? await Task.sleep(for: .milliseconds(25))

--- a/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ExpiredConversationsWorkerTests.swift
@@ -643,7 +643,11 @@ private final class ThrowingExplosionWriter: ConversationExplosionWriterProtocol
 /// out of time throws rather than returning quietly - a silent return surfaced
 /// as whichever `#expect` came next, which hid that the wait was the problem.
 private func waitForCondition(timeout: TimeInterval, condition: () -> Bool) async throws {
-    let deadline = Date().addingTimeInterval(timeout * testTimeoutScale)
+    // The per-call budgets here run from 1 to 5 seconds, which the whole suite
+    // under load can exceed even on a developer machine. A floor costs nothing
+    // when things are healthy - the poll returns the moment the condition holds
+    // - and only lengthens the path where the test was going to fail anyway.
+    let deadline = Date().addingTimeInterval(max(timeout, 30.0) * testTimeoutScale)
     while Date() < deadline {
         if condition() {
             return

--- a/ConvosCore/Tests/ConvosCoreTests/NetworkMonitorTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/NetworkMonitorTests.swift
@@ -23,7 +23,7 @@ struct NetworkMonitorTests {
         interval: Duration = .milliseconds(10),
         condition: () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + timeout * testTimeoutScale
+        let deadline = ContinuousClock.now + max(timeout, .seconds(30)) * testTimeoutScale
         while ContinuousClock.now < deadline {
             if await condition() {
                 return

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerPushReconciliationTests.swift
@@ -219,7 +219,7 @@ struct SyncingManagerPushReconciliationTests {
         interval: Duration = .milliseconds(50),
         condition: () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + timeout * testTimeoutScale
+        let deadline = ContinuousClock.now + max(timeout, .seconds(30)) * testTimeoutScale
         while ContinuousClock.now < deadline {
             if await condition() { return }
             try await Task.sleep(for: interval)

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -459,7 +459,7 @@ struct SyncingManagerTests {
         interval: Duration = .milliseconds(50),
         condition: () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + timeout * testTimeoutScale
+        let deadline = ContinuousClock.now + max(timeout, .seconds(30)) * testTimeoutScale
         while ContinuousClock.now < deadline {
             if await condition() {
                 return

--- a/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestHelpers.swift
@@ -50,11 +50,17 @@ private let _configureXMTPLogging: Void = {
     print("libxmtp log writer activated at \(directoryURL.path) (level=\(levelString))")
 }()
 
-/// Stretches every polled wait on CI. The timeouts callers pass are picked
-/// against a developer machine, where these conditions settle in well under a
-/// second; a loaded shared runner can take an order of magnitude longer for the
-/// same work, and the tests then fail on the clock rather than on behavior.
-/// Scaling the deadline keeps a real hang bounded while removing the race.
+/// Stretches polled waits further on CI, on top of the floor each helper
+/// applies.
+///
+/// The budgets callers pass were picked against a single test running on a
+/// developer machine, where these conditions settle in well under a second.
+/// They are not what the same work costs inside the full suite: 248 suites
+/// running together stretch it by more than an order of magnitude, locally as
+/// much as on a shared runner. A deadline here is a guard against a genuine
+/// hang, not a performance budget - the helpers return the instant the
+/// condition holds, so a generous deadline costs nothing on the healthy path
+/// and only lengthens a run that was going to fail regardless.
 let testTimeoutScale: Double = {
     let env = ProcessInfo.processInfo.environment
     let isCI = env["CI"] != nil || env["GITHUB_ACTIONS"] != nil
@@ -73,7 +79,7 @@ func waitUntil(
     interval: Duration = .milliseconds(50),
     condition: () async -> Bool
 ) async throws {
-    let deadline = ContinuousClock.now + timeout * testTimeoutScale
+    let deadline = ContinuousClock.now + max(timeout, .seconds(30)) * testTimeoutScale
     while ContinuousClock.now < deadline {
         if await condition() {
             return

--- a/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/UserPropertiesBuilderTests.swift
@@ -106,7 +106,7 @@ private func makeContacts(count: Int) -> [Contact] {
 struct UserPropertiesBuilderTests {
     /// Returns true as soon as `condition` holds, or false at `timeout`.
     private func waitUntil(_ timeout: Duration, _ condition: () -> Bool) async -> Bool {
-        let deadline = ContinuousClock.now.advanced(by: timeout * testTimeoutScale)
+        let deadline = ContinuousClock.now.advanced(by: max(timeout, .seconds(30)) * testTimeoutScale)
         while ContinuousClock.now < deadline {
             if condition() { return true }
             try? await Task.sleep(for: .milliseconds(25))


### PR DESCRIPTION
## Why

Follow-up to #1288, which only fixed half the problem — and introduced a small regression I should have caught before merging it.

**Half-fix:** #1288 scaled polled waits 6× on CI, on the theory that the shared runner was the slow part. It isn't only the runner. The budgets callers pass (1–10s) were picked against a *single test* on a developer machine. Inside the full suite they aren't close:

| | isolated | inside full suite |
|---|---|---|
| `VoiceMemoTranscriptionService` "happy path" (10s budget) | 0.7s | **> 10s — fails** |
| `ExpiredConversationsWorker` (2s / 5s budgets) | 6.3s | **exceeds — fails** |

248 suites running together stretch the same work by more than an order of magnitude. Both of those fail **locally**, on this machine, with no CI involved — which is why scaling only on CI left the flake in place.

**Regression:** #1288 also made `ExpiredConversationsWorkerTests.waitForCondition` throw on expiry instead of returning quietly. That was right for diagnostics — the silent return surfaced as `Expectation failed: matched` and hid the real cause — but it turned borderline waits into hard failures where they previously slipped through. That suite started failing locally under full-suite load. This fixes it properly instead of restoring the silence.

## What

Floors every polled wait at **30 seconds** before the CI multiplier, across all 8 helpers (`TestHelpers.waitUntil` plus the per-file ones in `ExpiredConversationsWorker`, `SyncingManager`, `SyncingManagerPushReconciliation`, `NetworkMonitor`, `AgentTemplateCacheCoordinator`, `UserPropertiesBuilder`, `AgentDmReconciler`).

A deadline in these helpers guards against a genuine hang — it is not a performance budget. The helpers return the instant the condition holds, so the floor costs nothing when things are healthy and only lengthens a run that was going to fail regardless.

## Verification

Three consecutive full-suite runs, 1816 tests / 248 suites, all green:

| run | result |
|---|---|
| local | 71.5s ✅ |
| local | 66.9s ✅ |
| `CI=1` | 72.7s ✅ |

Same runtime as before the change (73s), confirming the floor is free on the healthy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788547167&installation_model_id=20076&pr_number=1289&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1289&signature=9e5a44b45257bcbd1d3a93af5e323eda3551f816ce2225e5c5a469667839ef3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Floor polled `waitUntil` helpers at 30s to prevent flaky timeouts during suite load
> Test suite load time can dwarf per-call timeout budgets, causing spurious failures. All `waitUntil`/`waitForCondition` helpers across the test targets now use `max(timeout, .seconds(30))` (scaled by `testTimeoutScale`) as their deadline, ensuring a 30-second minimum wait regardless of the caller-supplied timeout. The change is applied consistently in [TestHelpers.swift](https://github.com/xmtplabs/convos-ios/pull/1289/files#diff-30cc9de0f0791e7a8631762f4a7590db2b113ca47cb39aab76befa02b71b3eb8) and each test-local helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19b91d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->