### PR TITLE
Add .devin/blueprint.yaml (Outpost bootstrap + secrets maintenance)

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,0 +1,15 @@
+# Devin repo blueprint for convos-ios
+# Bootstraps the macOS Outpost devbox (pool: namespace-convos-ios-dev-macos)
+# so coding-run sessions build + QA the app the validated way.
+# See the outpost-ios-qa runbook for the full procedure.
+
+name: convos-ios
+
+# One-time setup on a fresh Outpost box.
+initialize: |
+  Scripts/outpost-bootstrap.sh
+  brew install ffmpeg
+
+# Refreshed at the start of each session.
+maintenance: |
+  make ensure-secrets

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -5,11 +5,13 @@
 
 # One-time setup on a fresh Outpost box.
 initialize: |
-  Scripts/outpost-bootstrap.sh
-  # bare run only PRINTS the exports; persist them so every later session
-  # shell gets DEVELOPER_DIR + PATH (incl. the idb venv), not just this subshell.
-  Scripts/outpost-bootstrap.sh --env >> ~/.bashrc
-  brew install ffmpeg
+  if [ "$(uname)" = "Darwin" ]; then
+    Scripts/outpost-bootstrap.sh
+    Scripts/outpost-bootstrap.sh --env >> ~/.bashrc
+    brew install ffmpeg
+  else
+    echo "skipping macOS-only QA bootstrap (snapshot build host is Linux)"
+  fi
 
 # Refreshed at the start of each session.
 maintenance: |

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -5,6 +5,8 @@
 
 # One-time setup on a fresh Outpost box.
 initialize: |
++  set -e
+  if [ "$(uname)" = "Darwin" ]; then
   if [ "$(uname)" = "Darwin" ]; then
     Scripts/outpost-bootstrap.sh
     Scripts/outpost-bootstrap.sh --env >> ~/.bashrc

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -5,8 +5,7 @@
 
 # One-time setup on a fresh Outpost box.
 initialize: |
-+  set -e
-  if [ "$(uname)" = "Darwin" ]; then
+  set -e
   if [ "$(uname)" = "Darwin" ]; then
     Scripts/outpost-bootstrap.sh
     Scripts/outpost-bootstrap.sh --env >> ~/.bashrc

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -3,8 +3,6 @@
 # so coding-run sessions build + QA the app the validated way.
 # See the outpost-ios-qa runbook for the full procedure.
 
-name: convos-ios
-
 # One-time setup on a fresh Outpost box.
 initialize: |
   Scripts/outpost-bootstrap.sh

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -8,6 +8,9 @@ name: convos-ios
 # One-time setup on a fresh Outpost box.
 initialize: |
   Scripts/outpost-bootstrap.sh
+  # bare run only PRINTS the exports; persist them so every later session
+  # shell gets DEVELOPER_DIR + PATH (incl. the idb venv), not just this subshell.
+  Scripts/outpost-bootstrap.sh --env >> ~/.zshrc
   brew install ffmpeg
 
 # Refreshed at the start of each session.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -10,7 +10,7 @@ initialize: |
   Scripts/outpost-bootstrap.sh
   # bare run only PRINTS the exports; persist them so every later session
   # shell gets DEVELOPER_DIR + PATH (incl. the idb venv), not just this subshell.
-  Scripts/outpost-bootstrap.sh --env >> ~/.zshrc
+  Scripts/outpost-bootstrap.sh --env >> ~/.bashrc
   brew install ffmpeg
 
 # Refreshed at the start of each session.


### PR DESCRIPTION
Adds a Devin repo blueprint so coding-run sessions initialize the macOS Outpost devbox the same validated way every time, instead of rediscovering the setup per session.

**initialize** (one-time per fresh box):
- `Scripts/outpost-bootstrap.sh` — selects the pinned Xcode, installs `idb` (Py 3.13 venv) + `idb-companion`, and dev-initializes the convos CLI.
- `Scripts/outpost-bootstrap.sh --env >> ~/.bashrc` — persists the `DEVELOPER_DIR` + `PATH` exports into the session shell profile. The bare script only *prints* the exports to stdout; without this line every later step in the session stays on the old PATH/default Xcode and the `idb` venv isn't reachable.
- `brew install ffmpeg` — required for the QA harness video evidence capture.

**maintenance** (per-session refresh):
- `make ensure-secrets` — regenerates `Secrets.swift` so a cold build doesn't fail with `cannot find 'Secrets' in scope`.

Sourced from the validated Outpost QA procedure (outpost-ios-qa runbook) and the setup Devin itself proposed. Filed alongside CON-826.

Reviewer note: the `.devin/blueprint.yaml` schema (`initialize` / `maintenance` keys) is confirmed valid, and the env-persist target `~/.bashrc` is confirmed as the profile the session shell sources.

Proposed by jarod@xmtp.com via ConvosOS.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Adds a Devin repo blueprint so coding-run sessions initialize the macOS Outpost devbox the same validated way every time, instead of rediscovering the setup per session.
>
> **initialize** (one-time per fresh box):
> - `Scripts/outpost-bootstrap.sh` — selects the pinned Xcode, installs `idb` (Py 3.13 venv) + `idb-companion`, and dev-initializes the convos CLI.
> - `Scripts/outpost-bootstrap.sh --env >> ~/.bashrc` — persists the `DEVELOPER_DIR` + `PATH` exports into the session shell profile. The bare script only *prints* the exports to stdout; without this line every later step in the session stays on the old PATH/default Xcode and the `idb` venv isn't reachable.
> - `brew install ffmpeg` — required for the QA harness video evidence capture.
>
> **maintenance** (per-session refresh):
> - `make ensure-secrets` — regenerates `Secrets.swift` so a cold build doesn't fail with `cannot find 'Secrets' in scope`.
>
> Sourced from the validated Outpost QA procedure (outpost-ios-qa runbook) and the setup Devin itself proposed. Filed alongside CON-826.
>
> Reviewer note: the `.devin/blueprint.yaml` schema (`initialize` / `maintenance` keys) is confirmed valid, and the env-persist target `~/.bashrc` is confirmed as the profile the session shell sources.
>
> Proposed by jarod@xmtp.com via ConvosOS.<!-- Macroscope's changelog starts here -->
> #### Changes since #1290 opened
>
> - Changed the output redirection target in the `.devin/blueprint.yaml` initialization script from `~/.zshrc` to `~/.bashrc` [1565f06]
> - Removed the top-level name field from the blueprint configuration [764e6d0]
> - Added OS detection to initialization script with conditional execution of macOS-specific commands [dd7fe53]
> - Introduced syntax errors in the initialize script block within `.devin/blueprint.yaml` [b7e2663]
> - Corrected shell script syntax in the `initialize` block of `.devin/blueprint.yaml` by removing extraneous leading `+` character from `set -e` command [81f64fe]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->