### PR TITLE
docs(agent-dm): ADR 015 — agent-owned DM creation (iOS reflector)

### DIFF
--- a/docs/adr/014-idempotent-agent-join.md
+++ b/docs/adr/014-idempotent-agent-join.md
@@ -1,6 +1,6 @@
 # ADR 014: Idempotent Agent Join
 
-> **Status**: Proposed (2026-07-02).
+> **Status**: Accepted (shipped 2026-07-14, convos-ios #1171).
 > **Scope**: Cross-repo decision driven by the iOS/messaging team. Client
 > changes land in `convos-ios`; the passthrough lands in `convos-backend`; the
 > deduplicating change lands in `convos-assistants`.

--- a/docs/adr/015-agent-owned-dm-creation.md
+++ b/docs/adr/015-agent-owned-dm-creation.md
@@ -3,160 +3,119 @@
 > **Status**: Accepted (2026-08-12).
 > **Author**: jarod
 > **Ticket**: CON-761 (Agent DMs)
-> **Scope**: Cross-repo decision driven by the iOS/messaging team. The creation
-> authority moves to the agent (`convos-assistants` + vendored `herald-lite`);
-> `convos-ios` is reduced to a reflector. The backend half of this decision is
-> recorded in `convos-assistants` ADR 015. The full cross-repo design and build
-> notes live in [`docs/plans/agent-owned-dm-creation.md`](../plans/agent-owned-dm-creation.md);
-> this ADR is the durable decision record and documents the iOS as-built.
+> **Scope**: Cross-repo. DM creation is owned by the agent
+> (`convos-assistants` + vendored `herald-lite`); `convos-ios` is a reflector.
+> The backend half is recorded in `convos-assistants` ADR 015. Full cross-repo
+> design and migration notes live in
+> [`docs/plans/agent-owned-dm-creation.md`](../plans/agent-owned-dm-creation.md);
+> this ADR is the durable decision record and documents the iOS behavior.
 
 ## Context
 
-An "agent DM" is the private 1:1 channel between a human and an agent it shares
-a group with. It is transported as a 2-member MLS group (agent + human, agent is
-admin) carrying an `agentDm` marker in `ConversationCustomMetadata` (proto field
-8) whose `originConversationId` points at the primary group the pair shares. iOS
-renders it as a DM page nested under that primary in the conversation pager.
+An "agent DM" is the private 1:1 channel between a human and an agent they share
+a group with. It is transported as a 2-member MLS group (the agent's herald
+identity plus the human; the agent is admin) carrying an `agentDm` marker in
+`ConversationCustomMetadata` (proto field 8) whose `originConversationId` names
+the primary group the pair shares. iOS renders it as a DM page nested under that
+primary in the conversation pager.
 
-The first shipped implementation made the **iOS client** the creator: an eager
-reconciler (`AgentDmReconciler`, see [`agent-dms.md`](../plans/agent-dms.md)
-section 6.4.2) walked verified agents once per app session and created a DM with
-any agent it could not find a *verified* DM with. This produced DM pile-up on
-Dev TestFlight (field report: convos-ios #1274). The defect is architectural,
-not a loop bug: **the client both creates DMs and infers their existence from
-lossy local MLS state.** Any client is a poor authority here:
+DM existence is owned by a single durable authority: the agent's worker Assistant
+DO (see `convos-assistants` ADR 015), which creates the marked group through its
+herald identity and tracks it in a server-side registry. **iOS never creates an
+agent DM.** It receives the agent-created DM via welcome/sync and reflects it.
 
-- Multiple devices per user each run the loop and race to create the same DM.
-- In-memory dedup (`attemptedAgents`) resets on cold launch, so every launch
-  re-attempts creation for agents it cannot find a DM with.
-- MLS group creation is non-transactional (create group, then add member), so a
-  mid-flight failure strands an orphan group.
-- "Existence" is derived from live membership count, which drops to 1 the moment
-  the agent leaves - indistinguishable from "never created" - so a departed
-  agent looks missing and gets a fresh orphan every launch.
-
-convos-ios #1274 mitigated the *visible* symptom (hidden shells + a cleanup
-sweep) but left "attempt-per-launch for dead agents, no durable dedup, no
-backoff" intact, now happening silently.
+The authority sits server-side because DM existence must be single-writer and
+durable, and a client cannot be either: multiple devices per user would race to
+create the same DM; in-memory dedup resets on cold launch; MLS group creation is
+non-transactional, so a mid-flight failure strands an orphan; and "existence"
+inferred from live membership count is indistinguishable from "the agent left."
+A single server-side creator with a durable registry removes that whole class of
+failure, and leaves iOS a well-scoped job: classify, place, gate, and render what
+syncs down. (An earlier iOS-side creator was removed as part of this change; the
+migration is covered in the plan doc.)
 
 ## Decision Drivers
 
-- [x] Dissolve the DM-pile-up bug class rather than mitigate its symptom.
-- [x] One durable authority for DM existence, not N racing devices inferring it
-      from local state.
-- [x] Deterministic placement: a synced DM must nest under exactly one primary
-      group with zero client inference.
-- [x] Do not silently auto-allow a conversation a peer could forge into
-      existence (the marker is member-writable appData).
-- [x] Reuse the backend DM registry, atomic per-peer reserve, and revocation
-      sweep already built for CON-761 rather than adding parallel machinery.
-- [x] Keep iOS backward-compatible: an old client simply stops being the creator
-      and receives the agent-created DM via sync.
+- [x] One durable authority for DM existence; no device races or inference from
+      lossy local state.
+- [x] Deterministic placement: a synced DM nests under exactly one primary group
+      with zero client inference.
+- [x] Do not auto-allow a conversation a peer could forge - the `agentDm` marker
+      is member-writable appData.
+- [x] Backward-compatible: iOS renders whatever the agent creates; an older
+      client simply receives the DM via sync.
 
 ## Decision
 
-**Flip creation ownership to the agent, and reduce iOS to a pure reflector.** The
-agent (server-side, acting through its herald-lite XMTP identity) creates and
-owns the DM; every user device receives the one DM via welcome/sync and only
-*reflects* it. This is the symmetric other half of the design already
-documented: [`agent-dms.md`](../plans/agent-dms.md) section 5.2.1 names the
-backend atomic per-peer reserve "the cross-device authority," and section 5.5
-already has a server-side *revocation* sweep. Agent-owned creation is the
-matching *creation* sweep over the same registry. The client eager reconciler
-was the interim wrong turn.
+**iOS is a pure reflector for agent DMs.** It creates none and implements four
+responsibilities over the DM that syncs down:
 
-Under agent-owned creation the whole bug class dissolves: one writer (no device
-race), existence is a durable server registry row (not inferred from local
-state, so cold-launch cannot recreate), a departed peer is `revoked` rather than
-missing, a dead peer is backed off in the registry, and the agent creates
-atomically as group admin so a failed create leaves a server-side pending row,
-not a client-visible shell.
+1. **Classification** - `ConversationWriter.extractConversationMetadata`
+   classifies a conversation as an agent DM (`isAgentDm`) only when all three
+   hold: the `agentDm` marker is present, there are exactly 2 members, and one
+   member is an **attested/verified agent** (`anyMemberIsVerifiedAgent` reads
+   `DBProfile.agentVerification.isVerified`, which a human peer cannot forge).
+   The marker reader is `agentDmOriginConversationId` on `XMTPiOS.Group`
+   (`XMTPGroup+CustomMetadata.swift`), returning the origin conversation id from
+   `metadata.agentDm.originConversationID`. A one-way `applyingAgentDmLatch`
+   keeps a row classified once it was, while it stays 2-member with a verified
+   agent present.
 
-### iOS as-built (what the reflector does)
+2. **Placement** - `DBAgentDmOrigin` (`agent_dm_origin` table, PK
+   `conversationId` with a foreign key to `conversation` `onDelete: .cascade`,
+   plus an `originConversationId` column) persists the DM -> primary link, so iOS
+   nests the DM page under exactly the marker's origin group. `record(...)`
+   no-ops on a nil/empty origin, so a marker written without an origin never
+   clears a good link.
 
-**Deleted** (the client no longer creates DMs; landed in #1284):
+3. **Consent** - an agent DM arrives as a welcome with `unknown` consent.
+   `ConversationWriter` auto-allows it (`.unknown` -> `.allowed`) only when both
+   `isAgentDm` is true and `userStillSharesOrigin(originConversationId:selfInboxId:)`
+   holds - i.e. the marker's origin conversation still exists locally, lists the
+   user as a current member, and has no recorded departure. Otherwise the DM
+   keeps its `unknown` consent and surfaces as a normal request. This is a purely
+   local reflector decision (no server consent write); the shared-origin gate is
+   what stops a verified agent from forging an auto-allowed DM without a live
+   shared primary.
 
-- `ConvosCore/.../AgentBuilder/AgentDmReconciler.swift` and its tests.
-- `ConvosCore/.../AgentBuilder/AgentDmFlow.swift`.
-- `ConvosCore/.../Sessions/SessionManager+AgentDmReconciler.swift` and its
-  start/teardown in `SessionManager`.
-- The two former create call sites now **open-existing-or-no-op**:
-  `ContactDetailView.handleChatWithAgentDm()` opens the DM via
-  `findAgentDm(with:)` if it has synced, else returns (it arrives via sync);
-  `AgentDmPageView` shows a disabled "setting up" composer until the DM appears,
-  then binds it - no creation path.
+4. **Notifications** - the DM lane is tracked separately from the active
+   conversation because a DM's own id never appears in the parent-keyed
+   `activeConversationChanged`. `AgentDmPageView` posts `activeDmConversationChanged`;
+   `SessionManager` tracks `activeDmConversationId` and `shouldDisplayNotification(for:)`
+   suppresses a banner while the DM is on screen. Taps route through
+   `ConversationsRepository.agentDmTapRouting(forConversationId:)` (resolving the
+   parent group and verified-agent inbox from `DBAgentDmOrigin`) to
+   `.selectAgentDmPageRequested`, opening the DM page under its parent rather than
+   a bare group page.
 
-**Kept / built** (the reflector surface):
-
-1. **Marker reader** - `agentDmOriginConversationId` (a throwing computed `var`
-   on `XMTPiOS.Group` in `XMTPGroup+CustomMetadata.swift`) reads
-   `metadata.agentDm.originConversationID`, returning `nil` unless the marker is
-   present and the origin bytes are non-empty (otherwise hex-encodes them).
-
-2. **`isAgentDm` classification** (`ConversationWriter.extractConversationMetadata`)
-   requires all three: the `agentDm` marker present, exactly 2 members, and a
-   member that is an **attested/verified agent** (`anyMemberIsVerifiedAgent` -
-   reads `DBProfile.agentVerification.isVerified`, which a human peer cannot
-   forge). A one-way `applyingAgentDmLatch` keeps a row classified once it was
-   ever locally classified, while it stays 2-member with a verified agent
-   present.
-
-3. **Consent auto-allow with a shared-origin gate** (`ConversationWriter`).
-   An agent-created DM arrives as a welcome with `unknown` consent. It is
-   auto-allowed (`.unknown` -> `.allowed`) only when **both** hold: `isAgentDm`
-   is true, and `userStillSharesOrigin(originConversationId:selfInboxId:)` -
-   i.e. the marker's origin conversation still exists locally, lists the user as
-   a current member, and has no recorded departure. Anything short keeps the
-   synced `unknown` consent and surfaces as a normal request. The origin gate is
-   what stops a verified agent from forging an auto-allowed DM without a shared
-   primary (or one whose primary the user has left/deleted). Consent stays a
-   client-side reflector decision; there is no server consent write.
-
-4. **Deterministic placement** - `DBAgentDmOrigin` (`agent_dm_origin` table,
-   PK `conversationId` with a foreign key to `conversation` `onDelete: .cascade`,
-   plus an `originConversationId` column) persists the DM -> primary link so iOS
-   nests the DM page under exactly the marker's origin group with zero
-   inference. `record(...)` no-ops on a nil/empty origin so a marker written
-   without an origin never clears a good link.
-
-5. **Push-notification suppression + tap routing** (#1271). The DM lane is
-   tracked separately from the active conversation because a DM's own id never
-   appears in the parent-keyed `activeConversationChanged`: `AgentDmPageView`
-   posts `activeDmConversationChanged`, `SessionManager` tracks
-   `activeDmConversationId`, and `shouldDisplayNotification(for:)` suppresses a
-   banner while its DM is on screen. Taps route through
-   `ConversationsRepository.agentDmTapRouting(forConversationId:)` (resolves the
-   parent + verified-agent inbox from `DBAgentDmOrigin`) to
-   `.selectAgentDmPageRequested`, opening the DM page under its parent rather
-   than a bare group page.
+`AgentDmPageView` renders all of this: before the DM has synced it shows a
+disabled "setting up" composer, and it binds the real conversation
+(`findAgentDm(with:)`) once the agent-created DM appears. The former "Chat"
+entry points (`ContactDetailView.handleChatWithAgentDm`) open the existing DM if
+present and otherwise no-op - they never create.
 
 ## Consequences
 
 ### Positive
 
-- The DM-pile-up bug class is gone at the root, not mitigated: no device race,
-  no cold-launch recreation, no dead-agent hammering, no orphan shells.
 - Placement is deterministic and local: iOS resolves the parent group from the
   marker with no membership inference.
 - Auto-allow is safe against a forged marker because it is gated on both an
   attested-agent classification and a live shared origin.
-- iOS shed a whole subsystem (reconciler + flow + wiring), reducing surface area.
+- The client carries no DM-creation subsystem - just render, place, gate.
 
 ### Negative / trade-offs
 
-- Cross-repo change (herald primitive + worker loop + iOS reduction) rather than
-  a single-repo patch. Deploy order is herald-lite -> convos-assistants ->
-  convos-ios; each stage is backward-compatible.
-- iOS now depends on the agent to create the DM, so there is a brief window
-  after the user opens the agent's DM page before the DM has synced. It is
-  handled with a disabled "setting up" composer, not a client-side create.
+- iOS depends on the agent to create the DM, so there is a brief window after a
+  user opens the agent's DM page before the DM has synced. It is handled with a
+  disabled "setting up" composer, not a client-side create.
 - Before the marker syncs, iOS cannot classify or place the DM. Tolerated - the
-  DM simply is not shown yet; it appears once the welcome/marker arrives.
+  DM is simply not shown until its welcome/marker arrives.
 
 ### Neutral
 
-- The one-time `StrandedConversationSweeper` (#1274) retires the client-created
-  orphans/duplicates already on Dev; it can be removed once the fleet is clean.
+- Deploy order across repos is herald-lite -> convos-assistants -> convos-ios;
+  every stage is backward-compatible.
 
 ## Related Decisions
 
@@ -169,15 +128,15 @@ not a client-visible shell.
   that makes a human a member of the agent's primary group - the trigger that
   ensures a DM).
 - [`docs/plans/agent-owned-dm-creation.md`](../plans/agent-owned-dm-creation.md)
-  (full cross-repo design + build notes) and
-  [`docs/plans/agent-dms.md`](../plans/agent-dms.md) (the reused transport,
-  registry, and revocation design).
+  (full cross-repo design + migration notes) and
+  [`docs/plans/agent-dms.md`](../plans/agent-dms.md) (the transport, registry,
+  and revocation design).
 
 ## References
 
 Shipped across five PRs: convos-assistants #3191 (Herald `create-dm` + worker
 ensure-DM loop), convos-cli #116 (`agentDm` field-8 codec, published 0.10.16),
-convos-ios #1284 (reflector reduction), convos-assistants #3193 and #3195 (two
+convos-ios #1284 (iOS reflector), convos-assistants #3193 and #3195 (two
 follow-up bug fixes). iOS landings: #1284 (`91a3c7fd`) and #1271 (`c8dde3f5`).
 
 iOS files:
@@ -189,10 +148,10 @@ iOS files:
   `applyingAgentDmLatch`, `createDBConversation`).
 - Origin link: `ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentDmOrigin.swift`;
   migration in `ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift`
-  (`registerAgentDmMigrations`); marker write + deferred record in
+  (`registerAgentDmMigrations`); marker write + record in
   `ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift`
   (`markAsAgentDm`).
-- Push routing: `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+- Notifications: `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
   (`shouldDisplayNotification`, `activeDmConversationId`),
   `Convos/ConvosAppDelegate.swift`,
   `Convos/Conversations List/ConversationsViewModel.swift`

--- a/docs/adr/015-agent-owned-dm-creation.md
+++ b/docs/adr/015-agent-owned-dm-creation.md
@@ -1,0 +1,202 @@
+# ADR 015: Agent-Owned DM Creation (iOS Reflector)
+
+> **Status**: Accepted (2026-08-12).
+> **Author**: jarod
+> **Ticket**: CON-761 (Agent DMs)
+> **Scope**: Cross-repo decision driven by the iOS/messaging team. The creation
+> authority moves to the agent (`convos-assistants` + vendored `herald-lite`);
+> `convos-ios` is reduced to a reflector. The backend half of this decision is
+> recorded in `convos-assistants` ADR 015. The full cross-repo design and build
+> notes live in [`docs/plans/agent-owned-dm-creation.md`](../plans/agent-owned-dm-creation.md);
+> this ADR is the durable decision record and documents the iOS as-built.
+
+## Context
+
+An "agent DM" is the private 1:1 channel between a human and an agent it shares
+a group with. It is transported as a 2-member MLS group (agent + human, agent is
+admin) carrying an `agentDm` marker in `ConversationCustomMetadata` (proto field
+8) whose `originConversationId` points at the primary group the pair shares. iOS
+renders it as a DM page nested under that primary in the conversation pager.
+
+The first shipped implementation made the **iOS client** the creator: an eager
+reconciler (`AgentDmReconciler`, see [`agent-dms.md`](../plans/agent-dms.md)
+section 6.4.2) walked verified agents once per app session and created a DM with
+any agent it could not find a *verified* DM with. This produced DM pile-up on
+Dev TestFlight (field report: convos-ios #1274). The defect is architectural,
+not a loop bug: **the client both creates DMs and infers their existence from
+lossy local MLS state.** Any client is a poor authority here:
+
+- Multiple devices per user each run the loop and race to create the same DM.
+- In-memory dedup (`attemptedAgents`) resets on cold launch, so every launch
+  re-attempts creation for agents it cannot find a DM with.
+- MLS group creation is non-transactional (create group, then add member), so a
+  mid-flight failure strands an orphan group.
+- "Existence" is derived from live membership count, which drops to 1 the moment
+  the agent leaves - indistinguishable from "never created" - so a departed
+  agent looks missing and gets a fresh orphan every launch.
+
+convos-ios #1274 mitigated the *visible* symptom (hidden shells + a cleanup
+sweep) but left "attempt-per-launch for dead agents, no durable dedup, no
+backoff" intact, now happening silently.
+
+## Decision Drivers
+
+- [x] Dissolve the DM-pile-up bug class rather than mitigate its symptom.
+- [x] One durable authority for DM existence, not N racing devices inferring it
+      from local state.
+- [x] Deterministic placement: a synced DM must nest under exactly one primary
+      group with zero client inference.
+- [x] Do not silently auto-allow a conversation a peer could forge into
+      existence (the marker is member-writable appData).
+- [x] Reuse the backend DM registry, atomic per-peer reserve, and revocation
+      sweep already built for CON-761 rather than adding parallel machinery.
+- [x] Keep iOS backward-compatible: an old client simply stops being the creator
+      and receives the agent-created DM via sync.
+
+## Decision
+
+**Flip creation ownership to the agent, and reduce iOS to a pure reflector.** The
+agent (server-side, acting through its herald-lite XMTP identity) creates and
+owns the DM; every user device receives the one DM via welcome/sync and only
+*reflects* it. This is the symmetric other half of the design already
+documented: [`agent-dms.md`](../plans/agent-dms.md) section 5.2.1 names the
+backend atomic per-peer reserve "the cross-device authority," and section 5.5
+already has a server-side *revocation* sweep. Agent-owned creation is the
+matching *creation* sweep over the same registry. The client eager reconciler
+was the interim wrong turn.
+
+Under agent-owned creation the whole bug class dissolves: one writer (no device
+race), existence is a durable server registry row (not inferred from local
+state, so cold-launch cannot recreate), a departed peer is `revoked` rather than
+missing, a dead peer is backed off in the registry, and the agent creates
+atomically as group admin so a failed create leaves a server-side pending row,
+not a client-visible shell.
+
+### iOS as-built (what the reflector does)
+
+**Deleted** (the client no longer creates DMs; landed in #1284):
+
+- `ConvosCore/.../AgentBuilder/AgentDmReconciler.swift` and its tests.
+- `ConvosCore/.../AgentBuilder/AgentDmFlow.swift`.
+- `ConvosCore/.../Sessions/SessionManager+AgentDmReconciler.swift` and its
+  start/teardown in `SessionManager`.
+- The two former create call sites now **open-existing-or-no-op**:
+  `ContactDetailView.handleChatWithAgentDm()` opens the DM via
+  `findAgentDm(with:)` if it has synced, else returns (it arrives via sync);
+  `AgentDmPageView` shows a disabled "setting up" composer until the DM appears,
+  then binds it - no creation path.
+
+**Kept / built** (the reflector surface):
+
+1. **Marker reader** - `agentDmOriginConversationId` (a throwing computed `var`
+   on `XMTPiOS.Group` in `XMTPGroup+CustomMetadata.swift`) reads
+   `metadata.agentDm.originConversationID`, returning `nil` unless the marker is
+   present and the origin bytes are non-empty (otherwise hex-encodes them).
+
+2. **`isAgentDm` classification** (`ConversationWriter.extractConversationMetadata`)
+   requires all three: the `agentDm` marker present, exactly 2 members, and a
+   member that is an **attested/verified agent** (`anyMemberIsVerifiedAgent` -
+   reads `DBProfile.agentVerification.isVerified`, which a human peer cannot
+   forge). A one-way `applyingAgentDmLatch` keeps a row classified once it was
+   ever locally classified, while it stays 2-member with a verified agent
+   present.
+
+3. **Consent auto-allow with a shared-origin gate** (`ConversationWriter`).
+   An agent-created DM arrives as a welcome with `unknown` consent. It is
+   auto-allowed (`.unknown` -> `.allowed`) only when **both** hold: `isAgentDm`
+   is true, and `userStillSharesOrigin(originConversationId:selfInboxId:)` -
+   i.e. the marker's origin conversation still exists locally, lists the user as
+   a current member, and has no recorded departure. Anything short keeps the
+   synced `unknown` consent and surfaces as a normal request. The origin gate is
+   what stops a verified agent from forging an auto-allowed DM without a shared
+   primary (or one whose primary the user has left/deleted). Consent stays a
+   client-side reflector decision; there is no server consent write.
+
+4. **Deterministic placement** - `DBAgentDmOrigin` (`agent_dm_origin` table,
+   PK `conversationId` with a foreign key to `conversation` `onDelete: .cascade`,
+   plus an `originConversationId` column) persists the DM -> primary link so iOS
+   nests the DM page under exactly the marker's origin group with zero
+   inference. `record(...)` no-ops on a nil/empty origin so a marker written
+   without an origin never clears a good link.
+
+5. **Push-notification suppression + tap routing** (#1271). The DM lane is
+   tracked separately from the active conversation because a DM's own id never
+   appears in the parent-keyed `activeConversationChanged`: `AgentDmPageView`
+   posts `activeDmConversationChanged`, `SessionManager` tracks
+   `activeDmConversationId`, and `shouldDisplayNotification(for:)` suppresses a
+   banner while its DM is on screen. Taps route through
+   `ConversationsRepository.agentDmTapRouting(forConversationId:)` (resolves the
+   parent + verified-agent inbox from `DBAgentDmOrigin`) to
+   `.selectAgentDmPageRequested`, opening the DM page under its parent rather
+   than a bare group page.
+
+## Consequences
+
+### Positive
+
+- The DM-pile-up bug class is gone at the root, not mitigated: no device race,
+  no cold-launch recreation, no dead-agent hammering, no orphan shells.
+- Placement is deterministic and local: iOS resolves the parent group from the
+  marker with no membership inference.
+- Auto-allow is safe against a forged marker because it is gated on both an
+  attested-agent classification and a live shared origin.
+- iOS shed a whole subsystem (reconciler + flow + wiring), reducing surface area.
+
+### Negative / trade-offs
+
+- Cross-repo change (herald primitive + worker loop + iOS reduction) rather than
+  a single-repo patch. Deploy order is herald-lite -> convos-assistants ->
+  convos-ios; each stage is backward-compatible.
+- iOS now depends on the agent to create the DM, so there is a brief window
+  after the user opens the agent's DM page before the DM has synced. It is
+  handled with a disabled "setting up" composer, not a client-side create.
+- Before the marker syncs, iOS cannot classify or place the DM. Tolerated - the
+  DM simply is not shown yet; it appears once the welcome/marker arrives.
+
+### Neutral
+
+- The one-time `StrandedConversationSweeper` (#1274) retires the client-created
+  orphans/duplicates already on Dev; it can be removed once the fleet is clean.
+
+## Related Decisions
+
+- `convos-assistants` **ADR 015 - Agent-Owned DM Creation** (the backend half:
+  the Herald `create-dm` primitive, the worker `ensureDmsForPrimaryMembers`
+  loop, and the durable `dm_create_backoff`).
+- [ADR 011 - Single-Inbox Identity Model](./011-single-inbox-identity-model.md)
+  (agents join as members of the single-inbox conversation).
+- [ADR 014 - Idempotent Agent Join](./014-idempotent-agent-join.md) (the join
+  that makes a human a member of the agent's primary group - the trigger that
+  ensures a DM).
+- [`docs/plans/agent-owned-dm-creation.md`](../plans/agent-owned-dm-creation.md)
+  (full cross-repo design + build notes) and
+  [`docs/plans/agent-dms.md`](../plans/agent-dms.md) (the reused transport,
+  registry, and revocation design).
+
+## References
+
+Shipped across five PRs: convos-assistants #3191 (Herald `create-dm` + worker
+ensure-DM loop), convos-cli #116 (`agentDm` field-8 codec, published 0.10.16),
+convos-ios #1284 (reflector reduction), convos-assistants #3193 and #3195 (two
+follow-up bug fixes). iOS landings: #1284 (`91a3c7fd`) and #1271 (`c8dde3f5`).
+
+iOS files:
+
+- Marker reader: `ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift`
+  (`agentDmOriginConversationId`).
+- Classification + consent gate: `ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift`
+  (`extractConversationMetadata`, `isAgentDm`, `userStillSharesOrigin`,
+  `applyingAgentDmLatch`, `createDBConversation`).
+- Origin link: `ConvosCore/Sources/ConvosCore/Storage/Database Models/DBAgentDmOrigin.swift`;
+  migration in `ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift`
+  (`registerAgentDmMigrations`); marker write + deferred record in
+  `ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift`
+  (`markAsAgentDm`).
+- Push routing: `ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift`
+  (`shouldDisplayNotification`, `activeDmConversationId`),
+  `Convos/ConvosAppDelegate.swift`,
+  `Convos/Conversations List/ConversationsViewModel.swift`
+  (`routeToTappedConversation`),
+  `Convos/Contacts/ContactDetailView.swift`,
+  `Convos/Conversation Detail/AgentDmPageView.swift`.
+- Tests: `AgentDmTapRoutingTests.swift`, `AgentDmRegressionTests.swift`.

--- a/docs/plans/agent-dms.md
+++ b/docs/plans/agent-dms.md
@@ -1,6 +1,6 @@
 # Agent DMs — Implementation Plan
 
-> **Status**: Draft (spike output for CON-761)
+> **Status**: Draft (spike output for CON-761). **DM creation here is superseded.** Sections 4 and 6.4.2 describe a client-side DM creator that was replaced by agent-owned creation — the current design is [`agent-owned-dm-creation.md`](./agent-owned-dm-creation.md) and [ADR 015 — Agent-Owned DM Creation](../adr/015-agent-owned-dm-creation.md). The 2-member group transport, the DM registry + atomic per-peer reserve, and revocation described below remain current (they are reused unchanged).
 > **Author**: jarod
 > **Created**: 2026-07-22
 > **Ticket**: [CON-761 — Spike: Agent DM Viability](https://linear.app/convos/issue/CON-761/spike-agent-dm-viability)

--- a/docs/plans/agent-owned-dm-creation.md
+++ b/docs/plans/agent-owned-dm-creation.md
@@ -1,9 +1,10 @@
 # Agent-owned DM creation — design + as-built (CON-761)
 
-> **Status**: Implemented across 5 PRs (below), on top of latest `dev`. Sections 1-3 are the design rationale; **section 0 (As-built) is authoritative** for what actually shipped.
+> **Status**: Merged to `dev` (2026-08-12) across all 5 PRs (below). Sections 1-3 are the design rationale; **section 0 (As-built) is authoritative** for what actually shipped.
 > **Author**: jarod
 > **Created**: 2026-08-04
 > **Ticket**: CON-761 (Agent DMs)
+> **Decision record**: [ADR 015 — Agent-Owned DM Creation (iOS Reflector)](../adr/015-agent-owned-dm-creation.md) (iOS) and `convos-assistants` ADR 015 (backend). This plan doc holds the full cross-repo design + build notes.
 > **Amends**: [`agent-dms.md`](./agent-dms.md) — changes **who creates the DM** (the flow in agent-dms.md section 4 and section 6.4.2). The 2-member group transport (D4), the DM registry + atomic per-peer reserve (5.2.1), revocation (5.5), and the shared-brain stance (5.6) are reused unchanged.
 
 ## 0. As-built (authoritative)


### PR DESCRIPTION
Adds the durable decision record for the agent-owned DM architecture that shipped for CON-761, documenting the **as-built** iOS side (verified against `dev`, not the pre-merge plan).

## What's here
- **`docs/adr/015-agent-owned-dm-creation.md`** — the decision: the client was the wrong authority for DM existence (device races, cold-launch recreation, dead-agent hammering, orphan shells) → the agent owns creation and iOS is a pure reflector. Documents the as-built reflector: `agentDmOriginConversationId` marker reader, `isAgentDm` classification (marker + 2 members + attested verified agent), consent auto-allow gated on `userStillSharesOrigin`, deterministic placement via `DBAgentDmOrigin` (FK cascade), and the #1271 push suppression + tap routing. Lists what was deleted (`AgentDmReconciler`/`AgentDmFlow`/wiring).
- **`docs/plans/agent-owned-dm-creation.md`** — status bumped to *merged to dev* and cross-linked to the new ADR.

The backend half is documented in a sibling `convos-assistants` ADR 015 (herald `create-dm` + worker ensure-DM loop + `dm_create_backoff`).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789142811&installation_model_id=20076&pr_number=1309&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1309&signature=dd092585663cce6e4003ae1abe75a0062c251090e13bc79778142d86e4b1851d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ADR 015 documenting agent-owned DM creation for the iOS reflector
> - Adds [ADR 015](https://github.com/xmtplabs/convos-ios/pull/1309/files#diff-9c53f4e6fdf4cdbf9180f06902bd249cdac513974895e311f2e2723cc9974fc8) covering the accepted design for agent-owned DM creation, including conversation classification, placement, consent, and notification decisions.
> - Marks [ADR 014](https://github.com/xmtplabs/convos-ios/pull/1309/files#diff-3f808fdf79d6dfa9b2d3e09b90e4c9a597ab7c69e9b85cba976452badea68701) as accepted (shipped 2026-07-14, convos-ios #1171).
> - Updates [docs/plans/agent-dms.md](https://github.com/xmtplabs/convos-ios/pull/1309/files#diff-f080c3673bab889592a514d19703571e380c6bc2880a4c2f457a00ed9cc32830) to note its DM creation content is superseded by ADR 015, and updates [docs/plans/agent-owned-dm-creation.md](https://github.com/xmtplabs/convos-ios/pull/1309/files#diff-627fd1a80a2303b1de6db21dcedfa2589232878dc8fb4724badb1676e4126d6e) to reflect that all 5 PRs have merged to dev.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9eb5efb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->