### PR TITLE
fix: ability toggle wedges after failed enable

### DIFF
--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionGrantWriter.swift
@@ -7,19 +7,23 @@ public protocol CloudConnectionGrantWriterProtocol: Sendable {
     /// service (catalog ids like "calendar.events"). Pass nil when no picker
     /// was involved (full-service consent paths); the writer then grants
     /// every bundle the catalog lists for the service.
+    ///
+    /// The backend consent POST is part of the contract: when the push fails
+    /// (or fails closed without reaching the server), the writer rolls the
+    /// local grant row and published metadata back to their pre-attempt
+    /// state and throws. A failed enable therefore leaves nothing behind
+    /// that could make retry paths treat the grant as already applied — the
+    /// next attempt re-runs the whole flow, including after an app relaunch.
     func grantConnection(
         _ connectionId: String,
         to conversationId: String,
         grantedToInboxId: String,
         bundleIds: [String]?
     ) async throws
-    /// Same write as `grantConnection`, but the backend consent POST is part
-    /// of the contract: a push failure (or a push that fails closed without
-    /// reaching the server) throws instead of being logged and swallowed.
-    /// The local grant row and published metadata stand on failure, with the
-    /// row's missing `backendGrantId` marking the unconfirmed push so a
-    /// retry re-runs it. Callers that must not act on an unconfirmed grant
-    /// (the capability approval flow) use this variant.
+    /// Same contract as `grantConnection`. The separate name predates the
+    /// unification of the two variants' failure posture and is kept for the
+    /// capability approval flow's call sites, which must not act on an
+    /// unconfirmed grant.
     func grantConnectionConfirmingBackend(
         _ connectionId: String,
         to conversationId: String,
@@ -76,17 +80,12 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         grantedToInboxId: String,
         bundleIds: [String]?
     ) async throws {
-        let (grant, connection) = try await persistGrantLocally(
+        try await grantRollingBackOnPushFailure(
             connectionId,
             to: conversationId,
             grantedToInboxId: grantedToInboxId,
             bundleIds: bundleIds
         )
-        do {
-            try await pushGrantToBackend(grant, connection: connection)
-        } catch {
-            logBackendPushFailure(for: grant, error: error)
-        }
     }
 
     func grantConnectionConfirmingBackend(
@@ -95,6 +94,37 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
         grantedToInboxId: String,
         bundleIds: [String]?
     ) async throws {
+        try await grantRollingBackOnPushFailure(
+            connectionId,
+            to: conversationId,
+            grantedToInboxId: grantedToInboxId,
+            bundleIds: bundleIds
+        )
+    }
+
+    /// Shared enable core: persist locally, push to the backend, and on a
+    /// terminal push failure restore the pre-attempt state before
+    /// propagating. Leaving the unconfirmed row behind is what used to wedge
+    /// the conversation toggle: the row made `isGrantedForConversation` read
+    /// true, so every subsequent tap routed to the revoke leg and no grant
+    /// POST was ever attempted again — and the row survived relaunch. The
+    /// `unknown_bundle` rejection already gets its single retry inside
+    /// `pushGrantToBackend`; any error that escapes it is terminal here.
+    private func grantRollingBackOnPushFailure(
+        _ connectionId: String,
+        to conversationId: String,
+        grantedToInboxId: String,
+        bundleIds: [String]?
+    ) async throws {
+        let priorRow = try await databaseReader.read { db in
+            try DBCloudConnectionGrant
+                .filter(
+                    DBCloudConnectionGrant.Columns.connectionId == connectionId
+                        && DBCloudConnectionGrant.Columns.conversationId == conversationId
+                        && DBCloudConnectionGrant.Columns.grantedToInboxId == grantedToInboxId
+                )
+                .fetchOne(db)
+        }
         let (grant, connection) = try await persistGrantLocally(
             connectionId,
             to: conversationId,
@@ -105,7 +135,58 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
             try await pushGrantToBackend(grant, connection: connection)
         } catch {
             logBackendPushFailure(for: grant, error: error)
+            await rollBackUnconfirmedGrant(grant, restoring: priorRow)
             throw error
+        }
+    }
+
+    /// Restores the pre-attempt state after a failed backend push: the
+    /// unconfirmed row is deleted, or — when the attempt overwrote an
+    /// existing row (a re-approval over a confirmed grant) — the prior row
+    /// is put back, so a failed re-push can't regress a live backend grant
+    /// into a locally-off toggle. The metadata republish is best-effort: the
+    /// local rollback must stand even when the group can't be updated, so a
+    /// relaunch never finds a poisoned row; a failed republish is superseded
+    /// by the next successful grant/revoke publish.
+    private func rollBackUnconfirmedGrant(
+        _ grant: DBCloudConnectionGrant,
+        restoring priorRow: DBCloudConnectionGrant?
+    ) async {
+        do {
+            try await databaseWriter.write { db in
+                try DBCloudConnectionGrant
+                    .filter(
+                        DBCloudConnectionGrant.Columns.connectionId == grant.connectionId
+                            && DBCloudConnectionGrant.Columns.conversationId == grant.conversationId
+                            && DBCloudConnectionGrant.Columns.grantedToInboxId == grant.grantedToInboxId
+                    )
+                    .deleteAll(db)
+                if let priorRow {
+                    try priorRow.save(db)
+                }
+            }
+        } catch {
+            Log.error(
+                "[CloudConnections] failed to roll back the unconfirmed grant row after a backend " +
+                "push failure; the toggle may read granted until the next successful grant/revoke " +
+                "(connectionId=\(grant.connectionId), conversationId=\(grant.conversationId), " +
+                "grantedToInboxId=\(grant.grantedToInboxId)): \(error.localizedDescription)"
+            )
+            return
+        }
+        do {
+            let remaining = try await projectedGrants(
+                for: grant.conversationId,
+                addingOrReplacing: nil,
+                removing: nil
+            )
+            try await syncGrantsToMetadata(for: grant.conversationId, desiredGrants: remaining)
+        } catch {
+            Log.warning(
+                "[CloudConnections] failed to republish grants metadata after rolling back a " +
+                "failed grant push (conversationId=\(grant.conversationId)); the next successful " +
+                "grant/revoke publish supersedes it: \(error.localizedDescription)"
+            )
         }
     }
 
@@ -155,8 +236,8 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
 
     private func logBackendPushFailure(for grant: DBCloudConnectionGrant, error: Error) {
         Log.error(
-            "[CloudConnections] backend grant push failed; agent will get 403 from backend-mediated " +
-            "execution until the user re-grants (connectionId=\(grant.connectionId), " +
+            "[CloudConnections] backend grant push failed; rolling the local grant back so the " +
+            "next enable attempt retries the push (connectionId=\(grant.connectionId), " +
             "conversationId=\(grant.conversationId), grantedToInboxId=\(grant.grantedToInboxId)): " +
             error.localizedDescription
         )
@@ -214,11 +295,11 @@ final class CloudConnectionGrantWriter: CloudConnectionGrantWriterProtocol, @unc
     /// catalog cache is stale, so the push refetches it, drops ids the fresh
     /// catalog no longer knows, and retries exactly once. Throws when the
     /// push could not be confirmed -- an API failure, or a scope resolution
-    /// that fails closed without reaching the server. The caller decides
-    /// whether that is best-effort (`grantConnection` logs and moves on) or
-    /// contractual (`grantConnectionConfirmingBackend` propagates it).
-    /// A failure persisting the returned id locally is logged, not thrown:
-    /// the push itself was confirmed by then.
+    /// that fails closed without reaching the server. The caller rolls the
+    /// local grant back and propagates the error, so a failed push never
+    /// leaves an unconfirmed row that later attempts mistake for an applied
+    /// grant. A failure persisting the returned id locally is logged, not
+    /// thrown: the push itself was confirmed by then.
     private func pushGrantToBackend(_ grant: DBCloudConnectionGrant, connection: DBCloudConnection) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
         guard let scope = await resolveBundleScope(

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionGrantWriterTests.swift
@@ -359,8 +359,8 @@ struct ConnectionGrantWriterTests {
         #expect(stored.first?.backendGrantId == "backend-grant-1")
     }
 
-    @Test("Grant: backend push failure keeps the local grant with a nil backend id")
-    func grantSurvivesBackendPushFailure() async throws {
+    @Test("Grant: backend push failure rolls the local grant back and the next attempt retries the push")
+    func grantRollsBackOnPushFailureAndRetrySucceeds() async throws {
         let recordingClient = RecordingGrantAPIClient()
         struct PushFailure: Error {}
         recordingClient.createError = PushFailure()
@@ -371,14 +371,81 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_backend_fail"
         try fixture.seedConversation(id: conversationId)
 
+        // The wedge this pins: a leftover unconfirmed row made the toggle's
+        // routing treat the grant as applied, so no grant POST was ever
+        // attempted again for the conversation/provider.
+        await #expect(throws: PushFailure.self) {
+            try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+        }
+
+        let storedAfterFailure = try fixture.storedGrants(for: conversationId)
+        #expect(storedAfterFailure.isEmpty, "a failed enable must leave no unconfirmed row behind")
+
+        // The rollback republishes the metadata without the failed grant, so
+        // the group stops over-claiming it.
+        #expect(fixture.metadataWriter.updates.count == 2)
+        let rollbackPublish = try #require(fixture.metadataWriter.updates.last)
+        #expect(rollbackPublish.conversationId == conversationId)
+        #expect(rollbackPublish.metadata.isEmpty)
+
+        // With the backend healthy again, the same call retries the push and
+        // confirms — nothing from the failed attempt blocks it.
+        recordingClient.createError = nil
         try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
 
+        #expect(recordingClient.createCalls.count == 2, "the retry re-attempts the grant POST")
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.count == 1, "local grant should stand when the backend push fails")
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.count == 1)
+        #expect(stored.first?.backendGrantId == "backend-grant-2")
     }
 
-    @Test("Confirming grant: backend push failure propagates; local row stands unconfirmed for retry")
+    @Test("Grant: state left by a failed push does not survive a relaunch — a fresh writer grants cleanly")
+    func grantFailureStateHealsAcrossRelaunch() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        struct PushFailure: Error {}
+        recordingClient.createError = PushFailure()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_relaunch_heal"
+        try fixture.seedConversation(id: conversationId)
+
+        await #expect(throws: PushFailure.self) {
+            try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+        }
+
+        // Relaunch equivalent at the state level: only the database survives.
+        // A fresh writer stack over the same database finds no poisoned row
+        // and a fresh enable succeeds end to end.
+        let relaunchClient = RecordingGrantAPIClient()
+        let relaunchMetadataWriter = MockProfileMetadataWriter()
+        let relaunchWriter = CloudConnectionGrantWriter(
+            sessionStateManager: MockSessionStateManager(
+                mockClient: MockXMTPClientProvider(inboxId: "mock-inbox-id"),
+                mockAPIClient: relaunchClient
+            ),
+            databaseWriter: fixture.databaseManager.dbWriter,
+            databaseReader: fixture.databaseManager.dbReader,
+            profileMetadataWriter: relaunchMetadataWriter,
+            servicesStore: ConnectionServicesStore(fetchServices: {
+                try await relaunchClient.getConnectionServices()
+            })
+        )
+
+        let repository = CloudConnectionRepository(databaseReader: fixture.databaseManager.dbReader)
+        let grantsAfterRelaunch = try await repository.grants(for: conversationId)
+        #expect(grantsAfterRelaunch.isEmpty, "no wedged grant row may survive into the next launch")
+
+        try await relaunchWriter.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+
+        #expect(relaunchClient.createCalls.count == 1)
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.count == 1)
+        #expect(stored.first?.backendGrantId == "backend-grant-1")
+    }
+
+    @Test("Confirming grant: backend push failure propagates and the local row is rolled back for retry")
     func confirmingGrantThrowsWhenBackendPushFails() async throws {
         let recordingClient = RecordingGrantAPIClient()
         struct PushFailure: Error {}
@@ -406,11 +473,48 @@ struct ConnectionGrantWriterTests {
         }
         #expect(caughtExpectedError, "the swallowed-error path is exactly what this variant removes")
 
-        // The local row stands (same posture as grantConnection) with a nil
-        // backendGrantId marking the push still owed, so a retry re-runs it.
+        // Same rollback posture as grantConnection: nothing unconfirmed is
+        // left behind, so the approval flow's retry re-runs the whole persist
+        // and push (which it does unconditionally anyway).
+        let stored = try fixture.storedGrants(for: conversationId)
+        #expect(stored.isEmpty)
+    }
+
+    @Test("Confirming grant: a failed re-push restores the prior confirmed row instead of dropping it")
+    func confirmingGrantRestoresPriorConfirmedRowOnPushFailure() async throws {
+        let recordingClient = RecordingGrantAPIClient()
+        struct PushFailure: Error {}
+        recordingClient.createError = PushFailure()
+        let fixture = Fixture(apiClient: recordingClient)
+        defer { fixture.cleanup() }
+
+        let connection = try fixture.seedConnection()
+        let conversationId = "conv_confirm_reapprove_fail"
+        try fixture.seedConversation(id: conversationId)
+        try fixture.seedGrant(
+            connectionId: connection.id,
+            conversationId: conversationId,
+            serviceId: connection.serviceId,
+            backendGrantId: "backend-grant-prior"
+        )
+
+        // A re-approval over a confirmed grant re-runs the push (a cached id
+        // is not proof of server state). When that re-push fails, the
+        // rollback must restore the confirmed row — the backend still holds
+        // the grant, and dropping the row would show the toggle off while
+        // the agent keeps executing.
+        await #expect(throws: PushFailure.self) {
+            try await fixture.writer.grantConnectionConfirmingBackend(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: "agent-1",
+                bundleIds: nil
+            )
+        }
+
         let stored = try fixture.storedGrants(for: conversationId)
         #expect(stored.count == 1)
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.first?.backendGrantId == "backend-grant-prior")
     }
 
     @Test("Confirming grant: successful push stores the backend id and does not throw")
@@ -614,15 +718,17 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_zero_bundles"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+        await #expect(throws: CloudConnectionGrantError.self) {
+            try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+        }
 
         // A cataloged service with zero bundles must not materialize an empty
         // bundleIds array: the backend's legacy path treats that as
-        // whole-toolkit access. The push is skipped entirely.
+        // whole-toolkit access. The push is skipped entirely and the local
+        // grant is rolled back, same as any push failure.
         #expect(recordingClient.createCalls.isEmpty)
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.count == 1, "the local grant still stands, same as any push failure")
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.isEmpty)
     }
 
     @Test("Grant: fails closed on an explicit empty selection — never pushed as whole-toolkit")
@@ -638,19 +744,21 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_empty_selection"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(
-            connection.id,
-            to: conversationId,
-            grantedToInboxId: "agent-1",
-            bundleIds: []
-        )
+        await #expect(throws: CloudConnectionGrantError.self) {
+            try await fixture.writer.grantConnection(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: "agent-1",
+                bundleIds: []
+            )
+        }
 
         // An explicit empty selection means the user approved zero bundles;
         // pushing it would escalate to whole-toolkit access (the backend
         // treats an empty array as the legacy whole-toolkit path).
         #expect(recordingClient.createCalls.isEmpty)
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.isEmpty)
     }
 
     @Test("Grant: explicit empty selection fails closed even for an uncataloged service")
@@ -666,16 +774,18 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_empty_uncataloged"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(
-            connection.id,
-            to: conversationId,
-            grantedToInboxId: "agent-1",
-            bundleIds: []
-        )
+        await #expect(throws: CloudConnectionGrantError.self) {
+            try await fixture.writer.grantConnection(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: "agent-1",
+                bundleIds: []
+            )
+        }
 
         #expect(recordingClient.createCalls.isEmpty)
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.isEmpty)
     }
 
     @Test("Grant: unknown_bundle refetches the catalog, drops unknown ids, and retries once")
@@ -733,19 +843,20 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_stale_twice"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(
-            connection.id,
-            to: conversationId,
-            grantedToInboxId: "agent-1",
-            bundleIds: ["calendar.events"]
-        )
+        await #expect(throws: CloudConnectionsAPI.GrantError.self) {
+            try await fixture.writer.grantConnection(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: "agent-1",
+                bundleIds: ["calendar.events"]
+            )
+        }
 
         // Two attempts (original + one retry), then the push is abandoned:
-        // the local grant stands with no backend id, same as any push failure.
+        // the local grant is rolled back, same as any push failure.
         #expect(recordingClient.createCalls.count == 2)
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.count == 1)
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.isEmpty)
     }
 
     @Test("Grant: fails closed when the refreshed catalog knows none of the selected bundles")
@@ -765,18 +876,20 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_vanished"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(
-            connection.id,
-            to: conversationId,
-            grantedToInboxId: "agent-1",
-            bundleIds: ["calendar.old"]
-        )
+        await #expect(throws: CloudConnectionGrantError.self) {
+            try await fixture.writer.grantConnection(
+                connection.id,
+                to: conversationId,
+                grantedToInboxId: "agent-1",
+                bundleIds: ["calendar.old"]
+            )
+        }
 
         // No retry: pushing an empty bundle set would escalate to whole-toolkit
         // access, strictly more than the user approved.
         #expect(recordingClient.createCalls.count == 1)
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.isEmpty)
     }
 
     @Test("Grant: catalog outage with no explicit selection fails closed — no whole-toolkit push")
@@ -791,15 +904,17 @@ struct ConnectionGrantWriterTests {
         let conversationId = "conv_outage"
         try fixture.seedConversation(id: conversationId)
 
-        try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+        await #expect(throws: CloudConnectionGrantError.self) {
+            try await fixture.writer.grantConnection(connection.id, to: conversationId, grantedToInboxId: "agent-1")
+        }
 
         // An unreachable catalog must not be conflated with "service not in
         // catalog": omitting bundleIds here could grant whole-toolkit access
-        // for a service that IS cataloged. The push is skipped entirely.
+        // for a service that IS cataloged. The push is skipped entirely and
+        // the local grant is rolled back, same as any push failure.
         #expect(recordingClient.createCalls.isEmpty)
         let stored = try fixture.storedGrants(for: conversationId)
-        #expect(stored.count == 1, "the local grant still stands, same as any push failure")
-        #expect(stored.first?.backendGrantId == nil)
+        #expect(stored.isEmpty)
     }
 
     @Test("Grant: catalog outage with an explicit selection pushes it unfiltered, no version")


### PR DESCRIPTION
## Repro

Found by an end-to-end battery against a local stack. With an active Google Calendar connection, toggling the ability on for a conversation while the session's backend auth had expired produced 401s on the enable attempts (`requireAccount rejected request`). From that point the toggle was permanently wedged for that conversation/provider: taps registered but the switch never enabled, no `POST /v2/connections/grants` was ever sent again, and neither an app relaunch (with healthy re-auth) nor an account-level connections refresh healed it.

## Mechanism

The enable path persists optimistic state before the backend POST and leaves it behind when the POST fails:

1. `CloudConnectionGrantWriter.grantConnection` publishes the grant into group metadata and commits the `connectionGrant` row, then attempts the backend push. On failure it only logged, leaving the row with `backendGrantId = nil` and the metadata claiming the grant.
2. `ConversationConnectionsViewModel.toggleCloud` routes taps on row existence (`isGrantedForConversation`, fed by the unfiltered `grantsPublisher`), so with the leftover row present every subsequent tap takes the revoke leg. No grant POST is ever attempted again; failures on the grant leg vanish into a never-rendered `error` property, so taps appear to do nothing.
3. The row is durable GRDB state, and nothing on the toggle path re-runs the owed push for a nil-`backendGrantId` row, so relaunch does not heal.

Two more surfaces treat the same row as proof the grant applied: `AgentBuilderConnectionGrantReplayer` skips replaying it, and `CloudConnectionGrantRequestSheet.share()` reported success (`didComplete`) after a swallowed push failure. Same disease as the approval-path bug fixed in #1307 (unconfirmed local state treated as authoritative by the retry path).

## Fix

On any terminal push failure (401 or any other API failure, fail-closed scope resolution, exhausted `unknown_bundle` retry), the writer now rolls back to the exact pre-attempt state and propagates the error:

- no prior row: the unconfirmed row is deleted, so the wedge state never exists and the next tap retries the POST;
- prior confirmed row (a re-approval whose re-push fails): the prior row is restored, so a live backend grant is not regressed into a locally-off toggle;
- the group metadata is republished without the failed grant (best-effort; the local rollback stands regardless so a relaunch never finds a poisoned row).

Both `grantConnection` and `grantConnectionConfirmingBackend` share the posture via one core; `grantConnection` now throws instead of swallowing, which also stops the false "granted" transcript event and the sheet's false success. Approval-flow retry semantics are unchanged (#1307's retry re-runs the full persist and push unconditionally and never needed the standing row).

## Tests

`ConnectionGrantWriterTests` (all 28 pass; full ConvosCore suite green, 1844 tests):

- push failure rolls the row back, error propagates, and the same call retries the POST successfully once the backend is healthy (wedge-then-retry);
- state left by a failed push does not survive a relaunch: a fresh writer stack over the same database finds no grant and enables cleanly (wedge-then-relaunch-heals, state level);
- a failed re-push over a previously confirmed grant restores the confirmed row;
- rollback republishes metadata without the failed grant;
- fail-closed scope paths (empty selection, zero-bundle catalog entry, catalog outage, vanished bundles, second `unknown_bundle`) now also throw and roll back;
- normal success paths unchanged (persist + publish, backend id stored, bundle scoping, single `unknown_bundle` retry).

Validated with SwiftLint on touched files and a Dev-configuration arm64 simulator build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789227031&installation_model_id=20076&pr_number=1315&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1315&signature=a5bf1177925f5bc88d4434c03412677bbac1fd3a87428761f23187c34c86f5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wedged toggle state by rolling back local grant on backend push failure
> - `CloudConnectionGrantWriter.grantConnection` and `grantConnectionConfirmingBackend` previously swallowed backend push errors and left an unconfirmed grant row in the database, causing the toggle to appear stuck.
> - Both methods now delegate to a new shared `grantRollingBackOnPushFailure` helper that deletes the unconfirmed row (and restores any prior confirmed row) and republishes metadata before rethrowing the error.
> - Tests are updated to assert that `grantConnection` throws on push failure and the database is empty afterward, and that a fresh writer over the same database can retry cleanly.
> - Behavioral Change: callers previously received no error on backend push failure; they now receive a thrown error and must handle it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09dc779.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->