### PR TITLE
fix: honour the requested provider when resolving a capability request

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2894,6 +2894,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// toggles from it and treats unchecking as a revoke. Best-effort too: an
     /// unreadable grants table only loses the seeded state (the sheet falls
     /// back to all-ON and a re-approve is an idempotent upsert).
+    /// Nil when the request names providers this client doesn't know: the pill stays
+    /// in the transcript but no approval sheet is offered, rather than a sheet for
+    /// some other provider registered under the same subject.
     static func computeCapabilityPickerLayout( // swiftlint:disable:this function_parameter_count
         request: CapabilityRequest,
         registry: any CapabilityProviderRegistry,
@@ -2902,7 +2905,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         servicesStore: any ConnectionServicesStoreProtocol,
         cloudConnectionRepository: any CloudConnectionRepositoryProtocol,
         conversationId: String
-    ) async -> CapabilityPickerLayout {
+    ) async -> CapabilityPickerLayout? {
         let services = (try? await servicesStore.catalog()) ?? []
         let existingGrants = (try? await cloudConnectionRepository.grants(for: conversationId)) ?? []
         return await handler.computeLayout(

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityProviderBootstrap.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityProviderBootstrap.swift
@@ -61,7 +61,13 @@ public enum CapabilityProviderBootstrap {
         var seenServiceIds: Set<String> = []
         var desiredProviders: [(ProviderID, CloudCapabilityProvider)] = []
         for connection in connections {
-            guard let provider = CloudCapabilityProvider.from(connection) else { continue }
+            guard let provider = CloudCapabilityProvider.from(connection) else {
+                // The user linked a service this build can't route to a subject. Without a
+                // provider the service is invisible to every agent ask, so say so rather
+                // than dropping it silently.
+                Log.warning("CapabilityProviderBootstrap: no subject mapping for serviceId \(connection.serviceId) — not registered")
+                continue
+            }
             if !seenIds.insert(provider.id).inserted {
                 Log.warning("CapabilityProviderBootstrap: duplicate ProviderID \(provider.id.rawValue) — only one connection will be registered")
                 desiredProviders.removeAll { $0.0 == provider.id }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequest.swift
@@ -35,6 +35,12 @@ public struct CapabilityRequest: Codable, Sendable, Hashable {
     public let subject: CapabilitySubject
     public let capability: ConnectionCapability
     public let rationale: String
+    /// Providers the asking agent will actually exec against. When present this
+    /// constrains the approval card: only these providers may be offered, because a
+    /// different provider registered under the same subject would produce a grant the
+    /// agent cannot use for a service the user was never asked about. A request naming
+    /// only providers this client doesn't know resolves to no card at all.
+    /// Nil or empty means "whatever is registered for the subject".
     public let preferredProviders: [ProviderID]?
 
     public init(

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestHandler.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestHandler.swift
@@ -23,6 +23,11 @@ public struct CapabilityRequestHandler: Sendable {
     /// seed its toggles from the granted state (and treat unchecking as a revoke).
     /// Pass `[]` when grants can't be read — the sheet then seeds its default-ON
     /// posture and a re-approve is a harmless upsert.
+    ///
+    /// Returns nil when this client has nothing honest to offer for the request —
+    /// no provider it knows both satisfies the request's named providers and
+    /// supports the requested verb. The caller shows no card at all rather than a
+    /// card for some other provider registered under the same subject.
     public func computeLayout(
         request: CapabilityRequest,
         registry: any CapabilityProviderRegistry,
@@ -30,12 +35,21 @@ public struct CapabilityRequestHandler: Sendable {
         conversationId: String,
         services: [CloudConnectionsAPI.ServiceConfig] = [],
         existingGrants: [CloudConnectionGrant] = []
-    ) async -> CapabilityPickerLayout {
-        let providersForSubject = await registry.providers(for: request.subject)
+    ) async -> CapabilityPickerLayout? {
+        let registered = await registry.providers(for: request.subject)
+        let providersForSubject = Self.matchingRequestedProviders(registered, request: request)
         let summaries = await Self.summarize(
             providers: providersForSubject,
             requestedCapability: request.capability
         )
+        guard summaries.contains(where: \.supportsCapability) else {
+            Log.warning(
+                "[CapabilityResolution] ignoring capability_request requestId=\(request.requestId) "
+                    + "subject=\(request.subject.rawValue) capability=\(request.capability.rawValue) — "
+                    + "no registered provider matches requested=\(Self.describe(request.preferredProviders))"
+            )
+            return nil
+        }
         // Linked AND supports the requested verb. A provider that's linked but doesn't
         // implement the verb (e.g. Strava is read-only and the agent asks for
         // writeCreate) shouldn't be eligible for default-approve / pre-selection.
@@ -160,6 +174,26 @@ public struct CapabilityRequestHandler: Sendable {
     }
 
     // MARK: - Internals
+
+    /// Narrow the subject's registered providers to the ones the request actually
+    /// named. A request's `preferredProviders` is the toolkit the asking agent will
+    /// exec against, so another provider registered under the same subject is not a
+    /// substitute for it: approving one writes a grant the agent cannot use, for a
+    /// service the user was never asked about. When the request names nothing, every
+    /// provider registered for the subject stays eligible.
+    private static func matchingRequestedProviders(
+        _ providers: [any CapabilityProvider],
+        request: CapabilityRequest
+    ) -> [any CapabilityProvider] {
+        guard let requested = request.preferredProviders, !requested.isEmpty else { return providers }
+        let requestedIds = Set(requested)
+        return providers.filter { requestedIds.contains($0.id) }
+    }
+
+    private static func describe(_ providers: [ProviderID]?) -> String {
+        guard let providers, !providers.isEmpty else { return "<any>" }
+        return providers.map(\.rawValue).joined(separator: ",")
+    }
 
     private static func summarize(
         providers: [any CapabilityProvider],
@@ -324,6 +358,10 @@ public struct CapabilityRequestHandler: Sendable {
         }
     }
 
+    /// Pre-selection within the card's rows. `linked` has already been narrowed to the
+    /// request's named providers by `matchingRequestedProviders`, so this only decides
+    /// how many of them start checked: one on a single-select card, all of them on a
+    /// federating multi-select card.
     private func honorPreferredProviders(
         request: CapabilityRequest,
         linked: [CapabilityPickerLayout.ProviderSummary],

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestHandlerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityRequestHandlerTests.swift
@@ -48,7 +48,7 @@ struct ComputeLayoutVariantTests {
     }
 
     @Test("zero linked providers → connectAndApprove")
-    func variant3() async {
+    func variant3() async throws {
         let registry = await makeRegistry([
             StubProvider(
                 id: appleCalendar,
@@ -59,18 +59,18 @@ struct ComputeLayoutVariantTests {
             ),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .connectAndApprove)
         #expect(layout.defaultSelection.isEmpty)
     }
 
     @Test("exactly one linked provider → confirm with that provider preselected")
-    func variant1() async {
+    func variant1() async throws {
         let registry = await makeRegistry([
             StubProvider(
                 id: appleCalendar,
@@ -81,156 +81,254 @@ struct ComputeLayoutVariantTests {
             ),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .confirm)
         #expect(layout.defaultSelection == [appleCalendar])
     }
 
     @Test("multiple linked providers on non-federating subject → singleSelect")
-    func variant2aNonFederating() async {
+    func variant2aNonFederating() async throws {
         let registry = await makeRegistry([
             StubProvider(id: appleCalendar, subject: .calendar, displayName: "Apple Calendar", capabilities: [.read], linkedByUserValue: true),
             StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: true),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(subject: .calendar, capability: .read),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .singleSelect)
         #expect(layout.defaultSelection.isEmpty)
     }
 
     @Test("multiple linked providers on federating subject + read → multiSelect")
-    func variant2bFederatingRead() async {
+    func variant2bFederatingRead() async throws {
         let registry = await makeRegistry([
             StubProvider(id: strava, subject: .fitness, displayName: "Strava", capabilities: [.read], linkedByUserValue: true),
             StubProvider(id: fitbit, subject: .fitness, displayName: "Fitbit", capabilities: [.read], linkedByUserValue: true),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(subject: .fitness, capability: .read),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .multiSelect)
     }
 
     @Test("multiple linked providers on federating subject + write → singleSelect")
-    func variant2aFederatingWrite() async {
+    func variant2aFederatingWrite() async throws {
         let registry = await makeRegistry([
             StubProvider(id: strava, subject: .fitness, displayName: "Strava", capabilities: [.read, .writeCreate], linkedByUserValue: true),
             StubProvider(id: fitbit, subject: .fitness, displayName: "Fitbit", capabilities: [.read, .writeCreate], linkedByUserValue: true),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(subject: .fitness, capability: .writeCreate),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .singleSelect, "writes never federate, even on .fitness")
     }
 }
 
-@Suite("CapabilityRequestHandler.computeLayout — preferredProviders hint")
+@Suite("CapabilityRequestHandler.computeLayout — requested providers")
 struct ComputeLayoutPreferredProvidersTests {
     private let handler: CapabilityRequestHandler = CapabilityRequestHandler()
     private let conversationId: String = "conv-1"
     private let appleCalendar: ProviderID = ProviderID(rawValue: "device.calendar")
     private let googleCalendar: ProviderID = ProviderID(rawValue: "composio.googlecalendar")
+    private let outlook: ProviderID = ProviderID(rawValue: "composio.microsoftoutlook")
     private let strava: ProviderID = ProviderID(rawValue: "composio.strava")
     private let fitbit: ProviderID = ProviderID(rawValue: "composio.fitbit")
 
-    @Test("singleSelect picker honors first satisfiable preferredProvider")
-    func singleSelectHonorsHint() async {
+    private func makeRegistry(_ providers: [StubProvider]) async -> any CapabilityProviderRegistry {
         let registry = InMemoryCapabilityProviderRegistry()
-        for stub in [
+        for provider in providers { await registry.register(provider) }
+        return registry
+    }
+
+    private func request(
+        subject: CapabilitySubject = .calendar,
+        capability: ConnectionCapability = .read,
+        preferredProviders: [ProviderID]?
+    ) -> CapabilityRequest {
+        CapabilityRequest(
+            requestId: "req-1",
+            askerInboxId: "agent-1",
+            subject: subject,
+            capability: capability,
+            rationale: "test",
+            preferredProviders: preferredProviders
+        )
+    }
+
+    @Test("a named provider that is linked is the one confirmed, not a linked sibling")
+    func namedLinkedProviderWins() async throws {
+        let registry = await makeRegistry([
             StubProvider(id: appleCalendar, subject: .calendar, displayName: "Apple Calendar", capabilities: [.read], linkedByUserValue: true),
             StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: true),
-        ] {
-            await registry.register(stub)
-        }
+        ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
-            request: CapabilityRequest(
-                requestId: "req-1",
-                askerInboxId: "agent-1",
-                subject: .calendar,
-                capability: .read,
-                rationale: "test",
-                preferredProviders: [googleCalendar]
-            ),
+        let layout = try #require(await handler.computeLayout(
+            request: request(preferredProviders: [googleCalendar]),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
-        #expect(layout.variant == .singleSelect)
+        ))
+        // Both are linked, but only the named one may be offered — a card row for
+        // Apple Calendar would let the user grant a provider the agent never asked
+        // for and cannot exec against.
+        let offered: [ProviderID] = layout.providers.map(\.id)
+        #expect(offered == [googleCalendar])
+        #expect(layout.variant == .confirm)
         #expect(layout.defaultSelection == [googleCalendar])
     }
 
-    @Test("multiSelect picker honors all satisfiable preferredProviders")
-    func multiSelectHonorsHint() async {
-        let registry = InMemoryCapabilityProviderRegistry()
-        for stub in [
-            StubProvider(id: strava, subject: .fitness, displayName: "Strava", capabilities: [.read], linkedByUserValue: true),
-            StubProvider(id: fitbit, subject: .fitness, displayName: "Fitbit", capabilities: [.read], linkedByUserValue: true),
-        ] {
-            await registry.register(stub)
-        }
+    @Test("a named provider that is not linked yet is the one offered to connect")
+    func namedUnlinkedProviderIsOffered() async throws {
+        let registry = await makeRegistry([
+            StubProvider(id: appleCalendar, subject: .calendar, displayName: "Apple Calendar", capabilities: [.read], linkedByUserValue: true),
+            StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: false),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = try #require(await handler.computeLayout(
+            request: request(preferredProviders: [googleCalendar]),
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId
+        ))
+        // The user having some other calendar linked is not consent to use it: the
+        // card offers to connect the calendar the agent actually named.
+        let offered: [ProviderID] = layout.providers.map(\.id)
+        #expect(layout.variant == .connectAndApprove)
+        #expect(offered == [googleCalendar])
+    }
+
+    @Test("a request naming only unknown providers yields no card at all")
+    func unknownProviderYieldsNoLayout() async {
+        let registry = await makeRegistry([
+            StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: true),
+        ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
         let layout = await handler.computeLayout(
-            request: CapabilityRequest(
-                requestId: "req-1",
-                askerInboxId: "agent-1",
-                subject: .fitness,
-                capability: .read,
-                rationale: "test",
-                preferredProviders: [strava, fitbit]
-            ),
+            request: request(preferredProviders: [ProviderID(rawValue: "composio.someothercalendar")]),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
         )
+        // Substituting Google Calendar here would offer the user a service the agent
+        // never asked about and write a grant it cannot use.
+        #expect(layout == nil)
+    }
+
+    @Test("one known provider among unknown ones still resolves to the known one")
+    func partiallyKnownRequestResolvesToKnown() async throws {
+        let registry = await makeRegistry([
+            StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: true),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = try #require(await handler.computeLayout(
+            request: request(preferredProviders: [ProviderID(rawValue: "composio.someothercalendar"), googleCalendar]),
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId
+        ))
+        let offered: [ProviderID] = layout.providers.map(\.id)
+        #expect(offered == [googleCalendar])
+        #expect(layout.defaultSelection == [googleCalendar])
+    }
+
+    @Test("no named providers keeps the single registered provider on the card")
+    func noPreferenceKeepsSingleProviderBehaviour() async throws {
+        let registry = await makeRegistry([
+            StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: true),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = try #require(await handler.computeLayout(
+            request: request(preferredProviders: nil),
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId
+        ))
+        let offered: [ProviderID] = layout.providers.map(\.id)
+        #expect(layout.variant == .confirm)
+        #expect(offered == [googleCalendar])
+        #expect(layout.defaultSelection == [googleCalendar])
+    }
+
+    @Test("no named providers still offers every provider registered for the subject")
+    func noPreferenceKeepsEveryProvider() async throws {
+        let registry = await makeRegistry([
+            StubProvider(id: appleCalendar, subject: .calendar, displayName: "Apple Calendar", capabilities: [.read], linkedByUserValue: true),
+            StubProvider(id: outlook, subject: .calendar, displayName: "Microsoft Outlook", capabilities: [.read], linkedByUserValue: true),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = try #require(await handler.computeLayout(
+            request: request(preferredProviders: nil),
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId
+        ))
+        let offered: Set<ProviderID> = Set(layout.providers.map(\.id))
+        #expect(layout.variant == .singleSelect)
+        #expect(offered == [appleCalendar, outlook])
+    }
+
+    @Test("a federating read keeps every named provider selected")
+    func multiSelectHonorsEveryNamedProvider() async throws {
+        let registry = await makeRegistry([
+            StubProvider(id: strava, subject: .fitness, displayName: "Strava", capabilities: [.read], linkedByUserValue: true),
+            StubProvider(id: fitbit, subject: .fitness, displayName: "Fitbit", capabilities: [.read], linkedByUserValue: true),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = try #require(await handler.computeLayout(
+            request: request(subject: .fitness, preferredProviders: [strava, fitbit]),
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId
+        ))
         #expect(layout.variant == .multiSelect)
         #expect(layout.defaultSelection == [strava, fitbit])
     }
 
-    @Test("hint that points at unlinked providers is dropped")
-    func hintFallsBackOnUnlinked() async {
-        let registry = InMemoryCapabilityProviderRegistry()
-        for stub in [
-            StubProvider(id: appleCalendar, subject: .calendar, displayName: "Apple Calendar", capabilities: [.read], linkedByUserValue: true),
-            StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: false),
-        ] {
-            await registry.register(stub)
-        }
+    @Test("a request whose named provider cannot do the verb yields no card")
+    func namedProviderMissingVerbYieldsNoLayout() async {
+        let registry = await makeRegistry([
+            StubProvider(id: strava, subject: .fitness, displayName: "Strava", capabilities: [.read], linkedByUserValue: true),
+        ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
         let layout = await handler.computeLayout(
-            request: CapabilityRequest(
-                requestId: "req-1",
-                askerInboxId: "agent-1",
-                subject: .calendar,
-                capability: .read,
-                rationale: "test",
-                preferredProviders: [googleCalendar]
-            ),
+            request: request(subject: .fitness, capability: .writeCreate, preferredProviders: [strava]),
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
         )
-        // Only one linked provider → variant 1 (confirm), default selection is the
-        // single linked option, not the unlinked Google Calendar that the agent asked for.
-        #expect(layout.variant == .confirm)
-        #expect(layout.defaultSelection == [appleCalendar])
+        #expect(layout == nil)
+    }
+
+    @Test("a subject with nothing registered yields no card")
+    func unregisteredSubjectYieldsNoLayout() async {
+        let registry = await makeRegistry([
+            StubProvider(id: googleCalendar, subject: .calendar, displayName: "Google Calendar", capabilities: [.read], linkedByUserValue: true),
+        ])
+        let resolver = InMemoryCapabilityResolver(registry: registry)
+        let layout = await handler.computeLayout(
+            request: request(subject: .mail, preferredProviders: nil),
+            registry: registry,
+            resolver: resolver,
+            conversationId: conversationId
+        )
+        #expect(layout == nil)
     }
 }
 
@@ -257,7 +355,7 @@ struct ComputeLayoutVerbConsentTests {
             grantedToInboxId: "agent-1"
         )
 
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
                 askerInboxId: "agent-1",
@@ -268,7 +366,7 @@ struct ComputeLayoutVerbConsentTests {
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .verbConsent)
         #expect(layout.defaultSelection == [appleCalendar])
     }
@@ -291,7 +389,7 @@ struct ComputeLayoutVerbConsentTests {
             grantedToInboxId: "agent-1"
         )
 
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
                 askerInboxId: "agent-1",
@@ -302,7 +400,7 @@ struct ComputeLayoutVerbConsentTests {
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .verbConsent)
         // Writes never federate; default to the single deterministic pick.
         #expect(layout.defaultSelection.count == 1)
@@ -324,7 +422,7 @@ struct ComputeLayoutVerbConsentTests {
             grantedToInboxId: "agent-1"
         )
 
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
                 askerInboxId: "agent-1",
@@ -335,19 +433,19 @@ struct ComputeLayoutVerbConsentTests {
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         // Same-verb resolution → not the verb-consent path; falls through to confirm.
         #expect(layout.variant == .confirm)
     }
 
     @Test("no shortcut when no other verb has a resolution")
-    func noOtherVerbResolved() async {
+    func noOtherVerbResolved() async throws {
         let registry = InMemoryCapabilityProviderRegistry()
         await registry.register(
             StubProvider(id: appleCalendar, subject: .calendar, displayName: "Apple Calendar", capabilities: [.read], linkedByUserValue: true)
         )
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: CapabilityRequest(
                 requestId: "req-1",
                 askerInboxId: "agent-1",
@@ -358,7 +456,7 @@ struct ComputeLayoutVerbConsentTests {
             registry: registry,
             resolver: resolver,
             conversationId: conversationId
-        )
+        ))
         #expect(layout.variant == .confirm)
     }
 }
@@ -509,7 +607,7 @@ struct ComputeLayoutServiceBundlesTests {
     }
 
     @Test("cloud providers with a catalog entry get bundle rows; device providers don't")
-    func bundlesAttachToCloudProviders() async {
+    func bundlesAttachToCloudProviders() async throws {
         let registry = await makeRegistry([
             StubProvider(
                 id: googleCalendar,
@@ -527,13 +625,13 @@ struct ComputeLayoutServiceBundlesTests {
             ),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
             conversationId: "conv-1",
             services: [calendarService()]
-        )
+        ))
         #expect(layout.serviceBundles.count == 1)
         let group = layout.serviceBundles.first
         #expect(group?.providerId == googleCalendar)
@@ -545,7 +643,7 @@ struct ComputeLayoutServiceBundlesTests {
     }
 
     @Test("bundle rows carry the catalog's defaultEnabled flags")
-    func rowsCarryDefaultEnabledFlags() async {
+    func rowsCarryDefaultEnabledFlags() async throws {
         let registry = await makeRegistry([
             StubProvider(
                 id: googleCalendar,
@@ -556,20 +654,20 @@ struct ComputeLayoutServiceBundlesTests {
             ),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
             conversationId: "conv-1",
             services: [calendarService()]
-        )
+        ))
         let rows = layout.serviceBundles.first?.rows ?? []
         #expect(rows.map(\.id) == ["calendar.events", "calendar.events.read"])
         #expect(rows.map(\.defaultEnabled) == [false, true])
     }
 
     @Test("an empty catalog leaves the layout bundle-free")
-    func emptyCatalogMeansNoBundles() async {
+    func emptyCatalogMeansNoBundles() async throws {
         let registry = await makeRegistry([
             StubProvider(
                 id: googleCalendar,
@@ -580,12 +678,12 @@ struct ComputeLayoutServiceBundlesTests {
             ),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        let layout = await handler.computeLayout(
+        let layout = try #require(await handler.computeLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
             conversationId: "conv-1"
-        )
+        ))
         #expect(layout.serviceBundles.isEmpty)
     }
 
@@ -606,7 +704,7 @@ struct ComputeLayoutServiceBundlesTests {
         )
     }
 
-    private func computeLayout(existingGrants: [CloudConnectionGrant]) async -> CapabilityPickerLayout {
+    private func computeLayout(existingGrants: [CloudConnectionGrant]) async throws -> CapabilityPickerLayout {
         let registry = await makeRegistry([
             StubProvider(
                 id: googleCalendar,
@@ -617,46 +715,46 @@ struct ComputeLayoutServiceBundlesTests {
             ),
         ])
         let resolver = InMemoryCapabilityResolver(registry: registry)
-        return await handler.computeLayout(
+        return try #require(await handler.computeLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
             conversationId: "conv-1",
             services: [calendarService()],
             existingGrants: existingGrants
-        )
+        ))
     }
 
     @Test("the asking agent's grant stamps its bundle ids onto the group")
-    func existingGrantStampsBundleIds() async {
-        let layout = await computeLayout(existingGrants: [makeGrant(bundleIds: ["calendar.events"])])
+    func existingGrantStampsBundleIds() async throws {
+        let layout = try await computeLayout(existingGrants: [makeGrant(bundleIds: ["calendar.events"])])
         #expect(layout.serviceBundles.first?.grantedBundleIds == ["calendar.events"])
     }
 
     @Test("a whole-toolkit grant (nil bundleIds) materializes as every catalog row")
-    func wholeToolkitGrantCoversEveryRow() async {
-        let layout = await computeLayout(existingGrants: [makeGrant(bundleIds: nil)])
+    func wholeToolkitGrantCoversEveryRow() async throws {
+        let layout = try await computeLayout(existingGrants: [makeGrant(bundleIds: nil)])
         #expect(layout.serviceBundles.first?.grantedBundleIds == ["calendar.events", "calendar.events.read"])
     }
 
     @Test("no grant leaves grantedBundleIds nil")
-    func noGrantLeavesNil() async {
-        let layout = await computeLayout(existingGrants: [])
+    func noGrantLeavesNil() async throws {
+        let layout = try await computeLayout(existingGrants: [])
         #expect(layout.serviceBundles.count == 1)
         #expect(layout.serviceBundles.first?.grantedBundleIds == nil)
     }
 
     @Test("another agent's grant must not seed this agent's sheet")
-    func otherAgentsGrantIsIgnored() async {
-        let layout = await computeLayout(
+    func otherAgentsGrantIsIgnored() async throws {
+        let layout = try await computeLayout(
             existingGrants: [makeGrant(grantedToInboxId: "agent-2", bundleIds: ["calendar.events"])]
         )
         #expect(layout.serviceBundles.first?.grantedBundleIds == nil)
     }
 
     @Test("another conversation's grant must not seed this sheet")
-    func otherConversationsGrantIsIgnored() async {
-        let layout = await computeLayout(
+    func otherConversationsGrantIsIgnored() async throws {
+        let layout = try await computeLayout(
             existingGrants: [makeGrant(conversationId: "conv-2", bundleIds: ["calendar.events"])]
         )
         #expect(layout.serviceBundles.first?.grantedBundleIds == nil)

--- a/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
+++ b/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
@@ -11,7 +11,7 @@ import XCTest
 /// bundle rows so an approve silently escalated to full-service consent).
 @MainActor
 final class ConversationViewModelCapabilityConnectTests: XCTestCase {
-    func testComputeCapabilityPickerLayoutPopulatesBundleRows() async {
+    func testComputeCapabilityPickerLayoutPopulatesBundleRows() async throws {
         let registry = InMemoryCapabilityProviderRegistry()
         await registry.register(
             CloudCapabilityProvider(
@@ -44,7 +44,7 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
             ])
         })
 
-        let layout = await ConversationViewModel.computeCapabilityPickerLayout(
+        let layout = try XCTUnwrap(await ConversationViewModel.computeCapabilityPickerLayout(
             request: makeRequest(),
             registry: registry,
             resolver: resolver,
@@ -52,7 +52,7 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
             servicesStore: servicesStore,
             cloudConnectionRepository: MockConnectionRepository(),
             conversationId: "test-convo"
-        )
+        ))
 
         XCTAssertEqual(layout.serviceBundles.count, 1,
                        "Catalog-backed services must surface their bundle rows")


### PR DESCRIPTION
## The bug

An agent's `capability_request` carries `preferredProviders` on the wire — the provider ids it will actually exec against. Herald declares it (`preferred_providers`, `array(string).max(16).optional()`) and passes it through unmodified into the XMTP payload; the agent-side connections skill sets it on every calendar and gmail ask (`composio.googlecalendar`, `composio.gmail`). iOS decodes it fine.

`CapabilityRequestHandler.computeLayout` then ignored it when deciding what to show. The card's provider list came from `registry.providers(for: request.subject)` with no reference to what the request named. `honorPreferredProviders` existed but only fed `defaultSelection`, and only in the `>= 2 linked providers` branch — it never ran in the two branches that matter:

- `linkedSummaries.isEmpty` → `.connectAndApprove`, offering every provider registered for the subject
- `linkedSummaries.count == 1` → `.confirm`, pre-selecting that one provider whoever it is

## Why it matters

This is a wrong-toolkit grant. An agent asks for Google Calendar; the user has a different calendar provider linked; the card offers that other provider, pre-selected. Approving writes a resolution for a service the user was never asked about, and the asking agent still cannot exec — its toolkit is chosen by slug, so a grant for a sibling provider is useless to it.

The transcript pill made it worse rather than better: `CapabilityConnectPrompt.make` already resolves its label and icon from `request.preferredProviders?.first`, so the pill named the service the agent asked for while the sheet behind it offered a different one.

The old behaviour was pinned by a test (`"hint that points at unlinked providers is dropped"`) that asserted exactly this substitution as intended. It has been rewritten.

## The fix

`preferredProviders` now constrains **which providers may be offered**, not just which start selected:

1. `matchingRequestedProviders` narrows the subject's registered providers to the ones the request named. A request naming nothing keeps today's behaviour — every provider registered for the subject.
2. `computeLayout` returns `CapabilityPickerLayout?` and yields **nil** when nothing survives that supports the requested verb, logging requestId, subject, capability and the requested ids.

### Unknown-provider posture: honest no-op

A nil layout leaves `pendingCapabilityPickerLayout` nil. The pill stays in the transcript, labelled with the service the agent actually asked for, and the existing tap guard makes it inert. No sheet, no substitute, no grant, no new copy — showing nothing beats showing the wrong service.

Returning an optional rather than an empty-provider layout also closes a pre-existing case: a subject with nothing registered already produced a card with zero rows and nothing to approve. Making "nothing to offer" unrepresentable as a layout fixes that too and stops a future caller presenting an empty card. App-side churn is nil since `pendingCapabilityPickerLayout` was already optional.

### Also

Logged the `CapabilityProviderBootstrap` drop for a linked service with no `serviceSubjectMap` entry. That path silently made a service the user had linked invisible to every agent ask. Its sibling `CloudCapabilityProvider.placeholder` is left alone deliberately — its only caller iterates a compile-time allowlist, so a nil there is a developer error discoverable by inspection, not a runtime condition.

## Tests

Rewrote the requested-providers suite (9 tests):

- a named provider that is linked is the one confirmed, not a linked sibling
- a named provider not linked yet is the one offered to connect
- a request naming only unknown providers yields no card at all
- one known provider among unknown ones still resolves to the known one
- no named providers keeps the single registered provider on the card
- no named providers still offers every provider registered for the subject
- a federating read keeps every named provider selected
- a named provider that cannot do the requested verb yields no card
- a subject with nothing registered yields no card

Existing suites kept, mechanically converted to `try #require(...)`.

## Validation

- `swift test --package-path ConvosCore` — 1850 tests in 251 suites passed
- `xcodebuild build -scheme "Convos (Dev)" -configuration Dev`, arm64 simulator — BUILD SUCCEEDED
- `swiftlint --strict` and `swiftformat --lint` clean on all touched files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789242812&installation_model_id=20076&pr_number=1318&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1318&signature=dc22d8c0739a68602e4c3d46bd828ad5b437319a97d098a044a5cb8d614d032a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CapabilityRequestHandler.computeLayout` to honour `preferredProviders` when resolving capability requests
> - `computeLayout` now filters registered providers to those named in `request.preferredProviders` before building the picker layout, ensuring only requested providers are offered.
> - When no matching provider supports the requested capability, `computeLayout` returns `nil` instead of showing a picker with irrelevant options; callers up the stack handle the absent layout.
> - A new `matchingRequestedProviders` helper encapsulates the filtering logic; a warning is logged when named providers are unknown or unsupported.
> - Behavioral Change: `computeLayout` and `ConversationViewModel.computeCapabilityPickerLayout` now return optionals; any caller that previously assumed a non-nil layout must now handle `nil`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83da891.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->