### PR TITLE
docs: record what end-to-end local testing actually takes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,9 +437,15 @@ XMTP_CUSTOM_HOST=USE_CONFIG
 GATEWAY_URL=USE_CONFIG
 ```
 
-Then build **`Convos (Dev)`**. ngrok is what makes a physical device work: it
-gives the backend an HTTPS URL reachable off-machine. A LAN IP only ever works
-for the simulator, and `localhost` only for the simulator too.
+Then build **`Convos (Dev)`**. ngrok is what makes a physical device work on
+this scheme: it gives the backend an HTTPS URL, and `Info.Dev.plist` carries no
+ATS exception, so plain HTTP to a LAN IP is refused.
+
+`Convos (Local)` is the other route, and it needs no tunnel at all: its plist
+sets `NSAllowsLocalNetworking`, and a blank `CONVOS_API_BASE_URL` auto-detects
+the Mac's LAN IP — reachable from a simulator and from a device on the same
+network. It costs an App Check token registered for `org.convos.ios-local`,
+which is the trade-off against the scheme you already use.
 
 **Build the scheme whose App Check token you already have.** Debug tokens are
 registered per bundle id — `Convos (Dev)` is `org.convos.ios-preview`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,54 @@ Or Force Quit it from Activity Monitor. The Memory Pressure bar should return to
 
 The leak has no permanent fix on Apple's end — `killall` is the workaround. If you find yourself doing it every couple of hours, alias it: `alias xclean='killall lldb-rpc-server'`.
 
+## End-to-End Local Testing
+
+Running this app against a locally-running backend works, but nearly every
+failure points somewhere other than its cause. The setup that works:
+
+```
+app ──► ngrok (https) ──► convos-backend :4000 ──► assistants worker ──► herald
+```
+
+The app only ever talks to the backend. The agent is what lives on Cloudflare,
+so "point the app at my local stack" means pointing it at a local *backend* and
+nothing else.
+
+Configure through `.env` at the repo root — not `Convos/Config/config.*.json`:
+
+```
+FIREBASE_APP_CHECK_DEBUG_TOKEN=<the token registered for this bundle id>
+CONVOS_API_BASE_URL=https://<ngrok-id>.ngrok.app/api
+XMTP_CUSTOM_HOST=USE_CONFIG
+GATEWAY_URL=USE_CONFIG
+```
+
+Then build **`Convos (Dev)`**. ngrok is what makes a physical device work: it
+gives the backend an HTTPS URL reachable off-machine. A LAN IP only ever works
+for the simulator, and `localhost` only for the simulator too.
+
+**Build the scheme whose App Check token you already have.** Debug tokens are
+registered per bundle id — `Convos (Dev)` is `org.convos.ios-preview`,
+`Convos (Local)` is `org.convos.ios-local`. Building a scheme you have never
+used produces a bundle Firebase does not recognise: the client never obtains a
+token, every authenticated call 401s, and the app shows a generic "Something
+went wrong" with no auth error anywhere. `ENVIRONMENTS.md` covers this; it is
+worth reading before concluding the backend is down.
+
+**A worktree has no `.env`.** It is gitignored, so a build from a fresh
+worktree silently ships without an App Check token or a backend override.
+Nothing warns — the build succeeds and the app fails at runtime. Copy `.env`
+from the canonical checkout first.
+
+The backend side needs `SIWE_DOMAIN=dev.convos.org`, `SIWE_URI=https://dev.convos.org`,
+`SIWE_ALLOWED_CHAIN_IDS=1` and a `NONCE_HMAC_SECRET`. The `.env.example`
+defaults are not these, and what they produce is `/auth/nonce` 200 followed by
+`/auth/token` 401 "Invalid nonce".
+
+Compiling is not installing. `xcodebuild` succeeding changes nothing on the
+device — install and launch, and target simulators by UDID rather than
+`booted` when several are running.
+
 ## Build & Release
 
 ### Build Commands


### PR DESCRIPTION
Running the app against a locally-running backend works, but nearly every failure points somewhere other than its cause. This writes down the setup that works and the traps around it.

The one that cost the most: App Check debug tokens are registered per bundle id, so building a scheme you have never used produces a bundle Firebase does not recognise. The client never obtains a token, every authenticated call 401s, and the app shows a generic "Something went wrong" — no auth error anywhere. `ENVIRONMENTS.md` already documents the mechanism; this adds the practical consequence (build the scheme whose token you have) plus the ngrok setup a physical device needs, the fact that a worktree silently has no `.env`, and that compiling is not installing.

Companion sections land in convos-assistants `AGENTS.md` (herald sidecar, tunnel expiry) and convos-backend `CLAUDE.md` (SIWE, ngrok), each cross-referencing the others.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788705733&installation_model_id=20076&pr_number=1295&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1295&signature=c2f5030b4e6fbdf2ecd8d45c5bfaa2dd77af7be037129115bc9a40064edb7404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document end-to-end local testing setup in CLAUDE.md
> Adds a new 'End-to-End Local Testing' section to [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/1295/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) covering how to run the app against a local backend.
>
> - Describes the request path through ngrok to the backend and assistants worker, with required `.env` variables (`FIREBASE_APP_CHECK_DEBUG_TOKEN`, `CONVOS_API_BASE_URL`, `XMTP_CUSTOM_HOST`, `GATEWAY_URL`)
> - Documents the `Convos (Dev)` scheme (requires HTTPS via ngrok for ATS) and `Convos (Local)` scheme (uses `NSAllowsLocalNetworking` and auto-detects LAN IP when `CONVOS_API_BASE_URL` is blank)
> - Notes that Firebase App Check debug tokens are bundle-id specific and that using an unregistered bundle id produces 401s with generic errors
> - Covers backend `.env` requirements (`SIWE_DOMAIN`, `SIWE_URI`, `SIWE_ALLOWED_CHAIN_IDS`, `NONCE_HMAC_SECRET`) and warns that wrong defaults cause `/auth/token` 401s
> - Notes that git worktrees lack `.env` (due to `.gitignore`) and must copy it from the canonical checkout, and that compiling does not install — the app must be installed and launched manually
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab101b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->