### PR TITLE
feat: auto-enable live abilities when adding an agent to a conversation

### DIFF
--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -228,6 +228,13 @@ struct ConvosApp: App {
     /// the surfaces refresh again on appear.
     private static func configureAbilities(session: any SessionManagerProtocol, environment: AppEnvironment) {
         AbilitiesServices.configure(session: session, environment: environment)
+        // Auto-enable mirrors the v1 connections toggle, so it runs exactly
+        // when that surface renders: whenever the abilities v2 flag is off.
+        // The flag is re-read on every agent add, so a debug-menu flip takes
+        // effect without a relaunch.
+        session.configureAutoEnableAbilities {
+            await MainActor.run { !FeatureFlags.shared.isAbilitiesV2Enabled }
+        }
         if FeatureFlags.shared.isAbilitiesV2Enabled {
             Task { await AbilitiesServices.refreshCatalogInBackground() }
         }

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/AutoEnableAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/AutoEnableAbilitiesService.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Grants the acting user's own live cloud connections to an agent they just
+/// added to a conversation, so a fresh agent conversation starts with the
+/// user's already-connected abilities enabled instead of requiring a trip to
+/// the conversation-info toggles. Runs the same per-agent grant fan-out the
+/// manual toggle runs (the confirming grant writer plus one granted
+/// transcript line per service), so the resulting rows are indistinguishable
+/// from a manual toggle-on and the toggle UI stays truthful through its
+/// normal data flow.
+///
+/// Everything here is best-effort: the entry point never throws and callers
+/// run it detached from the join path, so a failure can never block or fail
+/// adding the agent. Grant state is device-local until normal sync paths
+/// run; another device on the same account sees the enablement only through
+/// those paths.
+public final class AutoEnableAbilitiesService: Sendable {
+    private let cloudConnectionRepository: any CloudConnectionRepositoryProtocol
+    private let grantWriter: any CloudConnectionGrantWriterProtocol
+    private let connectionEventWriter: any ConnectionEventWriterProtocol
+    /// Gate evaluated on every invocation. The abilities v2 surfaces replace
+    /// the v1 connections toggle this service mirrors, so the host wires this
+    /// to the same flag check that decides which surface renders; while v2 is
+    /// active the service stands down entirely.
+    private let isEnabled: @Sendable () async -> Bool
+
+    public init(
+        cloudConnectionRepository: any CloudConnectionRepositoryProtocol,
+        grantWriter: any CloudConnectionGrantWriterProtocol,
+        connectionEventWriter: any ConnectionEventWriterProtocol,
+        isEnabled: @escaping @Sendable () async -> Bool
+    ) {
+        self.cloudConnectionRepository = cloudConnectionRepository
+        self.grantWriter = grantWriter
+        self.connectionEventWriter = connectionEventWriter
+        self.isEnabled = isEnabled
+    }
+
+    /// Auto-enables every qualifying connection for `agentInboxId` in
+    /// `conversationId`. Qualifying means an active composio-backed
+    /// account-level connection for a supported service with no existing
+    /// grant row for this (connection, conversation, agent) tuple.
+    ///
+    /// Each connection goes through the confirming grant path so a row only
+    /// counts as enabled with a live backend grant behind it:
+    /// - Confirmed: the row stands and one granted transcript line posts.
+    /// - Refused with the typed connection-not-found (no live credential
+    ///   server-side): the just-published metadata and local row are rolled
+    ///   back through the revoke path and the service is left to the manual
+    ///   toggle, which can route the user through OAuth. No error surfaces;
+    ///   there is no user mid-flow here.
+    /// - Any other failure: the unconfirmed row stands (its nil
+    ///   backendGrantId marks the push as still owed, same as a manual
+    ///   toggle whose push failed) and no transcript line posts.
+    public func autoEnable(conversationId: String, agentInboxId: String) async {
+        guard await isEnabled() else {
+            Log.info("[AutoEnableAbilities] disabled; skipping for conversation \(conversationId)")
+            return
+        }
+        guard !agentInboxId.isEmpty else { return }
+        let connections: [CloudConnection]
+        let existingGrants: [CloudConnectionGrant]
+        do {
+            connections = try await cloudConnectionRepository.connections()
+            existingGrants = try await cloudConnectionRepository.grants(for: conversationId)
+        } catch {
+            Log.error("[AutoEnableAbilities] reading connection state failed for \(conversationId): \(error.localizedDescription)")
+            return
+        }
+        let candidates = Self.qualifyingConnections(
+            connections: connections,
+            existingGrants: existingGrants,
+            conversationId: conversationId,
+            agentInboxId: agentInboxId
+        )
+        for connection in candidates {
+            await grantAndAnnounce(
+                connection: connection,
+                conversationId: conversationId,
+                agentInboxId: agentInboxId
+            )
+        }
+    }
+
+    /// The connections worth granting: active composio-backed rows for
+    /// supported services, minus any the agent already holds a grant row for
+    /// in this conversation. Grants held by other agents don't count; grant
+    /// rows are per (connection, conversation, agent).
+    static func qualifyingConnections(
+        connections: [CloudConnection],
+        existingGrants: [CloudConnectionGrant],
+        conversationId: String,
+        agentInboxId: String
+    ) -> [CloudConnection] {
+        let alreadyGrantedConnectionIds = Set(
+            existingGrants
+                .filter { $0.conversationId == conversationId && $0.grantedToInboxId == agentInboxId }
+                .map(\.connectionId)
+        )
+        return connections.filter { connection in
+            connection.provider == .composio
+                && connection.status == .active
+                && SupportedConnections.isSupported(cloudServiceId: connection.serviceId)
+                && !alreadyGrantedConnectionIds.contains(connection.id)
+        }
+    }
+
+    private func grantAndAnnounce(
+        connection: CloudConnection,
+        conversationId: String,
+        agentInboxId: String
+    ) async {
+        let providerId = "composio.\(connection.serviceId)"
+        do {
+            try await grantWriter.grantConnectionConfirmingBackend(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: agentInboxId,
+                bundleIds: nil
+            )
+        } catch CloudConnectionsAPI.GrantError.connectionNotFound {
+            // The backend holds no live credential behind this connection, so
+            // it refused the grant after the local row and profile metadata
+            // were already published. Roll both back through the revoke path
+            // so nothing reads the refused grant as live.
+            Log.warning("[AutoEnableAbilities] backend holds no live connection for \(providerId); rolling back the local grant")
+            do {
+                try await grantWriter.revokeGrant(
+                    connectionId: connection.id,
+                    from: conversationId,
+                    grantedToInboxId: agentInboxId
+                )
+            } catch {
+                Log.error("[AutoEnableAbilities] rollback failed for \(providerId) in \(conversationId): \(error.localizedDescription)")
+            }
+            return
+        } catch {
+            Log.error("[AutoEnableAbilities] grant failed for \(providerId) -> \(agentInboxId) in \(conversationId): \(error.localizedDescription)")
+            return
+        }
+        // One conversation-level transcript line per service crediting the
+        // agent, the same shape the manual toggle posts. Best-effort: the
+        // grant is already confirmed, so a failed line is only cosmetic.
+        try? await connectionEventWriter.sendGranted(
+            providerId: providerId,
+            capability: nil,
+            grantedToInboxId: agentInboxId,
+            in: conversationId
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/AutoEnableAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/AutoEnableAbilitiesService.swift
@@ -57,7 +57,10 @@ public final class AutoEnableAbilitiesService: Sendable {
             Log.info("[AutoEnableAbilities] disabled; skipping for conversation \(conversationId)")
             return
         }
-        guard !agentInboxId.isEmpty else { return }
+        guard !agentInboxId.isEmpty else {
+            Log.warning("[AutoEnableAbilities] empty agent inbox id for conversation \(conversationId); skipping")
+            return
+        }
         let connections: [CloudConnection]
         let existingGrants: [CloudConnectionGrant]
         do {
@@ -73,6 +76,10 @@ public final class AutoEnableAbilitiesService: Sendable {
             conversationId: conversationId,
             agentInboxId: agentInboxId
         )
+        // Sequential on purpose: each confirming grant reads the
+        // conversation's current grant rows and republishes the projected
+        // set, so concurrent grants for one conversation would race that
+        // read-project-publish sequence.
         for connection in candidates {
             await grantAndAnnounce(
                 connection: connection,
@@ -112,6 +119,8 @@ public final class AutoEnableAbilitiesService: Sendable {
     ) async {
         let providerId = "composio.\(connection.serviceId)"
         do {
+            // Nil bundle selection is the no-picker consent shape: the writer
+            // materializes the full catalog bundle scope for the service.
             try await grantWriter.grantConnectionConfirmingBackend(
                 connection.id,
                 to: conversationId,

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+AutoEnableAbilities.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+AutoEnableAbilities.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+extension SessionManager {
+    /// Stores the gate the auto-enable service consults on every run. The
+    /// host app wires this to the same feature-flag check that decides
+    /// whether the v1 connections toggle renders; until it is configured the
+    /// service treats itself as disabled.
+    public func configureAutoEnableAbilities(isEnabled: @escaping @Sendable () async -> Bool) {
+        autoEnableAbilitiesEligibilityLock.withLock { provider in
+            provider = isEnabled
+        }
+    }
+
+    /// Returns the session-wide auto-enable service, instantiating it on
+    /// first access. The eligibility gate is read through the lock at call
+    /// time, so configuring after first access still takes effect.
+    func autoEnableAbilitiesService() -> AutoEnableAbilitiesService {
+        autoEnableAbilitiesServiceLock.withLock { service in
+            if let service { return service }
+            let eligibilityLock = autoEnableAbilitiesEligibilityLock
+            let new = AutoEnableAbilitiesService(
+                cloudConnectionRepository: cloudConnectionRepository(),
+                grantWriter: messagingService().connectionGrantWriter(),
+                connectionEventWriter: messagingService().connectionEventWriter(),
+                isEnabled: {
+                    guard let provider = eligibilityLock.withLock({ $0 }) else {
+                        return false
+                    }
+                    return await provider()
+                }
+            )
+            service = new
+            return new
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -1584,7 +1584,10 @@ extension SessionManager {
     /// Fire-and-forget fan-out of the user's live cloud connections to a
     /// freshly added agent. Detached from the join so a slow or failing
     /// grant push can never delay or fail adding the agent; the service
-    /// logs every skipped or failed grant.
+    /// logs every skipped or failed grant. The fan-out keys on the
+    /// provisioned agent inbox id handed over by the join and never reads
+    /// conversation membership, so it doesn't depend on the member add
+    /// having become visible to local observation yet.
     private func autoEnableCreatorAbilities(conversationId: String, agentInboxId: String) {
         let service = autoEnableAbilitiesService()
         Task {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -935,6 +935,13 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     /// Constructed by the accessor in `SessionManager+UnsentBriefReplayer.swift`.
     let unsentBriefReplayerLock: OSAllocatedUnfairLock<UnsentBuilderBriefReplayer?> = .init(initialState: nil)
 
+    /// Lazily-constructed auto-enable service plus the host-supplied gate it
+    /// consults. Both live behind locks so the accessor in
+    /// `SessionManager+AutoEnableAbilities.swift` can build the service once
+    /// while the gate stays reconfigurable at any time.
+    let autoEnableAbilitiesServiceLock: OSAllocatedUnfairLock<AutoEnableAbilitiesService?> = .init(initialState: nil)
+    let autoEnableAbilitiesEligibilityLock: OSAllocatedUnfairLock<(@Sendable () async -> Bool)?> = .init(initialState: nil)
+
     public func capabilityProviderRegistry() -> any CapabilityProviderRegistry {
         capabilityRegistryLock.withLock { registry in
             if let registry { return registry }
@@ -1491,12 +1498,18 @@ extension SessionManager {
     /// non-builder callers today) keeps the non-deduped behavior. Internal
     /// because only the agent-template repository's wired join handler
     /// threads a key; the public protocol surface stays as-is.
+    /// `autoEnablesCreatorAbilities` controls whether the join fans the
+    /// user's live cloud connections out to the freshly added agent; the
+    /// builder flow passes false because it grants exactly the connections
+    /// the user picked in the builder (via the grant replayer), and
+    /// auto-enable must not widen that picked set.
     func addAgentToConversation(
         conversationId: String,
         templateId: String?,
         options: ConvosAPI.AgentJoinOptions?,
         forceErrorCode: Int?,
-        idempotencyKey: ConvosAPI.JoinIdempotencyKey?
+        idempotencyKey: ConvosAPI.JoinIdempotencyKey?,
+        autoEnablesCreatorAbilities: Bool = true
     ) async throws -> ConvosAPI.AgentJoinResponse {
         // Capture the creator's device timezone on the main actor before any
         // async hop. This seeds the agent's baseline/default zone (Channel A);
@@ -1549,6 +1562,9 @@ extension SessionManager {
                 // own device timezone into the per-sender ProfileUpdate metadata
                 // (Channel B). Best-effort: a failure must not fail the join.
                 await publishTimezoneForAgentConversation(conversationId: conversationId)
+                if autoEnablesCreatorAbilities {
+                    autoEnableCreatorAbilities(conversationId: conversationId, agentInboxId: agentInboxId)
+                }
                 return resolved.response
             } catch {
                 lastError = error
@@ -1563,6 +1579,17 @@ extension SessionManager {
             }
         }
         throw lastError ?? APIError.invalidResponse
+    }
+
+    /// Fire-and-forget fan-out of the user's live cloud connections to a
+    /// freshly added agent. Detached from the join so a slow or failing
+    /// grant push can never delay or fail adding the agent; the service
+    /// logs every skipped or failed grant.
+    private func autoEnableCreatorAbilities(conversationId: String, agentInboxId: String) {
+        let service = autoEnableAbilitiesService()
+        Task {
+            await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+        }
     }
 
     /// Best-effort per-sender timezone publish (agent-timezone Channel B) for a
@@ -1708,12 +1735,16 @@ extension SessionManager {
             // byte-identical; when set, the same slug carries the join routing
             // and (via options.variantId) the load-bearing join-status poll.
             let options = variantId.map { ConvosAPI.AgentJoinOptions(onboarding: nil, variantId: $0) }
+            // The builder flow grants exactly the connections the user picked
+            // in the builder (via the grant replayer), so the join must not
+            // auto-enable the user's other live connections on top.
             _ = try await self.addAgentToConversation(
                 conversationId: conversationId,
                 templateId: templateId,
                 options: options,
                 forceErrorCode: nil,
-                idempotencyKey: joinIdempotencyKey
+                idempotencyKey: joinIdempotencyKey,
+                autoEnablesCreatorAbilities: false
             )
         }
         agentTemplateRepositoryInstance.resumePendingGenerations()

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -150,6 +150,12 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
         forceErrorCode: Int?
     ) async throws -> ConvosAPI.AgentJoinResponse
 
+    /// Configures the gate consulted before auto-enabling the user's live
+    /// cloud connections for an agent they add. The host app wires this to
+    /// the flag check that decides whether the v1 connections toggle
+    /// renders; sessions that are never configured leave auto-enable off.
+    func configureAutoEnableAbilities(isEnabled: @escaping @Sendable () async -> Bool)
+
     /// Opportunistic foreground republish of the user's timezone across every
     /// agent conversation (agent-timezone Channel B refresh). Throttled so a
     /// conversation is only republished when the device timezone changed since
@@ -331,4 +337,11 @@ extension SessionManagerProtocol {
     ) async throws -> ConvosAPI.AgentJoinResponse {
         try await addAgentToConversation(conversationId: conversationId, templateId: templateId, options: nil, forceErrorCode: nil)
     }
+
+    /// Configures the gate for auto-enabling the user's live cloud
+    /// connections when they add an agent. Default no-op so conformers
+    /// without the grant machinery (test mocks) compile unchanged; the
+    /// real storage lives on `SessionManager`, and an unconfigured session
+    /// leaves auto-enable off.
+    public func configureAutoEnableAbilities(isEnabled _: @escaping @Sendable () async -> Bool) {}
 }

--- a/ConvosCore/Tests/ConvosCoreTests/AutoEnableAbilitiesServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AutoEnableAbilitiesServiceTests.swift
@@ -186,6 +186,40 @@ struct AutoEnableAbilitiesServiceTests {
         ])
     }
 
+    @Test("a failing rollback is swallowed and sibling services still proceed")
+    func failingRollbackContinuesWithSiblings() async {
+        let grantWriter = SpyGrantWriter()
+        grantWriter.errorsByConnectionId = ["conn-cal": CloudConnectionsAPI.GrantError.connectionNotFound]
+        grantWriter.revokeErrorsByConnectionId = ["conn-cal": SpyGrantWriter.Failure()]
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [
+                makeConnection(id: "conn-cal", serviceId: "googlecalendar"),
+                makeConnection(id: "conn-mail", serviceId: "gmail"),
+            ],
+            grants: [],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.revokes == [
+            SpyGrantWriter.Revoke(
+                connectionId: "conn-cal",
+                conversationId: conversationId,
+                grantedToInboxId: agentInboxId
+            ),
+        ])
+        #expect(eventWriter.grantedEvents == [
+            SpyEventWriter.Event(
+                providerId: "composio.gmail",
+                grantedToInboxId: agentInboxId,
+                conversationId: conversationId
+            ),
+        ])
+    }
+
     @Test("a transient failure leaves the row alone and posts no line")
     func transientFailureRollsNothingBack() async {
         let grantWriter = SpyGrantWriter()
@@ -287,12 +321,17 @@ private final class SpyGrantWriter: CloudConnectionGrantWriterProtocol, @uncheck
     private var recordedConfirmingGrants: [Grant] = []
     private var recordedRevokes: [Revoke] = []
     private var errors: [String: Error] = [:]
+    private var revokeErrors: [String: Error] = [:]
 
     var confirmingGrants: [Grant] { lock.withLock { recordedConfirmingGrants } }
     var revokes: [Revoke] { lock.withLock { recordedRevokes } }
     var errorsByConnectionId: [String: Error] {
         get { lock.withLock { errors } }
         set { lock.withLock { errors = newValue } }
+    }
+    var revokeErrorsByConnectionId: [String: Error] {
+        get { lock.withLock { revokeErrors } }
+        set { lock.withLock { revokeErrors = newValue } }
     }
 
     func grantConnection(
@@ -332,6 +371,9 @@ private final class SpyGrantWriter: CloudConnectionGrantWriterProtocol, @uncheck
                 conversationId: conversationId,
                 grantedToInboxId: grantedToInboxId
             ))
+        }
+        if let error = revokeErrorsByConnectionId[connectionId] {
+            throw error
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/AutoEnableAbilitiesServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AutoEnableAbilitiesServiceTests.swift
@@ -1,0 +1,393 @@
+import Combine
+import ConvosConnections
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Decision coverage for the auto-enable fan-out that runs when the user
+/// adds an agent: which connections qualify, how the typed
+/// connection-not-found refusal rolls back, and that the gate turns the
+/// whole path into a no-op.
+@Suite("AutoEnableAbilitiesService")
+struct AutoEnableAbilitiesServiceTests {
+    private let conversationId = "convo-1"
+    private let agentInboxId = "agent-inbox"
+
+    @Test("disabled gate performs no writes at all")
+    func disabledGateDoesNothing() async {
+        let grantWriter = SpyGrantWriter()
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [makeConnection()],
+            grants: [],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter,
+            enabled: false
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.confirmingGrants.isEmpty)
+        #expect(grantWriter.revokes.isEmpty)
+        #expect(eventWriter.grantedEvents.isEmpty)
+    }
+
+    @Test("grants every live supported connection and posts one line per service")
+    func grantsLiveSupportedConnections() async {
+        let grantWriter = SpyGrantWriter()
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [
+                makeConnection(id: "conn-cal", serviceId: "googlecalendar"),
+                makeConnection(id: "conn-mail", serviceId: "gmail"),
+            ],
+            grants: [],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.confirmingGrants == [
+            SpyGrantWriter.Grant(
+                connectionId: "conn-cal",
+                conversationId: conversationId,
+                grantedToInboxId: agentInboxId,
+                bundleIds: nil
+            ),
+            SpyGrantWriter.Grant(
+                connectionId: "conn-mail",
+                conversationId: conversationId,
+                grantedToInboxId: agentInboxId,
+                bundleIds: nil
+            ),
+        ])
+        #expect(grantWriter.revokes.isEmpty)
+        #expect(eventWriter.grantedEvents == [
+            SpyEventWriter.Event(
+                providerId: "composio.googlecalendar",
+                grantedToInboxId: agentInboxId,
+                conversationId: conversationId
+            ),
+            SpyEventWriter.Event(
+                providerId: "composio.gmail",
+                grantedToInboxId: agentInboxId,
+                conversationId: conversationId
+            ),
+        ])
+    }
+
+    @Test("unsupported services and non-active connections do not qualify")
+    func skipsUnsupportedAndInactive() async {
+        let grantWriter = SpyGrantWriter()
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [
+                makeConnection(id: "conn-notion", serviceId: "notion"),
+                makeConnection(id: "conn-expired", serviceId: "googlecalendar", status: .expired),
+                makeConnection(id: "conn-revoked", serviceId: "gmail", status: .revoked),
+            ],
+            grants: [],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.confirmingGrants.isEmpty)
+        #expect(eventWriter.grantedEvents.isEmpty)
+    }
+
+    @Test("an existing grant for the same agent skips the connection")
+    func skipsAlreadyGrantedToSameAgent() async {
+        let grantWriter = SpyGrantWriter()
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [makeConnection(id: "conn-cal", serviceId: "googlecalendar")],
+            grants: [
+                makeGrant(connectionId: "conn-cal", conversationId: conversationId, grantedToInboxId: agentInboxId),
+            ],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.confirmingGrants.isEmpty)
+        #expect(eventWriter.grantedEvents.isEmpty)
+    }
+
+    @Test("another agent's grant does not block this agent")
+    func grantsWhenOnlyAnotherAgentHoldsTheConnection() async {
+        let grantWriter = SpyGrantWriter()
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [makeConnection(id: "conn-cal", serviceId: "googlecalendar")],
+            grants: [
+                makeGrant(connectionId: "conn-cal", conversationId: conversationId, grantedToInboxId: "other-agent"),
+            ],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.confirmingGrants.count == 1)
+        #expect(grantWriter.confirmingGrants.first?.grantedToInboxId == agentInboxId)
+    }
+
+    @Test("a grant for the same tuple in another conversation does not block")
+    func qualifyingIgnoresOtherConversationsGrants() {
+        let connections = [makeConnection(id: "conn-cal", serviceId: "googlecalendar")]
+        let grants = [
+            makeGrant(connectionId: "conn-cal", conversationId: "other-convo", grantedToInboxId: agentInboxId),
+        ]
+
+        let qualifying = AutoEnableAbilitiesService.qualifyingConnections(
+            connections: connections,
+            existingGrants: grants,
+            conversationId: conversationId,
+            agentInboxId: agentInboxId
+        )
+
+        #expect(qualifying.map(\.id) == ["conn-cal"])
+    }
+
+    @Test("connection-not-found rolls the grant back and posts no line")
+    func rollsBackOnConnectionNotFound() async {
+        let grantWriter = SpyGrantWriter()
+        grantWriter.errorsByConnectionId = ["conn-cal": CloudConnectionsAPI.GrantError.connectionNotFound]
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [
+                makeConnection(id: "conn-cal", serviceId: "googlecalendar"),
+                makeConnection(id: "conn-mail", serviceId: "gmail"),
+            ],
+            grants: [],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.revokes == [
+            SpyGrantWriter.Revoke(
+                connectionId: "conn-cal",
+                conversationId: conversationId,
+                grantedToInboxId: agentInboxId
+            ),
+        ])
+        #expect(eventWriter.grantedEvents == [
+            SpyEventWriter.Event(
+                providerId: "composio.gmail",
+                grantedToInboxId: agentInboxId,
+                conversationId: conversationId
+            ),
+        ])
+    }
+
+    @Test("a transient failure leaves the row alone and posts no line")
+    func transientFailureRollsNothingBack() async {
+        let grantWriter = SpyGrantWriter()
+        grantWriter.errorsByConnectionId = ["conn-cal": SpyGrantWriter.Failure()]
+        let eventWriter = SpyEventWriter()
+        let service = makeService(
+            connections: [
+                makeConnection(id: "conn-cal", serviceId: "googlecalendar"),
+                makeConnection(id: "conn-mail", serviceId: "gmail"),
+            ],
+            grants: [],
+            grantWriter: grantWriter,
+            eventWriter: eventWriter
+        )
+
+        await service.autoEnable(conversationId: conversationId, agentInboxId: agentInboxId)
+
+        #expect(grantWriter.revokes.isEmpty)
+        #expect(eventWriter.grantedEvents == [
+            SpyEventWriter.Event(
+                providerId: "composio.gmail",
+                grantedToInboxId: agentInboxId,
+                conversationId: conversationId
+            ),
+        ])
+    }
+
+    // MARK: - Fixtures
+
+    private func makeService(
+        connections: [CloudConnection],
+        grants: [CloudConnectionGrant],
+        grantWriter: SpyGrantWriter,
+        eventWriter: SpyEventWriter,
+        enabled: Bool = true
+    ) -> AutoEnableAbilitiesService {
+        AutoEnableAbilitiesService(
+            cloudConnectionRepository: StubConnectionsRepository(
+                stubbedConnections: connections,
+                stubbedGrants: grants
+            ),
+            grantWriter: grantWriter,
+            connectionEventWriter: eventWriter,
+            isEnabled: { enabled }
+        )
+    }
+
+    private func makeConnection(
+        id: String = "conn-1",
+        serviceId: String = "googlecalendar",
+        status: CloudConnectionStatus = .active
+    ) -> CloudConnection {
+        CloudConnection(
+            id: id,
+            serviceId: serviceId,
+            serviceName: serviceId,
+            provider: .composio,
+            composioEntityId: "entity-1",
+            composioConnectionId: "composio-1",
+            status: status,
+            connectedAt: Date()
+        )
+    }
+
+    private func makeGrant(
+        connectionId: String,
+        conversationId: String,
+        grantedToInboxId: String
+    ) -> CloudConnectionGrant {
+        CloudConnectionGrant(
+            connectionId: connectionId,
+            conversationId: conversationId,
+            serviceId: "googlecalendar",
+            grantedToInboxId: grantedToInboxId,
+            grantedAt: Date()
+        )
+    }
+}
+
+// MARK: - Spies
+
+private final class SpyGrantWriter: CloudConnectionGrantWriterProtocol, @unchecked Sendable {
+    struct Grant: Equatable {
+        let connectionId: String
+        let conversationId: String
+        let grantedToInboxId: String
+        let bundleIds: [String]?
+    }
+
+    struct Revoke: Equatable {
+        let connectionId: String
+        let conversationId: String
+        let grantedToInboxId: String
+    }
+
+    struct Failure: Error {}
+
+    private let lock = NSLock()
+    private var recordedConfirmingGrants: [Grant] = []
+    private var recordedRevokes: [Revoke] = []
+    private var errors: [String: Error] = [:]
+
+    var confirmingGrants: [Grant] { lock.withLock { recordedConfirmingGrants } }
+    var revokes: [Revoke] { lock.withLock { recordedRevokes } }
+    var errorsByConnectionId: [String: Error] {
+        get { lock.withLock { errors } }
+        set { lock.withLock { errors = newValue } }
+    }
+
+    func grantConnection(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {}
+
+    func grantConnectionConfirmingBackend(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        lock.withLock {
+            recordedConfirmingGrants.append(Grant(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId,
+                bundleIds: bundleIds
+            ))
+        }
+        if let error = errorsByConnectionId[connectionId] {
+            throw error
+        }
+    }
+
+    func revokeGrant(
+        connectionId: String,
+        from conversationId: String,
+        grantedToInboxId: String
+    ) async throws {
+        lock.withLock {
+            recordedRevokes.append(Revoke(
+                connectionId: connectionId,
+                conversationId: conversationId,
+                grantedToInboxId: grantedToInboxId
+            ))
+        }
+    }
+}
+
+private final class SpyEventWriter: ConnectionEventWriterProtocol, @unchecked Sendable {
+    struct Event: Equatable {
+        let providerId: String
+        let grantedToInboxId: String?
+        let conversationId: String
+    }
+
+    private let lock = NSLock()
+    private var granted: [Event] = []
+
+    var grantedEvents: [Event] { lock.withLock { granted } }
+
+    func sendGranted(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {
+        lock.withLock {
+            granted.append(Event(
+                providerId: providerId,
+                grantedToInboxId: grantedToInboxId,
+                conversationId: conversationId
+            ))
+        }
+    }
+
+    func sendRevoked(
+        providerId: String,
+        capability: ConnectionCapability?,
+        grantedToInboxId: String?,
+        in conversationId: String
+    ) async throws {}
+}
+
+private struct StubConnectionsRepository: CloudConnectionRepositoryProtocol {
+    let stubbedConnections: [CloudConnection]
+    let stubbedGrants: [CloudConnectionGrant]
+
+    func connections() async throws -> [CloudConnection] {
+        stubbedConnections
+    }
+
+    func connectionsPublisher() -> AnyPublisher<[CloudConnection], Never> {
+        Just(stubbedConnections).eraseToAnyPublisher()
+    }
+
+    func grants(for conversationId: String) async throws -> [CloudConnectionGrant] {
+        stubbedGrants.filter { $0.conversationId == conversationId }
+    }
+
+    func grantsPublisher(for conversationId: String) -> AnyPublisher<[CloudConnectionGrant], Never> {
+        Just(stubbedGrants).eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## What

When the user adds an agent to a conversation (at creation via the compose/agent-DM flows, or later via the add-agent menu), iOS now fans the user's own live cloud connections out to that agent automatically, running the same confirming grant path the conversation-info toggle runs: one backend-confirmed grant per (connection, agent) plus one granted transcript line per service. A fresh agent conversation starts with the user's already-connected abilities enabled instead of requiring a trip to the conversation-info toggles.

## Why

Users who already connected Calendar or Gmail at the account level still had to re-toggle each service in every new agent conversation. Auto-enabling only the acting user's own live connections keeps the consent story honest (nobody else's exposure changes, the transcript announces each grant, the toggle shows ON and can be flipped off) while removing the dead-end where an agent asks for an ability the user already connected.

## How

- New `AutoEnableAbilitiesService` (ConvosCore) encapsulates the decision logic: active composio-backed connections, filtered to supported services, minus connections the agent already holds a grant row for in the conversation. Grants go through `grantConnectionConfirmingBackend` (nil bundle selection = full catalog scope, same as other no-picker consent paths).
- Hooked in `SessionManager.addAgentToConversation` right after the member add succeeds, as a detached fire-and-forget task: a slow or failing grant push can never delay or fail adding the agent. The service never throws; every skip and failure is logged.
- The agent-builder flow opts out (`autoEnablesCreatorAbilities: false`): the builder grants exactly the connections the user picked in the builder via its grant replayer, and auto-enable must not widen that picked set.

## Live-and-connected gate + 409 handling

Only connections with an active local status are candidates, and the backend's live-credential gate is the final authority: a grant POST refused with the typed `connection_not_found` (HTTP 409 - no live credential server-side) makes the service roll back the just-published profile metadata and the local grant row through the existing revoke path, post no granted line, and leave the service to the manual toggle (which has an OAuth recovery leg; the unattended path has no user mid-flow). No ghost rows, no lying toggle, no error spam at creation time.

Any other failure (network, backend down) leaves the local row standing with a nil `backendGrantId` - the existing marker for a push still owed - and posts no transcript line.

## Feature-flag gating

The service consults the exact condition under which the v1 connections toggle renders: it stands down whenever the Abilities v2 flag is on. The gate is injected from the app (`configureAutoEnableAbilities`) and re-read on every agent add, so a debug-menu flip takes effect without a relaunch. An unconfigured session leaves auto-enable off.

## Deploy dependency

The 409 `connection_not_found` semantics this relies on ship with backend PR xmtplabs/convos-backend#3317 (grant issuance refuses credential-less grants). This PR should not reach users before that backend change is deployed; against the ungated backend, auto-enable would materialize grants with no live credential behind them.

## Known limitation

Grant state is device-local until normal sync paths run: another device on the same account sees the enablement only through those paths. Accepted for the current rollout; cross-device grant sync is follow-up work.

## Tests

`AutoEnableAbilitiesServiceTests` (ConvosCore, 8 tests): disabled gate is a full no-op; live supported connections are granted with one line per service; unsupported/expired/revoked connections do not qualify; an existing grant for the same agent skips the connection while another agent's grant or another conversation's grant does not; `connection_not_found` triggers the rollback and stays silent while sibling services proceed; a transient failure rolls nothing back and posts no line.

Full ConvosCore suite passes (1850 tests); Dev scheme builds for an arm64 simulator.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789210236&installation_model_id=20076&pr_number=1313&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1313&signature=0bf9429fa8434baf6616055f1a49142f5968f7a508caf8a007dfc82763b23a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-enable creator's live abilities when adding an agent to a conversation
> - Adds `AutoEnableAbilitiesService` which grants a user's active supported Composio cloud connections to a newly added agent, posting one transcript line per service on success.
> - `SessionManager.addAgentToConversation` triggers this fan-out in a detached background task after a successful join; failures do not affect the join outcome.
> - Builder-flow agent additions (via `wireAgentTemplateRepository`) pass `autoEnablesCreatorAbilities: false` to skip the fan-out.
> - The feature is gated by an async closure configured via `SessionManagerProtocol.configureAutoEnableAbilities`; in the app, the gate returns `true` only when the abilities v2 flag is off.
> - On backend `connectionNotFound` errors, the locally created grant is revoked and no transcript line is posted; other grant failures leave an unconfirmed grant row silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c6d621.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->