### PR TITLE
fix(participation): restore the Listen mode label the rebase reverted

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -30,7 +30,7 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
-        case .mentionsOnly: "Mentions only"
+        case .mentionsOnly: "Listen mode"
         case .listenOnly: "Listen only"
         case .paused: "Pause"
         }
@@ -39,7 +39,7 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     public var caption: String {
         switch self {
         case .speakFreely: "Chime in any time"
-        case .mentionsOnly: "Speak when you see your name"
+        case .mentionsOnly: "Only speaks if you @mention or say name"
         case .listenOnly: "Stay on, stay quiet"
         case .paused: "Go offline, use no credits"
         }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
@@ -42,7 +42,7 @@ public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendab
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
-        case .mentionsOnly: "Mentions only"
+        case .mentionsOnly: "Listen mode"
         case .listenOnly: "Listen only"
         case .paused: "Pause"
         }


### PR DESCRIPTION
`dev` had renamed `.mentionsOnly` to "Listen mode". Resolving the #1287 rebase conflict in favour of the branch silently took that back, so both the composer menu and the transcript update row went back to "Mentions only" — a label change nobody decided to undo.

The reasoning at the time was that #1287 adds a real `.listenOnly` level, and two "Listen" entries side by side would read as confusing. That does not hold: `.listenOnly` is filtered out of `selectableCases`, so a member never sees them together.

This restores dev's title and caption, and aligns `ConversationParticipationMode.title` (which the transcript renders, and which #1287 introduced) so the update row cannot contradict the menu.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788712338&installation_model_id=20076&pr_number=1296&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1296&signature=f7f4f4bc56d2843039a28007b5c6367cfe322a1cb04b56248ea90be6113b7439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore 'Listen mode' label for `mentionsOnly` participation level
> Reverts a rebase that accidentally changed the `mentionsOnly` title back to 'Mentions only' and its caption to 'Speak when you see your name'. Restores the correct values in both [`AgentParticipationLevel`](https://github.com/xmtplabs/convos-ios/pull/1296/files#diff-72aa8c1cb4eac940c14e9fcbb711650060c83f08c2f827991b6f9f8a2ff90ab0) and [`ConversationParticipationMode`](https://github.com/xmtplabs/convos-ios/pull/1296/files#diff-7c23310952fab6015d1f8775a484389153b2e67d7ef38050124886de6bdbb809).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6910ad3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->