### PR TITLE
default true for the participation control in production

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -71,10 +71,10 @@ final class FeatureFlags {
     /// production. Deliberately not prod-locked like the flags above: the
     /// control is reachable everywhere so Listen can be dogfooded in TestFlight.
     ///
-    /// The default follows the build: on for the internal Dev/local builds that
-    /// ship to TestFlight, off for production, so end users still have to opt in
-    /// from the prod debug menu. An explicit toggle in either direction is
-    /// remembered and wins over the default.
+    /// On by default in every build, production included, so the control is
+    /// there without anyone having to find a debug menu first. An explicit
+    /// toggle in either direction is remembered and wins over the default, so
+    /// turning it off from the prod debug menu still sticks.
     var isListenParticipationEnabled: Bool {
         get {
             access(keyPath: \.isListenParticipationEnabled)
@@ -90,9 +90,7 @@ final class FeatureFlags {
         }
     }
 
-    private static var listenParticipationDefault: Bool {
-        !ConfigManager.shared.currentEnvironment.isProduction
-    }
+    private static let listenParticipationDefault: Bool = true
 
     /// Off by default -- opts libxmtp streams onto the shared bidi wire by
     /// exporting `XMTP_BIDI_STREAMS_ENABLED` at launch (see `ConvosApp.init`;


### PR DESCRIPTION
## What

Listen (the per-conversation agent participation control: Speak freely / Listen mode / Paused) defaulted on only for the non-production builds. On production the control was simply absent until someone unlocked the prod debug menu and flipped it by hand.

Default it on everywhere, production included.

## How

One line: `listenParticipationDefault` goes from `!isProduction` to `true`.

Everything else about the flag is unchanged. The stored UserDefaults value still takes precedence, so an explicit toggle in either direction is remembered and wins over the default - turning it off from the prod debug menu still sticks. The prod debug menu row stays where it is.

## Testing

- `swiftlint --strict` clean.
- `xcodebuild build -scheme "Convos (Dev)" -configuration Dev` succeeds.
- No behavior change for anyone who has already toggled the flag; this only moves the first-run default on production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable listen participation feature flag by default in all environments
> Changes `FeatureFlags.listenParticipationDefault` from a computed var that returned `false` in production to a `static let` hardcoded to `true`, removing the dependency on `ConfigManager`. Behavioral Change: users in production with no `UserDefaults` override will now have listen participation enabled by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b24869.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->