### PR TITLE
ci(warm-xcode-cache): seed SPM clone cache on dev for Firebase PR builds

### DIFF
--- a/.github/workflows/warm-xcode-cache.yml
+++ b/.github/workflows/warm-xcode-cache.yml
@@ -2,10 +2,16 @@
 # subsequent PR runs hit on first try. Without this, GHA-style caches are
 # branch-scoped: a cache populated by a PR run is only visible to that PR.
 #
+# Seeds two caches: the pinned Xcode nix store and the SPM package clones
+# (the latter keyed on Package.resolved; libxmtp alone is ~2 GiB of git
+# history, and a cold fetch of it is what used to blow the Firebase PR
+# job's timeout).
+#
 # Runs:
 #   - On a daily schedule (cheap insurance against eviction).
-#   - When this workflow itself or the firebase-pr workflow changes (so
-#     cache-key drift on Xcode bumps gets re-warmed without waiting a day).
+#   - When this workflow, the firebase-pr workflow, or any Package.resolved
+#     changes (so cache-key drift on Xcode or dependency bumps gets
+#     re-warmed without waiting a day).
 #   - On manual dispatch.
 
 name: Warm Xcode Cache
@@ -20,6 +26,7 @@ on:
     paths:
       - .github/workflows/warm-xcode-cache.yml
       - .github/workflows/firebase-pr.yml
+      - '**/Package.resolved'
   workflow_dispatch:
 
 concurrency:
@@ -30,7 +37,9 @@ jobs:
   warm:
     name: Pin Xcode and seed WarpBuilds cache
     runs-on: warp-macos-latest-arm64-12x
-    timeout-minutes: 10
+    # A cold seed of the SPM clones has been observed at 17+ minutes when
+    # GitHub's pack generation for libxmtp is slow.
+    timeout-minutes: 40
     permissions:
       id-token: write
       contents: read
@@ -49,3 +58,29 @@ jobs:
         with:
           xcode-path: /Applications/Xcode_26.3.app
           xcode-nix-path: /nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app
+
+      # Same path/key the Firebase PR job restores (convos-releases
+      # ios-firebase-pr.yml). Seeding it here, on the default branch, is what
+      # makes fresh PRs hit on first try.
+      # Saves as `post-if: success()`, so a resolve that dies partway through
+      # leaves the previous key intact rather than publishing a half-cloned
+      # directory.
+      - name: Restore SPM package clones
+        uses: WarpBuilds/cache@v1
+        with:
+          path: .spm-clones
+          key: spm-clones-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-clones-
+
+      # Resolution only fetches the package graph; no build. Uses the runner's
+      # stock Xcode directly so this job stays independent of the nix shell.
+      - name: Resolve SPM dependencies into the clone cache
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Convos.xcodeproj \
+            -scheme "Convos (PR Preview)" \
+            -configuration "PR Preview" \
+            -clonedSourcePackagesDirPath .spm-clones


### PR DESCRIPTION
## Why

Companion to xmtplabs/convos-releases#39, which makes the Firebase PR job restore an `.spm-clones` cache (bare git clones of all SPM dependencies — `xmtp/libxmtp` alone is ~2 GiB, and a cold fetch of it is what intermittently blew the job's 25-minute timeout). WarpBuilds caches are branch-scoped like GHA caches: a key only ever created inside PR branches would miss on every fresh PR. This workflow already exists to solve exactly that for the Xcode nix cache, so extend it.

## What

- Restore + resolve the SPM package graph on `dev` (`xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath .spm-clones`), seeding the `spm-clones-${{ hashFiles('**/Package.resolved') }}` key in the scope every PR falls back to. Resolution only fetches packages; nothing is built.
- Trigger the warm run on `**/Package.resolved` changes so the exact key stays fresh after dependency bumps merge.
- Bump the job timeout 10 → 40 minutes: a cold seed can hit the same slow libxmtp fetch (observed at 17+ minutes).

No app code changes — CI YAML only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789150499&installation_model_id=20076&pr_number=1310&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1310&signature=2c073b93bf78af50af367cab3de3a32f67ae103d799ea22a23157b7c10f1a943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seed SPM package clone cache in warm-xcode-cache CI for Firebase PR builds
> - Adds a restore and populate step for `.spm-clones` cache keyed by `hashFiles('**/Package.resolved')` using `WarpBuilds/cache@v1`
> - Resolves SPM dependencies via `xcodebuild -resolvePackageDependencies` targeting `Convos.xcodeproj` with the `PR Preview` scheme, writing clones to `.spm-clones`
> - Extends push trigger paths to include `**/Package.resolved` so the cache is refreshed when dependencies change
> - Increases job timeout from 10 to 40 minutes to accommodate the dependency resolution step
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51f1d00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->