### PR TITLE
Make capability approval contingent on a confirmed backend grant

### DIFF
--- a/Convos/Capabilities/CapabilityApprovalSheetView.swift
+++ b/Convos/Capabilities/CapabilityApprovalSheetView.swift
@@ -433,13 +433,16 @@ private struct ApprovalSheetContent: View {
 }
 
 /// The design system's wide switch (68x28 track, 39x24 knob) from the Figma
-/// permission row — a stock `UISwitch` is 51x31 and visibly different.
+/// permission row — a stock `UISwitch` is 51x31 and visibly different. The
+/// on-state track uses the app's semantic green (the stock switch's on
+/// color); a luminosity-dependent fill would render white-on-white against
+/// the dark sheet.
 private struct WideSwitchToggleStyle: ToggleStyle {
     func makeBody(configuration: Configuration) -> some View {
         let action = { configuration.isOn.toggle() }
         return Button(action: action) {
             RoundedRectangle(cornerRadius: Constant.trackCornerRadius)
-                .fill(configuration.isOn ? Color.colorFillPrimary : Color.colorFillTertiary)
+                .fill(configuration.isOn ? Color.colorGreen : Color.colorFillTertiary)
                 .frame(width: Constant.trackWidth, height: Constant.trackHeight)
                 .overlay(alignment: configuration.isOn ? .trailing : .leading) {
                     RoundedRectangle(cornerRadius: Constant.trackCornerRadius)

--- a/Convos/Capabilities/CapabilityApprovalSheetView.swift
+++ b/Convos/Capabilities/CapabilityApprovalSheetView.swift
@@ -24,12 +24,34 @@ import SwiftUI
 struct CapabilityApprovalSheetView: View {
     let layout: CapabilityPickerLayout
     let agentName: String?
+    /// True while the approval pipeline (backend grant confirmation + result
+    /// send) runs; the primary button shows progress and won't re-submit.
+    let isApproving: Bool
+    /// Non-nil when the last approval attempt failed (grant POST or result
+    /// send). Rendered above the primary button, which becomes a retry.
+    let approvalErrorMessage: String?
     let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
+
+    init(
+        layout: CapabilityPickerLayout,
+        agentName: String?,
+        isApproving: Bool = false,
+        approvalErrorMessage: String? = nil,
+        onApprove: @escaping (Set<ProviderID>, [String: Set<String>]) -> Void
+    ) {
+        self.layout = layout
+        self.agentName = agentName
+        self.isApproving = isApproving
+        self.approvalErrorMessage = approvalErrorMessage
+        self.onApprove = onApprove
+    }
 
     var body: some View {
         ApprovalSheetContent(
             layout: layout,
             agentName: agentName,
+            isApproving: isApproving,
+            approvalErrorMessage: approvalErrorMessage,
             onApprove: onApprove
         )
         // Reseed the selection state if a newer request replaces the layout
@@ -89,6 +111,8 @@ struct CapabilityApprovalSheetView: View {
 private struct ApprovalSheetContent: View {
     let layout: CapabilityPickerLayout
     let agentName: String?
+    let isApproving: Bool
+    let approvalErrorMessage: String?
     let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
 
     @State private var selection: Set<ProviderID>
@@ -100,10 +124,14 @@ private struct ApprovalSheetContent: View {
     init(
         layout: CapabilityPickerLayout,
         agentName: String?,
+        isApproving: Bool,
+        approvalErrorMessage: String?,
         onApprove: @escaping (Set<ProviderID>, [String: Set<String>]) -> Void
     ) {
         self.layout = layout
         self.agentName = agentName
+        self.isApproving = isApproving
+        self.approvalErrorMessage = approvalErrorMessage
         self.onApprove = onApprove
         _selection = State(initialValue: CapabilityApprovalSheetView.seedSelection(for: layout))
         _enabledBundleIds = State(initialValue: CapabilityApprovalSheetView.seedBundleSelection(for: layout))
@@ -364,16 +392,36 @@ private struct ApprovalSheetContent: View {
 
     // MARK: - Primary button
 
+    /// "Connect" tells the user an OAuth / OS-permission step comes first;
+    /// "Done" is the Figma label for the grant-only confirmation. A failed
+    /// attempt turns the same tap into an explicit retry, and the in-flight
+    /// pipeline announces itself instead of appearing to do nothing.
+    private var approveButtonTitle: String {
+        if isApproving {
+            return "Confirming…"
+        }
+        if approvalErrorMessage != nil {
+            return "Try Again"
+        }
+        return needsConnect ? "Connect" : "Done"
+    }
+
     private var approveButton: some View {
         let approveAction: () -> Void = {
             onApprove(selection, approvedBundleSelection)
         }
-        // "Connect" tells the user an OAuth / OS-permission step comes first;
-        // "Done" is the Figma label for the grant-only confirmation.
-        return Button(needsConnect ? "Connect" : "Done", action: approveAction)
-            .convosButtonStyle(.rounded(fullWidth: true))
-            .disabled(!approveEnabled)
-            .padding(.horizontal, DesignConstants.Spacing.step4x)
+        let buttonDisabled: Bool = !approveEnabled || isApproving
+        return VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+            if let approvalErrorMessage {
+                Text(approvalErrorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.colorCaution)
+            }
+            Button(approveButtonTitle, action: approveAction)
+                .convosButtonStyle(.rounded(fullWidth: true))
+                .disabled(buttonDisabled)
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
     }
 
     private enum Constant {

--- a/Convos/Conversation Detail/ConversationConnectionsSection.swift
+++ b/Convos/Conversation Detail/ConversationConnectionsSection.swift
@@ -168,9 +168,9 @@ final class ConversationConnectionsViewModel {
                 // Order matches CloudConnectionManager.postRevocationSideEffects:
                 // post the user-visible group-update line first, then drop the
                 // provider from every (subject, verb, agent) row in this conversation.
-                // Resolver-cleanup is what unblocks persistApprovedCloudCapabilities'
-                // idempotency gate so a follow-up capability_request approval re-emits
-                // its own group-update line. Revoke text is a complete sentence
+                // Resolver-cleanup is what unblocks sendCloudGrantedEvents'
+                // resolver-diff gate so a follow-up capability_request approval
+                // re-emits its own group-update line. Revoke text is a complete sentence
                 // ("Calendar connection removed") so we keep grantedToInboxId nil and
                 // render it conversation-level.
                 try? await connectionEventWriter.sendRevoked(

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -444,6 +444,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
             CapabilityApprovalSheetView(
                 layout: layout,
                 agentName: viewModel.askerDisplayName(for: layout.request),
+                isApproving: viewModel.capabilityApprovalInFlight,
+                approvalErrorMessage: viewModel.capabilityApprovalErrorMessage,
                 onApprove: { providerIds, bundleSelection in
                     viewModel.onCapabilityApprove(
                         providerIds: providerIds,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2246,8 +2246,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// (connection, conversation, agent) and mirror the conversation-info
     /// revoke toggle's side effects in the same order — the user-visible
     /// `connection_event revoked` group-update line first, then resolver
-    /// cleanup (which re-arms `persistApprovedCloudCapabilities`' idempotency
-    /// gate so a later re-approval emits its own granted line). Services
+    /// cleanup (which re-arms `sendCloudGrantedEvents`' resolver-diff gate
+    /// so a later re-approval emits its own granted line). Services
     /// without an existing grant are a pure no-op: nothing is created,
     /// nothing is sent. Returns the service ids actually revoked.
     static func revokeUncheckedCloudGrants( // swiftlint:disable:this function_parameter_count
@@ -2575,10 +2575,16 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// confirmed -- no active local connection to grant against, or the grant
     /// write / backend POST failed. The caller must not broadcast an
     /// `.approved` result in that case: the agent would be woken with an
-    /// approval the backend then denies. A grant already confirmed
-    /// (`backendGrantId` present) with an unchanged bundle scope is skipped;
-    /// a row missing its backend id re-runs the confirming push so an
-    /// earlier failed POST is retried on the next Done tap.
+    /// approval the backend then denies.
+    ///
+    /// The confirming push runs unconditionally, even when a local grant row
+    /// already carries a `backendGrantId`: a locally cached id is not proof
+    /// of server state (a server-side revoke, reset, or purge leaves the row
+    /// stale, and trusting it would broadcast `.approved` with no server
+    /// grant behind it -- the agent then 403s on every execution). The
+    /// backend upserts the (owner, grantee, conversation, toolkit) tuple, so
+    /// re-approving is idempotent and self-healing, and the pushed scope
+    /// follows the user's latest picker state.
     static func persistApprovedCloudCapabilities(
         providerIds: [ProviderID],
         bundleSelection: [String: Set<String>],
@@ -2588,7 +2594,6 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         repository: any CloudConnectionRepositoryProtocol
     ) async -> Bool {
         let activeConnections = (try? await repository.connections()) ?? []
-        let existingGrants = (try? await repository.grants(for: conversationId)) ?? []
         var allConfirmed = true
 
         for providerId in providerIds {
@@ -2601,32 +2606,19 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 continue
             }
 
-            // The grant row is per-(connection, conversation, agent). Two agents
-            // approved for the same connection get two rows; the same agent re-
-            // approving the same connection with the same confirmed bundle scope
-            // is a no-op for the grant write but still needs its own
-            // connection_event. A re-approval with a *different* bundle selection
-            // re-grants so the backend scope follows the user's latest picker state.
+            // The grant row is per-(connection, conversation, agent); two
+            // agents approved for the same connection get two rows.
             let bundleIds = bundleSelection[serviceId].map { $0.sorted() }
-            let existingGrant = existingGrants.first {
-                $0.connectionId == connection.id && $0.grantedToInboxId == grantedToInboxId
-            }
-            let bundleScopeChanged = existingGrant.map {
-                bundleIds != nil && Set($0.bundleIds ?? []) != Set(bundleIds ?? [])
-            } ?? false
-            let backendUnconfirmed = existingGrant.map { $0.backendGrantId == nil } ?? true
-            if backendUnconfirmed || bundleScopeChanged {
-                do {
-                    try await grantWriter.grantConnectionConfirmingBackend(
-                        connection.id,
-                        to: conversationId,
-                        grantedToInboxId: grantedToInboxId,
-                        bundleIds: bundleIds
-                    )
-                } catch {
-                    Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")
-                    allConfirmed = false
-                }
+            do {
+                try await grantWriter.grantConnectionConfirmingBackend(
+                    connection.id,
+                    to: conversationId,
+                    grantedToInboxId: grantedToInboxId,
+                    bundleIds: bundleIds
+                )
+            } catch {
+                Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")
+                allConfirmed = false
             }
         }
         return allConfirmed

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2303,19 +2303,23 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// have confirmed. On failure nothing is broadcast: the sheet stays up
     /// with a retryable error and the pill stays pending, so a
     /// successful-looking approval can never wake the agent without a server
-    /// grant behind it.
+    /// grant behind it. A grant refused with the typed `connection_not_found`
+    /// (stale local connection row) drives the in-sheet OAuth leg and retries
+    /// once instead of surfacing an error; `allowConnectRecovery` is false on
+    /// that retry so a second refusal falls through to the retryable error.
     private func approveCapabilityRequest(
         _ request: CapabilityRequest,
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>],
-        conversationId: String
+        conversationId: String,
+        allowConnectRecovery: Bool = true
     ) {
         guard capabilityApprovalInFlightRequestId == nil else { return }
         capabilityApprovalInFlightRequestId = request.requestId
         capabilityApprovalErrorMessage = nil
         Task { [weak self] in
             guard let self else { return }
-            let sent = await self.sendCapabilityResult(
+            let outcome = await self.sendCapabilityResult(
                 request: request,
                 status: .approved,
                 providerIds: providerIds,
@@ -2328,16 +2332,68 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             // surface its own error in the newer request's sheet.
             guard self.capabilityApprovalInFlightRequestId == request.requestId else { return }
             self.capabilityApprovalInFlightRequestId = nil
-            guard sent else {
+            switch outcome {
+            case .sent:
+                self.locallyHandledCapabilityRequestIds.insert(request.requestId)
+                // Only dismiss the picker if it's still showing *this* request — a newer
+                // request might have arrived during the async hop and replaced the layout,
+                // and we mustn't blow that one away on the old request's behalf.
+                if self.pendingCapabilityPickerLayout?.request.requestId == request.requestId {
+                    self.pendingCapabilityPickerLayout = nil
+                }
+            case .needsConnect(let providers) where allowConnectRecovery:
+                self.connectStaleProvidersAndRetryApproval(
+                    providers,
+                    request: request,
+                    providerIds: providerIds,
+                    bundleSelection: bundleSelection,
+                    conversationId: conversationId
+                )
+            case .failed, .needsConnect:
                 self.capabilityApprovalErrorMessage = Constant.capabilityApprovalFailedMessage
-                return
             }
-            self.locallyHandledCapabilityRequestIds.insert(request.requestId)
-            // Only dismiss the picker if it's still showing *this* request — a newer
-            // request might have arrived during the async hop and replaced the layout,
-            // and we mustn't blow that one away on the old request's behalf.
-            if self.pendingCapabilityPickerLayout?.request.requestId == request.requestId {
-                self.pendingCapabilityPickerLayout = nil
+        }
+    }
+
+    /// Recovery for the backend's typed `connection_not_found` refusal: the
+    /// local snapshot claimed a linked connection but the server holds no
+    /// live credential (an OAuth that never completed, or a server-side
+    /// revoke/purge). Runs the same in-sheet OAuth leg a Connect tap uses,
+    /// then retries the approval once with recovery disabled. Cancelling the
+    /// OAuth session leaves the sheet up with the retryable error.
+    private func connectStaleProvidersAndRetryApproval(
+        _ providers: [ProviderID],
+        request: CapabilityRequest,
+        providerIds: Set<ProviderID>,
+        bundleSelection: [String: Set<String>],
+        conversationId: String
+    ) {
+        guard connectOnApproveInFlightRequestId != request.requestId else { return }
+        connectOnApproveInFlightRequestId = request.requestId
+        let authorizer = session.deviceConnectionAuthorizer()
+        let registry = session.capabilityProviderRegistry()
+        let manager = session.cloudConnectionManager(callbackURLScheme: ConfigManager.shared.appUrlScheme)
+        Task { [weak self] in
+            let allLinked = await Self.connectUnlinkedProviders(
+                providers,
+                authorizer: authorizer,
+                registry: registry,
+                cloudConnectionManager: manager
+            )
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.connectOnApproveInFlightRequestId = nil
+                guard allLinked else {
+                    self.capabilityApprovalErrorMessage = Constant.capabilityApprovalFailedMessage
+                    return
+                }
+                self.approveCapabilityRequest(
+                    request,
+                    providerIds: providerIds,
+                    bundleSelection: bundleSelection,
+                    conversationId: conversationId,
+                    allowConnectRecovery: false
+                )
             }
         }
     }
@@ -2351,15 +2407,16 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// either, since those (with resolver and device bookkeeping) run in
     /// `finalizeBroadcastApproval` only after the send succeeds. An unbacked
     /// "approved" would wake the agent only for the backend to deny its tool
-    /// calls, so the caller keeps the request pending. Returns true when the
-    /// result went out.
+    /// calls, so the caller keeps the request pending. A grant refused with
+    /// the typed `connection_not_found` comes back as `.needsConnect` so the
+    /// caller can drive the in-sheet OAuth leg instead of surfacing an error.
     private func sendCapabilityResult(
         request: CapabilityRequest,
         status: CapabilityRequestResult.Status,
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>] = [:],
         conversationId: String
-    ) async -> Bool {
+    ) async -> CapabilityResultSendOutcome {
         let resolver = session.capabilityResolver()
         let writer = messagingService.capabilityRequestResultWriter()
         // Snapshot the resolver's current providerIds for this (subject, verb,
@@ -2385,7 +2442,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let sortedIds = providerIds.sorted(by: { $0.rawValue < $1.rawValue })
 
         if status == .approved {
-            let cloudGrantsConfirmed = await Self.persistApprovedCloudCapabilities(
+            let confirmation = await Self.persistApprovedCloudCapabilities(
                 providerIds: sortedIds,
                 bundleSelection: bundleSelection,
                 conversationId: conversationId,
@@ -2393,7 +2450,12 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 grantWriter: messagingService.connectionGrantWriter(),
                 repository: session.cloudConnectionRepository()
             )
-            guard cloudGrantsConfirmed else { return false }
+            guard confirmation.allConfirmed else {
+                guard confirmation.providersNeedingConnect.isEmpty else {
+                    return .needsConnect(confirmation.providersNeedingConnect)
+                }
+                return .failed
+            }
         } else {
             // Resolver errors don't block the result: routing state is local
             // bookkeeping and a re-approval repairs it, whereas a swallowed
@@ -2426,7 +2488,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             try await writer.sendResult(result, in: conversationId)
         } catch {
             Log.error("Failed to send capability_request_result: \(error.localizedDescription)")
-            return false
+            return .failed
         }
         if status == .approved {
             await finalizeBroadcastApproval(
@@ -2437,7 +2499,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 conversationId: conversationId
             )
         }
-        return true
+        return .sent
+    }
+
+    /// How one `sendCapabilityResult` attempt ended. `.needsConnect` carries
+    /// the providers whose grant POST the backend refused with the typed
+    /// `connection_not_found` -- the local connection row is stale and the
+    /// in-sheet OAuth leg must run before the approval can confirm.
+    enum CapabilityResultSendOutcome: Equatable {
+        case sent
+        case failed
+        case needsConnect([ProviderID])
     }
 
     /// Post-broadcast bookkeeping for an approval whose `.approved` result
@@ -2592,9 +2664,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         grantedToInboxId: String,
         grantWriter: any CloudConnectionGrantWriterProtocol,
         repository: any CloudConnectionRepositoryProtocol
-    ) async -> Bool {
+    ) async -> CloudGrantConfirmation {
         let activeConnections = (try? await repository.connections()) ?? []
         var allConfirmed = true
+        var providersNeedingConnect: [ProviderID] = []
 
         for providerId in providerIds {
             guard let serviceId = providerId.cloudServiceId else { continue }
@@ -2616,12 +2689,33 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     grantedToInboxId: grantedToInboxId,
                     bundleIds: bundleIds
                 )
+            } catch CloudConnectionsAPI.GrantError.connectionNotFound {
+                // The backend's live-credential gate refused the grant: the
+                // local row is stale (an OAuth that never completed, or a
+                // server-side revoke/purge). The caller drives the in-sheet
+                // OAuth leg for these providers instead of surfacing an error.
+                Log.warning("Backend holds no live connection for \(providerId.rawValue); routing to the connect flow")
+                allConfirmed = false
+                providersNeedingConnect.append(providerId)
             } catch {
                 Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")
                 allConfirmed = false
             }
         }
-        return allConfirmed
+        return CloudGrantConfirmation(
+            allConfirmed: allConfirmed,
+            providersNeedingConnect: providersNeedingConnect
+        )
+    }
+
+    /// Outcome of confirming the cloud grants behind one approval.
+    struct CloudGrantConfirmation: Equatable {
+        /// Every approved cloud provider's grant is backend-confirmed.
+        let allConfirmed: Bool
+        /// Providers whose grant POST was refused with the typed
+        /// `connection_not_found`: no live credential exists server-side, so
+        /// OAuth must (re)run before the approval can confirm.
+        let providersNeedingConnect: [ProviderID]
     }
 
     /// The user-visible `connection_event granted` transcript lines for the

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -927,6 +927,18 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// request, the request was answered here, or observation reset).
     var presentingCapabilityApproval: Bool = false
     var showsCapabilityApprovedToast: Bool = false
+    /// Request id whose approval pipeline (backend grant confirmation + result
+    /// send) is in flight. Re-entrancy guard for the Done tap, and drives the
+    /// sheet's progress state. The request is only consumed once the pipeline
+    /// succeeds; until then the pill stays pending.
+    private(set) var capabilityApprovalInFlightRequestId: String?
+    var capabilityApprovalInFlight: Bool {
+        capabilityApprovalInFlightRequestId != nil
+    }
+    /// Failure the approval sheet surfaces when an approval could not be
+    /// completed -- the backend grant POST or the result send failed. The
+    /// request stays pending and the sheet's button retries the same approval.
+    private(set) var capabilityApprovalErrorMessage: String?
     var presentingProfileForMember: ConversationMember?
     var presentingNewConversationForInvite: NewConversationViewModel? {
         didSet { oldValue?.cleanUpIfNeeded() }
@@ -1757,6 +1769,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         pendingCapabilityPickerLayout = nil
         latestObservedCapabilityRequest = nil
         locallyHandledCapabilityRequestIds.removeAll()
+        capabilityApprovalInFlightRequestId = nil
+        capabilityApprovalErrorMessage = nil
         capabilityRequestsCancellable?.cancel()
         capabilityRequestsCancellable = session.capabilityRequestRepository(for: conversationId)
             .pendingRequestPublisher
@@ -2043,6 +2057,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         guard prompt.status == .pending else { return }
         guard let layout = pendingCapabilityPickerLayout,
               layout.request.requestId == prompt.requestId else { return }
+        // A failure from an earlier, since-dismissed attempt shouldn't greet
+        // the user on a fresh open; the sheet starts clean.
+        capabilityApprovalErrorMessage = nil
         presentingCapabilityApproval = true
     }
 
@@ -2073,6 +2090,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         guard let layout = pendingCapabilityPickerLayout else { return }
         let request = layout.request
         let conversationId = conversation.id
+        capabilityApprovalErrorMessage = nil
 
         let split = Self.splitCapabilityApproval(
             providerIds: providerIds,
@@ -2279,127 +2297,155 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         return revokedServiceIds
     }
 
+    /// Runs the approval pipeline for one Done tap. The request is consumed
+    /// (pill resolved, sheet dismissed) only after the `.approved` result
+    /// actually went out — which in turn requires the backend grant POST to
+    /// have confirmed. On failure nothing is broadcast: the sheet stays up
+    /// with a retryable error and the pill stays pending, so a
+    /// successful-looking approval can never wake the agent without a server
+    /// grant behind it.
     private func approveCapabilityRequest(
         _ request: CapabilityRequest,
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>],
         conversationId: String
     ) {
-        locallyHandledCapabilityRequestIds.insert(request.requestId)
-        // Only dismiss the picker if it's still showing *this* request — a newer
-        // request might have arrived during the async hop and replaced the layout,
-        // and we mustn't blow that one away on the old request's behalf.
-        if pendingCapabilityPickerLayout?.request.requestId == request.requestId {
-            pendingCapabilityPickerLayout = nil
+        guard capabilityApprovalInFlightRequestId == nil else { return }
+        capabilityApprovalInFlightRequestId = request.requestId
+        capabilityApprovalErrorMessage = nil
+        Task { [weak self] in
+            guard let self else { return }
+            let sent = await self.sendCapabilityResult(
+                request: request,
+                status: .approved,
+                providerIds: providerIds,
+                bundleSelection: bundleSelection,
+                conversationId: conversationId
+            )
+            self.capabilityApprovalInFlightRequestId = nil
+            guard sent else {
+                self.capabilityApprovalErrorMessage = Constant.capabilityApprovalFailedMessage
+                return
+            }
+            self.locallyHandledCapabilityRequestIds.insert(request.requestId)
+            // Only dismiss the picker if it's still showing *this* request — a newer
+            // request might have arrived during the async hop and replaced the layout,
+            // and we mustn't blow that one away on the old request's behalf.
+            if self.pendingCapabilityPickerLayout?.request.requestId == request.requestId {
+                self.pendingCapabilityPickerLayout = nil
+            }
         }
-        sendCapabilityResult(
-            request: request,
-            status: .approved,
-            providerIds: providerIds,
-            bundleSelection: bundleSelection,
-            conversationId: conversationId
-        )
     }
 
+    /// Posts the `capability_request_result` reply for `request`. Deny/cancel
+    /// results always post — the agent must see the user's intent even when
+    /// local bookkeeping fails. Approved results are contingent: every
+    /// approved cloud provider's grant must be confirmed against the backend
+    /// first, and the result message must actually send. If either fails,
+    /// nothing is broadcast (an unbacked "approved" would wake the agent only
+    /// for the backend to deny its tool calls) and the caller keeps the
+    /// request pending. Returns true when the result went out.
     private func sendCapabilityResult(
         request: CapabilityRequest,
         status: CapabilityRequestResult.Status,
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>] = [:],
         conversationId: String
-    ) {
+    ) async -> Bool {
         let resolver = session.capabilityResolver()
         let writer = messagingService.capabilityRequestResultWriter()
-        Task {
-            // The agent's contract is that a result is *always* posted — even cancel
-            // and deny — so we keep going on a resolver-side error and let the agent
-            // see the user's intent. Local persistence failure is logged and surfaced
-            // separately if it ever needs UI surfacing; it must not strand the agent.
-            //
-            // Snapshot the resolver's current providerIds for this (subject, verb,
-            // conversation) tuple before mutating it. The diff (`newlyApprovedProviderIds`)
-            // is what the cloud persist path uses to decide whether to fire a
-            // connection_event — fan-in semantics are per-(provider, verb), so a
-            // second verb approval on a provider already granted at the connection
-            // level still needs its own group-update line.
-            let askerInboxId = request.askerInboxId
-            let previouslyApproved: Set<ProviderID>
-            if status == .approved {
-                previouslyApproved = await resolver.resolution(
+        // Snapshot the resolver's current providerIds for this (subject, verb,
+        // conversation) tuple before mutating it. The diff (`newlyApprovedProviderIds`)
+        // is what the cloud persist path uses to decide whether to fire a
+        // connection_event — fan-in semantics are per-(provider, verb), so a
+        // second verb approval on a provider already granted at the connection
+        // level still needs its own group-update line.
+        let askerInboxId = request.askerInboxId
+        let previouslyApproved: Set<ProviderID>
+        if status == .approved {
+            previouslyApproved = await resolver.resolution(
+                subject: request.subject,
+                capability: request.capability,
+                conversationId: conversationId,
+                grantedToInboxId: askerInboxId
+            )
+        } else {
+            previouslyApproved = []
+        }
+        let newlyApprovedProviderIds = providerIds.subtracting(previouslyApproved)
+        let sortedIds = providerIds.sorted(by: { $0.rawValue < $1.rawValue })
+
+        if status == .approved {
+            let cloudGrantsConfirmed = await Self.persistApprovedCloudCapabilities(
+                providerIds: sortedIds,
+                newlyApprovedProviderIds: newlyApprovedProviderIds,
+                bundleSelection: bundleSelection,
+                capability: request.capability,
+                conversationId: conversationId,
+                grantedToInboxId: askerInboxId,
+                grantWriter: messagingService.connectionGrantWriter(),
+                eventWriter: messagingService.connectionEventWriter(),
+                repository: session.cloudConnectionRepository()
+            )
+            guard cloudGrantsConfirmed else { return false }
+        }
+
+        // Resolver errors don't block the result: routing state is local
+        // bookkeeping and a re-approval repairs it, whereas a swallowed
+        // result would strand the agent.
+        do {
+            switch status {
+            case .approved:
+                try await resolver.setResolution(
+                    providerIds,
                     subject: request.subject,
                     capability: request.capability,
                     conversationId: conversationId,
                     grantedToInboxId: askerInboxId
                 )
-            } else {
-                previouslyApproved = []
+            case .denied, .cancelled, .staleResource, .unknown:
+                try await resolver.clearResolution(
+                    subject: request.subject,
+                    capability: request.capability,
+                    conversationId: conversationId,
+                    grantedToInboxId: askerInboxId
+                )
             }
-            let newlyApprovedProviderIds = providerIds.subtracting(previouslyApproved)
+        } catch {
+            Log.error("Capability resolver update failed (still posting result to agent): \(error.localizedDescription)")
+        }
 
-            do {
-                switch status {
-                case .approved:
-                    try await resolver.setResolution(
-                        providerIds,
-                        subject: request.subject,
-                        capability: request.capability,
-                        conversationId: conversationId,
-                        grantedToInboxId: askerInboxId
-                    )
-                case .denied, .cancelled, .staleResource, .unknown:
-                    try await resolver.clearResolution(
-                        subject: request.subject,
-                        capability: request.capability,
-                        conversationId: conversationId,
-                        grantedToInboxId: askerInboxId
-                    )
-                }
-            } catch {
-                Log.error("Capability resolver update failed (still posting result to agent): \(error.localizedDescription)")
-            }
-
-            let availableActions = await self.availableActions(
-                for: providerIds.sorted(by: { $0.rawValue < $1.rawValue }),
-                capability: request.capability
-            )
-            let result = CapabilityRequestResult(
-                requestId: request.requestId,
-                status: status,
-                subject: request.subject,
+        if status == .approved {
+            await Self.persistApprovedDeviceCapabilities(
+                providerIds: sortedIds,
                 capability: request.capability,
-                providers: providerIds.sorted(by: { $0.rawValue < $1.rawValue }),
-                availableActions: availableActions
+                conversationId: conversationId,
+                grantedToInboxId: askerInboxId,
+                session: session
             )
-            if status == .approved {
-                let sortedIds = providerIds.sorted(by: { $0.rawValue < $1.rawValue })
-                await Self.persistApprovedDeviceCapabilities(
-                    providerIds: sortedIds,
-                    capability: request.capability,
-                    conversationId: conversationId,
-                    grantedToInboxId: askerInboxId,
-                    session: session
-                )
-                await Self.persistApprovedCloudCapabilities(
-                    providerIds: sortedIds,
-                    newlyApprovedProviderIds: newlyApprovedProviderIds,
-                    bundleSelection: bundleSelection,
-                    capability: request.capability,
-                    conversationId: conversationId,
-                    grantedToInboxId: askerInboxId,
-                    session: session
-                )
-            }
+        }
 
-            do {
-                try await writer.sendResult(result, in: conversationId)
-                if status == .approved {
-                    await MainActor.run { [weak self] in
-                        self?.flashCapabilityApprovedToast()
-                    }
-                }
-            } catch {
-                Log.error("Failed to send capability_request_result: \(error.localizedDescription)")
+        let availableActions = await self.availableActions(
+            for: sortedIds,
+            capability: request.capability
+        )
+        let result = CapabilityRequestResult(
+            requestId: request.requestId,
+            status: status,
+            subject: request.subject,
+            capability: request.capability,
+            providers: sortedIds,
+            availableActions: availableActions
+        )
+        do {
+            try await writer.sendResult(result, in: conversationId)
+            if status == .approved {
+                flashCapabilityApprovedToast()
             }
+            return true
+        } catch {
+            Log.error("Failed to send capability_request_result: \(error.localizedDescription)")
+            return false
         }
     }
 
@@ -2484,49 +2530,60 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     }
 
     /// For each approved `composio.<service>` provider, ensure a per-conversation
-    /// `CloudConnectionGrant` exists against the matching active `CloudConnection` and
-    /// emit a `connection_event granted` if the grant is newly created. Skips providers
-    /// whose CloudConnection isn't active locally — those would have been created by the
-    /// caller (e.g. picker → connectCloudProvider) and the publisher snapshot taken here
-    /// races against that path; if we miss it the next sync corrects state.
-    private static func persistApprovedCloudCapabilities( // swiftlint:disable:this function_parameter_count
+    /// `CloudConnectionGrant` exists against the matching active `CloudConnection`,
+    /// confirmed against the backend grant store, and emit a `connection_event
+    /// granted` if the grant is newly created.
+    ///
+    /// Returns false when any approved cloud provider's grant could not be
+    /// confirmed — no active local connection to grant against, or the grant
+    /// write / backend POST failed. The caller must not broadcast an
+    /// `.approved` result in that case: the agent would be woken with an
+    /// approval the backend then denies. A grant already confirmed
+    /// (`backendGrantId` present) with an unchanged bundle scope is skipped;
+    /// a row missing its backend id re-runs the confirming push so an
+    /// earlier failed POST is retried on the next Done tap.
+    static func persistApprovedCloudCapabilities( // swiftlint:disable:this function_parameter_count
         providerIds: [ProviderID],
         newlyApprovedProviderIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>],
         capability: ConnectionCapability,
         conversationId: String,
         grantedToInboxId: String,
-        session: any SessionManagerProtocol
-    ) async {
-        let messagingService = session.messagingService()
-        let grantWriter = messagingService.connectionGrantWriter()
-        let eventWriter = messagingService.connectionEventWriter()
-        let repository = session.cloudConnectionRepository()
+        grantWriter: any CloudConnectionGrantWriterProtocol,
+        eventWriter: any ConnectionEventWriterProtocol,
+        repository: any CloudConnectionRepositoryProtocol
+    ) async -> Bool {
         let activeConnections = (try? await repository.connections()) ?? []
         let existingGrants = (try? await repository.grants(for: conversationId)) ?? []
-        let existingGrantedKeys = Set(existingGrants.map { GrantKey(connectionId: $0.connectionId, grantedToInboxId: $0.grantedToInboxId) })
+        var allConfirmed = true
 
         for providerId in providerIds {
             guard let serviceId = providerId.cloudServiceId else { continue }
-            guard let connection = activeConnections.first(where: { $0.serviceId == serviceId }) else { continue }
+            guard let connection = activeConnections.first(where: { $0.serviceId == serviceId }) else {
+                // Without an active local connection there is nothing to grant
+                // against, so no server grant can back this approval.
+                Log.error("No active connection for approved provider \(providerId.rawValue); approval not confirmed")
+                allConfirmed = false
+                continue
+            }
 
             // The grant row is per-(connection, conversation, agent). Two agents
             // approved for the same connection get two rows; the same agent re-
-            // approving the same connection with the same bundle scope is a no-op
-            // for the grant write but still needs its own connection_event. A
-            // re-approval with a *different* bundle selection re-grants so the
-            // backend scope follows the user's latest picker state.
+            // approving the same connection with the same confirmed bundle scope
+            // is a no-op for the grant write but still needs its own
+            // connection_event. A re-approval with a *different* bundle selection
+            // re-grants so the backend scope follows the user's latest picker state.
             let bundleIds = bundleSelection[serviceId].map { $0.sorted() }
-            let grantKey = GrantKey(connectionId: connection.id, grantedToInboxId: grantedToInboxId)
             let existingGrant = existingGrants.first {
                 $0.connectionId == connection.id && $0.grantedToInboxId == grantedToInboxId
             }
             let bundleScopeChanged = existingGrant.map {
                 bundleIds != nil && Set($0.bundleIds ?? []) != Set(bundleIds ?? [])
             } ?? false
-            if !existingGrantedKeys.contains(grantKey) || bundleScopeChanged {
+            let backendUnconfirmed = existingGrant.map { $0.backendGrantId == nil } ?? true
+            if backendUnconfirmed || bundleScopeChanged {
                 do {
-                    try await grantWriter.grantConnection(
+                    try await grantWriter.grantConnectionConfirmingBackend(
                         connection.id,
                         to: conversationId,
                         grantedToInboxId: grantedToInboxId,
@@ -2534,6 +2591,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     )
                 } catch {
                     Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")
+                    allConfirmed = false
                     continue
                 }
             }
@@ -2549,11 +2607,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 in: conversationId
             )
         }
-    }
-
-    private struct GrantKey: Hashable {
-        let connectionId: String
-        let grantedToInboxId: String
+        return allConfirmed
     }
 
     private static func capabilityActionParameter(
@@ -2819,6 +2873,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         /// window in SyncingManager, which itself covers the assistant
         /// backend's roughly two-minute give-up with margin.
         static let assistantJoinWaitWindow: TimeInterval = 150
+        /// Shown in the approval sheet when an approval could not be
+        /// completed (backend grant confirmation or result send failed).
+        static let capabilityApprovalFailedMessage: String =
+            "Couldn't confirm this approval with the server. Check your connection and try again."
     }
 }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2322,6 +2322,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 bundleSelection: bundleSelection,
                 conversationId: conversationId
             )
+            // A conversation switch mid-flight resets the in-flight id and may
+            // hand it to a newer approval. A late completion that no longer
+            // owns the id must not clear that approval's re-entrancy guard or
+            // surface its own error in the newer request's sheet.
+            guard self.capabilityApprovalInFlightRequestId == request.requestId else { return }
             self.capabilityApprovalInFlightRequestId = nil
             guard sent else {
                 self.capabilityApprovalErrorMessage = Constant.capabilityApprovalFailedMessage
@@ -2338,13 +2343,16 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     }
 
     /// Posts the `capability_request_result` reply for `request`. Deny/cancel
-    /// results always post — the agent must see the user's intent even when
+    /// results always post -- the agent must see the user's intent even when
     /// local bookkeeping fails. Approved results are contingent: every
     /// approved cloud provider's grant must be confirmed against the backend
     /// first, and the result message must actually send. If either fails,
-    /// nothing is broadcast (an unbacked "approved" would wake the agent only
-    /// for the backend to deny its tool calls) and the caller keeps the
-    /// request pending. Returns true when the result went out.
+    /// nothing is broadcast -- no result, and no granted transcript line
+    /// either, since those (with resolver and device bookkeeping) run in
+    /// `finalizeBroadcastApproval` only after the send succeeds. An unbacked
+    /// "approved" would wake the agent only for the backend to deny its tool
+    /// calls, so the caller keeps the request pending. Returns true when the
+    /// result went out.
     private func sendCapabilityResult(
         request: CapabilityRequest,
         status: CapabilityRequestResult.Status,
@@ -2356,10 +2364,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let writer = messagingService.capabilityRequestResultWriter()
         // Snapshot the resolver's current providerIds for this (subject, verb,
         // conversation) tuple before mutating it. The diff (`newlyApprovedProviderIds`)
-        // is what the cloud persist path uses to decide whether to fire a
-        // connection_event — fan-in semantics are per-(provider, verb), so a
-        // second verb approval on a provider already granted at the connection
-        // level still needs its own group-update line.
+        // decides which granted connection_events fire after the result send --
+        // fan-in semantics are per-(provider, verb), so a second verb approval
+        // on a provider already granted at the connection level still needs its
+        // own group-update line. The resolver mutates only after a successful
+        // send, so a failed send leaves the diff intact for the retry.
         let askerInboxId = request.askerInboxId
         let previouslyApproved: Set<ProviderID>
         if status == .approved {
@@ -2378,51 +2387,27 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         if status == .approved {
             let cloudGrantsConfirmed = await Self.persistApprovedCloudCapabilities(
                 providerIds: sortedIds,
-                newlyApprovedProviderIds: newlyApprovedProviderIds,
                 bundleSelection: bundleSelection,
-                capability: request.capability,
                 conversationId: conversationId,
                 grantedToInboxId: askerInboxId,
                 grantWriter: messagingService.connectionGrantWriter(),
-                eventWriter: messagingService.connectionEventWriter(),
                 repository: session.cloudConnectionRepository()
             )
             guard cloudGrantsConfirmed else { return false }
-        }
-
-        // Resolver errors don't block the result: routing state is local
-        // bookkeeping and a re-approval repairs it, whereas a swallowed
-        // result would strand the agent.
-        do {
-            switch status {
-            case .approved:
-                try await resolver.setResolution(
-                    providerIds,
-                    subject: request.subject,
-                    capability: request.capability,
-                    conversationId: conversationId,
-                    grantedToInboxId: askerInboxId
-                )
-            case .denied, .cancelled, .staleResource, .unknown:
+        } else {
+            // Resolver errors don't block the result: routing state is local
+            // bookkeeping and a re-approval repairs it, whereas a swallowed
+            // result would strand the agent.
+            do {
                 try await resolver.clearResolution(
                     subject: request.subject,
                     capability: request.capability,
                     conversationId: conversationId,
                     grantedToInboxId: askerInboxId
                 )
+            } catch {
+                Log.error("Capability resolver update failed (still posting result to agent): \(error.localizedDescription)")
             }
-        } catch {
-            Log.error("Capability resolver update failed (still posting result to agent): \(error.localizedDescription)")
-        }
-
-        if status == .approved {
-            await Self.persistApprovedDeviceCapabilities(
-                providerIds: sortedIds,
-                capability: request.capability,
-                conversationId: conversationId,
-                grantedToInboxId: askerInboxId,
-                session: session
-            )
         }
 
         let availableActions = await self.availableActions(
@@ -2439,14 +2424,64 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         )
         do {
             try await writer.sendResult(result, in: conversationId)
-            if status == .approved {
-                flashCapabilityApprovedToast()
-            }
-            return true
         } catch {
             Log.error("Failed to send capability_request_result: \(error.localizedDescription)")
             return false
         }
+        if status == .approved {
+            await finalizeBroadcastApproval(
+                request: request,
+                providerIds: providerIds,
+                sortedProviderIds: sortedIds,
+                newlyApprovedProviderIds: newlyApprovedProviderIds,
+                conversationId: conversationId
+            )
+        }
+        return true
+    }
+
+    /// Post-broadcast bookkeeping for an approval whose `.approved` result
+    /// actually went out: resolver routing state, device enablement, the
+    /// user-visible granted transcript lines, and the toast. Deliberately
+    /// deferred until after `sendResult` succeeds -- a granted line in the
+    /// transcript must imply the agent was woken with the matching result.
+    /// On a failed send nothing here runs; the retry recomputes the same
+    /// resolver diff and runs it then, so the lines still emit exactly once.
+    private func finalizeBroadcastApproval(
+        request: CapabilityRequest,
+        providerIds: Set<ProviderID>,
+        sortedProviderIds: [ProviderID],
+        newlyApprovedProviderIds: Set<ProviderID>,
+        conversationId: String
+    ) async {
+        do {
+            try await session.capabilityResolver().setResolution(
+                providerIds,
+                subject: request.subject,
+                capability: request.capability,
+                conversationId: conversationId,
+                grantedToInboxId: request.askerInboxId
+            )
+        } catch {
+            // Routing state is local bookkeeping; a re-approval repairs it.
+            Log.error("Capability resolver update failed after broadcasting result: \(error.localizedDescription)")
+        }
+        await Self.persistApprovedDeviceCapabilities(
+            providerIds: sortedProviderIds,
+            capability: request.capability,
+            conversationId: conversationId,
+            grantedToInboxId: request.askerInboxId,
+            session: session
+        )
+        await Self.sendCloudGrantedEvents(
+            providerIds: sortedProviderIds,
+            newlyApprovedProviderIds: newlyApprovedProviderIds,
+            capability: request.capability,
+            conversationId: conversationId,
+            grantedToInboxId: request.askerInboxId,
+            eventWriter: messagingService.connectionEventWriter()
+        )
+        flashCapabilityApprovedToast()
     }
 
     private func availableActions(
@@ -2531,26 +2566,25 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
 
     /// For each approved `composio.<service>` provider, ensure a per-conversation
     /// `CloudConnectionGrant` exists against the matching active `CloudConnection`,
-    /// confirmed against the backend grant store, and emit a `connection_event
-    /// granted` if the grant is newly created.
+    /// confirmed against the backend grant store. The user-visible granted
+    /// transcript lines are not emitted here -- they follow the `.approved`
+    /// result send (see `sendCloudGrantedEvents`), so a confirmed grant whose
+    /// result never broadcasts leaves no granted line in the transcript.
     ///
     /// Returns false when any approved cloud provider's grant could not be
-    /// confirmed — no active local connection to grant against, or the grant
+    /// confirmed -- no active local connection to grant against, or the grant
     /// write / backend POST failed. The caller must not broadcast an
     /// `.approved` result in that case: the agent would be woken with an
     /// approval the backend then denies. A grant already confirmed
     /// (`backendGrantId` present) with an unchanged bundle scope is skipped;
     /// a row missing its backend id re-runs the confirming push so an
     /// earlier failed POST is retried on the next Done tap.
-    static func persistApprovedCloudCapabilities( // swiftlint:disable:this function_parameter_count
+    static func persistApprovedCloudCapabilities(
         providerIds: [ProviderID],
-        newlyApprovedProviderIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>],
-        capability: ConnectionCapability,
         conversationId: String,
         grantedToInboxId: String,
         grantWriter: any CloudConnectionGrantWriterProtocol,
-        eventWriter: any ConnectionEventWriterProtocol,
         repository: any CloudConnectionRepositoryProtocol
     ) async -> Bool {
         let activeConnections = (try? await repository.connections()) ?? []
@@ -2592,14 +2626,30 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 } catch {
                     Log.error("Failed to persist cloud grant for \(providerId.rawValue) → \(grantedToInboxId): \(error.localizedDescription)")
                     allConfirmed = false
-                    continue
                 }
             }
+        }
+        return allConfirmed
+    }
 
-            // Fan-in is per-(providerId, verb): if the resolver already had
-            // this providerId for this verb (re-approval after deny, picker
-            // shown twice), don't echo a duplicate group-update message.
-            guard newlyApprovedProviderIds.contains(providerId) else { continue }
+    /// The user-visible `connection_event granted` transcript lines for the
+    /// cloud providers this approval newly resolved. Fan-in is per-(provider,
+    /// verb) via the resolver diff: if the resolver already had a providerId
+    /// for this verb (re-approval after deny, picker shown twice), no
+    /// duplicate group-update message is echoed. Called only after the
+    /// `.approved` result broadcast, so a granted line always implies the
+    /// agent was woken with the matching result.
+    static func sendCloudGrantedEvents(
+        providerIds: [ProviderID],
+        newlyApprovedProviderIds: Set<ProviderID>,
+        capability: ConnectionCapability,
+        conversationId: String,
+        grantedToInboxId: String,
+        eventWriter: any ConnectionEventWriterProtocol
+    ) async {
+        for providerId in providerIds {
+            guard providerId.cloudServiceId != nil,
+                  newlyApprovedProviderIds.contains(providerId) else { continue }
             try? await eventWriter.sendGranted(
                 providerId: providerId.rawValue,
                 capability: capability,
@@ -2607,7 +2657,6 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 in: conversationId
             )
         }
-        return allConfirmed
     }
 
     private static func capabilityActionParameter(

--- a/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
@@ -36,13 +36,23 @@ public enum CloudConnectionsAPI {
         }
     }
 
-    /// Typed failure surfaced by `createConnectionGrant` when the backend
-    /// rejects a bundle id that isn't in its catalog for the toolkit
-    /// (HTTP 400 `{"code": "unknown_bundle", "bundleId": "<the bad id>"}`).
-    /// This is the staleness signal on the HTTP path: callers refetch
-    /// `GET /v2/connections/services`, drop unknown ids, and retry once.
+    /// Typed failures surfaced by `createConnectionGrant`.
+    ///
+    /// `unknownBundle` is the backend rejecting a bundle id that isn't in its
+    /// catalog for the toolkit (HTTP 400 `{"code": "unknown_bundle",
+    /// "bundleId": "<the bad id>"}`). This is the staleness signal on the
+    /// HTTP path: callers refetch `GET /v2/connections/services`, drop
+    /// unknown ids, and retry once.
+    ///
+    /// `connectionNotFound` is the backend's live-credential gate refusing to
+    /// issue a grant for a toolkit with no connected account behind it
+    /// (HTTP 409 `{"code": "connection_not_found"}`). The local connection
+    /// row is stale -- an OAuth that never completed, or a server-side
+    /// revoke/purge -- and the user must (re)connect before the grant can
+    /// confirm.
     public enum GrantError: Error, Sendable, Equatable {
         case unknownBundle(bundleId: String?)
+        case connectionNotFound
     }
 
     // MARK: - Services catalog (GET /v2/connections/services)

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -1217,18 +1217,31 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             // "bundleId": "<id>"}` — no `message`/`error` key, so
             // `parseErrorMessage` passes the raw JSON body through. Decode it
             // here so callers get a typed staleness signal they can retry on.
-            struct GrantErrorBody: Decodable {
-                let code: String
-                let bundleId: String?
-            }
-            if let message,
-               let data = message.data(using: .utf8),
-               let body = try? JSONDecoder().decode(GrantErrorBody.self, from: data),
-               body.code == "unknown_bundle" {
+            if let body = Self.grantErrorBody(from: message), body.code == "unknown_bundle" {
                 throw CloudConnectionsAPI.GrantError.unknownBundle(bundleId: body.bundleId)
             }
             throw APIError.badRequest(message)
+        } catch let APIError.serverError(message) {
+            // The live-credential gate's 409 body is `{"code":
+            // "connection_not_found"}`; performRequest folds non-subscription
+            // 409s into serverError with the raw body as the message. Decode
+            // it here so callers can drive the (re)connect flow instead of
+            // surfacing a generic failure.
+            if let body = Self.grantErrorBody(from: message), body.code == "connection_not_found" {
+                throw CloudConnectionsAPI.GrantError.connectionNotFound
+            }
+            throw APIError.serverError(message)
         }
+    }
+
+    private struct GrantErrorBody: Decodable {
+        let code: String
+        let bundleId: String?
+    }
+
+    private static func grantErrorBody(from message: String?) -> GrantErrorBody? {
+        guard let message, let data = message.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(GrantErrorBody.self, from: data)
     }
 
     func revokeConnectionGrant(id: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift
@@ -18,6 +18,7 @@ public enum SupportedConnections {
     public static let supportedDeviceKinds: Set<ConnectionKind> = []
 
     public static let supportedCloudServiceIds: Set<String> = [
+        "gmail",
         "googlecalendar",
     ]
 

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrant.swift
@@ -12,6 +12,11 @@ public struct CloudConnectionGrant: Codable, Sendable, Hashable {
     /// "calendar.events"). Nil for legacy whole-toolkit grants or services
     /// outside the catalog.
     public let bundleIds: [String]?
+    /// Id of the backend ConnectionGrant record created when this grant was
+    /// pushed to the server. Nil when the push hasn't happened or failed --
+    /// consumers that need a server-confirmed grant (the capability approval
+    /// flow) treat a nil id as a push still owed and retry it.
+    public let backendGrantId: String?
 
     public init(
         connectionId: String,
@@ -19,7 +24,8 @@ public struct CloudConnectionGrant: Codable, Sendable, Hashable {
         serviceId: String,
         grantedToInboxId: String,
         grantedAt: Date,
-        bundleIds: [String]? = nil
+        bundleIds: [String]? = nil,
+        backendGrantId: String? = nil
     ) {
         self.connectionId = connectionId
         self.conversationId = conversationId
@@ -27,5 +33,6 @@ public struct CloudConnectionGrant: Codable, Sendable, Hashable {
         self.grantedToInboxId = grantedToInboxId
         self.grantedAt = grantedAt
         self.bundleIds = bundleIds
+        self.backendGrantId = backendGrantId
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -217,6 +217,8 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     /// that fails closed without reaching the server. The caller decides
     /// whether that is best-effort (`grantConnection` logs and moves on) or
     /// contractual (`grantConnectionConfirmingBackend` propagates it).
+    /// A failure persisting the returned id locally is logged, not thrown:
+    /// the push itself was confirmed by then.
     private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
         guard let scope = await resolveBundleScope(
@@ -273,8 +275,24 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             bundleIds: pushedScope.bundleIds,
             serviceVersion: pushedScope.serviceVersion
         )
-        try await databaseWriter.write { db in
-            try updated.save(db)
+        // The backend confirmed the grant above; recording the returned id is
+        // local bookkeeping. Throwing here would make a confirming caller
+        // treat a live backend grant as unconfirmed and surface a retryable
+        // error for an authorization that already exists. Instead the row
+        // keeps its nil backendGrantId, so the next approval re-runs the push;
+        // the backend upserts the same tuple and returns the same id, and
+        // revocation targets the natural key rather than the stored id.
+        do {
+            try await databaseWriter.write { db in
+                try updated.save(db)
+            }
+        } catch {
+            Log.error(
+                "[CloudConnections] backend grant confirmed (id=\(response.id)) but persisting the " +
+                "backend id locally failed; the next approval re-runs the idempotent push " +
+                "(connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
+                "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+            )
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -13,6 +13,19 @@ public protocol CloudConnectionGrantWriterProtocol: Sendable {
         grantedToInboxId: String,
         bundleIds: [String]?
     ) async throws
+    /// Same write as `grantConnection`, but the backend consent POST is part
+    /// of the contract: a push failure (or a push that fails closed without
+    /// reaching the server) throws instead of being logged and swallowed.
+    /// The local grant row and published metadata stand on failure, with the
+    /// row's missing `backendGrantId` marking the unconfirmed push so a
+    /// retry re-runs it. Callers that must not act on an unconfirmed grant
+    /// (the capability approval flow) use this variant.
+    func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws
     func revokeGrant(
         connectionId: String,
         from conversationId: String,
@@ -63,6 +76,45 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         grantedToInboxId: String,
         bundleIds: [String]?
     ) async throws {
+        let (grant, connection) = try await persistGrantLocally(
+            connectionId,
+            to: conversationId,
+            grantedToInboxId: grantedToInboxId,
+            bundleIds: bundleIds
+        )
+        do {
+            try await pushGrantToBackend(grant, connection: connection)
+        } catch {
+            logBackendPushFailure(for: grant, error: error)
+        }
+    }
+
+    func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        let (grant, connection) = try await persistGrantLocally(
+            connectionId,
+            to: conversationId,
+            grantedToInboxId: grantedToInboxId,
+            bundleIds: bundleIds
+        )
+        do {
+            try await pushGrantToBackend(grant, connection: connection)
+        } catch {
+            logBackendPushFailure(for: grant, error: error)
+            throw error
+        }
+    }
+
+    private func persistGrantLocally(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws -> (DBCloudConnectionGrant, DBCloudConnection) {
         guard !grantedToInboxId.isEmpty else {
             throw CloudConnectionGrantError.missingGrantedToInboxId
         }
@@ -98,8 +150,16 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         try await databaseWriter.write { db in
             try grant.save(db)
         }
+        return (grant, connection)
+    }
 
-        await pushGrantToBackend(grant, connection: connection)
+    private func logBackendPushFailure(for grant: DBCloudConnectionGrant, error: Error) {
+        Log.error(
+            "[CloudConnections] backend grant push failed; agent will get 403 from backend-mediated " +
+            "execution until the user re-grants (connectionId=\(grant.connectionId), " +
+            "conversationId=\(grant.conversationId), grantedToInboxId=\(grant.grantedToInboxId)): " +
+            error.localizedDescription
+        )
     }
 
     func revokeGrant(
@@ -152,69 +212,69 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     /// Grants are bundle-scoped against the services catalog (see
     /// `resolveBundleScope`); a 400 `unknown_bundle` rejection means our
     /// catalog cache is stale, so the push refetches it, drops ids the fresh
-    /// catalog no longer knows, and retries exactly once. Otherwise
-    /// best-effort with no retry: on failure the local grant stands, but the
-    /// backend will deny the agent's tool execution (403) until the user
-    /// re-grants, so the failure is logged at error level.
-    private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async {
+    /// catalog no longer knows, and retries exactly once. Throws when the
+    /// push could not be confirmed -- an API failure, or a scope resolution
+    /// that fails closed without reaching the server. The caller decides
+    /// whether that is best-effort (`grantConnection` logs and moves on) or
+    /// contractual (`grantConnectionConfirmingBackend` propagates it).
+    private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async throws {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        guard let scope = await resolveBundleScope(
+            toolkit: connection.serviceId,
+            explicitSelection: grant.bundleIds
+        ) else {
+            throw CloudConnectionGrantError.backendPushNotConfirmed(
+                "bundle scope for \(connection.serviceId) could not be resolved; push skipped fail-closed"
+            )
+        }
+        let response: CloudConnectionsAPI.CreateGrantResponse
+        let pushedScope: BundleScope
         do {
-            let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
-            guard let scope = await resolveBundleScope(
-                toolkit: connection.serviceId,
-                explicitSelection: grant.bundleIds
-            ) else { return }
-            let response: CloudConnectionsAPI.CreateGrantResponse
-            let pushedScope: BundleScope
-            do {
-                response = try await inboxReady.apiClient.createConnectionGrant(
-                    ownerInboxId: inboxReady.client.inboxId,
-                    granteeInboxId: grant.grantedToInboxId,
-                    conversationId: grant.conversationId,
-                    toolkit: connection.serviceId,
-                    bundleIds: scope.bundleIds,
-                    serviceVersion: scope.serviceVersion
-                )
-                pushedScope = scope
-            } catch CloudConnectionsAPI.GrantError.unknownBundle(let bundleId) {
-                Log.warning(
-                    "[CloudConnections] grant rejected for stale bundle id " +
-                    "(toolkit=\(connection.serviceId), bundleId=\(bundleId ?? "?")); " +
-                    "refetching services catalog and retrying once"
-                )
-                guard let retryScope = try await retryScope(
-                    afterUnknownBundleFor: connection.serviceId,
-                    firstAttempt: scope
-                ) else { return }
-                response = try await inboxReady.apiClient.createConnectionGrant(
-                    ownerInboxId: inboxReady.client.inboxId,
-                    granteeInboxId: grant.grantedToInboxId,
-                    conversationId: grant.conversationId,
-                    toolkit: connection.serviceId,
-                    bundleIds: retryScope.bundleIds,
-                    serviceVersion: retryScope.serviceVersion
-                )
-                pushedScope = retryScope
-            }
-            let updated = DBCloudConnectionGrant(
-                connectionId: grant.connectionId,
+            response = try await inboxReady.apiClient.createConnectionGrant(
+                ownerInboxId: inboxReady.client.inboxId,
+                granteeInboxId: grant.grantedToInboxId,
                 conversationId: grant.conversationId,
-                serviceId: grant.serviceId,
-                grantedToInboxId: grant.grantedToInboxId,
-                grantedAt: grant.grantedAt,
-                backendGrantId: response.id,
-                bundleIds: pushedScope.bundleIds,
-                serviceVersion: pushedScope.serviceVersion
+                toolkit: connection.serviceId,
+                bundleIds: scope.bundleIds,
+                serviceVersion: scope.serviceVersion
             )
-            try await databaseWriter.write { db in
-                try updated.save(db)
+            pushedScope = scope
+        } catch CloudConnectionsAPI.GrantError.unknownBundle(let bundleId) {
+            Log.warning(
+                "[CloudConnections] grant rejected for stale bundle id " +
+                "(toolkit=\(connection.serviceId), bundleId=\(bundleId ?? "?")); " +
+                "refetching services catalog and retrying once"
+            )
+            guard let retryScope = try await retryScope(
+                afterUnknownBundleFor: connection.serviceId,
+                firstAttempt: scope
+            ) else {
+                throw CloudConnectionGrantError.backendPushNotConfirmed(
+                    "no valid bundle scope for \(connection.serviceId) after unknown_bundle rejection"
+                )
             }
-        } catch {
-            Log.error(
-                "[CloudConnections] backend grant push failed; agent will get 403 from backend-mediated " +
-                "execution until the user re-grants (connectionId=\(grant.connectionId), " +
-                "conversationId=\(grant.conversationId), grantedToInboxId=\(grant.grantedToInboxId)): " +
-                error.localizedDescription
+            response = try await inboxReady.apiClient.createConnectionGrant(
+                ownerInboxId: inboxReady.client.inboxId,
+                granteeInboxId: grant.grantedToInboxId,
+                conversationId: grant.conversationId,
+                toolkit: connection.serviceId,
+                bundleIds: retryScope.bundleIds,
+                serviceVersion: retryScope.serviceVersion
             )
+            pushedScope = retryScope
+        }
+        let updated = DBCloudConnectionGrant(
+            connectionId: grant.connectionId,
+            conversationId: grant.conversationId,
+            serviceId: grant.serviceId,
+            grantedToInboxId: grant.grantedToInboxId,
+            grantedAt: grant.grantedAt,
+            backendGrantId: response.id,
+            bundleIds: pushedScope.bundleIds,
+            serviceVersion: pushedScope.serviceVersion
+        )
+        try await databaseWriter.write { db in
+            try updated.save(db)
         }
     }
 
@@ -545,6 +605,7 @@ enum CloudConnectionGrantError: LocalizedError {
     case connectionNotActive(String, status: String)
     case conversationNotFound(String)
     case missingGrantedToInboxId
+    case backendPushNotConfirmed(String)
 
     var errorDescription: String? {
         switch self {
@@ -556,6 +617,8 @@ enum CloudConnectionGrantError: LocalizedError {
             "Conversation not found: \(id)"
         case .missingGrantedToInboxId:
             "grantedToInboxId is required and cannot be empty"
+        case .backendPushNotConfirmed(let reason):
+            "Backend grant push not confirmed: \(reason)"
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -338,8 +338,15 @@ enum CloudConnectionManagerError: LocalizedError {
 extension CloudConnectionStatus {
     static func from(composioStatus raw: String) -> CloudConnectionStatus {
         switch raw.uppercased() {
-        case "ACTIVE", "INITIATED", "INITIALIZING":
+        case "ACTIVE":
             return .active
+        case "INITIATED", "INITIALIZING":
+            // OAuth was started but never finished. Treating these as active
+            // minted phantom-linked providers: the approval sheet trusted the
+            // local snapshot and skipped its OAuth leg, then the grant sat on
+            // a connection with no credential behind it. Not usable until the
+            // flow completes, so surface the (re)connect prompt.
+            return .expired
         case "EXPIRED":
             return .expired
         case "FAILED", "INACTIVE":

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/MockCloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/MockCloudConnectionManager.swift
@@ -57,6 +57,13 @@ public final class MockConnectionGrantWriter: CloudConnectionGrantWriterProtocol
         bundleIds: [String]?
     ) async throws {}
 
+    public func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {}
+
     public func revokeGrant(
         connectionId: String,
         from conversationId: String,

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBCloudConnectionGrant.swift
@@ -61,7 +61,8 @@ extension DBCloudConnectionGrant {
             serviceId: serviceId,
             grantedToInboxId: grantedToInboxId,
             grantedAt: grantedAt,
-            bundleIds: bundleIds
+            bundleIds: bundleIds,
+            backendGrantId: backendGrantId
         )
     }
 
@@ -71,7 +72,7 @@ extension DBCloudConnectionGrant {
         self.serviceId = grant.serviceId
         self.grantedToInboxId = grant.grantedToInboxId
         self.grantedAt = grant.grantedAt
-        self.backendGrantId = nil
+        self.backendGrantId = grant.backendGrantId
         self.bundleIds = grant.bundleIds
         self.serviceVersion = nil
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -378,6 +378,63 @@ struct ConnectionGrantWriterTests {
         #expect(stored.first?.backendGrantId == nil)
     }
 
+    @Test("Confirming grant: backend push failure propagates; local row stands unconfirmed for retry")
+    func confirmingGrantThrowsWhenBackendPushFails() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        struct PushFailure: Error {}
+        recordingClient.createError = PushFailure()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_confirm_fail"
+        try fixture.seedConversation(id: conversationId)
+
+        var caughtExpectedError: Bool = false
+        do {
+            try await fixture.writer.grantConnectionConfirmingBackend(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: "agent-1",
+                bundleIds: nil
+            )
+            Issue.record("Expected grantConnectionConfirmingBackend to throw")
+        } catch is PushFailure {
+            caughtExpectedError = true
+        } catch {
+            Issue.record("Expected PushFailure but got \(error)")
+        }
+        #expect(caughtExpectedError, "the swallowed-error path is exactly what this variant removes")
+
+        // The local row stands (same posture as grantConnection) with a nil
+        // backendGrantId marking the push still owed, so a retry re-runs it.
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1)
+        #expect(stored.first?.backendGrantId == nil)
+    }
+
+    @Test("Confirming grant: successful push stores the backend id and does not throw")
+    func confirmingGrantStoresBackendIdOnSuccess() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_confirm_ok"
+        try fixture.seedConversation(id: conversationId)
+
+        try await fixture.writer.grantConnectionConfirmingBackend(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: nil
+        )
+
+        #expect(recordingClient.createCalls.count == 1)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.first?.backendGrantId == "backend-grant-1")
+    }
+
     @Test("Revoke: revokes the backend grant by natural key when a backend id is stored")
     func revokeRevokesBackendGrant() async throws {
         let recordingClient = RecordingGrantAPIClient()

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -435,6 +435,39 @@ struct ConnectionGrantWriterTests {
         #expect(stored.first?.backendGrantId == "backend-grant-1")
     }
 
+    @Test("Confirming grant: a local persistence failure after a confirmed push does not throw")
+    func confirmingGrantSurvivesLocalPersistenceFailureAfterConfirmedPush() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_confirm_persist_fail"
+        try fixture.seedConversation(id: conversationId)
+
+        // Sabotage the grant table between the confirmed POST and the
+        // writer's follow-up bookkeeping, so persisting the returned backend
+        // id fails while the backend grant is live. Throwing here would make
+        // the caller treat the confirmed authorization as unconfirmed and
+        // surface a retryable error for a grant that already exists.
+        let databaseWriter = fixture.databaseManager.dbWriter
+        recordingClient.onCreateSuccess = {
+            try await databaseWriter.write { db in
+                try db.drop(table: DBCloudConnectionGrant.databaseTableName)
+            }
+        }
+
+        try await fixture.writer.grantConnectionConfirmingBackend(
+            connection.id,
+            to: conversationId,
+            grantedToInboxId: "agent-1",
+            bundleIds: nil
+        )
+
+        #expect(recordingClient.createCalls.count == 1,
+                "the push reached the backend and was confirmed; only the local id write failed")
+    }
+
     @Test("Revoke: revokes the backend grant by natural key when a backend id is stored")
     func revokeRevokesBackendGrant() async throws {
         let recordingClient = RecordingGrantAPIClient()
@@ -862,6 +895,10 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
     var servicesFetchCount: Int = 0
     /// When set, every catalog fetch fails — models a backend/network outage.
     var servicesError: Error?
+    /// Runs after a create call succeeds, just before its response is
+    /// returned — lets a test sabotage local state between the confirmed
+    /// POST and the writer's follow-up bookkeeping.
+    var onCreateSuccess: (() async throws -> Void)?
 
     override func getConnectionServices() async throws -> CloudConnectionsAPI.ServicesResponse {
         servicesFetchCount += 1
@@ -899,6 +936,7 @@ private final class RecordingGrantAPIClient: TestStubAPIClient {
         if !createErrorQueue.isEmpty {
             throw createErrorQueue.removeFirst()
         }
+        try await onCreateSuccess?()
         return CloudConnectionsAPI.CreateGrantResponse(id: "backend-grant-\(createCalls.count)")
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -679,6 +679,13 @@ private actor RecordingGrantWriter: CloudConnectionGrantWriterProtocol {
         bundleIds: [String]?
     ) async throws {}
 
+    nonisolated func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {}
+
     func revokeGrant(
         connectionId: String,
         from conversationId: String,

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionStatusMappingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionStatusMappingTests.swift
@@ -9,10 +9,15 @@ struct ConnectionStatusMappingTests {
         #expect(CloudConnectionStatus.from(composioStatus: "ACTIVE") == .active)
     }
 
-    @Test("INITIATED and INITIALIZING map to .active (pre-complete states)")
-    func preCompleteStates() {
-        #expect(CloudConnectionStatus.from(composioStatus: "INITIATED") == .active)
-        #expect(CloudConnectionStatus.from(composioStatus: "INITIALIZING") == .active)
+    @Test("INITIATED and INITIALIZING are not active (OAuth never completed)")
+    func preCompleteStatesAreNotActive() {
+        // An OAuth that was started but never completed must not read as a
+        // connected account: treating these as active minted phantom-linked
+        // providers the approval sheet trusted, skipping its OAuth leg
+        // entirely. Expired surfaces the (re)connect prompt.
+        #expect(CloudConnectionStatus.from(composioStatus: "INITIATED") == .expired)
+        #expect(CloudConnectionStatus.from(composioStatus: "INITIALIZING") == .expired)
+        #expect(CloudConnectionStatus.from(composioStatus: "initiated") == .expired)
     }
 
     @Test("EXPIRED maps to .expired")

--- a/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
+++ b/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
@@ -7,9 +7,9 @@ import XCTest
 /// Approval-confirmation coverage: an `.approved` capability result is
 /// contingent on a confirmed backend grant POST. A failed POST leaves the
 /// approval unconfirmed (nothing may broadcast, the sheet surfaces a
-/// retryable error, the pill stays pending), a previously unconfirmed grant
-/// retries the push on the next Done tap, and a grant already confirmed with
-/// the same scope is skipped.
+/// retryable error, the pill stays pending), and the confirming push runs on
+/// every approval -- a locally cached backend grant id is never trusted as
+/// proof of server state, since server-side revokes or purges leave it stale.
 @MainActor
 final class ConversationViewModelApproveConfirmationTests: XCTestCase {
     private let googleCalendar = ProviderID(rawValue: "composio.googlecalendar")
@@ -64,7 +64,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
         ])
     }
 
-    func testExistingConfirmedGrantWithSameScopeSkipsRepush() async {
+    func testExistingConfirmedGrantStillRunsConfirmingPushOnApproval() async {
         let grantWriter = ConfigurableGrantWriter()
 
         let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
@@ -81,9 +81,37 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(confirmed, "A grant the backend already confirmed backs the approval as-is")
-        XCTAssertTrue(grantWriter.confirmingGrants.isEmpty,
-                      "Same scope + confirmed backend id: no re-push needed")
+        XCTAssertTrue(confirmed)
+        XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
+                       "A locally cached backend id is not proof of server state (server-side revokes " +
+                       "or purges leave it stale); every approval re-runs the idempotent confirming push")
+    }
+
+    func testStaleConfirmedGrantWithFailingPushLeavesApprovalUnconfirmed() async {
+        // The exact stale-marker shape: the local row carries a backend id
+        // from an earlier approval whose server rows were since removed. The
+        // push must run and its failure must block the .approved broadcast --
+        // trusting the cached id would wake the agent into 403s.
+        let grantWriter = ConfigurableGrantWriter()
+        grantWriter.confirmingGrantError = ConfigurableGrantWriter.Failure()
+
+        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            repository: StubConnectionsRepository(
+                stubbedConnections: [makeConnection()],
+                stubbedGrants: [
+                    makeGrant(backendGrantId: "backend-stale", bundleIds: ["calendar.events"]),
+                ]
+            )
+        )
+
+        XCTAssertFalse(confirmed,
+                       "An unconfirmable push blocks the broadcast even when a stale backend id is cached locally")
+        XCTAssertEqual(grantWriter.confirmingGrants.count, 1)
     }
 
     func testExistingUnconfirmedGrantRetriesBackendPush() async {

--- a/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
+++ b/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
@@ -19,17 +19,13 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
     func testGrantPostFailureLeavesApprovalUnconfirmed() async {
         let grantWriter = ConfigurableGrantWriter()
         grantWriter.confirmingGrantError = ConfigurableGrantWriter.Failure()
-        let eventWriter = SpyEventWriter()
 
         let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
-            newlyApprovedProviderIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
-            capability: .read,
             conversationId: "convo-1",
             grantedToInboxId: "agent-inbox",
             grantWriter: grantWriter,
-            eventWriter: eventWriter,
             repository: StubConnectionsRepository(
                 stubbedConnections: [makeConnection()],
                 stubbedGrants: []
@@ -40,23 +36,17 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
                        "A failed grant POST must leave the approval unconfirmed so no .approved result broadcasts")
         XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
                        "The confirming push was attempted exactly once")
-        XCTAssertTrue(eventWriter.grantedProviderIds.isEmpty,
-                      "No granted transcript line may announce a grant the backend never confirmed")
     }
 
-    func testConfirmedGrantPostApprovesAndEmitsGrantedEvent() async {
+    func testConfirmedGrantPostApproves() async {
         let grantWriter = ConfigurableGrantWriter()
-        let eventWriter = SpyEventWriter()
 
         let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
-            newlyApprovedProviderIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
-            capability: .read,
             conversationId: "convo-1",
             grantedToInboxId: "agent-inbox",
             grantWriter: grantWriter,
-            eventWriter: eventWriter,
             repository: StubConnectionsRepository(
                 stubbedConnections: [makeConnection()],
                 stubbedGrants: []
@@ -72,22 +62,17 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
                 bundleIds: ["calendar.events"]
             ),
         ])
-        XCTAssertEqual(eventWriter.grantedProviderIds, ["composio.googlecalendar"])
     }
 
     func testExistingConfirmedGrantWithSameScopeSkipsRepush() async {
         let grantWriter = ConfigurableGrantWriter()
-        let eventWriter = SpyEventWriter()
 
         let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
-            newlyApprovedProviderIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
-            capability: .read,
             conversationId: "convo-1",
             grantedToInboxId: "agent-inbox",
             grantWriter: grantWriter,
-            eventWriter: eventWriter,
             repository: StubConnectionsRepository(
                 stubbedConnections: [makeConnection()],
                 stubbedGrants: [
@@ -99,23 +84,17 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
         XCTAssertTrue(confirmed, "A grant the backend already confirmed backs the approval as-is")
         XCTAssertTrue(grantWriter.confirmingGrants.isEmpty,
                       "Same scope + confirmed backend id: no re-push needed")
-        XCTAssertEqual(eventWriter.grantedProviderIds, ["composio.googlecalendar"],
-                       "The granted line follows the resolver diff, not the grant write")
     }
 
     func testExistingUnconfirmedGrantRetriesBackendPush() async {
         let grantWriter = ConfigurableGrantWriter()
-        let eventWriter = SpyEventWriter()
 
         let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
-            newlyApprovedProviderIds: [],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
-            capability: .read,
             conversationId: "convo-1",
             grantedToInboxId: "agent-inbox",
             grantWriter: grantWriter,
-            eventWriter: eventWriter,
             repository: StubConnectionsRepository(
                 stubbedConnections: [makeConnection()],
                 stubbedGrants: [
@@ -131,24 +110,55 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
 
     func testMissingActiveConnectionLeavesApprovalUnconfirmed() async {
         let grantWriter = ConfigurableGrantWriter()
-        let eventWriter = SpyEventWriter()
 
         let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
-            newlyApprovedProviderIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
-            capability: .read,
             conversationId: "convo-1",
             grantedToInboxId: "agent-inbox",
             grantWriter: grantWriter,
-            eventWriter: eventWriter,
             repository: StubConnectionsRepository(stubbedConnections: [], stubbedGrants: [])
         )
 
         XCTAssertFalse(confirmed,
                        "Without an active connection no server grant can back the approval")
         XCTAssertTrue(grantWriter.confirmingGrants.isEmpty)
-        XCTAssertTrue(eventWriter.grantedProviderIds.isEmpty)
+    }
+
+    // MARK: - Granted transcript lines follow the result send
+
+    func testGrantedEventsEmitOnlyForNewlyApprovedCloudProviders() async {
+        let eventWriter = SpyEventWriter()
+        let alreadyApproved = ProviderID(rawValue: "composio.googledrive")
+        let deviceProvider = ProviderID(rawValue: "device.calendar")
+
+        await ConversationViewModel.sendCloudGrantedEvents(
+            providerIds: [googleCalendar, alreadyApproved, deviceProvider],
+            newlyApprovedProviderIds: [googleCalendar, deviceProvider],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            eventWriter: eventWriter
+        )
+
+        XCTAssertEqual(eventWriter.grantedProviderIds, ["composio.googlecalendar"],
+                       "The granted line follows the resolver diff and covers cloud providers only")
+    }
+
+    func testGrantedEventsSkipProvidersTheResolverAlreadyHad() async {
+        let eventWriter = SpyEventWriter()
+
+        await ConversationViewModel.sendCloudGrantedEvents(
+            providerIds: [googleCalendar],
+            newlyApprovedProviderIds: [],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            eventWriter: eventWriter
+        )
+
+        XCTAssertTrue(eventWriter.grantedProviderIds.isEmpty,
+                      "A re-approval of an already resolved provider must not echo a duplicate group-update line")
     }
 
     // MARK: - Approval pipeline keeps the request pending on failure

--- a/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
+++ b/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
@@ -20,7 +20,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
         let grantWriter = ConfigurableGrantWriter()
         grantWriter.confirmingGrantError = ConfigurableGrantWriter.Failure()
 
-        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
             conversationId: "convo-1",
@@ -32,8 +32,10 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(confirmed,
+        XCTAssertFalse(confirmation.allConfirmed,
                        "A failed grant POST must leave the approval unconfirmed so no .approved result broadcasts")
+        XCTAssertTrue(confirmation.providersNeedingConnect.isEmpty,
+                      "A generic push failure is retryable in place, not a connect-flow signal")
         XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
                        "The confirming push was attempted exactly once")
     }
@@ -41,7 +43,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
     func testConfirmedGrantPostApproves() async {
         let grantWriter = ConfigurableGrantWriter()
 
-        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
             conversationId: "convo-1",
@@ -53,7 +55,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(confirmed)
+        XCTAssertTrue(confirmation.allConfirmed)
         XCTAssertEqual(grantWriter.confirmingGrants, [
             ConfigurableGrantWriter.Grant(
                 connectionId: "conn-1",
@@ -67,7 +69,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
     func testExistingConfirmedGrantStillRunsConfirmingPushOnApproval() async {
         let grantWriter = ConfigurableGrantWriter()
 
-        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
             conversationId: "convo-1",
@@ -81,7 +83,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(confirmed)
+        XCTAssertTrue(confirmation.allConfirmed)
         XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
                        "A locally cached backend id is not proof of server state (server-side revokes " +
                        "or purges leave it stale); every approval re-runs the idempotent confirming push")
@@ -95,7 +97,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
         let grantWriter = ConfigurableGrantWriter()
         grantWriter.confirmingGrantError = ConfigurableGrantWriter.Failure()
 
-        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
             conversationId: "convo-1",
@@ -109,7 +111,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(confirmed,
+        XCTAssertFalse(confirmation.allConfirmed,
                        "An unconfirmable push blocks the broadcast even when a stale backend id is cached locally")
         XCTAssertEqual(grantWriter.confirmingGrants.count, 1)
     }
@@ -117,7 +119,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
     func testExistingUnconfirmedGrantRetriesBackendPush() async {
         let grantWriter = ConfigurableGrantWriter()
 
-        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
             conversationId: "convo-1",
@@ -131,7 +133,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(confirmed)
+        XCTAssertTrue(confirmation.allConfirmed)
         XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
                        "A local grant whose earlier POST never confirmed re-runs the confirming push on retry")
     }
@@ -139,7 +141,7 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
     func testMissingActiveConnectionLeavesApprovalUnconfirmed() async {
         let grantWriter = ConfigurableGrantWriter()
 
-        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
             providerIds: [googleCalendar],
             bundleSelection: ["googlecalendar": ["calendar.events"]],
             conversationId: "convo-1",
@@ -148,9 +150,39 @@ final class ConversationViewModelApproveConfirmationTests: XCTestCase {
             repository: StubConnectionsRepository(stubbedConnections: [], stubbedGrants: [])
         )
 
-        XCTAssertFalse(confirmed,
+        XCTAssertFalse(confirmation.allConfirmed,
                        "Without an active connection no server grant can back the approval")
+        XCTAssertTrue(confirmation.providersNeedingConnect.isEmpty)
         XCTAssertTrue(grantWriter.confirmingGrants.isEmpty)
+    }
+
+    func testConnectionNotFoundRefusalRoutesProviderToConnectFlow() async {
+        // The backend's live-credential gate refused the grant (typed 409
+        // connection_not_found): the local row claims a connection the server
+        // no longer holds. The provider must come back as needing the
+        // in-sheet OAuth leg, not as a plain retryable failure.
+        let grantWriter = ConfigurableGrantWriter()
+        grantWriter.confirmingGrantError = CloudConnectionsAPI.GrantError.connectionNotFound
+
+        let confirmation = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            repository: StubConnectionsRepository(
+                stubbedConnections: [makeConnection()],
+                stubbedGrants: [
+                    makeGrant(backendGrantId: "backend-stale", bundleIds: ["calendar.events"]),
+                ]
+            )
+        )
+
+        XCTAssertFalse(confirmation.allConfirmed,
+                       "A refused grant must not let the .approved result broadcast")
+        XCTAssertEqual(confirmation.providersNeedingConnect, [googleCalendar],
+                       "The typed refusal routes the provider into the connect flow")
+        XCTAssertEqual(grantWriter.confirmingGrants.count, 1)
     }
 
     // MARK: - Granted transcript lines follow the result send

--- a/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
+++ b/ConvosTests/ConversationViewModelApproveConfirmationTests.swift
@@ -1,0 +1,393 @@
+import Combine
+@testable import Convos
+import ConvosConnections
+import ConvosCore
+import XCTest
+
+/// Approval-confirmation coverage: an `.approved` capability result is
+/// contingent on a confirmed backend grant POST. A failed POST leaves the
+/// approval unconfirmed (nothing may broadcast, the sheet surfaces a
+/// retryable error, the pill stays pending), a previously unconfirmed grant
+/// retries the push on the next Done tap, and a grant already confirmed with
+/// the same scope is skipped.
+@MainActor
+final class ConversationViewModelApproveConfirmationTests: XCTestCase {
+    private let googleCalendar = ProviderID(rawValue: "composio.googlecalendar")
+
+    // MARK: - persistApprovedCloudCapabilities
+
+    func testGrantPostFailureLeavesApprovalUnconfirmed() async {
+        let grantWriter = ConfigurableGrantWriter()
+        grantWriter.confirmingGrantError = ConfigurableGrantWriter.Failure()
+        let eventWriter = SpyEventWriter()
+
+        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            newlyApprovedProviderIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            repository: StubConnectionsRepository(
+                stubbedConnections: [makeConnection()],
+                stubbedGrants: []
+            )
+        )
+
+        XCTAssertFalse(confirmed,
+                       "A failed grant POST must leave the approval unconfirmed so no .approved result broadcasts")
+        XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
+                       "The confirming push was attempted exactly once")
+        XCTAssertTrue(eventWriter.grantedProviderIds.isEmpty,
+                      "No granted transcript line may announce a grant the backend never confirmed")
+    }
+
+    func testConfirmedGrantPostApprovesAndEmitsGrantedEvent() async {
+        let grantWriter = ConfigurableGrantWriter()
+        let eventWriter = SpyEventWriter()
+
+        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            newlyApprovedProviderIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            repository: StubConnectionsRepository(
+                stubbedConnections: [makeConnection()],
+                stubbedGrants: []
+            )
+        )
+
+        XCTAssertTrue(confirmed)
+        XCTAssertEqual(grantWriter.confirmingGrants, [
+            ConfigurableGrantWriter.Grant(
+                connectionId: "conn-1",
+                conversationId: "convo-1",
+                grantedToInboxId: "agent-inbox",
+                bundleIds: ["calendar.events"]
+            ),
+        ])
+        XCTAssertEqual(eventWriter.grantedProviderIds, ["composio.googlecalendar"])
+    }
+
+    func testExistingConfirmedGrantWithSameScopeSkipsRepush() async {
+        let grantWriter = ConfigurableGrantWriter()
+        let eventWriter = SpyEventWriter()
+
+        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            newlyApprovedProviderIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            repository: StubConnectionsRepository(
+                stubbedConnections: [makeConnection()],
+                stubbedGrants: [
+                    makeGrant(backendGrantId: "backend-1", bundleIds: ["calendar.events"]),
+                ]
+            )
+        )
+
+        XCTAssertTrue(confirmed, "A grant the backend already confirmed backs the approval as-is")
+        XCTAssertTrue(grantWriter.confirmingGrants.isEmpty,
+                      "Same scope + confirmed backend id: no re-push needed")
+        XCTAssertEqual(eventWriter.grantedProviderIds, ["composio.googlecalendar"],
+                       "The granted line follows the resolver diff, not the grant write")
+    }
+
+    func testExistingUnconfirmedGrantRetriesBackendPush() async {
+        let grantWriter = ConfigurableGrantWriter()
+        let eventWriter = SpyEventWriter()
+
+        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            newlyApprovedProviderIds: [],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            repository: StubConnectionsRepository(
+                stubbedConnections: [makeConnection()],
+                stubbedGrants: [
+                    makeGrant(backendGrantId: nil, bundleIds: ["calendar.events"]),
+                ]
+            )
+        )
+
+        XCTAssertTrue(confirmed)
+        XCTAssertEqual(grantWriter.confirmingGrants.count, 1,
+                       "A local grant whose earlier POST never confirmed re-runs the confirming push on retry")
+    }
+
+    func testMissingActiveConnectionLeavesApprovalUnconfirmed() async {
+        let grantWriter = ConfigurableGrantWriter()
+        let eventWriter = SpyEventWriter()
+
+        let confirmed = await ConversationViewModel.persistApprovedCloudCapabilities(
+            providerIds: [googleCalendar],
+            newlyApprovedProviderIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]],
+            capability: .read,
+            conversationId: "convo-1",
+            grantedToInboxId: "agent-inbox",
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            repository: StubConnectionsRepository(stubbedConnections: [], stubbedGrants: [])
+        )
+
+        XCTAssertFalse(confirmed,
+                       "Without an active connection no server grant can back the approval")
+        XCTAssertTrue(grantWriter.confirmingGrants.isEmpty)
+        XCTAssertTrue(eventWriter.grantedProviderIds.isEmpty)
+    }
+
+    // MARK: - Approval pipeline keeps the request pending on failure
+
+    func testFailedApprovalKeepsSheetUpAndRequestPending() async throws {
+        // MockInboxesService's connection repository holds no active
+        // connections, so the approval pipeline cannot confirm a grant --
+        // the exact state a failed grant POST leaves behind.
+        let viewModel = ConversationViewModel(
+            conversation: .mock(id: "test-convo"),
+            session: MockInboxesService(),
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+        // Let the mock request repository's single nil emission land before
+        // seeding the layout, so the fixture's empty publisher can't clear
+        // the seeded layout mid-test. In production the publisher keeps
+        // emitting the still-pending request instead.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-1")
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1"))
+        XCTAssertTrue(viewModel.presentingCapabilityApproval)
+
+        viewModel.onCapabilityApprove(
+            providerIds: [googleCalendar],
+            bundleSelection: ["googlecalendar": ["calendar.events"]]
+        )
+
+        try await waitUntil("approval failure surfaces in the sheet") {
+            viewModel.capabilityApprovalErrorMessage != nil
+        }
+        XCTAssertNotNil(viewModel.pendingCapabilityPickerLayout,
+                        "A failed approval must not consume the prompt card -- the request stays pending")
+        XCTAssertTrue(viewModel.presentingCapabilityApproval,
+                      "The sheet stays up so the user can retry")
+        XCTAssertFalse(viewModel.capabilityApprovalInFlight,
+                       "The in-flight guard resets so the retry tap can run")
+        XCTAssertFalse(viewModel.showsCapabilityApprovedToast,
+                       "No approved toast for an approval that never broadcast")
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 5.0,
+        condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTFail("Timed out waiting for: \(description)")
+    }
+
+    private func makeConnection(
+        id: String = "conn-1",
+        serviceId: String = "googlecalendar"
+    ) -> CloudConnection {
+        CloudConnection(
+            id: id,
+            serviceId: serviceId,
+            serviceName: "Google Calendar",
+            provider: .composio,
+            composioEntityId: "entity-1",
+            composioConnectionId: "ca-1",
+            status: .active,
+            connectedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private func makeGrant(
+        backendGrantId: String?,
+        bundleIds: [String]
+    ) -> CloudConnectionGrant {
+        CloudConnectionGrant(
+            connectionId: "conn-1",
+            conversationId: "convo-1",
+            serviceId: "googlecalendar",
+            grantedToInboxId: "agent-inbox",
+            grantedAt: Date(timeIntervalSince1970: 0),
+            bundleIds: bundleIds,
+            backendGrantId: backendGrantId
+        )
+    }
+
+    private func makeLayout(requestId: String) -> CapabilityPickerLayout {
+        let request = CapabilityRequest(
+            requestId: requestId,
+            askerInboxId: "agent-inbox",
+            subject: .calendar,
+            capability: .read,
+            rationale: "To book that meeting"
+        )
+        return CapabilityPickerLayout(
+            request: request,
+            variant: .confirm,
+            providers: [
+                CapabilityPickerLayout.ProviderSummary(
+                    id: googleCalendar,
+                    displayName: "Google Calendar",
+                    iconName: "calendar",
+                    subject: .calendar,
+                    linked: true,
+                    supportsCapability: true
+                ),
+            ],
+            defaultSelection: [googleCalendar],
+            serviceBundles: [
+                CapabilityPickerLayout.ServiceBundles(
+                    providerId: googleCalendar,
+                    serviceId: "googlecalendar",
+                    serviceVersion: 5,
+                    rows: [
+                        .init(
+                            id: "calendar.events",
+                            title: "Events",
+                            description: "View and edit events on all calendars",
+                            defaultEnabled: false
+                        ),
+                    ],
+                    grantedBundleIds: nil
+                ),
+            ]
+        )
+    }
+
+    private func makePrompt(requestId: String) -> CapabilityConnectPrompt {
+        CapabilityConnectPrompt(
+            requestId: requestId,
+            askerInboxId: "agent-inbox",
+            serviceName: "Google Calendar",
+            serviceId: "googlecalendar",
+            icon: .calendar,
+            status: .pending
+        )
+    }
+}
+
+// MARK: - Spies
+
+private final class ConfigurableGrantWriter: CloudConnectionGrantWriterProtocol, @unchecked Sendable {
+    struct Grant: Equatable {
+        let connectionId: String
+        let conversationId: String
+        let grantedToInboxId: String
+        let bundleIds: [String]?
+    }
+
+    struct Failure: Error {}
+
+    private let lock = NSLock()
+    private var recordedConfirmingGrants: [Grant] = []
+    private var confirmingError: Error?
+
+    var confirmingGrants: [Grant] { lock.withLock { recordedConfirmingGrants } }
+    var confirmingGrantError: Error? {
+        get { lock.withLock { confirmingError } }
+        set { lock.withLock { confirmingError = newValue } }
+    }
+
+    func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {}
+
+    func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        lock.withLock {
+            recordedConfirmingGrants.append(Grant(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId,
+                bundleIds: bundleIds
+            ))
+        }
+        if let error = confirmingGrantError {
+            throw error
+        }
+    }
+
+    func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws {}
+}
+
+private final class SpyEventWriter: ConnectionEventWriterProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var granted: [String] = []
+    private var revoked: [String] = []
+
+    var grantedProviderIds: [String] { lock.withLock { granted } }
+    var revokedProviderIds: [String] { lock.withLock { revoked } }
+
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        lock.withLock { granted.append(providerId) }
+    }
+
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        lock.withLock { revoked.append(providerId) }
+    }
+}
+
+private struct StubConnectionsRepository: CloudConnectionRepositoryProtocol {
+    let stubbedConnections: [CloudConnection]
+    let stubbedGrants: [CloudConnectionGrant]
+
+    func connections() async throws -> [CloudConnection] {
+        stubbedConnections
+    }
+
+    func connectionsPublisher() -> AnyPublisher<[CloudConnection], Never> {
+        Just(stubbedConnections).eraseToAnyPublisher()
+    }
+
+    func grants(for conversationId: String) async throws -> [CloudConnectionGrant] {
+        stubbedGrants.filter { $0.conversationId == conversationId }
+    }
+
+    func grantsPublisher(for conversationId: String) -> AnyPublisher<[CloudConnectionGrant], Never> {
+        Just(stubbedGrants).eraseToAnyPublisher()
+    }
+}

--- a/ConvosTests/ConversationViewModelDoneRevokeTests.swift
+++ b/ConvosTests/ConversationViewModelDoneRevokeTests.swift
@@ -329,6 +329,20 @@ private final class SpyGrantWriter: CloudConnectionGrantWriterProtocol, @uncheck
         }
     }
 
+    func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        try await grantConnection(
+            connectionId,
+            to: conversationId,
+            grantedToInboxId: grantedToInboxId,
+            bundleIds: bundleIds
+        )
+    }
+
     func revokeGrant(
         connectionId: String,
         from conversationId: String,


### PR DESCRIPTION
## What

An approved capability request could wake the agent with no server grant behind it: the backend grant POST was best-effort with swallowed errors (`ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift`), and `Convos/Conversation Detail/ConversationViewModel.swift` broadcast `capability_request_result(.approved)` regardless. The agent then retried its tool call and got a 403 right after a successful-looking approval.

This PR makes the `.approved` result contingent on a confirmed backend grant:

- **`grantConnectionConfirmingBackend`** on `CloudConnectionGrantWriterProtocol`: same local write and group-metadata publish, but a backend push failure (or a push that fails closed without reaching the server) throws instead of being logged away. `grantConnection` keeps its best-effort semantics for the conversation-info toggles and the agent-builder replay path.
- **Approval pipeline**: cloud grants persist through the confirming variant first; only then does the `.approved` result broadcast and the toast fire. On failure nothing goes out — the request stays pending, the transcript pill is not consumed, and the approval sheet stays up with a retryable error.
- **Retry semantics**: a local grant whose earlier POST never confirmed keeps a nil `backendGrantId`; the next Done tap re-runs the confirming push instead of skipping an "existing" grant. A grant already confirmed with the same bundle scope is skipped as before.
- **Sheet UX** (`Convos/Capabilities/CapabilityApprovalSheetView.swift`): in-flight state ("Confirming…", button disabled) and failure state (error line above the primary button, which becomes "Try Again").
- **Gmail allowlist**: `SupportedConnections.supportedCloudServiceIds` adds `gmail` alongside `googlecalendar` (already mapped in `CloudCapabilityProvider`; non-breaking expansion of the connections surface).

## Rollout constraint

This ships as a **single-approver pilot**: 1:1 owner+agent conversations, or groups where exactly one member holds (or can hold) the credential. Any attested non-asker member can still approve or globally decline a request, and concurrent approvals in multi-approver groups can double-persist grants with no rollback of the losing decision — lifting that constraint requires server-side request state or compensation for approval races.

## Tests

- `ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift`: the confirming variant propagates a backend push failure (local row stands unconfirmed for retry) and stores the backend id on success; all existing best-effort grant/revoke behavior unchanged.
- `ConvosTests/ConversationViewModelApproveConfirmationTests.swift`: a failed grant POST leaves the approval unconfirmed with no granted transcript line; success confirms and emits the granted line; unconfirmed grants re-push on retry; confirmed grants skip the re-push; a missing active connection cannot back an approval; and a failed approval keeps the sheet up, the error surfaced, and the request pending.

Verified locally: full ConvosCore suite (1830 tests), Dev-configuration simulator build, SwiftLint strict.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789118812&installation_model_id=20076&pr_number=1307&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1307&signature=d9f301d0b863e49959034cdd7b45828daaad08cf6a4a90dd953cbc3cd853f16e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make capability approval contingent on confirmed backend grant before broadcasting
> - Approval now blocks on backend confirmation via a new `grantConnectionConfirmingBackend` method before sending the approved result; failures keep the request pending with a retryable error shown in the sheet.
> - Adds `capabilityApprovalInFlight` and `capabilityApprovalErrorMessage` state to `ConversationViewModel` to prevent duplicate submissions and surface errors in the UI.
> - A `connection_not_found` backend response triggers an OAuth reconnect flow and retries approval once automatically.
> - `persistApprovedCloudCapabilities` now returns a `CloudGrantConfirmation` struct and checks each grant against the backend; `sendCloudGrantedEvents` is deferred until after a successful broadcast.
> - Fixes `DBCloudConnectionGrant` to persist and restore `backendGrantId` instead of dropping it, and fixes `INITIATED`/`INITIALIZING` Composio statuses to map to `.expired` instead of `.active`.
> - Risk: Approval is now fail-closed — any backend push failure or unresolvable bundle scope blocks the approved result from being sent, whereas previously the send would proceed best-effort.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19b655c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->