### PR TITLE
Add Space share debug action

### DIFF
--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -147,6 +147,22 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- gates the internal action that copies a Space share
+    /// message to the clipboard so another conversation's agent can import
+    /// the Space. Deliberately reachable in every environment; production
+    /// users opt in from the curated prod debug menu.
+    var isSpaceShareEnabled: Bool {
+        get {
+            access(keyPath: \.isSpaceShareEnabled)
+            return UserDefaults.standard.bool(forKey: Constant.spaceShareEnabledKey)
+        }
+        set {
+            withMutation(keyPath: \.isSpaceShareEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.spaceShareEnabledKey)
+            }
+        }
+    }
+
     /// Mock credits/subscription state used by the in-app paywall preview surface
     /// in the Debug menu. Non-production only; defaults to `.plusAmple`.
     var mockCreditsPreset: CreditsStatePreset {
@@ -217,5 +233,6 @@ final class FeatureFlags {
         static let listenParticipationEnabledKey: String = "featureFlags.listenParticipationEnabled"
         static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
         static let abilitiesV2EnabledKey: String = "featureFlags.abilitiesV2Enabled"
+        static let spaceShareEnabledKey: String = "featureFlags.spaceShareEnabled"
     }
 }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -115,6 +115,7 @@ struct ConversationInfoView: View {
     @State private var showingRestoreInviteTagAlert: Bool = false
     @State private var restoreInviteTagText: String = ""
     @State private var showingLeaveConfirmation: Bool = false
+    @State private var spaceShareCoordinator: ConversationSpaceShareCoordinator = .init()
     @State private var navState: ConversationInfoNavigatorImpl = .init()
     @State private var navigator: ConversationInfoCollector?
 
@@ -658,13 +659,16 @@ struct ConversationInfoView: View {
 // MARK: - Support and debug section
 
 extension ConversationInfoView {
-    // The support rows ship in every environment so production users can
-    // send on-device diagnostics to support; the remaining rows are internal
-    // debugging tools and stay out of production builds.
+    // The support rows ship in every environment so production users can send
+    // on-device diagnostics to support. The Space share row follows its
+    // explicit opt-in flag; the remaining debug rows stay out of production.
     @ViewBuilder
     private var debugInfoSection: some View {
         let isProduction = ConfigManager.shared.currentEnvironment.isProduction
         Section {
+            if FeatureFlags.shared.isSpaceShareEnabled {
+                spaceShareRow
+            }
             if !isProduction {
                 internalDebugRows
             }
@@ -737,6 +741,49 @@ extension ConversationInfoView {
         } label: {
             Text("Restore invite tag")
         }
+    }
+
+    private var spaceShareRow: some View {
+        Button {
+            Task {
+                await spaceShareCoordinator.share(
+                    conversationId: viewModel.conversation.id,
+                    variantId: viewModel.conversation.agentVariant?.slug
+                )
+            }
+        } label: {
+            HStack {
+                Text("Share Space")
+                    .foregroundStyle(.colorTextPrimary)
+                Spacer()
+                if spaceShareCoordinator.isBusy {
+                    ProgressView()
+                }
+            }
+        }
+        .disabled(spaceShareCoordinator.isBusy)
+        .accessibilityIdentifier("share-space-button")
+        .accessibilityLabel("Copy Space share message")
+        .alert(
+            spaceShareCoordinator.alert?.title ?? "",
+            isPresented: spaceShareAlertIsPresented,
+            presenting: spaceShareCoordinator.alert
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { payload in
+            Text(payload.message)
+        }
+    }
+
+    private var spaceShareAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { spaceShareCoordinator.alert != nil },
+            set: { isPresented in
+                if !isPresented {
+                    spaceShareCoordinator.alert = nil
+                }
+            }
+        )
     }
 
     @ViewBuilder

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -748,7 +748,7 @@ extension ConversationInfoView {
             Task {
                 await spaceShareCoordinator.share(
                     conversationId: viewModel.conversation.id,
-                    variantId: viewModel.conversation.agentVariant?.slug
+                    variantId: viewModel.conversationAgentVariantSlug
                 )
             }
         } label: {
@@ -764,6 +764,7 @@ extension ConversationInfoView {
         .disabled(spaceShareCoordinator.isBusy)
         .accessibilityIdentifier("share-space-button")
         .accessibilityLabel("Copy Space share message")
+        .accessibilityHint("Creates a share link that works for 7 days and copies it to the clipboard")
         .alert(
             spaceShareCoordinator.alert?.title ?? "",
             isPresented: spaceShareAlertIsPresented,

--- a/Convos/Conversation Detail/ConversationSpaceShareCoordinator.swift
+++ b/Convos/Conversation Detail/ConversationSpaceShareCoordinator.swift
@@ -1,0 +1,110 @@
+import ConvosCore
+import Foundation
+import Observation
+import UIKit
+
+struct ConversationSpaceShareAlertPayload: Equatable {
+    let title: String
+    let message: String
+}
+
+/// Mints a Space share message through the backend relay and puts it on the
+/// clipboard. The message embeds an expiring read-only repository credential,
+/// so it goes straight from the response to the pasteboard — never into logs
+/// or alert text.
+@MainActor
+@Observable
+final class ConversationSpaceShareCoordinator {
+    typealias ShareOperation = (String, String?) async throws -> ConvosAPI.SpaceShareLink
+    typealias CopyToClipboard = (String) -> Void
+
+    private let shareOperation: ShareOperation
+    private let copyToClipboard: CopyToClipboard
+
+    private(set) var isBusy: Bool = false
+    var alert: ConversationSpaceShareAlertPayload?
+
+    init(
+        apiClient: any ConvosAPIClientProtocol = ConvosAPIClientFactory.client(
+            environment: ConfigManager.shared.currentEnvironment
+        )
+    ) {
+        shareOperation = { conversationId, variantId in
+            try await apiClient.shareSpace(
+                conversationId: conversationId,
+                variantId: variantId
+            )
+        }
+        copyToClipboard = { UIPasteboard.general.string = $0 }
+    }
+
+    init(
+        shareOperation: @escaping ShareOperation,
+        copyToClipboard: @escaping CopyToClipboard
+    ) {
+        self.shareOperation = shareOperation
+        self.copyToClipboard = copyToClipboard
+    }
+
+    func share(conversationId: String, variantId: String?) async {
+        guard !isBusy else { return }
+        isBusy = true
+        defer { isBusy = false }
+
+        do {
+            let link = try await shareOperation(conversationId, variantId)
+            copyToClipboard(link.message)
+            alert = ConversationSpaceShareAlertPayload(
+                title: "Copied to clipboard",
+                message: "Paste it into another conversation and that agent will rebuild this Space there. The link works for 7 days."
+            )
+        } catch {
+            alert = Self.alert(for: error)
+        }
+    }
+
+    private static func alert(for error: Error) -> ConversationSpaceShareAlertPayload {
+        if let shareError = error as? ConvosAPI.SpaceShareError {
+            return alert(for: shareError)
+        }
+        if let urlError = error as? URLError, urlError.code == .timedOut {
+            return alert(for: .timeout)
+        }
+        return ConversationSpaceShareAlertPayload(
+            title: "Couldn't create a share link",
+            message: "Try again. If the problem continues, check the selected deployment."
+        )
+    }
+
+    private static func alert(for error: ConvosAPI.SpaceShareError) -> ConversationSpaceShareAlertPayload {
+        let title: String
+        let message: String
+        switch error {
+        case .invalidRequest:
+            title = "Invalid conversation"
+            message = "This conversation can't be used for a Space share link."
+        case .spaceNotFound:
+            title = "No Space found"
+            message = "The selected deployment has no Space for this conversation."
+        case .repositoryUnavailable:
+            title = "Repository unavailable"
+            message = "This Space is not connected to a repository."
+        case .variantUnavailable:
+            title = "Variant unavailable"
+            message = "This conversation's agent variant is no longer available."
+        case .unavailable:
+            title = "Sharing unavailable"
+            message = "The selected deployment can't mint share links right now."
+        case .timeout:
+            title = "Request timed out"
+            message = "The request timed out. Nothing was copied; it is safe to try again."
+        case .failed:
+            title = "Couldn't create a share link"
+            message = "Try again. If the problem continues, check the selected deployment."
+        case .rateLimited:
+            title = "Too many share links"
+            message = "Wait a moment, then try again."
+        }
+        return ConversationSpaceShareAlertPayload(title: title, message: message)
+    }
+}

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -81,6 +81,7 @@ struct DebugViewSection: View {
             agentVariantToggles
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
+            Toggle("Share Space (copy import link)", isOn: Bindable(FeatureFlags.shared).isSpaceShareEnabled)
             abilitiesFeatureToggles
 
             let showInfoAction = { showingAgentsInfoSheet = true }

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -184,6 +184,7 @@ struct ProdDebugMenuView: View {
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
             Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
+            Toggle("Share Space (copy import link)", isOn: Bindable(FeatureFlags.shared).isSpaceShareEnabled)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Abilities.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Abilities.swift
@@ -85,46 +85,6 @@ extension ConvosAPIClient {
     }
 }
 
-// MARK: - URL construction (internal for tests)
-
-extension ConvosAPIClient {
-    /// Percent-encodes one path segment with the RFC 3986 unreserved set
-    /// only, so opaque ids containing `/`, `%`, `?`, or `#` stay a single
-    /// path component. `.urlPathAllowed` is not enough: it leaves `/`
-    /// intact, splitting the id into extra path segments.
-    static func strictPathComponentEncoded(_ raw: String) -> String {
-        raw.addingPercentEncoding(withAllowedCharacters: Constant.unreservedCharacters) ?? raw
-    }
-
-    /// Builds an abilities endpoint URL by setting the percent-encoded path
-    /// directly on URLComponents. `appendingPathComponent` cannot be used
-    /// with pre-encoded segments: it re-encodes `%` into `%25`, double
-    /// encoding the id.
-    static func abilitiesURL(baseURL: URL, pathSegments: [String], queryParameters: [String: String]?) throws -> URL {
-        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-            throw APIError.invalidURL
-        }
-        let encodedSegments: [String] = pathSegments.map { strictPathComponentEncoded($0) }
-        let basePath = components.percentEncodedPath.hasSuffix("/")
-            ? String(components.percentEncodedPath.dropLast())
-            : components.percentEncodedPath
-        components.percentEncodedPath = "\(basePath)/\(encodedSegments.joined(separator: "/"))"
-        if let queryParameters {
-            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
-        }
-        guard let url = components.url else {
-            throw APIError.invalidURL
-        }
-        return url
-    }
-
-    private enum Constant {
-        static let unreservedCharacters: CharacterSet = CharacterSet(
-            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
-        )
-    }
-}
-
 // MARK: - Shared plumbing
 
 private extension ConvosAPIClient {
@@ -133,7 +93,7 @@ private extension ConvosAPIClient {
         method: String,
         queryParameters: [String: String]? = nil
     ) throws -> URLRequest {
-        let url = try Self.abilitiesURL(baseURL: baseURL, pathSegments: pathSegments, queryParameters: queryParameters)
+        let url = try Self.endpointURL(baseURL: baseURL, pathSegments: pathSegments, queryParameters: queryParameters)
         var request = URLRequest(url: url)
         request.httpMethod = method
         return attachingAuthHeader(to: request)

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+EndpointURL.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+EndpointURL.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// Endpoint URL construction (internal for tests). Shared by every route
+// that carries an opaque identifier in its path — abilities and the
+// Space share mint today.
+
+extension ConvosAPIClient {
+    /// Percent-encodes one path segment with the RFC 3986 unreserved set
+    /// only, so opaque ids containing `/`, `%`, `?`, or `#` stay a single
+    /// path component. `.urlPathAllowed` is not enough: it leaves `/`
+    /// intact, splitting the id into extra path segments.
+    static func strictPathComponentEncoded(_ raw: String) -> String {
+        raw.addingPercentEncoding(withAllowedCharacters: Constant.unreservedCharacters) ?? raw
+    }
+
+    /// Builds an endpoint URL by setting the percent-encoded path
+    /// directly on URLComponents. `appendingPathComponent` cannot be used
+    /// with pre-encoded segments: it re-encodes `%` into `%25`, double
+    /// encoding the id.
+    static func endpointURL(baseURL: URL, pathSegments: [String], queryParameters: [String: String]?) throws -> URL {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw APIError.invalidURL
+        }
+        let encodedSegments: [String] = pathSegments.map { strictPathComponentEncoded($0) }
+        let basePath = components.percentEncodedPath.hasSuffix("/")
+            ? String(components.percentEncodedPath.dropLast())
+            : components.percentEncodedPath
+        components.percentEncodedPath = "\(basePath)/\(encodedSegments.joined(separator: "/"))"
+        if let queryParameters {
+            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+        return url
+    }
+
+    private enum Constant {
+        static let unreservedCharacters: CharacterSet = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -436,7 +436,92 @@ public enum ConvosAPI {
             }
         }
     }
+}
 
+extension ConvosAPI {
+    // MARK: - v2/conversations/:conversationId/debug/space-share
+
+    /// The paste-ready Space share payload. `message` is the exact clipboard
+    /// text: one sentence naming the receiving agent's `space-import` skill,
+    /// then a clone URL whose userinfo carries an expiring read-only
+    /// repository credential — treat the whole value as a secret and never
+    /// log it.
+    public struct SpaceShareLink: Decodable, Equatable, Sendable {
+        public let conversationId: String
+        public let message: String
+        public let expiresAt: String
+
+        public init(conversationId: String, message: String, expiresAt: String) {
+            self.conversationId = conversationId
+            self.message = message
+            self.expiresAt = expiresAt
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            guard try container.decode(Bool.self, forKey: .success) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .success,
+                    in: container,
+                    debugDescription: "Space share success envelope must set success to true"
+                )
+            }
+            conversationId = try container.decode(String.self, forKey: .conversationId)
+            message = try container.decode(String.self, forKey: .message)
+            expiresAt = try container.decode(String.self, forKey: .expiresAt)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case success
+            case conversationId
+            case message
+            case expiresAt
+        }
+    }
+
+    public enum SpaceShareError: Error, Equatable, Sendable {
+        case invalidRequest
+        case spaceNotFound
+        case repositoryUnavailable
+        case variantUnavailable
+        case unavailable
+        case timeout
+        case failed
+        case rateLimited
+
+        init?(body: Data) {
+            struct ErrorBody: Decodable {
+                let success: Bool
+                let error: String
+                let message: String
+            }
+            guard let response = try? JSONDecoder().decode(ErrorBody.self, from: body),
+                  !response.success else { return nil }
+            switch response.error {
+            case "INVALID_REQUEST":
+                self = .invalidRequest
+            case "SPACE_NOT_FOUND":
+                self = .spaceNotFound
+            case "SPACE_REPOSITORY_UNAVAILABLE":
+                self = .repositoryUnavailable
+            case "VARIANT_UNAVAILABLE":
+                self = .variantUnavailable
+            case "SPACE_SHARE_UNAVAILABLE":
+                self = .unavailable
+            case "SPACE_SHARE_TIMEOUT":
+                self = .timeout
+            case "SPACE_SHARE_FAILED":
+                self = .failed
+            case "RATE_LIMITED":
+                self = .rateLimited
+            default:
+                return nil
+            }
+        }
+    }
+}
+
+extension ConvosAPI {
     // MARK: - v2/agent-templates/:id
 
     // Subset of the agent-template object the backend returns from the

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SpaceShare.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SpaceShare.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+extension ConvosAPIClient {
+    func shareSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpaceShareLink {
+        let request = try spaceShareRequest(
+            conversationId: conversationId,
+            variantId: variantId
+        )
+        do {
+            let (data, response) = try await performAuthenticatedRequest(request)
+            guard (200...299).contains(response.statusCode) else {
+                throw spaceShareEndpointError(
+                    statusCode: response.statusCode,
+                    data: data,
+                    path: request.url?.path(percentEncoded: false)
+                )
+            }
+            return try Self.decodeSpaceShareLink(data)
+        } catch let error as URLError where error.code == .timedOut {
+            throw ConvosAPI.SpaceShareError.timeout
+        }
+    }
+
+    func spaceShareRequest(
+        conversationId: String,
+        variantId: String?
+    ) throws -> URLRequest {
+        // The strict per-segment URL builder, for the same reason the
+        // abilities routes need it — an opaque conversation id must stay
+        // one path component.
+        let url = try Self.endpointURL(
+            baseURL: baseURL,
+            pathSegments: ["v2", "conversations", conversationId, "debug", "space-share"],
+            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        return attachingAuthHeader(to: request)
+    }
+
+    static func decodeSpaceShareLink(_ data: Data) throws -> ConvosAPI.SpaceShareLink {
+        try JSONDecoder().decode(ConvosAPI.SpaceShareLink.self, from: data)
+    }
+
+    static func decodeSpaceShareError(_ data: Data) -> ConvosAPI.SpaceShareError? {
+        ConvosAPI.SpaceShareError(body: data)
+    }
+
+    /// Error bodies are loggable; the success body is not — it carries the
+    /// live share credential, so it must never reach this path.
+    private func spaceShareEndpointError(statusCode: Int, data: Data, path: String?) -> Error {
+        let bodyLimit = 512
+        let body = String(bytes: data.prefix(bodyLimit), encoding: .utf8) ?? "non-UTF-8 body"
+        let truncated = data.count > bodyLimit ? "…" : ""
+        Log.error("\(path ?? "space share endpoint") failed [\(statusCode)]: \(body)\(truncated)")
+        if let typedError = Self.decodeSpaceShareError(data) {
+            return typedError
+        }
+        switch statusCode {
+        case 400:
+            return APIError.badRequest(parseErrorMessage(from: data))
+        case 403:
+            return APIError.forbidden
+        case 404:
+            return APIError.notFound
+        case 429:
+            return APIError.rateLimitExceeded
+        default:
+            return APIError.serverError(parseErrorMessage(from: data))
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -127,6 +127,15 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
         variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse
 
+    /// Mints the paste-ready Space share message for a conversation: one
+    /// sentence naming the receiving agent's import skill plus a clone URL
+    /// carrying an expiring read-only repository credential. The caller puts
+    /// `message` on the clipboard verbatim and must never log it.
+    func shareSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpaceShareLink
+
     // Agent templates
     /// Public detail fetch for a published agent template, keyed by its
     /// template id (UUID) or hashed url slug (e.g. `gandalf.felpl`). Backs the

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -132,6 +132,17 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, conversationId: conversationId, mode: "speak")
     }
 
+    func shareSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpaceShareLink {
+        .init(
+            conversationId: conversationId,
+            message: "Import this space using the space-import skill:\nhttps://mock.invalid/space.git",
+            expiresAt: "2026-01-01T00:00:00.000Z"
+        )
+    }
+
     func getAgentTemplate(idOrUrlSlug: String) async throws -> ConvosAPI.AgentTemplate {
         .init(
             id: UUID().uuidString,

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/PushTopicSubscriptionDeniedDMTests.swift
@@ -204,4 +204,15 @@ private final class ThrowawayPushAPIClient: ConvosAPIClientProtocol, @unchecked 
     func listCloudConnections() async throws -> [CloudConnectionsAPI.ConnectionResponse] { [] }
 
     func revokeCloudConnection(connectionId: String) async throws {}
+
+    func shareSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpaceShareLink {
+        ConvosAPI.SpaceShareLink(
+            conversationId: conversationId,
+            message: "",
+            expiresAt: ""
+        )
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/TestStubAPIClientDefaults.swift
@@ -76,6 +76,20 @@ extension ConvosAPIClientProtocol {
         )
     }
 
+    /// Default for the Space share mint so pre-existing stubs don't re-stub
+    /// it. Tests that exercise the share flow should override on their
+    /// fixture.
+    func shareSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpaceShareLink {
+        ConvosAPI.SpaceShareLink(
+            conversationId: conversationId,
+            message: "Import this space using the space-import skill:\nhttps://test.invalid/space.git",
+            expiresAt: "2026-01-01T00:00:00.000Z"
+        )
+    }
+
     /// Default for the direct-add status poll so pre-existing stubs don't
     /// re-stub it. A coherent terminal state — joined ⇒ inbox present — so
     /// unrelated tests don't iterate the poll loop. Tests that exercise the

--- a/ConvosCore/Tests/ConvosCoreTests/AbilitiesEndpointsContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilitiesEndpointsContractTests.swift
@@ -262,7 +262,7 @@ struct AbilitiesURLConstructionTests {
     @Test("Opaque ids stay one path segment, never double-encoded")
     func urlBuildingSingleEncoding() throws {
         let baseURL = try #require(URL(string: "https://api.example.com"))
-        let url = try ConvosAPIClient.abilitiesURL(
+        let url = try ConvosAPIClient.endpointURL(
             baseURL: baseURL,
             pathSegments: ["v2", "conversations", "ab/c%d e?f#g", "abilities", "toolkit"],
             queryParameters: nil
@@ -273,7 +273,7 @@ struct AbilitiesURLConstructionTests {
     @Test("A base URL carrying a path keeps it, and query items attach")
     func urlBuildingWithBasePathAndQuery() throws {
         let baseURL = try #require(URL(string: "https://api.example.com/api/"))
-        let url = try ConvosAPIClient.abilitiesURL(
+        let url = try ConvosAPIClient.endpointURL(
             baseURL: baseURL,
             pathSegments: ["v2", "abilities", "spotify", "entitlement"],
             queryParameters: ["agentInboxId": "agent-1"]

--- a/ConvosCore/Tests/ConvosCoreTests/SpaceShareContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SpaceShareContractTests.swift
@@ -1,0 +1,159 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@Suite("Space share contract")
+struct SpaceShareContractTests {
+    @Test("Request keeps an opaque conversation id in one authenticated path segment")
+    func requestContract() throws {
+        let client = try makeClient(environment: .local(config: Self.configuration))
+        let request = try client.spaceShareRequest(
+            conversationId: "ab/c%d?e#f",
+            variantId: nil
+        )
+
+        #expect(request.httpMethod == "POST")
+        #expect(
+            request.url?.absoluteString ==
+                "https://api.example.com/api/v2/conversations/ab%2Fc%25d%3Fe%23f/debug/space-share"
+        )
+        #expect(request.url?.query == nil)
+        #expect(request.httpBody == nil)
+        #expect(request.timeoutInterval == 30)
+        #expect(request.value(forHTTPHeaderField: "X-Convos-AuthToken") == "test-jwt")
+    }
+
+    @Test("Non-production requests preserve the cosmetic slug as one encoded query item")
+    func nonProductionVariantQuery() throws {
+        let client = try makeClient(environment: .dev(config: Self.configuration))
+        let slug = "pr 123/qa?x=1"
+        let request = try client.spaceShareRequest(
+            conversationId: "conversation-1",
+            variantId: slug
+        )
+        let url = try #require(request.url)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+        #expect(components.queryItems == [URLQueryItem(name: "variantId", value: slug)])
+    }
+
+    @Test("Production drops the cosmetic slug")
+    func productionVariantOmission() throws {
+        let client = try makeClient(environment: .production(config: Self.configuration))
+        let request = try client.spaceShareRequest(
+            conversationId: "conversation-1",
+            variantId: "pr-1234"
+        )
+
+        #expect(request.url?.query == nil)
+        // The slug must be absent from the whole URL, not merely the query.
+        #expect(request.url?.absoluteString.contains("pr-1234") == false)
+    }
+
+    @Test("Success decodes the backend envelope")
+    func successDecode() throws {
+        let data = try #require("""
+        {
+          "success": true,
+          "conversationId": "conversation-1",
+          "message": "Import this space using the space-import skill:\\nhttps://user:secret@code.storage/xmtp/repo.git",
+          "expiresAt": "2026-08-20T12:00:00.000Z"
+        }
+        """.data(using: .utf8))
+        let link = try ConvosAPIClient.decodeSpaceShareLink(data)
+
+        #expect(link.conversationId == "conversation-1")
+        #expect(
+            link.message ==
+                "Import this space using the space-import skill:\nhttps://user:secret@code.storage/xmtp/repo.git"
+        )
+        #expect(link.expiresAt == "2026-08-20T12:00:00.000Z")
+    }
+
+    @Test("Success decoding ignores additive fields")
+    func additiveSuccessDecode() throws {
+        let data = try #require("""
+        {
+          "success": true,
+          "conversationId": "conversation-1",
+          "message": "Import this space using the space-import skill:\\nhttps://example.invalid/repo.git",
+          "expiresAt": "2026-08-20T12:00:00.000Z",
+          "futureField": { "isIgnored": true }
+        }
+        """.data(using: .utf8))
+
+        _ = try ConvosAPIClient.decodeSpaceShareLink(data)
+    }
+
+    @Test("A false success envelope is rejected")
+    func falseSuccessRejected() throws {
+        let data = try #require("""
+        {
+          "success": false,
+          "conversationId": "conversation-1",
+          "message": "not a real link",
+          "expiresAt": "2026-08-20T12:00:00.000Z"
+        }
+        """.data(using: .utf8))
+
+        #expect(throws: DecodingError.self) {
+            _ = try ConvosAPIClient.decodeSpaceShareLink(data)
+        }
+    }
+
+    @Test("Every backend error code maps to its typed client error")
+    func typedErrorDecode() throws {
+        let cases: [(String, ConvosAPI.SpaceShareError)] = [
+            ("INVALID_REQUEST", .invalidRequest),
+            ("VARIANT_UNAVAILABLE", .variantUnavailable),
+            ("SPACE_NOT_FOUND", .spaceNotFound),
+            ("SPACE_REPOSITORY_UNAVAILABLE", .repositoryUnavailable),
+            ("SPACE_SHARE_UNAVAILABLE", .unavailable),
+            ("SPACE_SHARE_FAILED", .failed),
+            ("SPACE_SHARE_TIMEOUT", .timeout),
+            ("RATE_LIMITED", .rateLimited)
+        ]
+
+        for (code, expected) in cases {
+            let data = try #require(
+                #"{"success":false,"error":"\#(code)","message":"human-readable message"}"#.data(using: .utf8)
+            )
+            #expect(ConvosAPIClient.decodeSpaceShareError(data) == expected)
+        }
+    }
+
+    @Test("Unknown and malformed error envelopes fall through")
+    func typedErrorFallthrough() throws {
+        let unknown = try #require(
+            #"{"success":false,"error":"SOMETHING_NEW","message":"new failure"}"#.data(using: .utf8)
+        )
+        let success = try #require(
+            #"{"success":true,"error":"SPACE_SHARE_FAILED","message":"not an error"}"#.data(using: .utf8)
+        )
+        let legacy = try #require(
+            #"{"error":"failed","code":"SPACE_SHARE_FAILED"}"#.data(using: .utf8)
+        )
+
+        #expect(ConvosAPIClient.decodeSpaceShareError(unknown) == nil)
+        #expect(ConvosAPIClient.decodeSpaceShareError(success) == nil)
+        #expect(ConvosAPIClient.decodeSpaceShareError(legacy) == nil)
+    }
+
+    private func makeClient(environment: AppEnvironment) throws -> ConvosAPIClient {
+        try #require(ConvosAPIClientFactory.client(
+            environment: environment,
+            overrideJWTToken: "test-jwt"
+        ) as? ConvosAPIClient)
+    }
+
+    private static let configuration: ConvosConfiguration = ConvosConfiguration(
+        apiBaseURL: "https://api.example.com/api",
+        appGroupIdentifier: "group.test",
+        relyingPartyIdentifier: "example.com",
+        siweConfiguration: SIWEConfiguration(
+            domain: "example.com",
+            uri: "https://example.com",
+            chainId: 1
+        )
+    )
+}

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -74,6 +74,20 @@ extension ConvosAPIClientProtocol {
         )
     }
 
+    /// Default for the Space share mint so pre-existing stubs don't re-stub
+    /// it. Tests that exercise the share flow should override on their
+    /// fixture.
+    func shareSpace(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.SpaceShareLink {
+        ConvosAPI.SpaceShareLink(
+            conversationId: conversationId,
+            message: "Import this space using the space-import skill:\nhttps://test.invalid/space.git",
+            expiresAt: "2026-01-01T00:00:00.000Z"
+        )
+    }
+
     /// Default for the direct-add status poll so pre-existing stubs don't
     /// re-stub it. A coherent terminal state — joined ⇒ inbox present — so
     /// unrelated tests don't iterate the poll loop. Tests that exercise the

--- a/ConvosTests/ConversationSpaceShareCoordinatorTests.swift
+++ b/ConvosTests/ConversationSpaceShareCoordinatorTests.swift
@@ -1,0 +1,108 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+@MainActor
+final class ConversationSpaceShareCoordinatorTests: XCTestCase {
+    func testSecondShareIsIgnoredWhileFirstIsBusy() async {
+        var callCount = 0
+        let coordinator = ConversationSpaceShareCoordinator(
+            shareOperation: { conversationId, _ in
+                callCount += 1
+                try await Task.sleep(for: .milliseconds(50))
+                return Self.link(conversationId: conversationId)
+            },
+            copyToClipboard: { _ in }
+        )
+
+        let firstShare = Task {
+            await coordinator.share(conversationId: "conversation-1", variantId: nil)
+        }
+        await Task.yield()
+        XCTAssertTrue(coordinator.isBusy)
+
+        await coordinator.share(conversationId: "conversation-1", variantId: nil)
+        await firstShare.value
+
+        XCTAssertEqual(callCount, 1)
+        XCTAssertFalse(coordinator.isBusy)
+    }
+
+    func testSuccessCopiesTheMessageVerbatimAndConfirms() async {
+        var copied: [String] = []
+        let coordinator = ConversationSpaceShareCoordinator(
+            shareOperation: { conversationId, _ in
+                Self.link(conversationId: conversationId)
+            },
+            copyToClipboard: { copied.append($0) }
+        )
+
+        await coordinator.share(conversationId: "conversation-1", variantId: "pr-1234")
+
+        XCTAssertFalse(coordinator.isBusy)
+        XCTAssertEqual(copied, [Self.message])
+        XCTAssertEqual(coordinator.alert?.title, "Copied to clipboard")
+        // The credential-bearing message stays on the clipboard, never in
+        // the alert the user reads.
+        XCTAssertEqual(coordinator.alert?.message.contains(Self.message), false)
+    }
+
+    func testTypedErrorsBuildTheirAlertsWithoutCopying() async {
+        let cases: [(ConvosAPI.SpaceShareError, String)] = [
+            (.invalidRequest, "Invalid conversation"),
+            (.spaceNotFound, "No Space found"),
+            (.repositoryUnavailable, "Repository unavailable"),
+            (.variantUnavailable, "Variant unavailable"),
+            (.unavailable, "Sharing unavailable"),
+            (.timeout, "Request timed out"),
+            (.failed, "Couldn't create a share link"),
+            (.rateLimited, "Too many share links")
+        ]
+
+        for (error, expectedTitle) in cases {
+            var copied: [String] = []
+            let coordinator = ConversationSpaceShareCoordinator(
+                shareOperation: { _, _ in throw error },
+                copyToClipboard: { copied.append($0) }
+            )
+
+            await coordinator.share(conversationId: "conversation-1", variantId: nil)
+
+            XCTAssertEqual(coordinator.alert?.title, expectedTitle)
+            XCTAssertTrue(copied.isEmpty)
+        }
+    }
+
+    func testURLTimeoutMapsToTheTimeoutAlert() async {
+        let coordinator = ConversationSpaceShareCoordinator(
+            shareOperation: { _, _ in throw URLError(.timedOut) },
+            copyToClipboard: { _ in XCTFail("Nothing should be copied on timeout") }
+        )
+
+        await coordinator.share(conversationId: "conversation-1", variantId: nil)
+
+        XCTAssertEqual(coordinator.alert?.title, "Request timed out")
+    }
+
+    func testUnexpectedErrorFallsBackToTheGenericAlert() async {
+        let coordinator = ConversationSpaceShareCoordinator(
+            shareOperation: { _, _ in throw URLError(.notConnectedToInternet) },
+            copyToClipboard: { _ in XCTFail("Nothing should be copied on failure") }
+        )
+
+        await coordinator.share(conversationId: "conversation-1", variantId: nil)
+
+        XCTAssertEqual(coordinator.alert?.title, "Couldn't create a share link")
+    }
+
+    private static let message =
+        "Import this space using the space-import skill:\nhttps://user:secret@code.storage/xmtp/repo.git"
+
+    private static func link(conversationId: String) -> ConvosAPI.SpaceShareLink {
+        .init(
+            conversationId: conversationId,
+            message: message,
+            expiresAt: "2026-08-20T12:00:00.000Z"
+        )
+    }
+}

--- a/ConvosTests/FeatureFlagsObservationTests.swift
+++ b/ConvosTests/FeatureFlagsObservationTests.swift
@@ -10,6 +10,35 @@ import XCTest
 /// without leaving and re-entering the screen.
 @MainActor
 final class FeatureFlagsObservationTests: XCTestCase {
+    func testSpaceShareDefaultsOffPersistsAndNotifiesObservers() {
+        let key = "featureFlags.spaceShareEnabled"
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: key)
+        defer {
+            if let original {
+                defaults.set(original, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        defaults.removeObject(forKey: key)
+
+        let flags = FeatureFlags.shared
+        XCTAssertFalse(flags.isSpaceShareEnabled)
+
+        let changed = expectation(description: "Space share flag observation fired")
+        withObservationTracking {
+            _ = flags.isSpaceShareEnabled
+        } onChange: {
+            changed.fulfill()
+        }
+
+        flags.isSpaceShareEnabled = true
+        wait(for: [changed], timeout: 1.0)
+        XCTAssertTrue(defaults.bool(forKey: key))
+        XCTAssertTrue(flags.isSpaceShareEnabled)
+    }
+
     func testTogglingAbilitiesV2NotifiesObservers() {
         let flags = FeatureFlags.shared
         let initial = flags.isAbilitiesV2Enabled


### PR DESCRIPTION
## Summary

Debug-gated "Share Space" row in the conversation info sheet, behind a new `isSpaceShareEnabled` flag (reachable in every environment; opt-in from the debug menus, including the curated prod menu). Tapping it calls the backend relay `POST /v2/conversations/:conversationId/debug/space-share`, which mints a paste-ready Space import message — one sentence naming the receiving agent's `space-import` skill plus a clone URL carrying a 7-day read-only repository credential — and copies it to the clipboard. Pasting it into another conversation makes that agent rebuild the Space there.

The message embeds a live credential, so it goes straight from the response to the pasteboard: alerts, logs, and error paths never carry it. `ConversationSpaceShareCoordinator` mirrors the existing info-sheet coordinator shape with injectable share + clipboard operations for tests.

One touch on shared plumbing: the strict per-segment URL builder gains a second, non-abilities consumer, so `abilitiesURL` is renamed `endpointURL` and the URL-construction block moves from `+Abilities.swift` to its own `ConvosAPIClient+EndpointURL.swift` — a pure move, no signature changes.

Parallel to convos-client#176 (Android); the Worker endpoint, backend relay, and `space-import` skill land via convos-assistants#3347.

## Why

Internal flow for handing a Space built in one conversation to another. The share is a bounded read grant — the link expires on its own and the receiving agent rebuilds in its own repository, gaining no standing on the source Space.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789250277&installation_model_id=20076&pr_number=1319&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1319&signature=953b5b53795da3cd3ec39a18bd6f91bd45f966affd4d601831c9c9bd2647b9ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Space share debug action to conversation info view
> - Adds a `shareSpace(conversationId:variantId:)` API method that POSTs to `/v2/conversations/{id}/debug/space-share`, decodes a `ConvosAPI.SpaceShareLink` on success, and maps backend error codes and timeouts to typed `ConvosAPI.SpaceShareError` cases.
> - Adds `ConversationSpaceShareCoordinator` to manage busy state and alert payloads; on success it copies the returned message to the clipboard and shows a confirmation alert.
> - Adds a "Share Space" button to the debug section of `ConversationInfoView`, visible only when the `isSpaceShareEnabled` feature flag is on; the button shows a spinner and is disabled while the request is in flight.
> - Exposes the feature flag as a toggle in both the internal debug view and the production debug menu.
> - Refactors URL construction into a shared `endpointURL`/`strictPathComponentEncoded` helper (previously duplicated in the abilities endpoint), updating contract tests accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b17682f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->