### PR TITLE
Add Propose PR from Space debug action

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -187,6 +187,22 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- gates the internal action that proposes a draft pull
+    /// request from a conversation's Space. Hard-locked off in production.
+    var isSpacePullRequestProposalEnabled: Bool {
+        get {
+            access(keyPath: \.isSpacePullRequestProposalEnabled)
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
+            return UserDefaults.standard.bool(forKey: Constant.spacePullRequestProposalEnabledKey)
+        }
+        set {
+            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
+            withMutation(keyPath: \.isSpacePullRequestProposalEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.spacePullRequestProposalEnabledKey)
+            }
+        }
+    }
+
     /// The read-site resolution for the new composer layout: desktop mode
     /// always uses the new composer, so either flag activates it. Reads two
     /// instrumented getters, so observation flows through without registrar
@@ -247,5 +263,6 @@ final class FeatureFlags {
         static let newComposerEnabledKey: String = "featureFlags.newComposerEnabled"
         static let desktopModeEnabledKey: String = "featureFlags.desktopModeEnabled"
         static let agentAutoJoinEnabledKey: String = "featureFlags.agentAutoJoinEnabled"
+        static let spacePullRequestProposalEnabledKey: String = "featureFlags.spacePullRequestProposalEnabled"
     }
 }

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -188,15 +188,14 @@ final class FeatureFlags {
     }
 
     /// Off by default -- gates the internal action that proposes a draft pull
-    /// request from a conversation's Space. Hard-locked off in production.
+    /// request from a conversation's Space. Deliberately reachable in every
+    /// environment; production users opt in from the curated prod debug menu.
     var isSpacePullRequestProposalEnabled: Bool {
         get {
             access(keyPath: \.isSpacePullRequestProposalEnabled)
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.spacePullRequestProposalEnabledKey)
         }
         set {
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
             withMutation(keyPath: \.isSpacePullRequestProposalEnabled) {
                 UserDefaults.standard.set(newValue, forKey: Constant.spacePullRequestProposalEnabledKey)
             }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -843,15 +843,14 @@ extension ConversationInfoView {
     }
 
     private var spacePullRequestProposalRow: some View {
-        let action = {
-            _ = Task {
+        Button {
+            Task {
                 await spacePullRequestCoordinator.propose(
                     conversationId: viewModel.conversation.id,
                     variantId: viewModel.conversation.agentVariant?.slug
                 )
             }
-        }
-        return Button(action: action) {
+        } label: {
             HStack {
                 Text("Propose PR from Space")
                     .foregroundStyle(.colorTextPrimary)
@@ -864,23 +863,31 @@ extension ConversationInfoView {
         .disabled(spacePullRequestCoordinator.isBusy)
         .accessibilityIdentifier("propose-space-pr-button")
         .accessibilityLabel("Propose pull request from Space")
-        .alert(item: $spacePullRequestCoordinator.alert) { payload in
+        .alert(
+            spacePullRequestCoordinator.alert?.title ?? "",
+            isPresented: spacePullRequestAlertIsPresented,
+            presenting: spacePullRequestCoordinator.alert
+        ) { payload in
             if let pullRequestURL = payload.pullRequestURL {
-                return Alert(
-                    title: Text(payload.title),
-                    message: Text(payload.message),
-                    primaryButton: .default(Text("Open PR")) {
-                        openURL(pullRequestURL)
-                    },
-                    secondaryButton: .cancel(Text("OK"))
-                )
+                Button("Open PR") {
+                    openURL(pullRequestURL)
+                }
             }
-            return Alert(
-                title: Text(payload.title),
-                message: Text(payload.message),
-                dismissButton: .default(Text("OK"))
-            )
+            Button("OK", role: .cancel) {}
+        } message: { payload in
+            Text(payload.message)
         }
+    }
+
+    private var spacePullRequestAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { spacePullRequestCoordinator.alert != nil },
+            set: { isPresented in
+                if !isPresented {
+                    spacePullRequestCoordinator.alert = nil
+                }
+            }
+        )
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -109,6 +109,7 @@ struct ConversationInfoView: View {
     @State private var showingRestoreInviteTagAlert: Bool = false
     @State private var restoreInviteTagText: String = ""
     @State private var showingLeaveConfirmation: Bool = false
+    @State private var spacePullRequestCoordinator: ConversationSpacePullRequestCoordinator = .init()
     /// "New Agent" builder, presented from here so it stacks on top of the
     /// Info sheet rather than racing the chat view's own builder sheet.
     @State private var presentingAgentBuilder: AgentBuilderViewModel?
@@ -781,6 +782,9 @@ extension ConversationInfoView {
 
     @ViewBuilder
     private var internalDebugRows: some View {
+        if FeatureFlags.shared.isSpacePullRequestProposalEnabled {
+            spacePullRequestProposalRow
+        }
         HStack {
             Text("Fork status")
             Spacer()
@@ -835,6 +839,47 @@ extension ConversationInfoView {
             showingRestoreInviteTagAlert = true
         } label: {
             Text("Restore invite tag")
+        }
+    }
+
+    private var spacePullRequestProposalRow: some View {
+        let action = {
+            _ = Task {
+                await spacePullRequestCoordinator.propose(
+                    conversationId: viewModel.conversation.id,
+                    variantId: viewModel.conversation.agentVariant?.slug
+                )
+            }
+        }
+        return Button(action: action) {
+            HStack {
+                Text("Propose PR from Space")
+                    .foregroundStyle(.colorTextPrimary)
+                Spacer()
+                if spacePullRequestCoordinator.isBusy {
+                    ProgressView()
+                }
+            }
+        }
+        .disabled(spacePullRequestCoordinator.isBusy)
+        .accessibilityIdentifier("propose-space-pr-button")
+        .accessibilityLabel("Propose pull request from Space")
+        .alert(item: $spacePullRequestCoordinator.alert) { payload in
+            if let pullRequestURL = payload.pullRequestURL {
+                return Alert(
+                    title: Text(payload.title),
+                    message: Text(payload.message),
+                    primaryButton: .default(Text("Open PR")) {
+                        openURL(pullRequestURL)
+                    },
+                    secondaryButton: .cancel(Text("OK"))
+                )
+            }
+            return Alert(
+                title: Text(payload.title),
+                message: Text(payload.message),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -758,13 +758,16 @@ struct ConversationInfoView: View {
 // MARK: - Support and debug section
 
 extension ConversationInfoView {
-    // The support rows ship in every environment so production users can
-    // send on-device diagnostics to support; the remaining rows are internal
-    // debugging tools and stay out of production builds.
+    // The support rows ship in every environment so production users can send
+    // on-device diagnostics to support. The Space proposal row follows its
+    // explicit opt-in flag; the remaining debug rows stay out of production.
     @ViewBuilder
     private var debugInfoSection: some View {
         let isProduction = ConfigManager.shared.currentEnvironment.isProduction
         Section {
+            if FeatureFlags.shared.isSpacePullRequestProposalEnabled {
+                spacePullRequestProposalRow
+            }
             if !isProduction {
                 internalDebugRows
             }
@@ -782,9 +785,6 @@ extension ConversationInfoView {
 
     @ViewBuilder
     private var internalDebugRows: some View {
-        if FeatureFlags.shared.isSpacePullRequestProposalEnabled {
-            spacePullRequestProposalRow
-        }
         HStack {
             Text("Fork status")
             Spacer()

--- a/Convos/Conversation Detail/ConversationSpacePullRequestCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationSpacePullRequestCoordinator.swift
@@ -1,0 +1,134 @@
+import ConvosCore
+import Foundation
+import Observation
+
+struct ConversationSpacePullRequestAlertPayload: Equatable, Identifiable {
+    let title: String
+    let message: String
+    let pullRequestURL: URL?
+
+    var id: String {
+        "\(title)|\(message)|\(pullRequestURL?.absoluteString ?? "")"
+    }
+}
+
+@MainActor
+@Observable
+final class ConversationSpacePullRequestCoordinator {
+    typealias ProposalOperation = (String, String?) async throws -> ConvosAPI.SpacePullRequestProposalOutcome
+
+    private let proposalOperation: ProposalOperation
+
+    private(set) var isBusy: Bool = false
+    var alert: ConversationSpacePullRequestAlertPayload?
+
+    init(
+        apiClient: any ConvosAPIClientProtocol = ConvosAPIClientFactory.client(
+            environment: ConfigManager.shared.currentEnvironment
+        )
+    ) {
+        proposalOperation = { conversationId, variantId in
+            try await apiClient.proposePullRequestFromSpace(
+                conversationId: conversationId,
+                variantId: variantId
+            )
+        }
+    }
+
+    init(proposalOperation: @escaping ProposalOperation) {
+        self.proposalOperation = proposalOperation
+    }
+
+    func propose(conversationId: String, variantId: String?) async {
+        guard !isBusy else { return }
+        isBusy = true
+        defer { isBusy = false }
+
+        do {
+            let outcome = try await proposalOperation(conversationId, variantId)
+            alert = Self.alert(for: outcome)
+        } catch {
+            alert = Self.alert(for: error)
+        }
+    }
+
+    private static func alert(
+        for outcome: ConvosAPI.SpacePullRequestProposalOutcome
+    ) -> ConversationSpacePullRequestAlertPayload {
+        switch outcome {
+        case .pullRequest(let pullRequest):
+            return ConversationSpacePullRequestAlertPayload(
+                title: "Pull request proposed",
+                message: "A draft pull request is ready to review.",
+                pullRequestURL: pullRequest.prURL
+            )
+        case .unchanged:
+            return ConversationSpacePullRequestAlertPayload(
+                title: "Already matches the starter",
+                message: "This Space has no changes to propose.",
+                pullRequestURL: nil
+            )
+        }
+    }
+
+    private static func alert(for error: Error) -> ConversationSpacePullRequestAlertPayload {
+        if let proposalError = error as? ConvosAPI.SpacePullRequestProposalError {
+            return alert(for: proposalError)
+        }
+        if let urlError = error as? URLError, urlError.code == .timedOut {
+            return alert(for: .timeout)
+        }
+        return ConversationSpacePullRequestAlertPayload(
+            title: "Couldn't propose a pull request",
+            message: "Try again. If the problem continues, check the selected deployment.",
+            pullRequestURL: nil
+        )
+    }
+
+    private static func alert(
+        for error: ConvosAPI.SpacePullRequestProposalError
+    ) -> ConversationSpacePullRequestAlertPayload {
+        let title: String
+        let message: String
+        switch error {
+        case .invalidRequest:
+            title = "Invalid conversation"
+            message = "This conversation can't be used for a Space pull request proposal."
+        case .notArmed:
+            title = "Deployment not armed"
+            message = "The selected deployment is not configured to propose Space pull requests."
+        case .spaceNotFound:
+            title = "No Space found"
+            message = "The selected deployment has no Space for this conversation."
+        case .repositoryUnavailable:
+            title = "Repository unavailable"
+            message = "This Space is not connected to a repository."
+        case .refused:
+            title = "Proposal refused"
+            message = "The Space contains changes that can't be proposed safely."
+        case .variantUnavailable:
+            title = "Variant unavailable"
+            message = "This conversation's agent variant is no longer available."
+        case .timeout:
+            title = "Request timed out"
+            message = "The request timed out. The PR may still have been updated; it is safe to try again."
+        case .githubFailed:
+            title = "GitHub rejected the proposal"
+            message = "Check repository access and try again."
+        case .unavailable:
+            title = "Proposal unavailable"
+            message = "The selected deployment does not support this action yet."
+        case .failed:
+            title = "Couldn't propose a pull request"
+            message = "Try again. If the problem continues, check the selected deployment."
+        case .rateLimited:
+            title = "Too many proposals"
+            message = "Wait a moment, then try again."
+        }
+        return ConversationSpacePullRequestAlertPayload(
+            title: title,
+            message: message,
+            pullRequestURL: nil
+        )
+    }
+}

--- a/Convos/Conversation Detail/ConversationSpacePullRequestCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationSpacePullRequestCoordinator.swift
@@ -2,14 +2,10 @@ import ConvosCore
 import Foundation
 import Observation
 
-struct ConversationSpacePullRequestAlertPayload: Equatable, Identifiable {
+struct ConversationSpacePullRequestAlertPayload: Equatable {
     let title: String
     let message: String
     let pullRequestURL: URL?
-
-    var id: String {
-        "\(title)|\(message)|\(pullRequestURL?.absoluteString ?? "")"
-    }
 }
 
 @MainActor

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -84,6 +84,7 @@ struct DebugViewSection: View {
             Toggle("New composer (Group/Agent switcher)", isOn: Bindable(FeatureFlags.shared).isNewComposerEnabled)
             Toggle("Desktop mode (implies new composer)", isOn: Bindable(FeatureFlags.shared).isDesktopModeEnabled)
             Toggle("Agent auto-join (new conversations)", isOn: Bindable(FeatureFlags.shared).isAgentAutoJoinEnabled)
+            Toggle("Propose PR from Space", isOn: Bindable(FeatureFlags.shared).isSpacePullRequestProposalEnabled)
             abilitiesFeatureToggles
 
             let showInfoAction = { showingAgentsInfoSheet = true }

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -20,14 +20,17 @@ import UserNotifications
 //
 // Hard rules enforced here:
 // - No mutating controls (no "Request Now", no "Register Device Again", no
-//   purchase / change-plan CTAs, no mock-credit toggles). Two deliberate
-//   exceptions, both flipping only a local default so a tester can opt this
+//   purchase / change-plan CTAs, no mock-credit toggles). Three deliberate
+//   exceptions, all flipping only a local default so a tester can opt this
 //   install into a feature we are dogfooding in production:
 //   - the XMTP bidi streaming opt-in, which selects the stream transport at
 //     next launch -- nothing account- or network-mutating.
 //   - the Listen opt-in, which only decides whether the participation control
 //     is built. Turning it on mutates nothing by itself; the writes happen
 //     later, in the control, when a member actually picks a level.
+//   - the Space pull-request opt-in, which only decides whether the Conversation
+//     Info action row is built; the network write happens later, when a member
+//     actually taps the action.
 // - The live `BackendAuthProbe` (JWT minter) is never imported or instantiated
 //   here. The identity readout uses `DeviceIdentitySnapshot`, which is
 //   network-free and carries no JWT.
@@ -168,17 +171,18 @@ struct ProdDebugMenuView: View {
         }
     }
 
-    // MARK: - Feature flags (display only, except the bidi opt-in)
+    // MARK: - Feature flags (display only, except curated opt-ins)
 
     @ViewBuilder
     private var featureFlagsSection: some View {
         let injectorEnabled: Bool = FeatureFlags.shared.isDebugInjectorEnabled
         Section("Feature flags") {
             labeledRow("Debug injector", injectorEnabled ? "On" : "Off")
-            // The two interactive controls in this curated menu; see the
+            // The three interactive controls in this curated menu; see the
             // module overview for why they are allowed here.
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
+            Toggle("Propose PR from Space", isOn: Bindable(FeatureFlags.shared).isSpacePullRequestProposalEnabled)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Abilities.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Abilities.swift
@@ -85,46 +85,6 @@ extension ConvosAPIClient {
     }
 }
 
-// MARK: - URL construction (internal for tests)
-
-extension ConvosAPIClient {
-    /// Percent-encodes one path segment with the RFC 3986 unreserved set
-    /// only, so opaque ids containing `/`, `%`, `?`, or `#` stay a single
-    /// path component. `.urlPathAllowed` is not enough: it leaves `/`
-    /// intact, splitting the id into extra path segments.
-    static func strictPathComponentEncoded(_ raw: String) -> String {
-        raw.addingPercentEncoding(withAllowedCharacters: Constant.unreservedCharacters) ?? raw
-    }
-
-    /// Builds an abilities endpoint URL by setting the percent-encoded path
-    /// directly on URLComponents. `appendingPathComponent` cannot be used
-    /// with pre-encoded segments: it re-encodes `%` into `%25`, double
-    /// encoding the id.
-    static func abilitiesURL(baseURL: URL, pathSegments: [String], queryParameters: [String: String]?) throws -> URL {
-        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw APIError.invalidURL
-        }
-        let encodedSegments: [String] = pathSegments.map { strictPathComponentEncoded($0) }
-        let basePath = components.percentEncodedPath.hasSuffix("/")
-            ? String(components.percentEncodedPath.dropLast())
-            : components.percentEncodedPath
-        components.percentEncodedPath = "\(basePath)/\(encodedSegments.joined(separator: "/"))"
-        if let queryParameters {
-            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
-        }
-        guard let url = components.url else {
-            throw APIError.invalidURL
-        }
-        return url
-    }
-
-    private enum Constant {
-        static let unreservedCharacters: CharacterSet = CharacterSet(
-            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-        )
-    }
-}
-
 // MARK: - Shared plumbing
 
 private extension ConvosAPIClient {
@@ -133,10 +93,11 @@ private extension ConvosAPIClient {
         method: String,
         queryParameters: [String: String]? = nil
     ) throws -> URLRequest {
-        let url = try Self.abilitiesURL(baseURL: baseURL, pathSegments: pathSegments, queryParameters: queryParameters)
-        var request = URLRequest(url: url)
-        request.httpMethod = method
-        return attachingAuthHeader(to: request)
+        try endpointRequest(
+            pathSegments: pathSegments,
+            method: method,
+            queryParameters: queryParameters
+        )
     }
 
     func performAbilitiesRequest<T: Decodable>(_ request: URLRequest) async throws -> T {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+EndpointURL.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+EndpointURL.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+extension ConvosAPIClient {
+    /// Percent-encodes one path segment with the RFC 3986 unreserved set
+    /// only, so opaque identifiers stay within a single path component.
+    static func strictPathComponentEncoded(_ raw: String) -> String {
+        raw.addingPercentEncoding(withAllowedCharacters: Constant.unreservedCharacters) ?? raw
+    }
+
+    /// Builds an endpoint URL by setting the percent-encoded path directly.
+    /// Appending pre-encoded path components would encode `%` a second time.
+    static func endpointURL(
+        baseURL: URL,
+        pathSegments: [String],
+        queryParameters: [String: String]?
+    ) throws -> URL {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw APIError.invalidURL
+        }
+        let encodedSegments: [String] = pathSegments.map { strictPathComponentEncoded($0) }
+        let basePath = components.percentEncodedPath.hasSuffix("/")
+            ? String(components.percentEncodedPath.dropLast())
+            : components.percentEncodedPath
+        components.percentEncodedPath = "\(basePath)/\(encodedSegments.joined(separator: "/"))"
+        if let queryParameters {
+            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+        return url
+    }
+
+    func endpointRequest(
+        pathSegments: [String],
+        method: String,
+        queryParameters: [String: String]? = nil
+    ) throws -> URLRequest {
+        let url = try Self.endpointURL(
+            baseURL: baseURL,
+            pathSegments: pathSegments,
+            queryParameters: queryParameters
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        return attachingAuthHeader(to: request)
+    }
+
+    private enum Constant {
+        static let unreservedCharacters: CharacterSet = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -426,11 +426,11 @@ public enum ConvosAPI {
 extension ConvosAPI {
     // MARK: - v2/conversations/:conversationId/debug/space-upstream
 
-    public enum SpacePullRequestProposalOutcome: Codable, Equatable, Sendable {
+    public enum SpacePullRequestProposalOutcome: Decodable, Equatable, Sendable {
         case pullRequest(PullRequest)
         case unchanged(Unchanged)
 
-        public struct PullRequest: Codable, Equatable, Sendable {
+        public struct PullRequest: Decodable, Equatable, Sendable {
             public let conversationId: String
             public let prURL: URL
             public let prNumber: Int
@@ -483,19 +483,6 @@ extension ConvosAPI {
                 refusedCount = try container.decode(Int.self, forKey: .refusedCount)
             }
 
-            public func encode(to encoder: Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                try container.encode(conversationId, forKey: .conversationId)
-                try container.encode(prURL.absoluteString, forKey: .prURL)
-                try container.encode(prNumber, forKey: .prNumber)
-                try container.encode(branch, forKey: .branch)
-                try container.encode(commitSha, forKey: .commitSha)
-                try container.encode(forkCommitSha, forKey: .forkCommitSha)
-                try container.encode(wrote, forKey: .wrote)
-                try container.encode(deleted, forKey: .deleted)
-                try container.encode(refusedCount, forKey: .refusedCount)
-            }
-
             private static func isValidPullRequestURL(_ url: URL) -> Bool {
                 url.scheme?.lowercased() == "https" && url.host != nil
             }
@@ -513,7 +500,7 @@ extension ConvosAPI {
             }
         }
 
-        public struct Unchanged: Codable, Equatable, Sendable {
+        public struct Unchanged: Decodable, Equatable, Sendable {
             public let conversationId: String
             public let forkCommitSha: String
             public let wrote: Int
@@ -537,6 +524,13 @@ extension ConvosAPI {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
+            guard try container.decode(Bool.self, forKey: .success) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .success,
+                    in: container,
+                    debugDescription: "Space pull request success envelope must set success to true"
+                )
+            }
             switch try container.decode(Discriminator.self, forKey: .outcome) {
             case .pullRequest:
                 self = .pullRequest(try PullRequest(from: decoder))
@@ -545,24 +539,13 @@ extension ConvosAPI {
             }
         }
 
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: DiscriminatorCodingKeys.self)
-            switch self {
-            case .pullRequest(let pullRequest):
-                try container.encode(Discriminator.pullRequest, forKey: .outcome)
-                try pullRequest.encode(to: encoder)
-            case .unchanged(let unchanged):
-                try container.encode(Discriminator.unchanged, forKey: .outcome)
-                try unchanged.encode(to: encoder)
-            }
-        }
-
-        private enum Discriminator: String, Codable {
+        private enum Discriminator: String, Decodable {
             case pullRequest = "pull_request"
             case unchanged
         }
 
         private enum DiscriminatorCodingKeys: String, CodingKey {
+            case success
             case outcome
         }
     }
@@ -581,8 +564,14 @@ extension ConvosAPI {
         case rateLimited
 
         init?(body: Data) {
-            guard let response = try? JSONDecoder().decode(SpacePullRequestProposalErrorResponse.self, from: body) else { return nil }
-            switch response.code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+            struct ErrorBody: Decodable {
+                let success: Bool
+                let error: String
+                let message: String
+            }
+            guard let response = try? JSONDecoder().decode(ErrorBody.self, from: body),
+                  !response.success else { return nil }
+            switch response.error {
             case "INVALID_REQUEST":
                 self = .invalidRequest
             case "SPACE_UPSTREAM_NOT_ARMED":
@@ -609,11 +598,6 @@ extension ConvosAPI {
                 return nil
             }
         }
-    }
-
-    struct SpacePullRequestProposalErrorResponse: Codable, Equatable, Sendable {
-        let error: String
-        let code: String
     }
 
     enum SpacePullRequestProposalDecodingError: Error, Equatable {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -421,7 +421,207 @@ public enum ConvosAPI {
             }
         }
     }
+}
 
+extension ConvosAPI {
+    // MARK: - v2/conversations/:conversationId/debug/space-upstream
+
+    public enum SpacePullRequestProposalOutcome: Codable, Equatable, Sendable {
+        case pullRequest(PullRequest)
+        case unchanged(Unchanged)
+
+        public struct PullRequest: Codable, Equatable, Sendable {
+            public let conversationId: String
+            public let prURL: URL
+            public let prNumber: Int
+            public let branch: String
+            public let commitSha: String
+            public let forkCommitSha: String
+            public let wrote: Int
+            public let deleted: Int
+            public let refusedCount: Int
+
+            public init(
+                conversationId: String,
+                prURL: URL,
+                prNumber: Int,
+                branch: String,
+                commitSha: String,
+                forkCommitSha: String,
+                wrote: Int,
+                deleted: Int,
+                refusedCount: Int
+            ) throws {
+                guard Self.isValidPullRequestURL(prURL) else {
+                    throw SpacePullRequestProposalDecodingError.invalidPullRequestURL
+                }
+                self.conversationId = conversationId
+                self.prURL = prURL
+                self.prNumber = prNumber
+                self.branch = branch
+                self.commitSha = commitSha
+                self.forkCommitSha = forkCommitSha
+                self.wrote = wrote
+                self.deleted = deleted
+                self.refusedCount = refusedCount
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let prURLString = try container.decode(String.self, forKey: .prURL)
+                guard let prURL = URL(string: prURLString), Self.isValidPullRequestURL(prURL) else {
+                    throw SpacePullRequestProposalDecodingError.invalidPullRequestURL
+                }
+                conversationId = try container.decode(String.self, forKey: .conversationId)
+                self.prURL = prURL
+                prNumber = try container.decode(Int.self, forKey: .prNumber)
+                branch = try container.decode(String.self, forKey: .branch)
+                commitSha = try container.decode(String.self, forKey: .commitSha)
+                forkCommitSha = try container.decode(String.self, forKey: .forkCommitSha)
+                wrote = try container.decode(Int.self, forKey: .wrote)
+                deleted = try container.decode(Int.self, forKey: .deleted)
+                refusedCount = try container.decode(Int.self, forKey: .refusedCount)
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(conversationId, forKey: .conversationId)
+                try container.encode(prURL.absoluteString, forKey: .prURL)
+                try container.encode(prNumber, forKey: .prNumber)
+                try container.encode(branch, forKey: .branch)
+                try container.encode(commitSha, forKey: .commitSha)
+                try container.encode(forkCommitSha, forKey: .forkCommitSha)
+                try container.encode(wrote, forKey: .wrote)
+                try container.encode(deleted, forKey: .deleted)
+                try container.encode(refusedCount, forKey: .refusedCount)
+            }
+
+            private static func isValidPullRequestURL(_ url: URL) -> Bool {
+                url.scheme?.lowercased() == "https" && url.host != nil
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case conversationId
+                case prURL = "prUrl"
+                case prNumber
+                case branch
+                case commitSha
+                case forkCommitSha
+                case wrote
+                case deleted
+                case refusedCount
+            }
+        }
+
+        public struct Unchanged: Codable, Equatable, Sendable {
+            public let conversationId: String
+            public let forkCommitSha: String
+            public let wrote: Int
+            public let deleted: Int
+            public let refusedCount: Int
+
+            public init(
+                conversationId: String,
+                forkCommitSha: String,
+                wrote: Int,
+                deleted: Int,
+                refusedCount: Int
+            ) {
+                self.conversationId = conversationId
+                self.forkCommitSha = forkCommitSha
+                self.wrote = wrote
+                self.deleted = deleted
+                self.refusedCount = refusedCount
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
+            switch try container.decode(Discriminator.self, forKey: .outcome) {
+            case .pullRequest:
+                self = .pullRequest(try PullRequest(from: decoder))
+            case .unchanged:
+                self = .unchanged(try Unchanged(from: decoder))
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: DiscriminatorCodingKeys.self)
+            switch self {
+            case .pullRequest(let pullRequest):
+                try container.encode(Discriminator.pullRequest, forKey: .outcome)
+                try pullRequest.encode(to: encoder)
+            case .unchanged(let unchanged):
+                try container.encode(Discriminator.unchanged, forKey: .outcome)
+                try unchanged.encode(to: encoder)
+            }
+        }
+
+        private enum Discriminator: String, Codable {
+            case pullRequest = "pull_request"
+            case unchanged
+        }
+
+        private enum DiscriminatorCodingKeys: String, CodingKey {
+            case outcome
+        }
+    }
+
+    public enum SpacePullRequestProposalError: Error, Equatable, Sendable {
+        case invalidRequest
+        case notArmed
+        case spaceNotFound
+        case repositoryUnavailable
+        case refused
+        case variantUnavailable
+        case timeout
+        case githubFailed
+        case unavailable
+        case failed
+        case rateLimited
+
+        init?(body: Data) {
+            guard let response = try? JSONDecoder().decode(SpacePullRequestProposalErrorResponse.self, from: body) else { return nil }
+            switch response.code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+            case "INVALID_REQUEST":
+                self = .invalidRequest
+            case "SPACE_UPSTREAM_NOT_ARMED":
+                self = .notArmed
+            case "SPACE_NOT_FOUND":
+                self = .spaceNotFound
+            case "SPACE_REPOSITORY_UNAVAILABLE":
+                self = .repositoryUnavailable
+            case "SPACE_UPSTREAM_REFUSED":
+                self = .refused
+            case "VARIANT_UNAVAILABLE":
+                self = .variantUnavailable
+            case "SPACE_UPSTREAM_TIMEOUT":
+                self = .timeout
+            case "SPACE_UPSTREAM_GITHUB_FAILED":
+                self = .githubFailed
+            case "SPACE_UPSTREAM_UNAVAILABLE":
+                self = .unavailable
+            case "SPACE_UPSTREAM_FAILED":
+                self = .failed
+            case "RATE_LIMITED":
+                self = .rateLimited
+            default:
+                return nil
+            }
+        }
+    }
+
+    struct SpacePullRequestProposalErrorResponse: Codable, Equatable, Sendable {
+        let error: String
+        let code: String
+    }
+
+    enum SpacePullRequestProposalDecodingError: Error, Equatable {
+        case invalidPullRequestURL
+    }
+}
+
+extension ConvosAPI {
     // MARK: - v2/agent-templates/:id
 
     // Subset of the agent-template object the backend returns from the

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SpacePullRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SpacePullRequest.swift
@@ -12,7 +12,11 @@ extension ConvosAPIClient {
         do {
             let (data, response) = try await performAuthenticatedRequest(request)
             guard (200...299).contains(response.statusCode) else {
-                throw spacePullRequestProposalEndpointError(statusCode: response.statusCode, data: data)
+                throw spacePullRequestProposalEndpointError(
+                    statusCode: response.statusCode,
+                    data: data,
+                    path: request.url?.path(percentEncoded: false)
+                )
             }
             return try Self.decodeSpacePullRequestProposalOutcome(data)
         } catch let error as URLError where error.code == .timedOut {
@@ -24,8 +28,8 @@ extension ConvosAPIClient {
         conversationId: String,
         variantId: String?
     ) throws -> URLRequest {
-        var request = try authenticatedRequest(
-            for: "v2/conversations/\(participationPathComponent(conversationId))/debug/space-upstream",
+        var request = try endpointRequest(
+            pathSegments: ["v2", "conversations", conversationId, "debug", "space-upstream"],
             method: "POST",
             queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
         )
@@ -41,7 +45,11 @@ extension ConvosAPIClient {
         ConvosAPI.SpacePullRequestProposalError(body: data)
     }
 
-    private func spacePullRequestProposalEndpointError(statusCode: Int, data: Data) -> Error {
+    private func spacePullRequestProposalEndpointError(statusCode: Int, data: Data, path: String?) -> Error {
+        let bodyLimit = 512
+        let body = String(bytes: data.prefix(bodyLimit), encoding: .utf8) ?? "non-UTF-8 body"
+        let truncated = data.count > bodyLimit ? "…" : ""
+        Log.error("\(path ?? "space pull request endpoint") failed [\(statusCode)]: \(body)\(truncated)")
         if let typedError = Self.decodeSpacePullRequestProposalError(data) {
             return typedError
         }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SpacePullRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SpacePullRequest.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+extension ConvosAPIClient {
+    func proposePullRequestFromSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpacePullRequestProposalOutcome {
+        let request = try spacePullRequestProposalRequest(
+            conversationId: conversationId,
+            variantId: variantId
+        )
+        do {
+            let (data, response) = try await performAuthenticatedRequest(request)
+            guard (200...299).contains(response.statusCode) else {
+                throw spacePullRequestProposalEndpointError(statusCode: response.statusCode, data: data)
+            }
+            return try Self.decodeSpacePullRequestProposalOutcome(data)
+        } catch let error as URLError where error.code == .timedOut {
+            throw ConvosAPI.SpacePullRequestProposalError.timeout
+        }
+    }
+
+    func spacePullRequestProposalRequest(
+        conversationId: String,
+        variantId: String?
+    ) throws -> URLRequest {
+        var request = try authenticatedRequest(
+            for: "v2/conversations/\(participationPathComponent(conversationId))/debug/space-upstream",
+            method: "POST",
+            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
+        )
+        request.timeoutInterval = 55
+        return request
+    }
+
+    static func decodeSpacePullRequestProposalOutcome(_ data: Data) throws -> ConvosAPI.SpacePullRequestProposalOutcome {
+        try JSONDecoder().decode(ConvosAPI.SpacePullRequestProposalOutcome.self, from: data)
+    }
+
+    static func decodeSpacePullRequestProposalError(_ data: Data) -> ConvosAPI.SpacePullRequestProposalError? {
+        ConvosAPI.SpacePullRequestProposalError(body: data)
+    }
+
+    private func spacePullRequestProposalEndpointError(statusCode: Int, data: Data) -> Error {
+        if let typedError = Self.decodeSpacePullRequestProposalError(data) {
+            return typedError
+        }
+        switch statusCode {
+        case 400:
+            return APIError.badRequest(parseErrorMessage(from: data))
+        case 403:
+            return APIError.forbidden
+        case 404:
+            return APIError.notFound
+        case 429:
+            return APIError.rateLimitExceeded
+        default:
+            return APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -127,6 +127,11 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
         variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse
 
+    func proposePullRequestFromSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpacePullRequestProposalOutcome
+
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
     /// template id (UUID) or hashed url slug (e.g. `gandalf.felpl`). Backs the
@@ -1042,7 +1047,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         return try await performRequest(request)
     }
 
-    private func participationPathComponent(_ conversationId: String) -> String {
+    func participationPathComponent(_ conversationId: String) -> String {
         conversationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? conversationId
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -132,6 +132,19 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, conversationId: conversationId, mode: "speak")
     }
 
+    func proposePullRequestFromSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpacePullRequestProposalOutcome {
+        .unchanged(.init(
+            conversationId: conversationId,
+            forkCommitSha: "mock-space-commit",
+            wrote: 0,
+            deleted: 0,
+            refusedCount: 0
+        ))
+    }
+
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         .init(
             id: UUID().uuidString,

--- a/ConvosCore/Tests/ConvosCoreTests/AbilitiesEndpointsContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilitiesEndpointsContractTests.swift
@@ -247,8 +247,8 @@ struct AbilitiesEndpointsContractTests {
     }
 }
 
-@Suite("Abilities endpoint URL construction")
-struct AbilitiesURLConstructionTests {
+@Suite("Endpoint URL construction")
+struct EndpointURLConstructionTests {
     @Test("Path components encode reserved characters with the unreserved-only set")
     func strictComponentEncoding() {
         #expect(ConvosAPIClient.strictPathComponentEncoded("plain-id_1.2~x") == "plain-id_1.2~x")
@@ -262,7 +262,7 @@ struct AbilitiesURLConstructionTests {
     @Test("Opaque ids stay one path segment, never double-encoded")
     func urlBuildingSingleEncoding() throws {
         let baseURL = try #require(URL(string: "https://api.example.com"))
-        let url = try ConvosAPIClient.abilitiesURL(
+        let url = try ConvosAPIClient.endpointURL(
             baseURL: baseURL,
             pathSegments: ["v2", "conversations", "ab/c%d e?f#g", "abilities", "toolkit"],
             queryParameters: nil
@@ -273,7 +273,7 @@ struct AbilitiesURLConstructionTests {
     @Test("A base URL carrying a path keeps it, and query items attach")
     func urlBuildingWithBasePathAndQuery() throws {
         let baseURL = try #require(URL(string: "https://api.example.com/api/"))
-        let url = try ConvosAPIClient.abilitiesURL(
+        let url = try ConvosAPIClient.endpointURL(
             baseURL: baseURL,
             pathSegments: ["v2", "abilities", "spotify", "entitlement"],
             queryParameters: ["agentInboxId": "agent-1"]

--- a/ConvosCore/Tests/ConvosCoreTests/SpacePullRequestProposalContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SpacePullRequestProposalContractTests.swift
@@ -4,16 +4,19 @@ import Testing
 
 @Suite("Space pull request proposal contract")
 struct SpacePullRequestProposalContractTests {
-    @Test("Request is an authenticated bodyless POST with the 55-second budget")
+    @Test("Request keeps an opaque conversation id in one authenticated path segment")
     func requestContract() throws {
         let client = try makeClient(environment: .local(config: Self.configuration))
         let request = try client.spacePullRequestProposalRequest(
-            conversationId: "ABC_123-",
+            conversationId: "ab/c%d?e#f",
             variantId: nil
         )
 
         #expect(request.httpMethod == "POST")
-        #expect(request.url?.path == "/api/v2/conversations/ABC_123-/debug/space-upstream")
+        #expect(
+            request.url?.absoluteString ==
+                "https://api.example.com/api/v2/conversations/ab%2Fc%25d%3Fe%23f/debug/space-upstream"
+        )
         #expect(request.url?.query == nil)
         #expect(request.httpBody == nil)
         #expect(request.timeoutInterval == 55)
@@ -48,10 +51,11 @@ struct SpacePullRequestProposalContractTests {
         #expect(request.url?.query == nil)
     }
 
-    @Test("Pull request success decodes additively and exposes only a validated HTTPS URL")
+    @Test("Pull request success decodes the backend envelope and exposes only a validated HTTPS URL")
     func pullRequestDecode() throws {
         let data = try #require("""
         {
+          "success": true,
           "conversationId": "conversation-1",
           "outcome": "pull_request",
           "prUrl": "https://github.com/xmtplabs/convos-assistants/pull/123",
@@ -59,10 +63,9 @@ struct SpacePullRequestProposalContractTests {
           "branch": "space-upstream/conversation-1",
           "commitSha": "commit-1",
           "forkCommitSha": "fork-1",
-          "wrote": 4,
-          "deleted": 1,
-          "refusedCount": 2,
-          "futureField": { "isIgnored": true }
+          "wrote": 0,
+          "deleted": 0,
+          "refusedCount": 0
         }
         """.data(using: .utf8))
         let outcome = try ConvosAPIClient.decodeSpacePullRequestProposalOutcome(data)
@@ -73,20 +76,20 @@ struct SpacePullRequestProposalContractTests {
         }
         #expect(pullRequest.conversationId == "conversation-1")
         #expect(pullRequest.prURL.absoluteString == "https://github.com/xmtplabs/convos-assistants/pull/123")
-        #expect(pullRequest.refusedCount == 2)
+        #expect(pullRequest.refusedCount == 0)
     }
 
-    @Test("Unchanged success decodes with additive fields")
+    @Test("Unchanged success decodes the backend envelope")
     func unchangedDecode() throws {
         let data = try #require("""
         {
+          "success": true,
           "conversationId": "conversation-1",
           "outcome": "unchanged",
           "forkCommitSha": "fork-1",
           "wrote": 0,
           "deleted": 0,
-          "refusedCount": 1,
-          "futureField": true
+          "refusedCount": 0
         }
         """.data(using: .utf8))
         let outcome = try ConvosAPIClient.decodeSpacePullRequestProposalOutcome(data)
@@ -96,7 +99,28 @@ struct SpacePullRequestProposalContractTests {
             return
         }
         #expect(unchanged.conversationId == "conversation-1")
-        #expect(unchanged.refusedCount == 1)
+        #expect(unchanged.refusedCount == 0)
+    }
+
+    @Test("Success decoding ignores additive fields")
+    func additiveSuccessDecode() throws {
+        let data = try #require("""
+        {
+          "success": true,
+          "conversationId": "conversation-1",
+          "outcome": "unchanged",
+          "forkCommitSha": "fork-1",
+          "wrote": 0,
+          "deleted": 0,
+          "refusedCount": 0,
+          "futureField": { "isIgnored": true }
+        }
+        """.data(using: .utf8))
+
+        guard case .unchanged = try ConvosAPIClient.decodeSpacePullRequestProposalOutcome(data) else {
+            Issue.record("Expected unchanged outcome")
+            return
+        }
     }
 
     @Test("Pull request decode rejects non-HTTPS and hostless URLs")
@@ -104,6 +128,7 @@ struct SpacePullRequestProposalContractTests {
         for prURL in ["http://github.com/x/pull/1", "https:///pull/1"] {
             let data = try #require("""
             {
+              "success": true,
               "conversationId": "conversation-1",
               "outcome": "pull_request",
               "prUrl": "\(prURL)",
@@ -122,15 +147,45 @@ struct SpacePullRequestProposalContractTests {
         }
     }
 
-    @Test("Known error codes normalize while unknown envelopes fall through")
+    @Test("Every backend error code maps to its typed client error")
     func typedErrorDecode() throws {
-        let lowercased = try #require(#"{"error":"not armed","code":"space_upstream_not_armed"}"#.data(using: .utf8))
-        let timeout = try #require(#"{"error":"timed out","code":"SPACE_UPSTREAM_TIMEOUT"}"#.data(using: .utf8))
-        let unknown = try #require(#"{"error":"new failure","code":"SOMETHING_NEW"}"#.data(using: .utf8))
+        let cases: [(String, ConvosAPI.SpacePullRequestProposalError)] = [
+            ("INVALID_REQUEST", .invalidRequest),
+            ("VARIANT_UNAVAILABLE", .variantUnavailable),
+            ("SPACE_NOT_FOUND", .spaceNotFound),
+            ("SPACE_REPOSITORY_UNAVAILABLE", .repositoryUnavailable),
+            ("SPACE_UPSTREAM_NOT_ARMED", .notArmed),
+            ("SPACE_UPSTREAM_UNAVAILABLE", .unavailable),
+            ("SPACE_UPSTREAM_REFUSED", .refused),
+            ("SPACE_UPSTREAM_GITHUB_FAILED", .githubFailed),
+            ("SPACE_UPSTREAM_FAILED", .failed),
+            ("SPACE_UPSTREAM_TIMEOUT", .timeout),
+            ("RATE_LIMITED", .rateLimited)
+        ]
 
-        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(lowercased) == .notArmed)
-        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(timeout) == .timeout)
+        for (code, expected) in cases {
+            let data = try #require(
+                #"{"success":false,"error":"\#(code)","message":"human-readable message"}"#.data(using: .utf8)
+            )
+            #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(data) == expected)
+        }
+    }
+
+    @Test("Unknown and malformed error envelopes fall through")
+    func typedErrorFallthrough() throws {
+        let unknown = try #require(
+            #"{"success":false,"error":"SOMETHING_NEW","message":"new failure"}"#.data(using: .utf8)
+        )
+        let success = try #require(
+            #"{"success":true,"error":"SPACE_UPSTREAM_FAILED","message":"not an error"}"#.data(using: .utf8)
+        )
+        let legacy = try #require(
+            #"{"error":"failed","code":"SPACE_UPSTREAM_FAILED"}"#.data(using: .utf8)
+        )
+
         #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(unknown) == nil)
+        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(success) == nil)
+        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(legacy) == nil)
     }
 
     private func makeClient(environment: AppEnvironment) throws -> ConvosAPIClient {

--- a/ConvosCore/Tests/ConvosCoreTests/SpacePullRequestProposalContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SpacePullRequestProposalContractTests.swift
@@ -1,0 +1,153 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("Space pull request proposal contract")
+struct SpacePullRequestProposalContractTests {
+    @Test("Request is an authenticated bodyless POST with the 55-second budget")
+    func requestContract() throws {
+        let client = try makeClient(environment: .local(config: Self.configuration))
+        let request = try client.spacePullRequestProposalRequest(
+            conversationId: "ABC_123-",
+            variantId: nil
+        )
+
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.path == "/api/v2/conversations/ABC_123-/debug/space-upstream")
+        #expect(request.url?.query == nil)
+        #expect(request.httpBody == nil)
+        #expect(request.timeoutInterval == 55)
+        #expect(request.value(forHTTPHeaderField: "X-Convos-AuthToken") == "test-jwt")
+    }
+
+    @Test("Non-production requests preserve the cosmetic slug as one encoded query item")
+    func nonProductionVariantQuery() throws {
+        let client = try makeClient(environment: .dev(config: Self.configuration))
+        let slug = "pr 123/qa?x=1"
+        let request = try client.spacePullRequestProposalRequest(
+            conversationId: "conversation-1",
+            variantId: slug
+        )
+        let url = try #require(request.url)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        #expect(components.queryItems == [URLQueryItem(name: "variantId", value: slug)])
+        #expect(components.percentEncodedQuery?.contains("variantId=") == true)
+        #expect(components.percentEncodedQuery?.contains("%20") == true)
+        #expect(components.percentEncodedQuery?.contains("%3D") == true)
+    }
+
+    @Test("Production drops the cosmetic slug")
+    func productionVariantOmission() throws {
+        let client = try makeClient(environment: .production(config: Self.configuration))
+        let request = try client.spacePullRequestProposalRequest(
+            conversationId: "conversation-1",
+            variantId: "pr-1234"
+        )
+
+        #expect(request.url?.query == nil)
+    }
+
+    @Test("Pull request success decodes additively and exposes only a validated HTTPS URL")
+    func pullRequestDecode() throws {
+        let data = try #require("""
+        {
+          "conversationId": "conversation-1",
+          "outcome": "pull_request",
+          "prUrl": "https://github.com/xmtplabs/convos-assistants/pull/123",
+          "prNumber": 123,
+          "branch": "space-upstream/conversation-1",
+          "commitSha": "commit-1",
+          "forkCommitSha": "fork-1",
+          "wrote": 4,
+          "deleted": 1,
+          "refusedCount": 2,
+          "futureField": { "isIgnored": true }
+        }
+        """.data(using: .utf8))
+        let outcome = try ConvosAPIClient.decodeSpacePullRequestProposalOutcome(data)
+
+        guard case .pullRequest(let pullRequest) = outcome else {
+            Issue.record("Expected pull_request outcome")
+            return
+        }
+        #expect(pullRequest.conversationId == "conversation-1")
+        #expect(pullRequest.prURL.absoluteString == "https://github.com/xmtplabs/convos-assistants/pull/123")
+        #expect(pullRequest.refusedCount == 2)
+    }
+
+    @Test("Unchanged success decodes with additive fields")
+    func unchangedDecode() throws {
+        let data = try #require("""
+        {
+          "conversationId": "conversation-1",
+          "outcome": "unchanged",
+          "forkCommitSha": "fork-1",
+          "wrote": 0,
+          "deleted": 0,
+          "refusedCount": 1,
+          "futureField": true
+        }
+        """.data(using: .utf8))
+        let outcome = try ConvosAPIClient.decodeSpacePullRequestProposalOutcome(data)
+
+        guard case .unchanged(let unchanged) = outcome else {
+            Issue.record("Expected unchanged outcome")
+            return
+        }
+        #expect(unchanged.conversationId == "conversation-1")
+        #expect(unchanged.refusedCount == 1)
+    }
+
+    @Test("Pull request decode rejects non-HTTPS and hostless URLs")
+    func pullRequestURLValidation() throws {
+        for prURL in ["http://github.com/x/pull/1", "https:///pull/1"] {
+            let data = try #require("""
+            {
+              "conversationId": "conversation-1",
+              "outcome": "pull_request",
+              "prUrl": "\(prURL)",
+              "prNumber": 1,
+              "branch": "space-upstream/conversation-1",
+              "commitSha": "commit-1",
+              "forkCommitSha": "fork-1",
+              "wrote": 1,
+              "deleted": 0,
+              "refusedCount": 0
+            }
+            """.data(using: .utf8))
+            #expect(throws: ConvosAPI.SpacePullRequestProposalDecodingError.invalidPullRequestURL) {
+                _ = try ConvosAPIClient.decodeSpacePullRequestProposalOutcome(data)
+            }
+        }
+    }
+
+    @Test("Known error codes normalize while unknown envelopes fall through")
+    func typedErrorDecode() throws {
+        let lowercased = try #require(#"{"error":"not armed","code":"space_upstream_not_armed"}"#.data(using: .utf8))
+        let timeout = try #require(#"{"error":"timed out","code":"SPACE_UPSTREAM_TIMEOUT"}"#.data(using: .utf8))
+        let unknown = try #require(#"{"error":"new failure","code":"SOMETHING_NEW"}"#.data(using: .utf8))
+
+        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(lowercased) == .notArmed)
+        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(timeout) == .timeout)
+        #expect(ConvosAPIClient.decodeSpacePullRequestProposalError(unknown) == nil)
+    }
+
+    private func makeClient(environment: AppEnvironment) throws -> ConvosAPIClient {
+        try #require(ConvosAPIClientFactory.client(
+            environment: environment,
+            overrideJWTToken: "test-jwt"
+        ) as? ConvosAPIClient)
+    }
+
+    private static let configuration: ConvosConfiguration = ConvosConfiguration(
+        apiBaseURL: "https://api.example.com/api",
+        appGroupIdentifier: "group.test",
+        relyingPartyIdentifier: "example.com",
+        siweConfiguration: SIWEConfiguration(
+            domain: "example.com",
+            uri: "https://example.com",
+            chainId: 1
+        )
+    )
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -193,18 +193,6 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
         AssetRenewalResult(renewed: 0, failed: 0, expiredKeys: [])
     }
-    func proposePullRequestFromSpace(
-        conversationId: String,
-        variantId: String?
-    ) async throws -> ConvosAPI.SpacePullRequestProposalOutcome {
-        .unchanged(.init(
-            conversationId: conversationId,
-            forkCommitSha: "test-space-commit",
-            wrote: 0,
-            deleted: 0,
-            refusedCount: 0
-        ))
-    }
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
         throw CancellationError()
     }

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -74,6 +74,19 @@ extension ConvosAPIClientProtocol {
         )
     }
 
+    func proposePullRequestFromSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpacePullRequestProposalOutcome {
+        .unchanged(.init(
+            conversationId: conversationId,
+            forkCommitSha: "test-space-commit",
+            wrote: 0,
+            deleted: 0,
+            refusedCount: 0
+        ))
+    }
+
     /// Default for the direct-add status poll so pre-existing stubs don't
     /// re-stub it. A coherent terminal state — joined ⇒ inbox present — so
     /// unrelated tests don't iterate the poll loop. Tests that exercise the
@@ -179,6 +192,18 @@ class TestStubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
     func unregisterInstallation(clientId: String) async throws {}
     func renewAssetsBatch(assetKeys: [String]) async throws -> AssetRenewalResult {
         AssetRenewalResult(renewed: 0, failed: 0, expiredKeys: [])
+    }
+    func proposePullRequestFromSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpacePullRequestProposalOutcome {
+        .unchanged(.init(
+            conversationId: conversationId,
+            forkCommitSha: "test-space-commit",
+            wrote: 0,
+            deleted: 0,
+            refusedCount: 0
+        ))
     }
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
         throw CancellationError()

--- a/ConvosTests/ConversationSpacePullRequestCoordinatorTests.swift
+++ b/ConvosTests/ConversationSpacePullRequestCoordinatorTests.swift
@@ -1,0 +1,121 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+@MainActor
+final class ConversationSpacePullRequestCoordinatorTests: XCTestCase {
+    func testSecondProposalIsIgnoredWhileFirstIsBusy() async {
+        var callCount = 0
+        let coordinator = ConversationSpacePullRequestCoordinator { conversationId, _ in
+            callCount += 1
+            try await Task.sleep(for: .milliseconds(50))
+            return Self.unchanged(conversationId: conversationId)
+        }
+
+        let firstProposal = Task {
+            await coordinator.propose(conversationId: "conversation-1", variantId: nil)
+        }
+        await Task.yield()
+        XCTAssertTrue(coordinator.isBusy)
+
+        await coordinator.propose(conversationId: "conversation-1", variantId: nil)
+        await firstProposal.value
+
+        XCTAssertEqual(callCount, 1)
+        XCTAssertFalse(coordinator.isBusy)
+    }
+
+    func testPullRequestOutcomeClearsBusyAndBuildsOpenAlert() async throws {
+        let prURL = try XCTUnwrap(URL(string: "https://github.com/xmtplabs/convos-assistants/pull/123"))
+        let coordinator = ConversationSpacePullRequestCoordinator { conversationId, _ in
+            .pullRequest(try .init(
+                conversationId: conversationId,
+                prURL: prURL,
+                prNumber: 123,
+                branch: "space-upstream/conversation-1",
+                commitSha: "commit-1",
+                forkCommitSha: "fork-1",
+                wrote: 1,
+                deleted: 0,
+                refusedCount: 0
+            ))
+        }
+
+        await coordinator.propose(conversationId: "conversation-1", variantId: "pr-1234")
+
+        XCTAssertFalse(coordinator.isBusy)
+        XCTAssertEqual(coordinator.alert?.title, "Pull request proposed")
+        XCTAssertEqual(coordinator.alert?.pullRequestURL, prURL)
+    }
+
+    func testUnchangedOutcomeClearsBusyAndBuildsMatchingAlert() async {
+        let coordinator = ConversationSpacePullRequestCoordinator { conversationId, _ in
+            Self.unchanged(conversationId: conversationId)
+        }
+
+        await coordinator.propose(conversationId: "conversation-1", variantId: nil)
+
+        XCTAssertFalse(coordinator.isBusy)
+        XCTAssertEqual(coordinator.alert?.title, "Already matches the starter")
+        XCTAssertNil(coordinator.alert?.pullRequestURL)
+    }
+
+    func testTypedFailureClearsBusyAndBuildsGuidanceAlert() async {
+        let coordinator = ConversationSpacePullRequestCoordinator { _, _ in
+            throw ConvosAPI.SpacePullRequestProposalError.notArmed
+        }
+
+        await coordinator.propose(conversationId: "conversation-1", variantId: nil)
+
+        XCTAssertFalse(coordinator.isBusy)
+        XCTAssertEqual(coordinator.alert?.title, "Deployment not armed")
+        XCTAssertEqual(
+            coordinator.alert?.message,
+            "The selected deployment is not configured to propose Space pull requests."
+        )
+    }
+
+    func testTimeoutUsesUncertaintyAndSafeRetryCopy() async {
+        let coordinator = ConversationSpacePullRequestCoordinator { _, _ in
+            throw ConvosAPI.SpacePullRequestProposalError.timeout
+        }
+
+        await coordinator.propose(conversationId: "conversation-1", variantId: nil)
+
+        XCTAssertFalse(coordinator.isBusy)
+        XCTAssertEqual(
+            coordinator.alert?.message,
+            "The request timed out. The PR may still have been updated; it is safe to try again."
+        )
+    }
+
+    func testProposalPassesOnlyRouteIdentifiersAndLeavesConversationSnapshotUnchanged() async throws {
+        var conversation = Conversation.mock(id: "conversation-1")
+        conversation.spaceURL = try XCTUnwrap(URL(string: "https://space.example.com/conversation-1"))
+        let before = conversation
+        var receivedConversationId: String?
+        var receivedVariantId: String?
+        let coordinator = ConversationSpacePullRequestCoordinator { conversationId, variantId in
+            receivedConversationId = conversationId
+            receivedVariantId = variantId
+            return Self.unchanged(conversationId: conversationId)
+        }
+
+        await coordinator.propose(conversationId: conversation.id, variantId: "pr-1234")
+
+        XCTAssertEqual(receivedConversationId, "conversation-1")
+        XCTAssertEqual(receivedVariantId, "pr-1234")
+        XCTAssertEqual(conversation, before)
+        XCTAssertEqual(conversation.spaceURL, before.spaceURL)
+    }
+
+    private static func unchanged(conversationId: String) -> ConvosAPI.SpacePullRequestProposalOutcome {
+        .unchanged(.init(
+            conversationId: conversationId,
+            forkCommitSha: "fork-1",
+            wrote: 0,
+            deleted: 0,
+            refusedCount: 0
+        ))
+    }
+}

--- a/ConvosTests/ConversationSpacePullRequestCoordinatorTests.swift
+++ b/ConvosTests/ConversationSpacePullRequestCoordinatorTests.swift
@@ -89,10 +89,7 @@ final class ConversationSpacePullRequestCoordinatorTests: XCTestCase {
         )
     }
 
-    func testProposalPassesOnlyRouteIdentifiersAndLeavesConversationSnapshotUnchanged() async throws {
-        var conversation = Conversation.mock(id: "conversation-1")
-        conversation.spaceURL = try XCTUnwrap(URL(string: "https://space.example.com/conversation-1"))
-        let before = conversation
+    func testProposalPassesRouteIdentifiers() async {
         var receivedConversationId: String?
         var receivedVariantId: String?
         let coordinator = ConversationSpacePullRequestCoordinator { conversationId, variantId in
@@ -101,12 +98,10 @@ final class ConversationSpacePullRequestCoordinatorTests: XCTestCase {
             return Self.unchanged(conversationId: conversationId)
         }
 
-        await coordinator.propose(conversationId: conversation.id, variantId: "pr-1234")
+        await coordinator.propose(conversationId: "conversation-1", variantId: "pr-1234")
 
         XCTAssertEqual(receivedConversationId, "conversation-1")
         XCTAssertEqual(receivedVariantId, "pr-1234")
-        XCTAssertEqual(conversation, before)
-        XCTAssertEqual(conversation.spaceURL, before.spaceURL)
     }
 
     private static func unchanged(conversationId: String) -> ConvosAPI.SpacePullRequestProposalOutcome {

--- a/ConvosTests/FeatureFlagsObservationTests.swift
+++ b/ConvosTests/FeatureFlagsObservationTests.swift
@@ -10,6 +10,35 @@ import XCTest
 /// without leaving and re-entering the screen.
 @MainActor
 final class FeatureFlagsObservationTests: XCTestCase {
+    func testSpacePullRequestProposalDefaultsOffPersistsAndNotifiesObservers() {
+        let key = "featureFlags.spacePullRequestProposalEnabled"
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        defaults.removeObject(forKey: key)
+
+        let flags = FeatureFlags.shared
+        XCTAssertFalse(flags.isSpacePullRequestProposalEnabled)
+
+        let changed = expectation(description: "Space pull request proposal flag observation fired")
+        withObservationTracking {
+            _ = flags.isSpacePullRequestProposalEnabled
+        } onChange: {
+            changed.fulfill()
+        }
+
+        flags.isSpacePullRequestProposalEnabled = true
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertTrue(defaults.bool(forKey: key))
+        XCTAssertTrue(flags.isSpacePullRequestProposalEnabled)
+    }
+
     func testTogglingAbilitiesV2NotifiesObservers() {
         let flags = FeatureFlags.shared
         let initial = flags.isAbilitiesV2Enabled


### PR DESCRIPTION
## Summary

- Adds a production-reachable opt-in debug flag and conversation action for proposing a draft PR from the conversation's Space.
- Adds the authenticated 55-second API contract, typed outcome/error handling, HTTPS validation, and focused state and contract tests.

## Why

Production access is available through explicit opt-in in the curated prod debug menu; the endpoint creates a draft PR, and human merge remains the final gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789111005&installation_model_id=20076&pr_number=1305&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1305&signature=e0fa5b6c657759aff63483beb6cd9ef9f0f22d98c3622e5eceb7bad8e998c1c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Propose PR from Space' debug action to conversation info view
> - Adds a debug-only button in `ConversationInfoView` that calls the `v2/conversations/{id}/debug/space-upstream` endpoint to propose a pull request from Space.
> - Introduces `ConversationSpacePullRequestCoordinator` to manage async state: prevents concurrent calls via `isBusy`, and surfaces outcomes and errors as alerts with an optional deep link to the created PR.
> - Adds `ConvosAPI.SpacePullRequestProposalOutcome` and `SpacePullRequestProposalError` to decode typed responses, rejecting non-HTTPS or hostless PR URLs.
> - The feature is gated behind `FeatureFlags.isSpacePullRequestProposalEnabled`, togglable from `DebugView` in non-production builds and from the curated production debug menu.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbac9d9. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->