### PR TITLE
Stop writing connection grants to appData

### DIFF
--- a/ConvosAppData/Sources/ConvosAppData/ProfileHelpers.swift
+++ b/ConvosAppData/Sources/ConvosAppData/ProfileHelpers.swift
@@ -93,8 +93,9 @@ extension ConversationProfile {
     ///   When it carries one, its own fields stand (the initializers already
     ///   clear the variant they don't use). Removal is an explicit operation
     ///   (`clearProfileAvatar`), never a side effect of empty local state.
-    /// - `connections`: preserved when absent on the incoming side - it lives
-    ///   only in remote metadata and is managed by its own update/clear APIs.
+    /// - `connections`: deprecated - current clients no longer write it, but
+    ///   an entry written by an older release is preserved when absent on the
+    ///   incoming side so a merge never clobbers another writer's payload.
     public func merged(over existing: ConversationProfile) -> ConversationProfile {
         var result = self
         let carriesImage = (hasEncryptedImage && encryptedImage.isValid) || hasImage

--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.pb.swift
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.pb.swift
@@ -252,7 +252,9 @@ public nonisolated struct ConversationProfile: Sendable {
   /// Clears the value of `encryptedImage`. Subsequent reads from it will return its default value.
   public mutating func clearEncryptedImage() {self._encryptedImage = nil}
 
-  /// JSON grants payload for this sender's connections (see connections.mjs)
+  /// Deprecated: connection grants travel in ProfileUpdate message metadata
+  /// now; no client reads or writes this field anymore. Kept defined so the
+  /// field number stays claimed and payloads from older releases keep decoding.
   public var connections: String {
     get {_connections ?? String()}
     set {_connections = newValue}

--- a/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
+++ b/ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto
@@ -19,8 +19,9 @@ message ConversationCustomMetadata {
     optional bytes imageEncryptionKey = 4;  // 32-byte AES-256 key for encrypting all images
     optional EncryptedImageRef encryptedGroupImage = 5;  // Encrypted group avatar
     optional string emoji = 6;
-    // Field 7 was a short-lived group-level connectionsJson blob; connections
-    // now live on each sender's ConversationProfile.connections (field 5).
+    // Field 7 was a short-lived group-level connectionsJson blob; connection
+    // grants travel in ProfileUpdate message metadata now (the per-profile
+    // ConversationProfile.connections field 5 is deprecated as well).
     reserved 7;
     optional AgentDmInfo agentDm = 8;  // Present when this conversation is a DM with an agent
     optional ParticipationMode participationMode = 9;  // How much the conversation's agents may speak
@@ -67,5 +68,8 @@ message ConversationProfile {
     optional string name = 2;
     optional string image = 3;  // Legacy: plain URL (backward compatibility)
     optional EncryptedImageRef encryptedImage = 4;  // New: encrypted image reference
-    optional string connections = 5;  // JSON grants payload for this sender's connections (see connections.mjs)
+    // Deprecated: connection grants travel in ProfileUpdate message metadata
+    // now; no client reads or writes this field anymore. Kept defined so the
+    // field number stays claimed and payloads from older releases keep decoding.
+    optional string connections = 5;
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -439,34 +439,17 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             Log.info("[CloudConnections] clearing grants for groupId=\(conversationId) senderId=\(senderId)")
         }
 
-        // Primary: send a ProfileUpdate message with metadata["connections"]. This is
-        // the CLI's (and therefore the agent's) current read path. We use the throwing
-        // variant so a send failure propagates to the caller, which then declines to
-        // persist the local grant change. We run this before the best-effort appData
-        // write so a ProfileUpdate failure can't leave a stale grant in appData.
+        // Send a ProfileUpdate message with metadata["connections"]. This is
+        // the CLI's (and therefore the agent's) read path. We use the throwing
+        // variant so a send failure propagates to the caller, which then declines
+        // to persist the local grant change. Grants are no longer mirrored into
+        // appData: the deprecated ConversationProfile.connections field had no
+        // readers on any client, and the CLI strips it on decode.
         try await sendProfileUpdateWithConnections(
             conversationId: conversationId,
             senderId: senderId,
             grantsJson: grantsJson
         )
-
-        // Best-effort: stash on the sender's ConversationProfile in appData (field 5).
-        // Forward-compat hedge for any CLI reader that looks at appData — failures are logged only,
-        // including failure to locate the group (appData isn't on the critical path).
-        do {
-            guard let conversation = try await inboxReady.client.conversation(with: conversationId),
-                  case .group(let group) = conversation else {
-                Log.warning("[CloudConnections] appData write skipped (best-effort), conversation not found: \(conversationId)")
-                return
-            }
-            if let grantsJson {
-                try await group.updateSenderConnections(grantsJson, senderInboxId: senderId)
-            } else {
-                try await group.clearSenderConnections(senderInboxId: senderId)
-            }
-        } catch {
-            Log.warning("[CloudConnections] appData write failed (best-effort), continuing: \(error.localizedDescription)")
-        }
     }
 
     private func sendProfileUpdateWithConnections(

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -145,45 +145,6 @@ extension XMTPiOS.Group {
         }
     }
 
-    // MARK: - Connections (per-sender-profile)
-
-    /// Returns the JSON grants payload stored on a specific sender's profile.
-    /// The runtime reads grants from `profile.metadata.connections` per sender,
-    /// so each member's grants live under their own profile entry.
-    public func senderConnections(forInboxId inboxId: String) throws -> String? {
-        let metadata = try currentCustomMetadata
-        guard let profile = metadata.findProfile(inboxId: inboxId),
-              profile.hasConnections,
-              !profile.connections.isEmpty else {
-            return nil
-        }
-        return profile.connections
-    }
-
-    public func updateSenderConnections(_ json: String, senderInboxId: String) async throws {
-        guard let seedProfile = ConversationProfile(inboxIdString: senderInboxId) else {
-            throw ConversationCustomMetadataError.invalidInboxIdHex(senderInboxId)
-        }
-        try await atomicUpdateMetadata(operation: "updateSenderConnections") { metadata in
-            var profile = metadata.findProfile(inboxId: senderInboxId) ?? seedProfile
-            profile.connections = json
-            metadata.upsertProfile(profile)
-        } verify: { metadata in
-            metadata.findProfile(inboxId: senderInboxId)?.connections == json
-        }
-    }
-
-    public func clearSenderConnections(senderInboxId: String) async throws {
-        try await atomicUpdateMetadata(operation: "clearSenderConnections") { metadata in
-            guard var profile = metadata.findProfile(inboxId: senderInboxId) else { return }
-            profile.clearConnections()
-            metadata.upsertProfile(profile)
-        } verify: { metadata in
-            let profile = metadata.findProfile(inboxId: senderInboxId)
-            return profile == nil || !(profile?.hasConnections ?? false)
-        }
-    }
-
     // MARK: - Image Encryption Key Management
 
     public var imageEncryptionKey: Data? {


### PR DESCRIPTION
## What

Stops mirroring connection grants into appData. Grants travel exclusively in ProfileUpdate message metadata (`metadata["connections"]`), which is what agents actually read.

- `ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift`: removes the best-effort appData block at the end of `syncGrantsToMetadata`. The ProfileUpdate write (the load-bearing transport) is unchanged.
- `ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift`: removes the now-unused `senderConnections` / `updateSenderConnections` / `clearSenderConnections` accessors.
- `ConvosAppData/Sources/ConvosAppData/Proto/conversation_custom_metadata.proto` (and the generated Swift): `ConversationProfile.connections` (field 5) stays defined and is marked deprecated in comments, so the field number stays claimed and payloads from older releases keep decoding. Proto fields are never renumbered or removed.
- `ConvosAppData/Sources/ConvosAppData/ProfileHelpers.swift`: `merged(over:)` still preserves an existing connections entry, so a profile merge from a current build never clobbers a payload written by an older release in a mixed-version group.

## Why it is safe

The appData mirror was a write-only forward-compat hedge with zero readers anywhere:

- iOS: the only read API (`senderConnections(forInboxId:)`) has no call sites in the current codebase or in any shipped tag (2.0.0, 2.0.1, v2.1.0, v2.2.0, v2.3.0 — checked with per-tag `git grep`). Grants UI has always rendered from local database rows plus the ProfileUpdate transport, so older builds that still receive no appData grants lose nothing they ever used.
- convos-cli: its `ConversationProfile` schema omits field 5 entirely; a test pins that the deprecated field is ignored on decode and stripped on re-serialize. Agent-side appData rewrites therefore already erased the mirror, making it unreliable as well as unread.
- convos-agent / convos-ai: their proto copies omit the field.
- Backend and the assistants runtime never parse appData profiles (the herald snapshot exposes tag, emoji, and image fields only).
- Android: its proto schema has profile fields 1-4 only, so the field does not exist for it. Verified against a local checkout; the remote HEAD was not re-checked, which is the one residual verification left open.

No tests exercised the removed write path; the merge-preservation tests still apply and pass.

## Verification

- SwiftLint strict on touched files: clean.
- `Convos (Dev)` simulator build: succeeded.
- ConvosCore suite: 1828 tests in 250 suites, all passing (re-run after rebasing onto the latest libxmtp bump).
- ConvosAppData suite: 51 tests in 12 suites, all passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789117088&installation_model_id=20076&pr_number=1306&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1306&signature=841d684ce6824db70a72c497602d0f35746d4a9efebcd9ee087ac6eb8049900d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop writing connection grants to `ConversationProfile.connections` in appData
> - Removes the appData write path from `CloudConnectionGrantWriter.grantConnection`; grants now travel exclusively via `ProfileUpdate` message metadata.
> - Removes the `senderConnections`, `updateSenderConnections`, and `clearSenderConnections` methods from `XMTPiOS.Group` in [XMTPGroup+CustomMetadata.swift](https://github.com/xmtplabs/convos-ios/pull/1306/files#diff-531b5042f2639e0a548e07f4a8bbe3b6e8a8ed4a8e2c9b643211b6d00ba5ec85).
> - Marks `ConversationProfile.connections` (field 5) as deprecated in the proto and generated code; the field is retained for backward decoding.
> - Behavioral Change: callers that previously read per-sender connections from appData will no longer find data written there by current clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18db7a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->