### PR TITLE
fix: size provider connect sheet to its content

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -1,3 +1,4 @@
+import ConvosComposer
 import ConvosCore
 import SwiftUI
 
@@ -56,7 +57,7 @@ struct AbilitiesListView: View {
             .searchable(text: $viewModel.searchText, prompt: "Search abilities")
             .overlay { listOverlay }
             .task { await viewModel.refresh() }
-            .sheet(item: $viewModel.pendingAuthorization, onDismiss: handleAuthorizationDismissed) { context in
+            .selfSizingSheet(item: $viewModel.pendingAuthorization, onDismiss: handleAuthorizationDismissed) { context in
                 authorizationSheet(context)
             }
     }

--- a/Convos/Abilities/AbilityAuthorizationSheet.swift
+++ b/Convos/Abilities/AbilityAuthorizationSheet.swift
@@ -21,7 +21,6 @@ struct AbilityAuthorizationSheet: View {
             actionButtons
         }
         .padding(.vertical, DesignConstants.Spacing.step6x)
-        .presentationDetents([.medium])
         // Swipe-down stays allowed: the presenting sheet's onDismiss
         // routes it through the same cancel lifecycle as the Cancel
         // button (`AbilitiesListViewModel.handleAuthorizationDismissed`).

--- a/Convos/Abilities/AbilityAuthorizationSheet.swift
+++ b/Convos/Abilities/AbilityAuthorizationSheet.swift
@@ -14,13 +14,16 @@ struct AbilityAuthorizationSheet: View {
     let onAuthorize: () -> Void
     let onCancel: () -> Void
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+
     var body: some View {
         VStack(spacing: DesignConstants.Spacing.step4x) {
             header
             redirectPreview
             actionButtons
         }
-        .padding(.vertical, DesignConstants.Spacing.step6x)
+        .padding(.top, DesignConstants.Spacing.step6x)
+        .padding(.bottom, horizontalSizeClass == .regular ? DesignConstants.Spacing.step6x : 0)
         // Swipe-down stays allowed: the presenting sheet's onDismiss
         // routes it through the same cancel lifecycle as the Cancel
         // button (`AbilitiesListViewModel.handleAuthorizationDismissed`).

--- a/Convos/Abilities/AbilityConnectSheet.swift
+++ b/Convos/Abilities/AbilityConnectSheet.swift
@@ -26,6 +26,7 @@ struct AbilityConnectSheet: View {
     let onConnected: (AbilitiesAPI.Ability) -> Void
 
     @Environment(\.dismiss) private var dismiss: DismissAction
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @State private var viewModel: AbilitiesListViewModel
 
     /// Takes the whole selection so the service and its authorizer are
@@ -87,7 +88,8 @@ struct AbilityConnectSheet: View {
             }
             actionButtons
         }
-        .padding(.vertical, DesignConstants.Spacing.step6x)
+        .padding(.top, DesignConstants.Spacing.step6x)
+        .padding(.bottom, horizontalSizeClass == .regular ? DesignConstants.Spacing.step6x : 0)
         .accessibilityIdentifier("ability-connect-sheet")
     }
 

--- a/Convos/Abilities/AbilityConnectSheet.swift
+++ b/Convos/Abilities/AbilityConnectSheet.swift
@@ -42,7 +42,6 @@ struct AbilityConnectSheet: View {
 
     var body: some View {
         content
-            .presentationDetents([.medium])
             .task { await viewModel.refresh() }
             .onChange(of: connectedAbility) { _, newValue in
                 guard let newValue else { return }

--- a/Convos/Abilities/ConversationAbilitiesSection.swift
+++ b/Convos/Abilities/ConversationAbilitiesSection.swift
@@ -1,3 +1,4 @@
+import ConvosComposer
 import ConvosCore
 import SwiftUI
 
@@ -172,7 +173,7 @@ private struct ConversationAbilitiesActiveSheetsModifier: ViewModifier {
             .sheet(item: $viewModel.bundleSelection) { context in
                 bundleSelectionSheet(context)
             }
-            .sheet(item: $viewModel.connectContext, onDismiss: handleConnectSheetDismissed) { context in
+            .selfSizingSheet(item: $viewModel.connectContext, onDismiss: handleConnectSheetDismissed) { context in
                 connectSheet(context)
             }
     }


### PR DESCRIPTION
## What

The provider connect confirmation sheet ("Connect Google Calendar?" / "Connect Gmail?" — `AbilityConnectSheet`) and its mock authorization sibling (`AbilityAuthorizationSheet`) presented on a fixed `.medium` detent: half the screen (and near-full-height in the nested-sheet context reported on device) for content that needs about a third of that.

## How

Present both sheets through the existing `selfSizingSheet(item:)` helper from ConvosComposer — the codebase's fitted-sheet mechanism: content height is measured (`readHeight`) and feeds `.presentationDetents([.height(h)])`, so the sheet hugs its content. The fixed `.presentationDetents([.medium])` inside both sheet bodies is removed; height now derives from measured layout, so larger Dynamic Type sizes grow the sheet instead of leaving it oversized or clipping.

This covers every provider the component serves — the view interpolates the ability's display name and icon; verified the Google Calendar and Gmail variants plus an accessibility size.

Surfaces changed:
- Conversation info abilities toggles -> `AbilityConnectSheet` (hosted by `ConversationAbilitiesSheetsModifier`)
- Abilities list (App Settings) mock authorization -> `AbilityAuthorizationSheet`

While QA-ing on the simulator, the plain chained `.sheet(item:)` hosting the connect context also failed to present intermittently from the conversation toggles; presentation through `selfSizingSheet` was reliable across retests.

## Testing

- Dev scheme simulator build succeeds; SwiftLint clean on touched files.
- Visual QA on an iPhone 17 simulator: before (fixed medium detent, large dead zones) vs after (fitted) for the authorization sheet; fitted connect sheet verified for both the Google Calendar and Gmail variants; AX1 (accessibility-medium) shows the text wrapping and the sheet growing to fit — no clipping.
- ConvosCore suite not run: the diff touches only app-target SwiftUI presentation code (4 files under Convos/Abilities); ConvosCore is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqcUMYJ8VG2LYZoScDLNty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789224823&installation_model_id=20076&pr_number=1314&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1314&signature=351668b62b48800d764f437c1f6aa3381c747902b7bcd0d64078ae632b069804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Size provider connect and authorization sheets to their content
> Replaces standard `.sheet` with `.selfSizingSheet` for the provider connect and authorization flows so sheets size to their content rather than snapping to a medium detent. Conditional bottom padding is applied only on regular horizontal size class to handle layout differences across device sizes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e421b2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->