### PR TITLE
perf: batch the agent-DM fold into one query per read

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -247,9 +247,9 @@ extension Database {
 
     /// Fold each group's separate agent DM into its row so the list can
     /// render a combined preview and a DM-aware unread indicator. Only
-    /// groups with a verified-agent member resolve a DM; the extra
-    /// `composeOneToOne` read runs inside this same `db` transaction so
-    /// GRDB's ValueObservation tracks the DM and keeps the list reactive.
+    /// groups with a verified-agent member resolve a DM; the DM read runs
+    /// inside this same `db` transaction so GRDB's ValueObservation tracks
+    /// the DM and keeps the list reactive.
     ///
     /// `resortByActivity`: the SQL order only knows each group's own
     /// messages; a reply in the folded DM lane must float the origin
@@ -262,16 +262,19 @@ extension Database {
         consent: [Consent],
         resortByActivity: Bool
     ) throws -> [Conversation] {
-        let folded = try conversations.map { (conversation: Conversation) -> Conversation in
-            guard let agentMember = conversation.members.first(where: { $0.isVerifiedAgent }) else {
-                return conversation
-            }
-            guard let dm = try composeOneToOne(
-                with: agentMember.profile.inboxId,
-                excluding: nil,
-                consent: consent,
-                onlyAgentDms: true
-            ) else {
+        // Every agent inbox this page mentions, resolved in a single read
+        // below. A page with no agent members needs no DM query at all.
+        var agentInboxIds: Set<String> = []
+        for conversation in conversations {
+            guard let agentMember = conversation.members.first(where: { $0.isVerifiedAgent }) else { continue }
+            agentInboxIds.insert(agentMember.profile.inboxId)
+        }
+        guard !agentInboxIds.isEmpty else { return conversations }
+        let dmsByAgentInboxId = try composeAgentDms(forAgentInboxIds: agentInboxIds, consent: consent)
+
+        let folded = conversations.map { (conversation: Conversation) -> Conversation in
+            guard let agentMember = conversation.members.first(where: { $0.isVerifiedAgent }),
+                  let dm = dmsByAgentInboxId[agentMember.profile.inboxId] else {
                 return conversation
             }
             var row = conversation
@@ -293,6 +296,71 @@ extension Database {
                 return lhs.offset < rhs.offset
             }
             .map(\.element)
+    }
+
+    /// Every agent DM belonging to `agentInboxIds`, keyed by the agent's
+    /// inbox id and keeping the most recently active DM per agent. One read
+    /// covers the whole page: the fold used to call `composeOneToOne` per
+    /// row, and each of those calls ran its own detailed query plus a full
+    /// contact-table scan, so a window of N agent rows cost N of each.
+    ///
+    /// No row limit here the way the 1:1 lookup has one - the predicate is
+    /// already narrow (agent DMs, exactly two members, one of them an agent
+    /// on this page), so the result set is the user's agent DMs and nothing
+    /// else. Capping globally could starve one agent's only DM behind
+    /// another agent's busier lane.
+    private func composeAgentDms(
+        forAgentInboxIds agentInboxIds: Set<String>,
+        consent: [Consent]
+    ) throws -> [String: Conversation] {
+        // Same membership shape the 1:1 lookup asserts: the agent is a
+        // member, the current user is a member, and that pair is the entire
+        // membership. Sorted so repeated pages generate identical SQL.
+        let sortedAgentInboxIds: [String] = agentInboxIds.sorted()
+        let agentDmPredicate: SQL = """
+            EXISTS (
+                SELECT 1 FROM conversation_members AS cm_agent
+                WHERE cm_agent.conversationId = conversation.id
+                AND cm_agent.inboxId IN \(sortedAgentInboxIds)
+            )
+            AND EXISTS (
+                SELECT 1 FROM conversation_members AS cm_self
+                WHERE cm_self.conversationId = conversation.id
+                AND cm_self.inboxId IN (SELECT inboxId FROM inbox)
+            )
+            AND (
+                SELECT COUNT(*) FROM conversation_members AS cm_count
+                WHERE cm_count.conversationId = conversation.id
+            ) = 2
+            """
+        let dbConversationDetailsList = try DBConversation
+            .filter(
+                !DBConversation.Columns.id.like("draft-%")
+                || (DBConversation.Columns.inviteTag != nil
+                    && length(DBConversation.Columns.inviteTag) > 0)
+            )
+            .filter(consent.contains(DBConversation.Columns.consent))
+            .filter(DBConversation.Columns.expiresAt == nil || DBConversation.Columns.expiresAt > Date())
+            .filter(DBConversation.Columns.isUnused == false)
+            .filter(DBConversation.Columns.isAgentDm == true)
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
+            .filter(literal: agentDmPredicate)
+            .detailedConversationQuery()
+            .fetchAll(self)
+        guard !dbConversationDetailsList.isEmpty else { return [:] }
+        let conversations = try dbConversationDetailsList.composeConversations(from: self)
+        // `detailedConversationQuery` orders by recency, so the first DM seen
+        // for an agent is that agent's most recently active one - the same row
+        // the per-row lookup used to return.
+        var dmsByAgentInboxId: [String: Conversation] = [:]
+        for dm in conversations {
+            guard let agentInboxId = dm.members
+                .first(where: { agentInboxIds.contains($0.profile.inboxId) })?
+                .profile.inboxId else { continue }
+            guard dmsByAgentInboxId[agentInboxId] == nil else { continue }
+            dmsByAgentInboxId[agentInboxId] = dm
+        }
+        return dmsByAgentInboxId
     }
 
     /// A single conversation by id under the same eligibility filters as

--- a/ConvosCore/Tests/ConvosCoreTests/AgentDmFoldTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AgentDmFoldTests.swift
@@ -1,0 +1,433 @@
+import Foundation
+import GRDB
+import Testing
+@testable import ConvosCore
+
+/// Covers the agent-DM fold that gives each list row its DM lane: which DM a
+/// row resolves to, how the fold re-sorts by the newer of the two lanes, and
+/// that the lookup costs one query per read rather than one per row.
+@Suite("Agent DM Fold Tests", .serialized)
+struct AgentDmFoldTests {
+    private static let currentInboxId: String = "inbox-current"
+
+    /// Counts the DM lookups a read performs. Every such lookup asserts its
+    /// membership shape through `conversation_members AS cm_...` subqueries,
+    /// so counting statements that mention one distinguishes "one query for
+    /// the page" from "one query per row" regardless of the aliases used.
+    private final class QueryCounter: @unchecked Sendable {
+        private let lock: NSLock = .init()
+        private var value: Int = 0
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+
+        func increment() {
+            lock.lock()
+            value += 1
+            lock.unlock()
+        }
+    }
+
+    private static func tracedQueue(_ counter: QueryCounter) throws -> DatabaseQueue {
+        var configuration = Configuration()
+        configuration.prepareDatabase { db in
+            db.trace { event in
+                guard "\(event)".contains("conversation_members AS cm_") else { return }
+                counter.increment()
+            }
+        }
+        let queue = try DatabaseQueue(configuration: configuration)
+        try SharedDatabaseMigrator.shared.migrate(database: queue)
+        return queue
+    }
+
+    private static func seedBase(_ db: Database) throws {
+        try DBMember(inboxId: currentInboxId).save(db, onConflict: .ignore)
+        try DBInbox(inboxId: currentInboxId, clientId: "client-current").save(db, onConflict: .ignore)
+    }
+
+    private static func seedAgent(_ db: Database, inboxId: String, name: String) throws {
+        try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        try DBProfile(
+            inboxId: inboxId,
+            name: name,
+            memberKind: .verifiedConvos,
+            profileSource: .profileUpdate,
+            updatedAt: Date()
+        ).save(db)
+    }
+
+    /// A conversation plus the local state every list read joins on. `memberInboxIds`
+    /// excludes the current user, who is always a member.
+    private static func seedConversation(
+        _ db: Database,
+        id: String,
+        createdAt: Date,
+        isAgentDm: Bool = false,
+        isUnread: Bool = false,
+        memberInboxIds: [String] = []
+    ) throws {
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: currentInboxId,
+            kind: .group,
+            consent: .allowed,
+            createdAt: createdAt,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+            isAgentDm: isAgentDm
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: false,
+            isUnread: isUnread,
+            isUnreadUpdatedAt: Date(),
+            isMuted: false,
+            pinnedOrder: nil,
+            hidesInviteCard: false,
+            leftHostedInviteSession: false,
+            wasRemoved: false,
+            hasHadOtherMembers: false,
+            hasSharedInvite: false
+        ).insert(db)
+
+        try DBConversationMember(
+            conversationId: id,
+            inboxId: currentInboxId,
+            role: .superAdmin,
+            consent: .allowed,
+            createdAt: createdAt,
+            invitedByInboxId: nil
+        ).insert(db)
+        for memberInboxId in memberInboxIds {
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: memberInboxId,
+                role: .member,
+                consent: .allowed,
+                createdAt: createdAt,
+                invitedByInboxId: nil
+            ).insert(db)
+        }
+    }
+
+    @discardableResult
+    private static func seedMessage(
+        _ db: Database,
+        conversationId: String,
+        id: String,
+        senderId: String,
+        date: Date,
+        text: String
+    ) throws -> String {
+        let dateNs = Int64(date.timeIntervalSince1970 * 1_000_000_000)
+        try DBMessage(
+            id: id,
+            clientMessageId: id,
+            conversationId: conversationId,
+            senderId: senderId,
+            dateNs: dateNs,
+            date: date,
+            sortId: dateNs,
+            status: .published,
+            messageType: .original,
+            contentType: .text,
+            text: text,
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: nil,
+            attachmentUrls: [],
+            update: nil
+        ).insert(db)
+        return id
+    }
+
+    private func repo(_ queue: DatabaseQueue) -> ConversationsRepository {
+        ConversationsRepository(dbReader: queue, consent: [.allowed, .unknown])
+    }
+
+    @Test("A group with a verified agent folds in that agent's DM")
+    func foldsAgentDmIntoGroup() throws {
+        let counter = QueryCounter()
+        let queue = try Self.tracedQueue(counter)
+        try queue.write { db in
+            try Self.seedBase(db)
+            try Self.seedAgent(db, inboxId: "agent-1", name: "Ada")
+            try Self.seedConversation(
+                db,
+                id: "group-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedConversation(
+                db,
+                id: "dm-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                isAgentDm: true,
+                isUnread: true,
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "dm-1",
+                id: "dm-msg-1",
+                senderId: "agent-1",
+                date: Date(timeIntervalSince1970: 2_000),
+                text: "from the agent"
+            )
+        }
+
+        let conversations = try repo(queue).fetchAll()
+
+        #expect(conversations.count == 1)
+        let agentDm = try #require(conversations.first?.agentDm)
+        #expect(agentDm.inboxId == "agent-1")
+        #expect(agentDm.displayName == "Ada")
+        #expect(agentDm.isUnread)
+        #expect(agentDm.lastMessage?.text == "from the agent")
+    }
+
+    @Test("A group with no verified agent folds nothing and runs no DM query")
+    func skipsGroupsWithoutAgents() throws {
+        let counter = QueryCounter()
+        let queue = try Self.tracedQueue(counter)
+        try queue.write { db in
+            try Self.seedBase(db)
+            try Self.seedConversation(
+                db,
+                id: "group-1",
+                createdAt: Date(timeIntervalSince1970: 1_000)
+            )
+        }
+
+        let conversations = try repo(queue).fetchAll()
+
+        #expect(conversations.count == 1)
+        #expect(conversations.first?.agentDm == nil)
+        // The fast path matters: a list of agent-free rows should not pay for
+        // the lookup at all.
+        #expect(counter.count == 0)
+    }
+
+    @Test("Many rows sharing one agent all fold from a single DM query")
+    func foldsManyRowsInOneQuery() throws {
+        let counter = QueryCounter()
+        let queue = try Self.tracedQueue(counter)
+        let groupCount = 25
+        try queue.write { db in
+            try Self.seedBase(db)
+            try Self.seedAgent(db, inboxId: "agent-1", name: "Ada")
+            for i in 0..<groupCount {
+                try Self.seedConversation(
+                    db,
+                    id: "group-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 1_000 + Double(i)),
+                    memberInboxIds: ["agent-1"]
+                )
+            }
+            try Self.seedConversation(
+                db,
+                id: "dm-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                isAgentDm: true,
+                memberInboxIds: ["agent-1"]
+            )
+        }
+
+        let conversations = try repo(queue).fetchAll()
+
+        #expect(conversations.count == groupCount)
+        #expect(conversations.allSatisfy { $0.agentDm?.inboxId == "agent-1" })
+        // The regression this guards: the fold used to issue one DM lookup per
+        // row, so this count tracked `groupCount` instead of staying flat.
+        #expect(counter.count == 1)
+    }
+
+    @Test("Each row resolves its own agent when several agents are on the page")
+    func foldsPerAgent() throws {
+        let counter = QueryCounter()
+        let queue = try Self.tracedQueue(counter)
+        try queue.write { db in
+            try Self.seedBase(db)
+            try Self.seedAgent(db, inboxId: "agent-1", name: "Ada")
+            try Self.seedAgent(db, inboxId: "agent-2", name: "Grace")
+            try Self.seedConversation(
+                db,
+                id: "group-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedConversation(
+                db,
+                id: "group-2",
+                createdAt: Date(timeIntervalSince1970: 1_100),
+                memberInboxIds: ["agent-2"]
+            )
+            try Self.seedConversation(
+                db,
+                id: "dm-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                isAgentDm: true,
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "dm-1",
+                id: "dm-msg-1",
+                senderId: "agent-1",
+                date: Date(timeIntervalSince1970: 2_000),
+                text: "from Ada"
+            )
+            try Self.seedConversation(
+                db,
+                id: "dm-2",
+                createdAt: Date(timeIntervalSince1970: 1_100),
+                isAgentDm: true,
+                memberInboxIds: ["agent-2"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "dm-2",
+                id: "dm-msg-2",
+                senderId: "agent-2",
+                date: Date(timeIntervalSince1970: 2_100),
+                text: "from Grace"
+            )
+        }
+
+        let conversations = try repo(queue).fetchAll()
+        let byId = Dictionary(uniqueKeysWithValues: conversations.map { ($0.id, $0) })
+
+        #expect(byId["group-1"]?.agentDm?.lastMessage?.text == "from Ada")
+        #expect(byId["group-2"]?.agentDm?.lastMessage?.text == "from Grace")
+        #expect(counter.count == 1)
+    }
+
+    @Test("An agent with several DMs folds in its most recently active one")
+    func foldsMostRecentDmPerAgent() throws {
+        let counter = QueryCounter()
+        let queue = try Self.tracedQueue(counter)
+        try queue.write { db in
+            try Self.seedBase(db)
+            try Self.seedAgent(db, inboxId: "agent-1", name: "Ada")
+            try Self.seedConversation(
+                db,
+                id: "group-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedConversation(
+                db,
+                id: "dm-old",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                isAgentDm: true,
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "dm-old",
+                id: "dm-msg-old",
+                senderId: "agent-1",
+                date: Date(timeIntervalSince1970: 2_000),
+                text: "older lane"
+            )
+            try Self.seedConversation(
+                db,
+                id: "dm-new",
+                createdAt: Date(timeIntervalSince1970: 1_100),
+                isAgentDm: true,
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "dm-new",
+                id: "dm-msg-new",
+                senderId: "agent-1",
+                date: Date(timeIntervalSince1970: 3_000),
+                text: "newer lane"
+            )
+        }
+
+        let conversations = try repo(queue).fetchAll()
+
+        #expect(conversations.first?.agentDm?.lastMessage?.text == "newer lane")
+    }
+
+    @Test("A DM reply floats its origin row above a more recently messaged group")
+    func resortsByNewerLane() throws {
+        let counter = QueryCounter()
+        let queue = try Self.tracedQueue(counter)
+        try queue.write { db in
+            try Self.seedBase(db)
+            try Self.seedAgent(db, inboxId: "agent-1", name: "Ada")
+            // Quiet on its own lane, but its DM just replied.
+            try Self.seedConversation(
+                db,
+                id: "group-quiet",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "group-quiet",
+                id: "quiet-msg",
+                senderId: Self.currentInboxId,
+                date: Date(timeIntervalSince1970: 2_000),
+                text: "old group message"
+            )
+            // Newer on its own lane, so it wins the SQL ordering.
+            try Self.seedConversation(
+                db,
+                id: "group-busy",
+                createdAt: Date(timeIntervalSince1970: 1_100)
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "group-busy",
+                id: "busy-msg",
+                senderId: Self.currentInboxId,
+                date: Date(timeIntervalSince1970: 3_000),
+                text: "newer group message"
+            )
+            try Self.seedConversation(
+                db,
+                id: "dm-1",
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                isAgentDm: true,
+                memberInboxIds: ["agent-1"]
+            )
+            try Self.seedMessage(
+                db,
+                conversationId: "dm-1",
+                id: "dm-msg-1",
+                senderId: "agent-1",
+                date: Date(timeIntervalSince1970: 4_000),
+                text: "freshest of all"
+            )
+        }
+
+        let conversations = try repo(queue).fetchAll()
+
+        #expect(conversations.map(\.id) == ["group-quiet", "group-busy"])
+    }
+}


### PR DESCRIPTION
Stacked on #1300.

## Summary

#1300 landed R2 (debounce/dedupe the list observation) and R3 (paginate the list) from `docs/investigations/2026-08-04-startup-performance.md`. That doc names **R2/R3/R5** as the sequence to land before re-measuring. This is R5.

The conversations list folds each group's separate agent DM into its row so it can show a combined preview and a DM-aware unread dot. `foldAgentDms` did that with a `composeOneToOne` call **per row**, and each of those calls ran its own `detailedConversationQuery` plus a full `DBContact.fetchAll` scan. A window of N agent-bearing rows cost N of each.

Pagination made this hotter rather than cooler. The fold now runs on every page fetch and on every throttled re-emission, across both the pinned and unpinned lanes.

This collects the agent inboxes a page mentions and resolves them in **one** read keyed by agent inbox id. A page with no agent members skips the lookup entirely.

The same N+1 was independently flagged by the automated review on #1300 ("N+1 query risk ... For M conversations with N agent members, this is M×N queries").

## Behavior is unchanged

- **Which DM a row folds in.** `detailedConversationQuery` already orders by `COALESCE(lastMessage.date, createdAt) DESC`, so the first DM seen for an agent is the most recently active one — exactly the row `composeOneToOne(onlyAgentDms: true)` returned.
- **Eligibility.** The batched query asserts the same membership shape (agent is a member, current user is a member, that pair is the whole membership) and the same consent / expiry / unused / `wasRemoved` filters.
- **Reactivity.** The read still runs inside the caller's transaction, so the `ValueObservation` tracks the DM rows and DM activity keeps refreshing the list.
- **Re-sort.** The `resortByActivity` float-on-DM-reply behavior is untouched.

One deliberate difference: the batched query drops the `LIMIT 8` the single-inbox lookup carries. The predicate is already narrow enough that the result set is just the user's agent DMs, and a global cap could starve one agent's only DM behind another agent's busier lane.

## Test plan

New `AgentDmFoldTests` (6 tests) covers the fold's behavior and traces how many DM lookups a read actually performs:

- A group with a verified agent folds in that agent's DM (name, unread, last message)
- A group with no verified agent folds nothing **and runs no DM query at all**
- Many rows sharing one agent all fold **from a single DM query**
- Each row resolves its own agent when several agents are on the page
- An agent with several DMs folds in its most recently active one
- A DM reply floats its origin row above a more recently messaged group

The query-count assertions are real regression tests, not decoration. Reverting just the repository change and re-running gives:

```
Expectation failed: (counter.count → 25) == 1
Expectation failed: (counter.count → 2) == 1
```

25 rows sharing one agent issued 25 queries before this change and issue 1 after. The four behavioral tests pass against both implementations, which is what establishes that semantics are preserved.

Full suite: **1858 tests in 255 suites passed**. SwiftFormat and SwiftLint `--strict` clean.

## Still open from the perf doc

R4 (per-message `conversation.sync()` on the stream path), R8 (per-row profile observations), and the `ShareSuggestionDonator` throttle are untouched here and remain good candidates for the next PR in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789080186&installation_model_id=20076&pr_number=1302&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1302&signature=06381d55bd8bbac48a4fd8d16291b7b4a4ed69cd0dd8d1734538de232661e6a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch agent-DM fold into a single query per conversation page read
> - Replaces per-row `composeOneToOne` calls in `Database.foldAgentDms` with a single batched `composeAgentDms(forAgentInboxIds:consent:)` query that fetches all candidate DMs for the full page at once.
> - Early-returns without any DM query when no conversations on the page have verified agents.
> - Adds `AgentDmFoldTests` covering correctness (folded fields, per-agent mapping, most-recent-DM selection, resort-by-activity) and query-count assertions (counter == 1 for batched cases, counter == 0 for no-agent pages).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21ed0fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->