### PR TITLE
refactor(participation): drop the listen-only level the spec cut

### DIFF
--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.pb.swift
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.pb.swift
@@ -8,7 +8,11 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/apple/swift-protobuf/
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -16,7 +20,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -29,14 +33,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Carried in appData rather than a message so it rides the group-metadata
 /// rails: new members read the current mode on join, and MLS metadata's
 /// last-writer-wins resolution settles two members changing it at once.
-public enum ParticipationMode: SwiftProtobuf.Enum, Swift.CaseIterable {
+public nonisolated enum ParticipationMode: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   /// Never written; an unset mode is the product default
   case unspecified // = 0
   case speakFreely // = 1
   case mentionsOnly // = 2
-  case listenOnly // = 3
   case paused // = 4
   case UNRECOGNIZED(Int)
 
@@ -49,7 +52,6 @@ public enum ParticipationMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 0: self = .unspecified
     case 1: self = .speakFreely
     case 2: self = .mentionsOnly
-    case 3: self = .listenOnly
     case 4: self = .paused
     default: self = .UNRECOGNIZED(rawValue)
     }
@@ -60,7 +62,6 @@ public enum ParticipationMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .unspecified: return 0
     case .speakFreely: return 1
     case .mentionsOnly: return 2
-    case .listenOnly: return 3
     case .paused: return 4
     case .UNRECOGNIZED(let i): return i
     }
@@ -71,7 +72,6 @@ public enum ParticipationMode: SwiftProtobuf.Enum, Swift.CaseIterable {
     .unspecified,
     .speakFreely,
     .mentionsOnly,
-    .listenOnly,
     .paused,
   ]
 
@@ -88,7 +88,7 @@ public enum ParticipationMode: SwiftProtobuf.Enum, Swift.CaseIterable {
 /// - One 32-byte AES-256 key per group (imageEncryptionKey)
 /// - Per-image: URL + salt + nonce (no digest - AES-GCM auth tag provides integrity)
 /// - ~48 bytes overhead per image
-public struct ConversationCustomMetadata: Sendable {
+public nonisolated struct ConversationCustomMetadata: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -171,7 +171,7 @@ public struct ConversationCustomMetadata: Sendable {
 /// The agent's identity comes from the membership itself (member_kind plus
 /// attestation), not from this marker; clients only honor the marker when the
 /// conversation has exactly 2 members and the other member is an agent.
-public struct AgentDmInfo: Sendable {
+public nonisolated struct AgentDmInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -195,7 +195,7 @@ public struct AgentDmInfo: Sendable {
 
 /// EncryptedImageRef stores encrypted image metadata
 /// AES-GCM auth tag (16 bytes) is appended to ciphertext, providing integrity verification
-public struct EncryptedImageRef: Sendable {
+public nonisolated struct EncryptedImageRef: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -215,7 +215,7 @@ public struct EncryptedImageRef: Sendable {
 }
 
 /// ConversationProfile represents a participant in the conversation
-public struct ConversationProfile: Sendable {
+public nonisolated struct ConversationProfile: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -274,11 +274,11 @@ public struct ConversationProfile: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-extension ParticipationMode: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PARTICIPATION_MODE_UNSPECIFIED\0\u{1}PARTICIPATION_MODE_SPEAK_FREELY\0\u{1}PARTICIPATION_MODE_MENTIONS_ONLY\0\u{1}PARTICIPATION_MODE_LISTEN_ONLY\0\u{1}PARTICIPATION_MODE_PAUSED\0")
+nonisolated extension ParticipationMode: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0PARTICIPATION_MODE_UNSPECIFIED\0\u{1}PARTICIPATION_MODE_SPEAK_FREELY\0\u{1}PARTICIPATION_MODE_MENTIONS_ONLY\0\u{2}\u{2}PARTICIPATION_MODE_PAUSED\0")
 }
 
-extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "ConversationCustomMetadata"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}tag\0\u{1}profiles\0\u{1}expiresAtUnix\0\u{1}imageEncryptionKey\0\u{1}encryptedGroupImage\0\u{1}emoji\0\u{2}\u{2}agentDm\0\u{1}participationMode\0\u{c}\u{7}\u{1}")
 
@@ -347,7 +347,7 @@ extension ConversationCustomMetadata: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension AgentDmInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension AgentDmInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "AgentDmInfo"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}originConversationId\0")
 
@@ -381,7 +381,7 @@ extension AgentDmInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementati
   }
 }
 
-extension EncryptedImageRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension EncryptedImageRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "EncryptedImageRef"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}url\0\u{1}salt\0\u{1}nonce\0")
 
@@ -421,7 +421,7 @@ extension EncryptedImageRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 }
 
-extension ConversationProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension ConversationProfile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "ConversationProfile"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}inboxId\0\u{1}name\0\u{1}image\0\u{1}encryptedImage\0\u{1}connections\0")
 

--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
@@ -38,7 +38,10 @@ enum ParticipationMode {
     PARTICIPATION_MODE_UNSPECIFIED = 0;  // Never written; an unset mode is the product default
     PARTICIPATION_MODE_SPEAK_FREELY = 1;
     PARTICIPATION_MODE_MENTIONS_ONLY = 2;
-    PARTICIPATION_MODE_LISTEN_ONLY = 3;
+    // 3 was LISTEN_ONLY, cut from the spec (2026-07-20 product revision) after
+    // it briefly shipped. Reserved so the number can never mean something else
+    // to a client built against the version that had it.
+    reserved 3;
     PARTICIPATION_MODE_PAUSED = 4;
 }
 

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -14,24 +14,17 @@ import SwiftUI
 public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendable {
     case speakFreely
     case mentionsOnly
-    case listenOnly
     case paused
 
     public var id: String { rawValue }
 
-    /// The levels the menu offers. `listenOnly` is readable and rendered but not
-    /// yet offered here: the mode travels in appData so a client that does offer
-    /// it is understood rather than shown as an unknown level, and it joins this
-    /// list once its copy and runtime behavior are settled.
-    public static var selectableCases: [AgentParticipationLevel] {
-        allCases.filter { $0 != .listenOnly }
-    }
+    /// The levels the menu offers — every level there is.
+    public static var selectableCases: [AgentParticipationLevel] { allCases }
 
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
-        case .mentionsOnly: "Mentions only"
-        case .listenOnly: "Listen only"
+        case .mentionsOnly: "Listen mode"
         case .paused: "Pause"
         }
     }
@@ -39,8 +32,7 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     public var caption: String {
         switch self {
         case .speakFreely: "Chime in any time"
-        case .mentionsOnly: "Speak when you see your name"
-        case .listenOnly: "Stay on, stay quiet"
+        case .mentionsOnly: "Only speaks if you @mention or say name"
         case .paused: "Go offline, use no credits"
         }
     }
@@ -52,7 +44,6 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
         switch self {
         case .speakFreely: "speaker.wave.2"
         case .mentionsOnly: "at"
-        case .listenOnly: "ear"
         case .paused: "pause.circle"
         }
     }
@@ -69,7 +60,6 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
         switch self {
         case .speakFreely: .speakFreely
         case .mentionsOnly: .mentionsOnly
-        case .listenOnly: .listenOnly
         case .paused: .paused
         }
     }
@@ -78,7 +68,6 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
         switch mode {
         case .speakFreely: self = .speakFreely
         case .mentionsOnly: self = .mentionsOnly
-        case .listenOnly: self = .listenOnly
         case .paused: self = .paused
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
@@ -19,7 +19,6 @@ import Foundation
 public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendable {
     case speakFreely = "speak"
     case mentionsOnly = "mention"
-    case listenOnly = "listen"
     case paused
 
     /// The mode a conversation is in until someone sets one. An unset
@@ -33,7 +32,7 @@ public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendab
     public var isQuiet: Bool {
         switch self {
         case .speakFreely: false
-        case .mentionsOnly, .listenOnly, .paused: true
+        case .mentionsOnly, .paused: true
         }
     }
 
@@ -42,8 +41,7 @@ public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendab
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
-        case .mentionsOnly: "Mentions only"
-        case .listenOnly: "Listen only"
+        case .mentionsOnly: "Listen mode"
         case .paused: "Pause"
         }
     }
@@ -60,7 +58,6 @@ public extension ConversationParticipationMode {
         switch proto {
         case .speakFreely: self = .speakFreely
         case .mentionsOnly: self = .mentionsOnly
-        case .listenOnly: self = .listenOnly
         case .paused: self = .paused
         case .unspecified, .UNRECOGNIZED: return nil
         }
@@ -70,7 +67,6 @@ public extension ConversationParticipationMode {
         switch self {
         case .speakFreely: .speakFreely
         case .mentionsOnly: .mentionsOnly
-        case .listenOnly: .listenOnly
         case .paused: .paused
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -221,6 +221,7 @@ extension SharedDatabaseMigrator {
         Self.registerAgentDmMigrations(on: &migrator)
         migrator.registerMigration("addConversationAddedById", migrate: Self.addConversationAddedById)
         migrator.registerMigration("addConversationParticipationMode", migrate: Self.addConversationParticipationMode)
+        migrator.registerMigration("clearCutListenParticipationMode", migrate: Self.clearCutListenParticipationMode)
     }
 
     /// The conversation's agent participation mode, mirrored from the group's
@@ -235,6 +236,23 @@ extension SharedDatabaseMigrator {
         try db.alter(table: "conversation") { t in
             t.add(column: "participationMode", .text)
         }
+    }
+
+    /// Clears the `listen` mode that shipped briefly before the level was cut.
+    ///
+    /// The enum no longer has a case for it, and GRDB throws rather than
+    /// shrugging at a raw value it cannot map — so a single stale row would
+    /// fail the whole `DBConversation` fetch and take the conversation with it.
+    /// Null is the honest replacement: the column is nullable exactly so "no
+    /// mode set" is representable, and that is what a level this build no
+    /// longer understands amounts to. Readers resolve null to the product
+    /// default, which is also what the control plane now does with a
+    /// `LISTEN_ONLY` still arriving on the wire.
+    static func clearCutListenParticipationMode(_ db: Database) throws {
+        try db.execute(
+            sql: "UPDATE conversation SET participationMode = NULL WHERE participationMode = ?",
+            arguments: ["listen"]
+        )
     }
 
     /// Per-conversation catch-up cursor (see DBConversationCatchUpCursor).

--- a/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
@@ -192,6 +192,6 @@ struct ParticipationModeSyncTests {
             ]
         )
 
-        #expect(update.summary == "Shane set the participation mode to \"Mentions only\"")
+        #expect(update.summary == "Shane set the participation mode to \"Listen mode\"")
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
@@ -39,6 +39,50 @@ struct ParticipationModeSyncTests {
         }
     }
 
+    @Test("the cut listen mode is cleared, so a stale row cannot fail the fetch")
+    func migrationClearsCutListenMode() throws {
+        // `listen` shipped briefly before the level was cut. The enum has no
+        // case for it now and GRDB throws rather than shrugging, so one stale
+        // row would fail the whole DBConversation fetch and take the
+        // conversation with it.
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "conversation") { t in
+                t.column("id", .text).notNull().primaryKey()
+            }
+            try db.execute(sql: "INSERT INTO conversation (id) VALUES (?)", arguments: ["convo-listen"])
+            try db.execute(sql: "INSERT INTO conversation (id) VALUES (?)", arguments: ["convo-paused"])
+            try SharedDatabaseMigrator.addConversationParticipationMode(db)
+            try db.execute(
+                sql: "UPDATE conversation SET participationMode = ? WHERE id = ?",
+                arguments: ["listen", "convo-listen"]
+            )
+            try db.execute(
+                sql: "UPDATE conversation SET participationMode = ? WHERE id = ?",
+                arguments: ["paused", "convo-paused"]
+            )
+
+            try SharedDatabaseMigrator.clearCutListenParticipationMode(db)
+        }
+
+        try dbQueue.read { db in
+            let cleared = try String.fetchOne(
+                db,
+                sql: "SELECT participationMode FROM conversation WHERE id = ?",
+                arguments: ["convo-listen"]
+            )
+            #expect(cleared == nil)
+
+            // A level this build still has is left exactly where it was.
+            let kept = try String.fetchOne(
+                db,
+                sql: "SELECT participationMode FROM conversation WHERE id = ?",
+                arguments: ["convo-paused"]
+            )
+            #expect(kept == "paused")
+        }
+    }
+
     @Test("a stored mode round-trips through the column")
     func storedModeRoundTrips() throws {
         let dbQueue = try DatabaseQueue()

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -2,8 +2,8 @@
   "codecs" : {
     "device_removed" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInNjaGVtYVZlcnNpb24iOjEsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
-      "contentJSON" : "{\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"schemaVersion\":1,\"removedAt\":1750000200}",
+      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJyZW1vdmVkQXQiOjE3NTAwMDAyMDAsInJldm9rZWRJbnN0YWxsYXRpb25JZCI6ImIxOTQ2YWM5MjQ5MmQyMzQ3YzYyMzViNGQyNjExMTg0In0=",
+      "contentJSON" : "{\"schemaVersion\":1,\"removedAt\":1750000200,\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\"}",
       "contentType" : "convos.org/device_removed:1.0",
       "typeId" : "device_removed",
       "versionMajor" : 1,
@@ -11,8 +11,8 @@
     },
     "identity_share" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaW5ib3hJZCI6IjNmOWExYzBlNWI3ZDI4NDZhMWYzMGM5ZTRkOGI2NzUyZTBhNGM5MTM3ZmI1NjI4ZDBlM2E3YzE0YjlkNWY2ODIiLCJwcml2YXRlS2V5RGF0YSI6IklpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUk9IiwiaW5pdGlhdG9yRGV2aWNlTmFtZSI6IkNhbWVyb24ncyBpUGhvbmUiLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpc3N1ZWRBdCI6MTc1MDAwMDEwMCwic2NoZW1hVmVyc2lvbiI6MX0=",
-      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"displayName\":\"Cameron\",\"issuedAt\":1750000100,\"schemaVersion\":1}",
+      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaW5pdGlhdG9yRGV2aWNlTmFtZSI6IkNhbWVyb24ncyBpUGhvbmUiLCJpc3N1ZWRBdCI6MTc1MDAwMDEwMCwicHJpdmF0ZUtleURhdGEiOiJJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJPSIsInNjaGVtYVZlcnNpb24iOjEsImRpc3BsYXlOYW1lIjoiQ2FtZXJvbiIsImluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0=",
+      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"issuedAt\":1750000100,\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"schemaVersion\":1,\"displayName\":\"Cameron\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\"}",
       "contentType" : "convos.org/identity_share:1.0",
       "typeId" : "identity_share",
       "versionMajor" : 1,
@@ -20,8 +20,8 @@
     },
     "pairing_join_request" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzbHVnIjoiZXlKelkyaGxiV0ZXWlhKemFXOXVJam94TENKcGJtbDBhV0YwYjNKSmJtSnZlRWxrSWpvaU0yWTVZVEZqTUdVMVlqZGtNamcwTm1FeFpqTXdZemxsTkdRNFlqWTNOVEpsTUdFMFl6a3hNemRtWWpVMk1qaGtNR1V6WVRkak1UUmlPV1ExWmpZNE1pSXNJbk5wWjI1aGRIVnlaU0k2SWl0WVptTTVVREZ0UnpsT1lURmNMMkowVTBoVldWcFZiMDg1TmxoM00wUmlVRGxvYTFocFJsZ3pkVkZqVGs1Y0wxZE5TamhjTHpKdmNFTk9ibE5aWTNCRVIxQkJTbk51T0VOSWFIUkRhMmd3WnpGak16TnJOSFpvZHowaUxDSnBibWwwYVdGMGIzSkJaR1J5WlhOeklqb2lNSGd4T1dVM1pUTTNObVUzWXpJeE0ySTNaVGRsTjJVME5tTmpOekJoTldSa01EZzJaR0ZtWmpKaElpd2laWGh3YVhKbGMwRjBJam94TnpVd01EQXdNVEl3TENKdWIyNWpaU0k2SWtGQ1JXbE5NRkpXV201bFNXMWhjVGQ2VGpOMVhDOTNQVDBpTENKcGMzTjFaV1JCZENJNk1UYzFNREF3TURBd01IMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIiwic2NoZW1hVmVyc2lvbiI6MX0=",
-      "contentJSON" : "{\"slug\":\"eyJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIiwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJpc3N1ZWRBdCI6MTc1MDAwMDAwMH0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\",\"schemaVersion\":1}",
+      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJkZXZpY2VOYW1lIjoiUGl4ZWwgOSBQcm8iLCJzbHVnIjoiZXlKcGMzTjFaV1JCZENJNk1UYzFNREF3TURBd01Dd2lhVzVwZEdsaGRHOXlRV1JrY21WemN5STZJakI0TVRsbE4yVXpOelpsTjJNeU1UTmlOMlUzWlRkbE5EWmpZemN3WVRWa1pEQTRObVJoWm1ZeVlTSXNJbWx1YVhScFlYUnZja2x1WW05NFNXUWlPaUl6WmpsaE1XTXdaVFZpTjJReU9EUTJZVEZtTXpCak9XVTBaRGhpTmpjMU1tVXdZVFJqT1RFek4yWmlOVFl5T0dRd1pUTmhOMk14TkdJNVpEVm1Oamd5SWl3aWMyTm9aVzFoVm1WeWMybHZiaUk2TVN3aWMybG5ibUYwZFhKbElqb2lLMWhtWXpsUU1XMUhPVTVoTVZ3dlluUlRTRlZaV2xWdlR6azJXSGN6UkdKUU9XaHJXR2xHV0ROMVVXTk9UbHd2VjAxS09Gd3ZNbTl3UTA1dVUxbGpjRVJIVUVGS2MyNDRRMGhvZEVOcmFEQm5NV016TTJzMGRtaDNQU0lzSW1WNGNHbHlaWE5CZENJNk1UYzFNREF3TURFeU1Dd2libTl1WTJVaU9pSkJRa1ZwVFRCU1ZscHVaVWx0WVhFM2VrNHpkVnd2ZHowOUluMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIn0=",
+      "contentJSON" : "{\"schemaVersion\":1,\"deviceName\":\"Pixel 9 Pro\",\"slug\":\"eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiaW5pdGlhdG9yQWRkcmVzcyI6IjB4MTllN2UzNzZlN2MyMTNiN2U3ZTdlNDZjYzcwYTVkZDA4NmRhZmYyYSIsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIiwic2NoZW1hVmVyc2lvbiI6MSwic2lnbmF0dXJlIjoiK1hmYzlQMW1HOU5hMVwvYnRTSFVZWlVvTzk2WHczRGJQOWhrWGlGWDN1UWNOTlwvV01KOFwvMm9wQ05uU1ljcERHUEFKc244Q0hodENraDBnMWMzM2s0dmh3PSIsImV4cGlyZXNBdCI6MTc1MDAwMDEyMCwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09In0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\"}",
       "contentType" : "convos.org/pairing_join_request:1.0",
       "typeId" : "pairing_join_request",
       "versionMajor" : 1,
@@ -29,8 +29,8 @@
     },
     "pairing_message_error" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJwYXlsb2FkIjoiUGFpcmluZyBmYWlsZWQiLCJ0eXBlIjoiZXJyb3IifQ==",
-      "contentJSON" : "{\"payload\":\"Pairing failed\",\"type\":\"error\"}",
+      "contentBase64" : "eyJ0eXBlIjoiZXJyb3IiLCJwYXlsb2FkIjoiUGFpcmluZyBmYWlsZWQifQ==",
+      "contentJSON" : "{\"type\":\"error\",\"payload\":\"Pairing failed\"}",
       "contentType" : "convos.org/pairing_message:1.0",
       "typeId" : "pairing_message",
       "versionMajor" : 1,
@@ -241,7 +241,7 @@
     "signatureRecoveryByte" : 28,
     "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
     "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
-    "slug" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIiwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJpc3N1ZWRBdCI6MTc1MDAwMDAwMH0",
+    "slug" : "eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiaW5pdGlhdG9yQWRkcmVzcyI6IjB4MTllN2UzNzZlN2MyMTNiN2U3ZTdlNDZjYzcwYTVkZDA4NmRhZmYyYSIsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIiwic2NoZW1hVmVyc2lvbiI6MSwic2lnbmF0dXJlIjoiK1hmYzlQMW1HOU5hMVwvYnRTSFVZWlVvTzk2WHczRGJQOWhrWGlGWDN1UWNOTlwvV01KOFwvMm9wQ05uU1ljcERHUEFKc244Q0hodENraDBnMWMzM2s0dmh3PSIsImV4cGlyZXNBdCI6MTc1MDAwMDEyMCwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09In0",
     "verifyAtUnixSeconds" : 1750000001
   },
   "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -11,8 +11,8 @@
     },
     "identity_share" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaW5pdGlhdG9yRGV2aWNlTmFtZSI6IkNhbWVyb24ncyBpUGhvbmUiLCJpc3N1ZWRBdCI6MTc1MDAwMDEwMCwicHJpdmF0ZUtleURhdGEiOiJJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJPSIsInNjaGVtYVZlcnNpb24iOjEsImRpc3BsYXlOYW1lIjoiQ2FtZXJvbiIsImluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0=",
-      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"issuedAt\":1750000100,\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"schemaVersion\":1,\"displayName\":\"Cameron\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\"}",
+      "contentBase64" : "eyJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsImlzc3VlZEF0IjoxNzUwMDAwMTAwLCJwcml2YXRlS2V5RGF0YSI6IklpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUk9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaW5ib3hJZCI6IjNmOWExYzBlNWI3ZDI4NDZhMWYzMGM5ZTRkOGI2NzUyZTBhNGM5MTM3ZmI1NjI4ZDBlM2E3YzE0YjlkNWY2ODIiLCJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiZGlzcGxheU5hbWUiOiJDYW1lcm9uIn0=",
+      "contentJSON" : "{\"initiatorDeviceName\":\"Cameron's iPhone\",\"issuedAt\":1750000100,\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"schemaVersion\":1,\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"displayName\":\"Cameron\"}",
       "contentType" : "convos.org/identity_share:1.0",
       "typeId" : "identity_share",
       "versionMajor" : 1,
@@ -20,8 +20,8 @@
     },
     "pairing_join_request" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJkZXZpY2VOYW1lIjoiUGl4ZWwgOSBQcm8iLCJzbHVnIjoiZXlKcGMzTjFaV1JCZENJNk1UYzFNREF3TURBd01Dd2lhVzVwZEdsaGRHOXlRV1JrY21WemN5STZJakI0TVRsbE4yVXpOelpsTjJNeU1UTmlOMlUzWlRkbE5EWmpZemN3WVRWa1pEQTRObVJoWm1ZeVlTSXNJbWx1YVhScFlYUnZja2x1WW05NFNXUWlPaUl6WmpsaE1XTXdaVFZpTjJReU9EUTJZVEZtTXpCak9XVTBaRGhpTmpjMU1tVXdZVFJqT1RFek4yWmlOVFl5T0dRd1pUTmhOMk14TkdJNVpEVm1Oamd5SWl3aWMyTm9aVzFoVm1WeWMybHZiaUk2TVN3aWMybG5ibUYwZFhKbElqb2lLMWhtWXpsUU1XMUhPVTVoTVZ3dlluUlRTRlZaV2xWdlR6azJXSGN6UkdKUU9XaHJXR2xHV0ROMVVXTk9UbHd2VjAxS09Gd3ZNbTl3UTA1dVUxbGpjRVJIVUVGS2MyNDRRMGhvZEVOcmFEQm5NV016TTJzMGRtaDNQU0lzSW1WNGNHbHlaWE5CZENJNk1UYzFNREF3TURFeU1Dd2libTl1WTJVaU9pSkJRa1ZwVFRCU1ZscHVaVWx0WVhFM2VrNHpkVnd2ZHowOUluMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIn0=",
-      "contentJSON" : "{\"schemaVersion\":1,\"deviceName\":\"Pixel 9 Pro\",\"slug\":\"eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiaW5pdGlhdG9yQWRkcmVzcyI6IjB4MTllN2UzNzZlN2MyMTNiN2U3ZTdlNDZjYzcwYTVkZDA4NmRhZmYyYSIsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIiwic2NoZW1hVmVyc2lvbiI6MSwic2lnbmF0dXJlIjoiK1hmYzlQMW1HOU5hMVwvYnRTSFVZWlVvTzk2WHczRGJQOWhrWGlGWDN1UWNOTlwvV01KOFwvMm9wQ05uU1ljcERHUEFKc244Q0hodENraDBnMWMzM2s0dmh3PSIsImV4cGlyZXNBdCI6MTc1MDAwMDEyMCwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09In0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\"}",
+      "contentBase64" : "eyJqb2luZXJJbmJveElkIjoiOGMyZDQwYjZlMWY5N2EzNWMwZDgyYjRlNmYxOWE3ZDM1YzBlMjhiNGY2YTE5ZDczYzU4ZTAyYjRmNmExOWQ3MyIsInNjaGVtYVZlcnNpb24iOjEsImRldmljZU5hbWUiOiJQaXhlbCA5IFBybyIsInNsdWciOiJleUp6WTJobGJXRldaWEp6YVc5dUlqb3hMQ0p6YVdkdVlYUjFjbVVpT2lJcldHWmpPVkF4YlVjNVRtRXhYQzlpZEZOSVZWbGFWVzlQT1RaWWR6TkVZbEE1YUd0WWFVWllNM1ZSWTA1T1hDOVhUVW80WEM4eWIzQkRUbTVUV1dOd1JFZFFRVXB6YmpoRFNHaDBRMnRvTUdjeFl6TXphelIyYUhjOUlpd2libTl1WTJVaU9pSkJRa1ZwVFRCU1ZscHVaVWx0WVhFM2VrNHpkVnd2ZHowOUlpd2lhVzVwZEdsaGRHOXlTVzVpYjNoSlpDSTZJak5tT1dFeFl6QmxOV0kzWkRJNE5EWmhNV1l6TUdNNVpUUmtPR0kyTnpVeVpUQmhOR001TVRNM1ptSTFOakk0WkRCbE0yRTNZekUwWWpsa05XWTJPRElpTENKcGJtbDBhV0YwYjNKQlpHUnlaWE56SWpvaU1IZ3hPV1UzWlRNM05tVTNZekl4TTJJM1pUZGxOMlUwTm1Oak56QmhOV1JrTURnMlpHRm1aakpoSWl3aWFYTnpkV1ZrUVhRaU9qRTNOVEF3TURBd01EQXNJbVY0Y0dseVpYTkJkQ0k2TVRjMU1EQXdNREV5TUgwIn0=",
+      "contentJSON" : "{\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"schemaVersion\":1,\"deviceName\":\"Pixel 9 Pro\",\"slug\":\"eyJzY2hlbWFWZXJzaW9uIjoxLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09IiwiaW5pdGlhdG9ySW5ib3hJZCI6IjNmOWExYzBlNWI3ZDI4NDZhMWYzMGM5ZTRkOGI2NzUyZTBhNGM5MTM3ZmI1NjI4ZDBlM2E3YzE0YjlkNWY2ODIiLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIiwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImV4cGlyZXNBdCI6MTc1MDAwMDEyMH0\"}",
       "contentType" : "convos.org/pairing_join_request:1.0",
       "typeId" : "pairing_join_request",
       "versionMajor" : 1,
@@ -29,8 +29,8 @@
     },
     "pairing_message_error" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJ0eXBlIjoiZXJyb3IiLCJwYXlsb2FkIjoiUGFpcmluZyBmYWlsZWQifQ==",
-      "contentJSON" : "{\"type\":\"error\",\"payload\":\"Pairing failed\"}",
+      "contentBase64" : "eyJwYXlsb2FkIjoiUGFpcmluZyBmYWlsZWQiLCJ0eXBlIjoiZXJyb3IifQ==",
+      "contentJSON" : "{\"payload\":\"Pairing failed\",\"type\":\"error\"}",
       "contentType" : "convos.org/pairing_message:1.0",
       "typeId" : "pairing_message",
       "versionMajor" : 1,
@@ -38,8 +38,8 @@
     },
     "pairing_message_pin" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJ0eXBlIjoicGluIiwicGF5bG9hZCI6IjEyMzQ1NiJ9",
-      "contentJSON" : "{\"type\":\"pin\",\"payload\":\"123456\"}",
+      "contentBase64" : "eyJwYXlsb2FkIjoiMTIzNDU2IiwidHlwZSI6InBpbiJ9",
+      "contentJSON" : "{\"payload\":\"123456\",\"type\":\"pin\"}",
       "contentType" : "convos.org/pairing_message:1.0",
       "typeId" : "pairing_message",
       "versionMajor" : 1,
@@ -47,8 +47,8 @@
     },
     "pairing_message_pin_echo" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJ0eXBlIjoicGluX2VjaG8iLCJwYXlsb2FkIjoiMTIzNDU2In0=",
-      "contentJSON" : "{\"type\":\"pin_echo\",\"payload\":\"123456\"}",
+      "contentBase64" : "eyJwYXlsb2FkIjoiMTIzNDU2IiwidHlwZSI6InBpbl9lY2hvIn0=",
+      "contentJSON" : "{\"payload\":\"123456\",\"type\":\"pin_echo\"}",
       "contentType" : "convos.org/pairing_message:1.0",
       "typeId" : "pairing_message",
       "versionMajor" : 1,
@@ -241,7 +241,7 @@
     "signatureRecoveryByte" : 28,
     "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
     "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
-    "slug" : "eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiaW5pdGlhdG9yQWRkcmVzcyI6IjB4MTllN2UzNzZlN2MyMTNiN2U3ZTdlNDZjYzcwYTVkZDA4NmRhZmYyYSIsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIiwic2NoZW1hVmVyc2lvbiI6MSwic2lnbmF0dXJlIjoiK1hmYzlQMW1HOU5hMVwvYnRTSFVZWlVvTzk2WHczRGJQOWhrWGlGWDN1UWNOTlwvV01KOFwvMm9wQ05uU1ljcERHUEFKc244Q0hodENraDBnMWMzM2s0dmh3PSIsImV4cGlyZXNBdCI6MTc1MDAwMDEyMCwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09In0",
+    "slug" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09IiwiaW5pdGlhdG9ySW5ib3hJZCI6IjNmOWExYzBlNWI3ZDI4NDZhMWYzMGM5ZTRkOGI2NzUyZTBhNGM5MTM3ZmI1NjI4ZDBlM2E3YzE0YjlkNWY2ODIiLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIiwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImV4cGlyZXNBdCI6MTc1MDAwMDEyMH0",
     "verifyAtUnixSeconds" : 1750000001
   },
   "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",


### PR DESCRIPTION
The 2026-07-20 product revision reduced participation to three levels and removed listen-only explicitly. It shipped anyway — `selectableCases` filtered it out of the menu while both enums and the proto still carried it.

Hidden is not harmless. The control plane maps `listen` to `speak` because no runtime listen behaviour exists, so an agent set to "stay on, stay quiet" would have spoken more than one on mention-only. And with mention-only named "Listen mode", the two read as the same level.

Proto field 3 is `reserved` rather than deleted, so a client built against the version that offered it can never have that number come to mean something else; an unknown mode already decodes to nil and falls back to the default.

Also restores the "Listen mode" title and caption on mention-only. dev had renamed it, and resolving the #1287 rebase conflict in favour of the branch took that back without anyone deciding to — this supersedes #1296, which did only that part.

Pairs with the convos-assistants side.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788714269&installation_model_id=20076&pr_number=1297&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1297&signature=e20419c790de6f7fac90b3f2dd95d126c498cc9b274a66a713511e52ae19939e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `listenOnly` participation mode from proto, model, and composer UI
> - Removes `PARTICIPATION_MODE_LISTEN_ONLY` from the proto enum and reserves value 3; existing proto messages decoding value 3 will now yield an `UNRECOGNIZED` state.
> - Removes the `listenOnly` case from `ConversationParticipationMode` and `AgentParticipationLevel`; `.mentionsOnly` is relabeled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e04eeb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->