### PR TITLE
Mpr/startup perf

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e3a7fb703b300f5795218a1468302f5997f7528cc66dd7de616c5acb6cde7a14",
+  "originHash" : "1bddfee5c49b616a3e402144d5ff6d7a4d3b9fc36a79e7fb7e8837b8b8b91a1f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Convos/Conversations List/BootSettlementMonitor.swift
+++ b/Convos/Conversations List/BootSettlementMonitor.swift
@@ -1,0 +1,82 @@
+import ConvosCore
+import Foundation
+import Observation
+
+/// Tracks whether the initial boot catch-up has settled so the
+/// conversations list can switch from cheap full reloads to diffed,
+/// animated snapshot applies.
+///
+/// The session state machine emits `.ready` only after the batch
+/// catch-up completes, so reaching `.ready` means the burst of catch-up
+/// writes has landed. A fallback timeout guarantees the list never
+/// stays in reload-mode when the session errors or never reaches
+/// `.ready` (fresh installs, previews, mock sessions).
+///
+/// `isSettled` latches true for the remainder of the launch; foreground
+/// re-catch-ups stay on the diffed path because the user may be
+/// mid-scroll, where a full reload would jump the list.
+@MainActor
+@Observable
+final class BootSettlementMonitor {
+    private(set) var isSettled: Bool = false
+
+    @ObservationIgnored private var stateObserver: (any SessionStateObserver)?
+    @ObservationIgnored private weak var stateManager: (any SessionStateManagerProtocol)?
+    @ObservationIgnored private var fallbackTask: Task<Void, Never>?
+
+    /// Binds the monitor to a session's state manager. Safe to call
+    /// multiple times before settling — rebinding replaces the prior
+    /// observation. A no-op once settled.
+    func bind(
+        to stateManager: any SessionStateManagerProtocol,
+        fallbackTimeout: TimeInterval = 10
+    ) {
+        guard !isSettled else { return }
+        unbind()
+        self.stateManager = stateManager
+
+        if case .ready = stateManager.currentState {
+            settle(reason: "ready at bind")
+            return
+        }
+
+        let closure = ClosureStateObserver { [weak self] state in
+            guard case .ready = state else { return }
+            Task { @MainActor [weak self] in
+                self?.settle(reason: "ready")
+            }
+        }
+        stateManager.addObserver(closure)
+        stateObserver = closure
+
+        fallbackTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(fallbackTimeout))
+            guard !Task.isCancelled else { return }
+            self?.settle(reason: "timeout")
+        }
+    }
+
+    private func settle(reason: String) {
+        guard !isSettled else { return }
+        isSettled = true
+        Log.info("[PERF] conversations list settled (\(reason))")
+        fallbackTask?.cancel()
+        fallbackTask = nil
+        unbind()
+    }
+
+    private func unbind() {
+        if let observer = stateObserver, let manager = stateManager {
+            manager.removeObserver(observer)
+        }
+        stateObserver = nil
+        stateManager = nil
+    }
+
+    deinit {
+        fallbackTask?.cancel()
+        if let observer = stateObserver, let manager = stateManager {
+            manager.removeObserver(observer)
+        }
+    }
+}

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -178,6 +178,7 @@ struct ConversationsView: View {
             selectedConversationId: viewModel.selectedConversationId,
             isFilteredResultEmpty: viewModel.isFilteredResultEmpty,
             filterEmptyMessage: viewModel.activeFilter.emptyStateMessage,
+            hasMoreConversations: viewModel.hasMoreConversations,
             onSelectConversation: { conversation in
                 viewModel.select(conversation)
             },
@@ -198,6 +199,7 @@ struct ConversationsView: View {
             },
             onShowAllFilter: { viewModel.activeFilter = .all },
             onScrollOffsetChange: onScrollOffsetChange,
+            onLoadMoreConversations: { viewModel.loadMoreConversationsIfNeeded() },
             topChromeInset: topChromeInset,
             bottomChromeInset: bottomChromeInset
         )

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -179,6 +179,7 @@ struct ConversationsView: View {
             isFilteredResultEmpty: viewModel.isFilteredResultEmpty,
             filterEmptyMessage: viewModel.activeFilter.emptyStateMessage,
             hasMoreConversations: viewModel.hasMoreConversations,
+            isBootSettled: viewModel.bootSettlement.isSettled,
             onSelectConversation: { conversation in
                 viewModel.select(conversation)
             },

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -152,6 +152,7 @@ final class ConversationsViewModel {
     @ObservationIgnored
     private let incomingPairingObservers: PairingNotificationObservers = .init()
     let staleDeviceObserver: StaleDeviceObserver = .init()
+    let bootSettlement: BootSettlementMonitor = .init()
 
     var newConversationViewModel: NewConversationViewModel? {
         didSet {
@@ -413,8 +414,11 @@ final class ConversationsViewModel {
         // revoked from the network. Done asynchronously because
         // messagingService() may need to construct the service.
         let stale = staleDeviceObserver
+        let settlement = bootSettlement
         Task { @MainActor in
-            stale.bind(to: session.messagingService().sessionStateManager)
+            let stateManager = session.messagingService().sessionStateManager
+            stale.bind(to: stateManager)
+            settlement.bind(to: stateManager)
         }
         self.conversationsCountRepository = session.conversationsCountRepo(
             for: .allowed,
@@ -763,7 +767,7 @@ final class ConversationsViewModel {
         if let inPage = conversationInPage(id: id) {
             return inPage
         }
-        return (try? conversationsPager.fetchConversation(id: id)) ?? nil
+        return try? conversationsPager.fetchConversation(id: id)
     }
 
     /// Selects a conversation by id, caching an out-of-window row first so
@@ -789,6 +793,39 @@ final class ConversationsViewModel {
         conversationsPager.loadMore()
     }
 
+    /// Ends the selected host conversation's invite session on a real
+    /// pop-to-home and mirrors the flipped flag into the in-memory list.
+    /// The persist is async (GRDB); without the mirror, an instant re-entry
+    /// builds the next detail view model from the stale list row and the big
+    /// inline Invite/Scan card flashes until the write round-trips.
+    func endHostedInviteSessionOnPop() {
+        guard let detailViewModel = selectedConversationViewModel else { return }
+        detailViewModel.markInviteSessionEndedIfHosting()
+        let endedConversation = detailViewModel.conversation
+        guard endedConversation.leftHostedInviteSession,
+              let index = conversations.firstIndex(where: { $0.id == endedConversation.id }) else { return }
+        conversations[index] = endedConversation
+    }
+
+    private func markConversationAsRead(_ conversation: Conversation) {
+        let conversationId = conversation.id
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let messagingService = session.messagingService()
+                let writer = messagingService.conversationLocalStateWriter()
+                try await writer.setUnread(false, for: conversationId)
+            } catch {
+                Log.warning("Failed marking conversation as read: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+// MARK: - Conversation Actions
+
+extension ConversationsViewModel {
     func toggleMute(conversation: Conversation) {
         let conversationId = conversation.id
         let currentlyMuted = conversation.isMuted
@@ -837,35 +874,6 @@ final class ConversationsViewModel {
                 }
             } catch {
                 Log.error("Failed toggling pin for conversation \(conversationId): \(error.localizedDescription)")
-            }
-        }
-    }
-
-    /// Ends the selected host conversation's invite session on a real
-    /// pop-to-home and mirrors the flipped flag into the in-memory list.
-    /// The persist is async (GRDB); without the mirror, an instant re-entry
-    /// builds the next detail view model from the stale list row and the big
-    /// inline Invite/Scan card flashes until the write round-trips.
-    func endHostedInviteSessionOnPop() {
-        guard let detailViewModel = selectedConversationViewModel else { return }
-        detailViewModel.markInviteSessionEndedIfHosting()
-        let endedConversation = detailViewModel.conversation
-        guard endedConversation.leftHostedInviteSession,
-              let index = conversations.firstIndex(where: { $0.id == endedConversation.id }) else { return }
-        conversations[index] = endedConversation
-    }
-
-    private func markConversationAsRead(_ conversation: Conversation) {
-        let conversationId = conversation.id
-
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let messagingService = session.messagingService()
-                let writer = messagingService.conversationLocalStateWriter()
-                try await writer.setUnread(false, for: conversationId)
-            } catch {
-                Log.warning("Failed marking conversation as read: \(error.localizedDescription)")
             }
         }
     }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -343,6 +343,10 @@ final class ConversationsViewModel {
     let session: any SessionManagerProtocol
     let coreActions: any CoreActions
     private let conversationsPager: any ConversationsPagerProtocol
+    /// Kept alongside the pager for targeted reads the pager doesn't cover
+    /// (agent-DM tap routing). Its list observation is never subscribed
+    /// here, so holding it costs nothing.
+    private let conversationsRepository: any ConversationsRepositoryProtocol
     private let conversationsCountRepository: any ConversationsCountRepositoryProtocol
     @ObservationIgnored
     private var cancellables: Set<AnyCancellable> = .init()
@@ -409,6 +413,7 @@ final class ConversationsViewModel {
         self.focusCoordinator = coordinator
         self.appSettingsViewModel = AppSettingsViewModel(session: session)
         self.conversationsPager = session.conversationsPager(for: .allowed)
+        self.conversationsRepository = session.conversationsRepository(for: .allowed)
         // Bind the stale-device observer to the session's state manager
         // so the banner appears when this device's installation is
         // revoked from the network. Done asynchronously because
@@ -744,16 +749,23 @@ final class ConversationsViewModel {
     /// outside the active filter. A targeted list-scoped fetch
     /// disambiguates: found means keep the selection alive (refreshing the
     /// cached copy the getter serves), nil means genuinely gone, so clear.
+    /// A thrown read is neither - it says nothing about the row - so the
+    /// selection and its cached copy survive; the next page emission
+    /// re-runs this check.
     private func refreshSelectionAfterPageChange() {
         guard let selectedId = _selectedConversationId else { return }
         if conversationInPage(id: selectedId) != nil {
             outOfWindowSelectedConversation = nil
             return
         }
-        if let fetched = try? conversationsPager.fetchConversation(id: selectedId) {
-            outOfWindowSelectedConversation = fetched
-        } else {
-            selectedConversationId = nil
+        do {
+            if let fetched = try conversationsPager.fetchConversation(id: selectedId) {
+                outOfWindowSelectedConversation = fetched
+            } else {
+                selectedConversationId = nil
+            }
+        } catch {
+            Log.warning("Failed to fetch out-of-window selected conversation \(selectedId), keeping selection: \(error)")
         }
     }
 
@@ -763,11 +775,19 @@ final class ConversationsViewModel {
 
     /// The window lookup, falling back to a list-scoped by-id fetch for
     /// rows beyond the LIMIT (notification taps, deep links, scans).
+    /// A thrown fetch resolves to nil - callers treat that as "not
+    /// resolvable right now", which for these one-shot navigation entry
+    /// points is the only available answer.
     private func resolveConversation(id: String) -> Conversation? {
         if let inPage = conversationInPage(id: id) {
             return inPage
         }
-        return try? conversationsPager.fetchConversation(id: id)
+        do {
+            return try conversationsPager.fetchConversation(id: id)
+        } catch {
+            Log.warning("Failed to fetch conversation \(id) for navigation: \(error)")
+            return nil
+        }
     }
 
     /// Selects a conversation by id, caching an out-of-window row first so

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -948,6 +948,12 @@ extension ConversationsViewModel {
             } catch {
                 self.hiddenConversationIds.remove(conversationId)
                 Log.error("Error exploding conversation from list: \(error.localizedDescription)")
+                // Same as leave(conversation:): the failed write left the
+                // database unchanged, so no emission will undo the optimistic
+                // removal above; re-apply the latest page to bring the row back.
+                if let page = self.lastReceivedPage {
+                    self.applyPage(page)
+                }
             }
         }
     }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -20,9 +20,19 @@ final class ConversationsViewModel {
     @ObservationIgnored
     private var _selectedConversationId: String? {
         didSet {
+            if outOfWindowSelectedConversation?.id != _selectedConversationId {
+                outOfWindowSelectedConversation = nil
+            }
             updateSelectionState()
         }
     }
+
+    /// The selected conversation when it lives outside the loaded window
+    /// (deep link, notification tap, or a row that scrolled past the LIMIT).
+    /// Set before the selection id so `selectedConversation` can resolve it;
+    /// refreshed on every page emission and cleared when selection moves on.
+    @ObservationIgnored
+    private var outOfWindowSelectedConversation: Conversation?
 
     var selectedConversationId: Conversation.ID? {
         get { _selectedConversationId }
@@ -35,7 +45,7 @@ final class ConversationsViewModel {
     private(set) var selectedConversation: Conversation? {
         get {
             guard let id = _selectedConversationId else { return nil }
-            return conversations.first(where: { $0.id == id })
+            return conversationInPage(id: id) ?? outOfWindowSelectedConversation
         }
         set {
             selectedConversationId = newValue?.id
@@ -182,7 +192,22 @@ final class ConversationsViewModel {
     var presentingExplodeInfo: Bool = false
     var presentingPinLimitInfo: Bool = false
 
+    /// The loaded window of unpinned conversations (SQL-filtered and
+    /// LIMIT-bounded by the pager). Kept assignable for tests and previews.
     var conversations: [Conversation] = []
+    /// All pinned conversations from the pager (bounded by the pin limit,
+    /// never windowed).
+    private(set) var pinnedFromPage: [Conversation] = []
+    /// Whether unpinned rows exist beyond the loaded window.
+    private(set) var hasMoreConversations: Bool = false
+    /// Whether any unpinned row exists ignoring the active filter; drives
+    /// the filter-empty states without depending on the filtered window.
+    @ObservationIgnored
+    private var hasAnyUnpinnedFromPage: Bool = false
+    /// In-flight guard for `loadMoreConversationsIfNeeded`; cleared when the
+    /// grown window's emission lands.
+    @ObservationIgnored
+    private var isLoadingMore: Bool = false
     /// Whether `conversations` has received its first real value from the
     /// database (first-frame prime or first publisher emission). Until then
     /// an empty array means "not loaded yet", not "no conversations", so the
@@ -212,9 +237,28 @@ final class ConversationsViewModel {
                 return "No exploding convos"
             }
         }
+
+        var pagerFilter: ConversationsListFilter {
+            switch self {
+            case .all:
+                return .all
+            case .unread:
+                return .unread
+            case .exploding:
+                return .exploding
+            }
+        }
     }
 
-    var activeFilter: ConversationFilter = .all
+    var activeFilter: ConversationFilter = .all {
+        didSet {
+            guard activeFilter != oldValue else { return }
+            // Push the predicate into the pager's SQL window; the in-memory
+            // filter below keeps the switch feeling instant on the old
+            // window until the new emission lands.
+            conversationsPager.filter = activeFilter.pagerFilter
+        }
+    }
 
     var pinnedConversations: [Conversation] {
         let baseConversations = pinnedBaseConversations
@@ -222,10 +266,13 @@ final class ConversationsViewModel {
     }
 
     private var pinnedBaseConversations: [Conversation] {
-        conversations
-            .filter { $0.isPinned }
-            .filter { $0.kind == .group }
-            .sorted { ($0.pinnedOrder ?? Int.max) < ($1.pinnedOrder ?? Int.max) }
+        // The pager serves pinned rows separately (the window excludes
+        // them). The in-memory fallback keeps previews and tests working
+        // when only `conversations` was assigned directly.
+        let base = pinnedFromPage.isEmpty
+            ? conversations.filter { $0.isPinned && $0.kind == .group }
+            : pinnedFromPage
+        return base.sorted { ($0.pinnedOrder ?? Int.max) < ($1.pinnedOrder ?? Int.max) }
     }
 
     private static func applyFilter(_ filter: ConversationFilter, to conversations: [Conversation]) -> [Conversation] {
@@ -252,7 +299,7 @@ final class ConversationsViewModel {
     }
 
     var hasUnpinnedConversations: Bool {
-        conversations.contains { !$0.isPinned && $0.kind == .group }
+        hasAnyUnpinnedFromPage || conversations.contains { !$0.isPinned && $0.kind == .group }
     }
 
     var isFilteredResultEmpty: Bool {
@@ -294,7 +341,7 @@ final class ConversationsViewModel {
 
     let session: any SessionManagerProtocol
     let coreActions: any CoreActions
-    private let conversationsRepository: any ConversationsRepositoryProtocol
+    private let conversationsPager: any ConversationsPagerProtocol
     private let conversationsCountRepository: any ConversationsCountRepositoryProtocol
     @ObservationIgnored
     private var cancellables: Set<AnyCancellable> = .init()
@@ -360,9 +407,7 @@ final class ConversationsViewModel {
         let coordinator = FocusCoordinator(horizontalSizeClass: horizontalSizeClass)
         self.focusCoordinator = coordinator
         self.appSettingsViewModel = AppSettingsViewModel(session: session)
-        self.conversationsRepository = session.conversationsRepository(
-            for: .allowed
-        )
+        self.conversationsPager = session.conversationsPager(for: .allowed)
         // Bind the stale-device observer to the session's state manager
         // so the banner appears when this device's installation is
         // revoked from the network. Done asynchronously because
@@ -415,7 +460,7 @@ final class ConversationsViewModel {
     }
 
     func makeGrantRequestSheetViewModel(for request: PendingGrantRequest) -> CloudConnectionGrantRequestSheetViewModel {
-        let conversation = conversations.first(where: { $0.id == request.conversationId })
+        let conversation = resolveConversation(id: request.conversationId)
         return CloudConnectionGrantRequestSheetViewModel(
             serviceId: request.serviceId,
             conversationId: request.conversationId,
@@ -433,7 +478,7 @@ final class ConversationsViewModel {
         case .joinConversation(inviteCode: let inviteCode):
             join(from: inviteCode)
         case let .connectionGrant(serviceId: serviceId, conversationId: conversationId):
-            guard conversations.contains(where: { $0.id == conversationId }) else {
+            guard resolveConversation(id: conversationId) != nil else {
                 // On cold launch the list may not have loaded yet (the
                 // initial prime and the repository publisher both arrive
                 // asynchronously), so park the link and resolve it once the
@@ -576,6 +621,7 @@ final class ConversationsViewModel {
         if let index = conversations.firstIndex(of: conversation) {
             conversations.remove(at: index)
         }
+        pinnedFromPage.removeAll { $0.id == conversation.id }
         if selectedConversation == conversation {
             selectedConversation = nil
         }
@@ -607,6 +653,7 @@ final class ConversationsViewModel {
                     // ConversationViewModel.leaveConvo for the same pattern.
                     hiddenConversationIds.insert(conversationId)
                     conversations.removeAll { $0.id == conversationId }
+                    pinnedFromPage.removeAll { $0.id == conversationId }
                     if _selectedConversationId == conversationId {
                         _selectedConversationId = nil
                         selectedConversationViewModel = nil
@@ -641,30 +688,13 @@ final class ConversationsViewModel {
                 self?.conversationsCount = conversationsCount
             }
             .store(in: &cancellables)
-        conversationsRepository.conversationsPublisher
+        conversationsPager.pagePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] conversations in
+            .sink { [weak self] page in
                 guard let self else { return }
                 self.conversationsObservationHasEmitted = true
                 self.hasLoadedInitialConversations = true
-                self.conversations = hiddenConversationIds.isEmpty
-                    ? conversations
-                    : conversations.filter { !hiddenConversationIds.contains($0.id) }
-
-                ShareSuggestionDonator.donate(self.conversations)
-
-                if let selectedId = _selectedConversationId,
-                   !conversations.contains(where: { $0.id == selectedId }) {
-                    selectedConversationId = nil
-                }
-
-                resolvePendingScanNavigationIfPossible()
-                resolvePendingConnectionGrantIfPossible()
-                resolvePendingConversationTapIfPossible()
-
-                if !conversations.contains(where: { !$0.isPinned && $0.kind == .group }) {
-                    activeFilter = .all
-                }
+                self.applyPage(page)
             }
             .store(in: &cancellables)
 
@@ -680,6 +710,83 @@ final class ConversationsViewModel {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    private func applyPage(_ page: ConversationsPage) {
+        isLoadingMore = false
+        hasMoreConversations = page.hasMore
+        hasAnyUnpinnedFromPage = page.hasAnyUnpinned
+        pinnedFromPage = hiddenConversationIds.isEmpty
+            ? page.pinned
+            : page.pinned.filter { !hiddenConversationIds.contains($0.id) }
+        conversations = hiddenConversationIds.isEmpty
+            ? page.unpinned
+            : page.unpinned.filter { !hiddenConversationIds.contains($0.id) }
+
+        ShareSuggestionDonator.donate(pinnedFromPage + conversations)
+
+        refreshSelectionAfterPageChange()
+        resolvePendingScanNavigationIfPossible()
+        resolvePendingConnectionGrantIfPossible()
+        resolvePendingConversationTapIfPossible()
+
+        if !page.hasAnyUnpinned {
+            activeFilter = .all
+        }
+    }
+
+    /// Under a windowed list, "absent from the emission" no longer implies
+    /// "deleted" - the selected row may simply sit beyond the LIMIT or
+    /// outside the active filter. A targeted list-scoped fetch
+    /// disambiguates: found means keep the selection alive (refreshing the
+    /// cached copy the getter serves), nil means genuinely gone, so clear.
+    private func refreshSelectionAfterPageChange() {
+        guard let selectedId = _selectedConversationId else { return }
+        if conversationInPage(id: selectedId) != nil {
+            outOfWindowSelectedConversation = nil
+            return
+        }
+        if let fetched = try? conversationsPager.fetchConversation(id: selectedId) {
+            outOfWindowSelectedConversation = fetched
+        } else {
+            selectedConversationId = nil
+        }
+    }
+
+    private func conversationInPage(id: String) -> Conversation? {
+        conversations.first { $0.id == id } ?? pinnedFromPage.first { $0.id == id }
+    }
+
+    /// The window lookup, falling back to a list-scoped by-id fetch for
+    /// rows beyond the LIMIT (notification taps, deep links, scans).
+    private func resolveConversation(id: String) -> Conversation? {
+        if let inPage = conversationInPage(id: id) {
+            return inPage
+        }
+        return (try? conversationsPager.fetchConversation(id: id)) ?? nil
+    }
+
+    /// Selects a conversation by id, caching an out-of-window row first so
+    /// the selection getter can serve it. Returns false when the id no
+    /// longer resolves to a list-eligible conversation.
+    @discardableResult
+    private func selectConversation(id: String) -> Bool {
+        guard let conversation = resolveConversation(id: id) else { return false }
+        if conversationInPage(id: id) == nil {
+            outOfWindowSelectedConversation = conversation
+        }
+        selectedInitialAgentDmInboxId = agentDmInboxIdForMostRecentUnread(in: conversation)
+        selectedConversationId = id
+        return true
+    }
+
+    /// Grow the unpinned window by one page. Called by the list as it
+    /// approaches the end; gated on the last page reporting more rows and
+    /// on the previous grow having landed.
+    func loadMoreConversationsIfNeeded() {
+        guard hasMoreConversations, !isLoadingMore else { return }
+        isLoadingMore = true
+        conversationsPager.loadMore()
     }
 
     func toggleMute(conversation: Conversation) {
@@ -772,6 +879,7 @@ final class ConversationsViewModel {
             selectedConversation = nil
         }
         conversations.removeAll { $0.id == conversationId }
+        pinnedFromPage.removeAll { $0.id == conversationId }
 
         Task { [weak self] in
             guard let self else { return }
@@ -1394,13 +1502,13 @@ extension ConversationsViewModel {
     /// once the switch lands.
     func resolvePendingScanNavigationIfPossible() {
         guard let pendingId = pendingScanNavigationConversationId,
-              conversations.contains(where: { $0.id == pendingId }) else { return }
+              resolveConversation(id: pendingId) != nil else { return }
         guard isChatsTabActive else {
             bringChatsTabToFront?()
             return
         }
         pendingScanNavigationConversationId = nil
-        selectedConversationId = pendingId
+        selectConversation(id: pendingId)
     }
 
     static var mock: ConversationsViewModel {
@@ -1431,20 +1539,20 @@ extension ConversationsViewModel {
 /// of truth either way.
 extension ConversationsViewModel {
     fileprivate struct InitialPrime {
-        let conversations: [Conversation]?
+        let page: ConversationsPage?
         let count: Int?
     }
 
     fileprivate func primeInitialConversations() {
         // The reads are pure GRDB pool reads and thread-safe; the
         // existentials just aren't Sendable.
-        nonisolated(unsafe) let primeRepository = conversationsRepository
+        nonisolated(unsafe) let primePager = conversationsPager
         nonisolated(unsafe) let primeCountRepository = conversationsCountRepository
         let primed: InitialPrime? = BoundedInitialRead.prime(read: {
-            var fetched: [Conversation]?
+            var fetchedPage: ConversationsPage?
             var count: Int?
             do {
-                fetched = try primeRepository.fetchAll()
+                fetchedPage = try primePager.fetchInitialPage()
             } catch {
                 // Distinguish a failed read from a merely slow one: the
                 // deadline-miss log alone would hide real database errors.
@@ -1455,7 +1563,7 @@ extension ConversationsViewModel {
             } catch {
                 Log.error("Initial conversations count prime failed: \(error.localizedDescription)")
             }
-            return InitialPrime(conversations: fetched, count: count)
+            return InitialPrime(page: fetchedPage, count: count)
         }, late: { [weak self] payload in
             self?.applyInitialPrime(payload, deliveredLate: true)
         })
@@ -1467,21 +1575,20 @@ extension ConversationsViewModel {
     }
 
     private func applyInitialPrime(_ prime: InitialPrime, deliveredLate: Bool) {
-        if prime.conversations != nil {
+        if prime.page != nil {
             // The read succeeded, so the database state is known even when
             // the snapshot below is discarded in favor of a publisher
             // emission that arrived first.
             hasLoadedInitialConversations = true
         }
-        if let fetched = prime.conversations {
-            // On the late path the conversations publisher may have emitted
-            // already; it is the source of truth, so never replace its
-            // emission with this older snapshot. An emission can legitimately
-            // be an empty list (the last conversation was just deleted), so
-            // check the explicit flag rather than inferring from the data.
-            if !deliveredLate || (!conversationsObservationHasEmitted && conversations.isEmpty) {
-                conversations = fetched
-                resolvePendingConnectionGrantIfPossible()
+        if let page = prime.page {
+            // On the late path the pager may have emitted already; it is the
+            // source of truth, so never replace its emission with this older
+            // snapshot. An emission can legitimately be an empty page (the
+            // last conversation was just deleted), so check the explicit
+            // flag rather than inferring from the data.
+            if !deliveredLate || (!conversationsObservationHasEmitted && conversations.isEmpty && pinnedFromPage.isEmpty) {
+                applyPage(page)
             }
         }
         // Assigning the count latches hasCreatedMoreThanOneConvo via its
@@ -1495,6 +1602,12 @@ extension ConversationsViewModel {
         // Discard any older parked link so it cannot fire later and yank the
         // user away from the grant that is being handled now.
         pendingConnectionGrantLink = nil
+        // Cache an out-of-window row before selecting so the selection
+        // getter can serve it (the grant target may sit beyond the window).
+        if conversationInPage(id: conversationId) == nil,
+           let fetched = resolveConversation(id: conversationId) {
+            outOfWindowSelectedConversation = fetched
+        }
         _selectedConversationId = conversationId
         pendingGrantRequest = PendingGrantRequest(
             serviceId: serviceId,
@@ -1504,7 +1617,7 @@ extension ConversationsViewModel {
 
     fileprivate func resolvePendingConnectionGrantIfPossible() {
         guard let link = pendingConnectionGrantLink,
-              conversations.contains(where: { $0.id == link.conversationId }) else { return }
+              resolveConversation(id: link.conversationId) != nil else { return }
         pendingConnectionGrantLink = nil
         openConnectionGrant(serviceId: link.serviceId, conversationId: link.conversationId)
     }

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -215,6 +215,12 @@ final class ConversationsViewModel {
     /// empty-state CTA must stay hidden.
     private(set) var hasLoadedInitialConversations: Bool = false
     private(set) var hiddenConversationIds: Set<String> = []
+    /// The latest raw page, kept so a failed optimistic hide (see
+    /// `leave(conversation:)`) can restore the row by re-applying it: the
+    /// failed write leaves the database untouched, so no fresh emission is
+    /// coming to undo the hide.
+    @ObservationIgnored
+    private var lastReceivedPage: ConversationsPage?
     private var conversationsCount: Int = 0 {
         didSet {
             if conversationsCount > 1 {
@@ -645,6 +651,12 @@ final class ConversationsViewModel {
             } catch {
                 self.hiddenConversationIds.remove(conversationId)
                 Log.error("Failed to persist delete for \(conversationId): \(error.localizedDescription)")
+                // The write never landed, so the database is unchanged and
+                // no emission will undo the optimistic hide above; re-apply
+                // the latest page to bring the row back.
+                if let page = self.lastReceivedPage {
+                    self.applyPage(page)
+                }
             }
         }
     }
@@ -722,6 +734,7 @@ final class ConversationsViewModel {
     }
 
     private func applyPage(_ page: ConversationsPage) {
+        lastReceivedPage = page
         isLoadingMore = false
         hasMoreConversations = page.hasMore
         hasAnyUnpinnedFromPage = page.hasAnyUnpinned

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -15,6 +15,7 @@ final class ConversationsViewController: UIViewController {
         var isFilteredResultEmpty: Bool
         var filterEmptyMessage: String
         var horizontalSizeClass: UserInterfaceSizeClass?
+        var hasMoreConversations: Bool
 
         static let empty: State = State(
             pinnedConversations: [],
@@ -22,7 +23,8 @@ final class ConversationsViewController: UIViewController {
             selectedConversationId: nil,
             isFilteredResultEmpty: false,
             filterEmptyMessage: "",
-            horizontalSizeClass: nil
+            horizontalSizeClass: nil,
+            hasMoreConversations: false
         )
     }
 
@@ -100,6 +102,9 @@ final class ConversationsViewController: UIViewController {
     /// builder bar between expanded and collapsed states based on whether
     /// the list is at the top.
     var onScrollOffsetChange: ((CGFloat) -> Void)?
+    /// Fired when the list approaches its end and `hasMoreConversations`
+    /// is set - asks the view model to grow the paged window.
+    var onLoadMoreConversations: (() -> Void)?
 
     /// Extra top inset to clear the SwiftUI top chrome (the agent builder
     /// bar that lives under the nav bar in the host's safe-area inset
@@ -657,6 +662,14 @@ extension ConversationsViewController: UICollectionViewDelegate {
         onSelectConversation?(conversation)
     }
 
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        guard currentState.hasMoreConversations else { return }
+        guard let item = dataSource.itemIdentifier(for: indexPath), case .conversation = item else { return }
+        let listCount = currentState.unpinnedConversations.count
+        guard listCount > 0, indexPath.item >= listCount - Constant.loadMoreThreshold else { return }
+        onLoadMoreConversations?()
+    }
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // Report scrolled distance from the natural top — zero when the
         // list is at rest at the top, positive when scrolled down,
@@ -802,4 +815,9 @@ extension ConversationsViewController: UICollectionViewDelegate {
 
         return UIMenu(title: "", children: actions)
     }
+}
+
+private enum Constant {
+    /// How many rows before the end of the list the next page is requested.
+    static let loadMoreThreshold: Int = 10
 }

--- a/Convos/Conversations List/View Controller/ConversationsViewController.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewController.swift
@@ -16,6 +16,10 @@ final class ConversationsViewController: UIViewController {
         var filterEmptyMessage: String
         var horizontalSizeClass: UserInterfaceSizeClass?
         var hasMoreConversations: Bool
+        /// False while the boot catch-up burst is still landing. Snapshots
+        /// apply via `applySnapshotUsingReloadData` (no diffing, no
+        /// animation) until this flips true.
+        var isBootSettled: Bool
 
         static let empty: State = State(
             pinnedConversations: [],
@@ -24,7 +28,8 @@ final class ConversationsViewController: UIViewController {
             isFilteredResultEmpty: false,
             filterEmptyMessage: "",
             horizontalSizeClass: nil,
-            hasMoreConversations: false
+            hasMoreConversations: false,
+            isBootSettled: false
         )
     }
 
@@ -78,6 +83,7 @@ final class ConversationsViewController: UIViewController {
     }()
     private lazy var dataSource: UICollectionViewDiffableDataSource<ConversationsSection, Item> = makeDataSource()
     private var currentState: State = .empty
+    private var hasAppliedInitialSnapshot: Bool = false
 
     /// Inbox → user-contact override applied to auto-generated cell
     /// titles and avatar substitution. Set by the SwiftUI parent
@@ -159,8 +165,12 @@ final class ConversationsViewController: UIViewController {
             collectionView.setCollectionViewLayout(createLayout(), animated: false)
         }
 
-        let changedIds = changedConversationIds(old: oldState, new: state, selectionChanged: selectionChanged)
-        applySnapshot(animated: !pinnedMembershipChanged, changedIds: changedIds)
+        // Pre-settle applies go through the reload path, which re-dequeues
+        // every visible cell, so computing per-row changes would be wasted work.
+        let changedIds = state.isBootSettled
+            ? changedConversationIds(old: oldState, new: state, selectionChanged: selectionChanged)
+            : []
+        applySnapshot(animated: state.isBootSettled && !pinnedMembershipChanged, changedIds: changedIds)
     }
 
     private func changedConversationIds(old: State, new: State, selectionChanged: Bool) -> Set<String> {
@@ -456,23 +466,31 @@ final class ConversationsViewController: UIViewController {
             snapshot.appendItems(listItems, toSection: .list)
         }
 
-        dataSource.apply(snapshot, animatingDifferences: animated)
+        if currentState.isBootSettled && hasAppliedInitialSnapshot {
+            dataSource.apply(snapshot, animatingDifferences: animated)
 
-        if !changedIds.isEmpty {
-            var applied = dataSource.snapshot()
-            let itemsToReconfigure = applied.itemIdentifiers.filter { item in
-                switch item {
-                case .pinned(let c), .conversation(let c):
-                    return changedIds.contains(c.id)
-                case .filteredEmpty:
-                    return false
+            if !changedIds.isEmpty {
+                var applied = dataSource.snapshot()
+                let itemsToReconfigure = applied.itemIdentifiers.filter { item in
+                    switch item {
+                    case .pinned(let c), .conversation(let c):
+                        return changedIds.contains(c.id)
+                    case .filteredEmpty:
+                        return false
+                    }
+                }
+                if !itemsToReconfigure.isEmpty {
+                    applied.reconfigureItems(itemsToReconfigure)
+                    dataSource.apply(applied, animatingDifferences: false)
                 }
             }
-            if !itemsToReconfigure.isEmpty {
-                applied.reconfigureItems(itemsToReconfigure)
-                dataSource.apply(applied, animatingDifferences: false)
-            }
+        } else {
+            // Boot burst (or the very first apply): skip diffing entirely.
+            // The reload re-dequeues every visible cell, so the reconfigure
+            // pass above has no stale-cell case to fix.
+            dataSource.applySnapshotUsingReloadData(snapshot)
         }
+        hasAppliedInitialSnapshot = true
 
         updateSelection()
     }

--- a/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
@@ -10,6 +10,10 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
     let isFilteredResultEmpty: Bool
     let filterEmptyMessage: String
     var hasMoreConversations: Bool = false
+    /// False while the boot catch-up burst is still landing; the view
+    /// controller applies snapshots without diffing or animation until
+    /// this flips. See `BootSettlementMonitor`.
+    var isBootSettled: Bool = true
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Environment(\.memberContactOverride) private var memberContactOverride: @Sendable (String) -> Contact?
 
@@ -41,7 +45,8 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
             isFilteredResultEmpty: isFilteredResultEmpty,
             filterEmptyMessage: filterEmptyMessage,
             horizontalSizeClass: horizontalSizeClass,
-            hasMoreConversations: hasMoreConversations
+            hasMoreConversations: hasMoreConversations,
+            isBootSettled: isBootSettled
         )
         viewController.memberContactOverride = memberContactOverride
         viewController.updateState(state)

--- a/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
+++ b/Convos/Conversations List/View Controller/ConversationsViewRepresentable.swift
@@ -9,6 +9,7 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
     let selectedConversationId: String?
     let isFilteredResultEmpty: Bool
     let filterEmptyMessage: String
+    var hasMoreConversations: Bool = false
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Environment(\.memberContactOverride) private var memberContactOverride: @Sendable (String) -> Contact?
 
@@ -21,6 +22,7 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
     var onTogglePin: ((Conversation) -> Void)?
     var onShowAllFilter: (() -> Void)?
     var onScrollOffsetChange: ((CGFloat) -> Void)?
+    var onLoadMoreConversations: (() -> Void)?
     var topChromeInset: CGFloat = 0
     var bottomChromeInset: CGFloat = 0
 
@@ -38,7 +40,8 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
             selectedConversationId: selectedConversationId,
             isFilteredResultEmpty: isFilteredResultEmpty,
             filterEmptyMessage: filterEmptyMessage,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            hasMoreConversations: hasMoreConversations
         )
         viewController.memberContactOverride = memberContactOverride
         viewController.updateState(state)
@@ -58,5 +61,6 @@ struct ConversationsViewRepresentable: UIViewControllerRepresentable {
         viewController.onTogglePin = onTogglePin
         viewController.onShowAllFilter = onShowAllFilter
         viewController.onScrollOffsetChange = onScrollOffsetChange
+        viewController.onLoadMoreConversations = onLoadMoreConversations
     }
 }

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -114,6 +114,12 @@ struct MainTabView: View {
     /// builder sheet and in builders presented from descendant conversation
     /// screens -- can read the cached hints.
     @State private var promptHints: PromptHintsModel = .live()
+    /// Live suggested-agents service for the Contacts tab. Held in state so it
+    /// is built once (each `.live()` spins up a fresh API client and logs),
+    /// rather than on every `TabView` body pass -- `contactsTabContent` is
+    /// re-evaluated whenever the shell body recomputes, even while another tab
+    /// is frontmost.
+    @State private var suggestedAgentsService: SuggestedAgentsService = .live()
     /// Shared namespace for the agent-builder bar -> sheet zoom
     /// transition and the app-settings pill -> sheet zoom transition.
     /// The bar / pill apply
@@ -354,7 +360,7 @@ struct MainTabView: View {
             coreActions: coreActions,
             profileSettingsViewModel: profileSettingsViewModel,
             showsComposeButton: false,
-            suggestedAgentsService: SuggestedAgentsService.live(),
+            suggestedAgentsService: suggestedAgentsService,
             scrollTarget: $contactsScrollTarget,
             onMakeAgent: { conversationsViewModel.onStartAgent() },
             onScanJoinedConversation: handleContactsScanJoinedConversation,

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -87,15 +87,15 @@ public enum AppEnvironment: Sendable {
     var apiBaseURL: String {
         switch self {
         case .local(let config):
-            Log.info("Using API URL from local config: \(config.apiBaseURL)")
+            Log.debug("Using API URL from local config: \(config.apiBaseURL)")
             return config.apiBaseURL
         case .tests:
             return "http://localhost:4000/api"
         case .dev(let config):
-            Log.info("Using API URL from dev config: \(config.apiBaseURL)")
+            Log.debug("Using API URL from dev config: \(config.apiBaseURL)")
             return config.apiBaseURL
         case .production(let config):
-            Log.info("Using API URL from production config: \(config.apiBaseURL)")
+            Log.debug("Using API URL from production config: \(config.apiBaseURL)")
             return config.apiBaseURL
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -92,6 +92,10 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         MockConversationsRepository()
     }
 
+    public func conversationsPager(for consent: [Consent]) -> any ConversationsPagerProtocol {
+        MockConversationsPager()
+    }
+
     public func conversationsCountRepo(for consent: [Consent], kinds: [ConversationKind]) -> any ConversationsCountRepositoryProtocol {
         MockConversationsCountRepository()
     }

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -124,6 +124,20 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     private nonisolated(unsafe) var revocationObserver: (any NSObjectProtocol)?
     private var foregroundRetryCount: Int = 0
     private static let maxForegroundRetries: Int = 2
+    /// Monotonic stamp of the last completed batch catch-up. Foreground and
+    /// network-reconnect events that land inside `catchUpSkipWindow` of it
+    /// skip the batch entirely - rapid app-switching and network flaps were
+    /// each re-running the full catch-up pipeline back to back. Streams and
+    /// the resume-path sync still run on every transition, so short-window
+    /// activity arrives per-event instead of batched, which is fine at that
+    /// volume.
+    private var lastCatchUpCompletedAt: ContinuousClock.Instant?
+    private static let catchUpSkipWindow: Duration = .seconds(30)
+    /// Pending debounced resume after a network reconnect. Cancelled by a
+    /// disconnect (or a newer reconnect) arriving inside the debounce, so a
+    /// flapping link doesn't restart streams and re-sync on every blip.
+    private var pendingNetworkResumeTask: Task<Void, Never>?
+    private static let networkResumeDebounce: Duration = .seconds(2)
 
     // MARK: - Nonisolated State Cache (SessionStateManagerProtocol)
 
@@ -680,7 +694,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
         try Task.checkCancellation()
 
-        try await assertInstallationActive(client: client)
+        try await assertInstallationActive(inboxId: client.inboxId, installationId: client.installationId)
 
         reconcileStaleOwnInstallations()
 
@@ -977,15 +991,25 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
         try await result.client.reconnectLocalDatabase()
 
+        // Run the installation-active probe concurrently with the batch
+        // catch-up instead of blocking the whole foreground path on the
+        // network round trip. Catch-up work done before a failed probe is
+        // harmless - every persist is idempotent - and the teardown below
+        // still runs before the error propagates.
+        async let installationCheck: Void = assertInstallationActive(
+            inboxId: result.client.inboxId,
+            installationId: result.client.installationId
+        )
+
+        // Drain the backlog in batched form before streams resume.
+        await runBatchCatchUp(client: result.client)
+
         do {
-            try await assertInstallationActive(client: result.client)
+            try await installationCheck
         } catch {
             try? result.client.dropLocalDatabaseConnection()
             throw error
         }
-
-        // Drain the backlog in batched form before streams resume.
-        await runBatchCatchUp(client: result.client)
 
         await startNetworkMonitoring()
         await syncingManager?.resume()
@@ -998,16 +1022,19 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     /// Probes the XMTP network for whether this device's installation is
     /// still in the inbox's active set. Throws `DeviceReplacedError`
     /// (terminal) if it isn't — typically meaning another paired device
-    /// revoked us from its `Devices` screen.
-    private func assertInstallationActive(client: any XMTPClientProvider) async throws {
+    /// revoked us from its `Devices` screen. Takes plain identifiers (not
+    /// the client) so the foreground path can run it as a child task
+    /// concurrently with the catch-up without moving the non-Sendable
+    /// client across the task boundary.
+    private func assertInstallationActive(inboxId: String, installationId: String) async throws {
         if await XMTPInstallationStateChecker.isInstallationActive(
-            inboxId: client.inboxId,
-            installationId: client.installationId,
+            inboxId: inboxId,
+            installationId: installationId,
             environment: environment
         ) {
             return
         }
-        Log.warning("SessionStateMachine: installation \(client.installationId) not in active set — DeviceReplacedError")
+        Log.warning("SessionStateMachine: installation \(installationId) not in active set — DeviceReplacedError")
         throw DeviceReplacedError()
     }
 
@@ -1057,6 +1084,10 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     /// reason). `syncingManager` is captured locally so we don't need
     /// to hop the actor for it either.
     private nonisolated func runBatchCatchUp(client: any XMTPClientProvider) async {
+        guard await shouldRunCatchUp() else {
+            Log.info("[catchup] skipped - last catch-up completed within \(Self.catchUpSkipWindow)")
+            return
+        }
         let inboxId = client.inboxId
         let cursor = Self.readLastCatchUpCursor(for: inboxId)
         Log.info("[catchup] running batch since=\(cursor.map { "\($0)" } ?? "nil") for inbox=\(inboxId.prefix(8))")
@@ -1071,6 +1102,16 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
         }
         await syncingManager.runBatchCatchUp(client: client, since: cursor)
         Self.writeLastCatchUpCursor(Date(), for: inboxId)
+        await markCatchUpCompleted()
+    }
+
+    private func shouldRunCatchUp() -> Bool {
+        guard let lastCatchUpCompletedAt else { return true }
+        return ContinuousClock.now - lastCatchUpCompletedAt >= Self.catchUpSkipWindow
+    }
+
+    private func markCatchUpCompleted() {
+        lastCatchUpCompletedAt = ContinuousClock.now
     }
 
     /// Persisted catch-up cursor shared with `MessagingService+PushNotifications`.
@@ -1472,6 +1513,8 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
     // MARK: - Network Monitoring
 
     private func stopNetworkMonitoring() async {
+        pendingNetworkResumeTask?.cancel()
+        pendingNetworkResumeTask = nil
         networkMonitorTask?.cancel()
         networkMonitorTask = nil
         await networkMonitor.stop()
@@ -1496,14 +1539,28 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
 
         switch status {
         case .connected(let type):
-            Log.debug("Network connected (\(type)) - resuming sync")
-            await syncingManager?.resume()
+            Log.debug("Network connected (\(type)) - scheduling debounced resume")
+            pendingNetworkResumeTask?.cancel()
+            pendingNetworkResumeTask = Task { [weak self] in
+                guard (try? await Task.sleep(for: Self.networkResumeDebounce)) != nil else { return }
+                guard let self, !Task.isCancelled else { return }
+                await self.resumeAfterNetworkDebounce()
+            }
         case .disconnected:
             Log.debug("Network disconnected - pausing sync")
+            pendingNetworkResumeTask?.cancel()
+            pendingNetworkResumeTask = nil
             await syncingManager?.pause()
         case .connecting, .unknown:
             break
         }
+    }
+
+    private func resumeAfterNetworkDebounce() async {
+        pendingNetworkResumeTask = nil
+        guard case .ready = _state else { return }
+        Log.debug("Network still connected after debounce - resuming sync")
+        await syncingManager?.resume()
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockRepositories.swift
@@ -68,6 +68,40 @@ public final class MockConversationsRepository: ConversationsRepositoryProtocol,
     }
 }
 
+// MARK: - Mock Conversations Pager
+
+/// Mock implementation of ConversationsPagerProtocol for testing
+public final class MockConversationsPager: ConversationsPagerProtocol, @unchecked Sendable {
+    public var mockPage: ConversationsPage {
+        didSet { pageSubject.send(mockPage) }
+    }
+    public var filter: ConversationsListFilter = .all
+    public private(set) var loadMoreCallCount: Int = 0
+
+    private let pageSubject: CurrentValueSubject<ConversationsPage, Never>
+
+    public init(page: ConversationsPage = .empty) {
+        self.mockPage = page
+        self.pageSubject = CurrentValueSubject(page)
+    }
+
+    public var pagePublisher: AnyPublisher<ConversationsPage, Never> {
+        pageSubject.eraseToAnyPublisher()
+    }
+
+    public func loadMore() {
+        loadMoreCallCount += 1
+    }
+
+    public func fetchInitialPage() throws -> ConversationsPage {
+        mockPage
+    }
+
+    public func fetchConversation(id: String) throws -> Conversation? {
+        (mockPage.pinned + mockPage.unpinned).first { $0.id == id }
+    }
+}
+
 // MARK: - Mock Conversations Count Repository
 
 /// Mock implementation of ConversationsCountRepositoryProtocol for testing

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -778,6 +778,10 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         ConversationsRepository(dbReader: databaseReader, consent: consent)
     }
 
+    public func conversationsPager(for consent: [Consent]) -> any ConversationsPagerProtocol {
+        ConversationsPager(dbReader: databaseReader, consent: consent)
+    }
+
     public func conversationsCountRepo(for consent: [Consent], kinds: [ConversationKind]) -> any ConversationsCountRepositoryProtocol {
         ConversationsCountRepository(databaseReader: databaseReader, consent: consent, kinds: kinds)
     }

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManagerProtocol.swift
@@ -198,6 +198,10 @@ public protocol SessionManagerProtocol: AnyObject, Sendable {
     func inviteMembershipResolver() -> any InviteMembershipResolving
 
     func conversationsRepository(for consent: [Consent]) -> any ConversationsRepositoryProtocol
+    /// Windowed variant of `conversationsRepository` for the conversations
+    /// list screen: pinned rows unlimited, unpinned rows behind a growing
+    /// LIMIT window. Full-list consumers keep using `conversationsRepository`.
+    func conversationsPager(for consent: [Consent]) -> any ConversationsPagerProtocol
     func conversationsCountRepo(
         for consent: [Consent],
         kinds: [ConversationKind]

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsCountRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsCountRepository.swift
@@ -19,6 +19,9 @@ class ConversationsCountRepository: ConversationsCountRepositoryProtocol {
             .tracking { db in
                 try db.composeConversationsCount(consent: consent, kinds: kinds)
             }
+            // The tracked region spans the conversation tables, so without
+            // this an unrelated write would re-emit an identical count.
+            .removeDuplicates()
             .publisher(in: databaseReader)
             .replaceError(with: 0)
             .eraseToAnyPublisher()

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsPager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsPager.swift
@@ -62,6 +62,9 @@ final class ConversationsPager: ConversationsPagerProtocol {
     private struct PageRequest: Equatable {
         var filter: ConversationsListFilter
         var limit: Int
+        /// Bumped after an observation error so the resend survives
+        /// `removeDuplicates` and spawns a fresh inner observation.
+        var generation: Int = 0
     }
 
     private let dbReader: any DatabaseReader
@@ -75,11 +78,14 @@ final class ConversationsPager: ConversationsPagerProtocol {
     /// `throttleInterval` matches `ConversationsRepository`'s: leading-edge
     /// delivery coalescing during write bursts, applied per inner
     /// observation so a window change always emits promptly.
+    /// `observationRetryDelay` spaces the resubscribe attempts after an
+    /// observation error; see `scheduleRetry`.
     init(
         dbReader: any DatabaseReader,
         consent: [Consent],
         pageSize: Int = 60,
-        throttleInterval: TimeInterval = 0.3
+        throttleInterval: TimeInterval = 0.3,
+        observationRetryDelay: TimeInterval = 1
     ) {
         self.dbReader = dbReader
         self.consent = consent
@@ -96,7 +102,10 @@ final class ConversationsPager: ConversationsPagerProtocol {
                     dbReader: dbReader,
                     consent: consent,
                     request: request,
-                    throttleInterval: throttleInterval
+                    throttleInterval: throttleInterval,
+                    onError: {
+                        Self.scheduleRetry(of: request, on: subject, after: observationRetryDelay)
+                    }
                 )
             }
             .switchToLatest()
@@ -107,7 +116,10 @@ final class ConversationsPager: ConversationsPagerProtocol {
         get { requestSubject.value.filter }
         set {
             guard newValue != requestSubject.value.filter else { return }
-            requestSubject.send(PageRequest(filter: newValue, limit: pageSize))
+            var request = requestSubject.value
+            request.filter = newValue
+            request.limit = pageSize
+            requestSubject.send(request)
         }
     }
 
@@ -138,7 +150,8 @@ final class ConversationsPager: ConversationsPagerProtocol {
         dbReader: any DatabaseReader,
         consent: [Consent],
         request: PageRequest,
-        throttleInterval: TimeInterval
+        throttleInterval: TimeInterval,
+        onError: @escaping () -> Void
     ) -> AnyPublisher<ConversationsPage, Never> {
         let base: AnyPublisher<ConversationsPage, Never> = ValueObservation
             .tracking { db in
@@ -157,11 +170,45 @@ final class ConversationsPager: ConversationsPagerProtocol {
             // an unrelated write would re-emit an identical page.
             .removeDuplicates()
             .publisher(in: dbReader)
-            .replaceError(with: .empty)
+            // An error terminates the observation, and a substituted value
+            // (replaceError) would both blank the list and complete this
+            // inner publisher, leaving switchToLatest frozen with nothing
+            // to re-trigger it. Keep the last delivered page on screen and
+            // let the caller resubscribe with a fresh observation instead.
+            .catch { (error: any Error) -> Empty<ConversationsPage, Never> in
+                Log.error("Conversations page observation failed, scheduling retry: \(error)")
+                onError()
+                return Empty(completeImmediately: false)
+            }
             .eraseToAnyPublisher()
         guard throttleInterval > 0 else { return base }
         return base
             .throttle(for: .seconds(throttleInterval), scheduler: DispatchQueue.main, latest: true)
             .eraseToAnyPublisher()
+    }
+
+    /// Resubscribes after an observation error by resending the failed
+    /// request with a bumped generation. Skipped when a newer request has
+    /// already replaced the failed one - its observation is unaffected by
+    /// the error - and when the pager itself is gone.
+    private static func scheduleRetry(
+        of request: PageRequest,
+        on subject: CurrentValueSubject<PageRequest, Never>,
+        after delay: TimeInterval
+    ) {
+        let box = WeakRequestSubjectBox(subject: subject)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard let subject = box.subject, subject.value == request else { return }
+            var next = request
+            next.generation += 1
+            subject.send(next)
+        }
+    }
+
+    /// Combine subjects are thread-safe for `send` but carry no Sendable
+    /// annotation; the weak reference also lets a deallocated pager drop
+    /// its pending retry instead of being kept alive by the dispatch queue.
+    private struct WeakRequestSubjectBox: @unchecked Sendable {
+        weak var subject: CurrentValueSubject<PageRequest, Never>?
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsPager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsPager.swift
@@ -1,0 +1,167 @@
+import Combine
+import Foundation
+import GRDB
+
+/// The list filter the conversations screen exposes. Mirrors the view
+/// model's `ConversationFilter`; lives in Core so the pager can push the
+/// predicate into SQL instead of filtering a partial window in memory.
+public enum ConversationsListFilter: Equatable, Sendable {
+    case all
+    case unread
+    case exploding
+}
+
+/// One emission of the paged conversations list.
+public struct ConversationsPage: Equatable, Sendable {
+    /// Every pinned row, unlimited and unfiltered - bounded by the pin
+    /// limit (see `ConversationLocalStateWriter.maxPinnedConversations`),
+    /// so it never needs the window treatment. The view model applies the
+    /// active filter and the `pinnedOrder` sort, same as before.
+    public let pinned: [Conversation]
+    /// The filtered, windowed unpinned rows in list order.
+    public let unpinned: [Conversation]
+    /// Whether rows exist beyond the current window.
+    public let hasMore: Bool
+    /// Whether any unpinned row exists ignoring the filter - drives the
+    /// "nothing matches this filter" (vs "no conversations") empty states.
+    public let hasAnyUnpinned: Bool
+
+    public static let empty: ConversationsPage = ConversationsPage(
+        pinned: [],
+        unpinned: [],
+        hasMore: false,
+        hasAnyUnpinned: false
+    )
+}
+
+/// A growing-window pager over the conversations list.
+///
+/// One live GRDB observation whose query carries `LIMIT <window>`; the
+/// window grows on `loadMore()` and resets when `filter` changes. Growing
+/// swaps the inner observation (cheap - GRDB re-subscribes and re-emits),
+/// while `pagePublisher` stays a single stable publisher via
+/// `switchToLatest`. Callers gate `loadMore()` on the latest page's
+/// `hasMore` plus their own in-flight flag; the pager itself is
+/// deliberately stateless about emissions.
+public protocol ConversationsPagerProtocol: AnyObject {
+    var pagePublisher: AnyPublisher<ConversationsPage, Never> { get }
+    /// Setting resets the window to the first page.
+    var filter: ConversationsListFilter { get set }
+    /// Grow the window by one page.
+    func loadMore()
+    /// One-shot first-page read for the cold-start prime
+    /// (`BoundedInitialRead`), bypassing the observation machinery.
+    func fetchInitialPage() throws -> ConversationsPage
+    /// A single conversation by id under the same list-eligibility filters
+    /// as the page. Nil means gone from the list's perspective (deleted,
+    /// removed, blocked, expired), not merely outside the window.
+    func fetchConversation(id: String) throws -> Conversation?
+}
+
+final class ConversationsPager: ConversationsPagerProtocol {
+    private struct PageRequest: Equatable {
+        var filter: ConversationsListFilter
+        var limit: Int
+    }
+
+    private let dbReader: any DatabaseReader
+    private let consent: [Consent]
+    private let pageSize: Int
+    private let throttleInterval: TimeInterval
+    private let requestSubject: CurrentValueSubject<PageRequest, Never>
+
+    let pagePublisher: AnyPublisher<ConversationsPage, Never>
+
+    /// `throttleInterval` matches `ConversationsRepository`'s: leading-edge
+    /// delivery coalescing during write bursts, applied per inner
+    /// observation so a window change always emits promptly.
+    init(
+        dbReader: any DatabaseReader,
+        consent: [Consent],
+        pageSize: Int = 60,
+        throttleInterval: TimeInterval = 0.3
+    ) {
+        self.dbReader = dbReader
+        self.consent = consent
+        self.pageSize = pageSize
+        self.throttleInterval = throttleInterval
+        let subject = CurrentValueSubject<PageRequest, Never>(
+            PageRequest(filter: .all, limit: pageSize)
+        )
+        self.requestSubject = subject
+        self.pagePublisher = subject
+            .removeDuplicates()
+            .map { (request: PageRequest) -> AnyPublisher<ConversationsPage, Never> in
+                Self.observationPublisher(
+                    dbReader: dbReader,
+                    consent: consent,
+                    request: request,
+                    throttleInterval: throttleInterval
+                )
+            }
+            .switchToLatest()
+            .eraseToAnyPublisher()
+    }
+
+    var filter: ConversationsListFilter {
+        get { requestSubject.value.filter }
+        set {
+            guard newValue != requestSubject.value.filter else { return }
+            requestSubject.send(PageRequest(filter: newValue, limit: pageSize))
+        }
+    }
+
+    func loadMore() {
+        var request = requestSubject.value
+        request.limit += pageSize
+        requestSubject.send(request)
+    }
+
+    func fetchInitialPage() throws -> ConversationsPage {
+        let request = requestSubject.value
+        return try dbReader.read { db in
+            try db.composeConversationsPage(
+                consent: self.consent,
+                filter: request.filter,
+                limit: request.limit
+            )
+        }
+    }
+
+    func fetchConversation(id: String) throws -> Conversation? {
+        try dbReader.read { db in
+            try db.composeListConversation(id: id, consent: self.consent)
+        }
+    }
+
+    private static func observationPublisher(
+        dbReader: any DatabaseReader,
+        consent: [Consent],
+        request: PageRequest,
+        throttleInterval: TimeInterval
+    ) -> AnyPublisher<ConversationsPage, Never> {
+        let base: AnyPublisher<ConversationsPage, Never> = ValueObservation
+            .tracking { db in
+                do {
+                    return try db.composeConversationsPage(
+                        consent: consent,
+                        filter: request.filter,
+                        limit: request.limit
+                    )
+                } catch {
+                    Log.error("Error composing conversations page: \(error)")
+                    throw error
+                }
+            }
+            // The tracked region spans every conversation-related table, so
+            // an unrelated write would re-emit an identical page.
+            .removeDuplicates()
+            .publisher(in: dbReader)
+            .replaceError(with: .empty)
+            .eraseToAnyPublisher()
+        guard throttleInterval > 0 else { return base }
+        return base
+            .throttle(for: .seconds(throttleInterval), scheduler: DispatchQueue.main, latest: true)
+            .eraseToAnyPublisher()
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -355,17 +355,16 @@ extension Database {
                 .filter(DBConversation.Columns.expiresAt != nil && DBConversation.Columns.expiresAt < oneYearFromNow)
         }
 
-        // limit+1 answers hasMore; the surplus row is dropped before
-        // hydration and the DM fold so the fold's re-sort cannot leak it
-        // into the window.
-        var unpinnedDetails = try unpinnedRequest
+        // The SQL order only knows each group's own messages, so a group
+        // whose folded agent DM holds the newest activity can rank below
+        // the LIMIT cutoff. Over-fetch a margin of candidates, fold and
+        // re-sort the wider set, then truncate back to the window so such
+        // a group can climb in. The +1 answers hasMore.
+        let unpinnedDetails = try unpinnedRequest
             .detailedConversationQuery()
-            .limit(limit + 1)
+            .limit(limit + Constant.agentDmFoldMargin + 1)
             .fetchAll(self)
         let hasMore = unpinnedDetails.count > limit
-        if hasMore {
-            unpinnedDetails.removeLast()
-        }
 
         // Unfiltered existence check for the filter-empty states: "you have
         // conversations, none match this filter" must not depend on the
@@ -379,11 +378,14 @@ extension Database {
             consent: consent,
             resortByActivity: false
         )
-        let unpinned = try foldAgentDms(
+        var unpinned = try foldAgentDms(
             into: unpinnedDetails.composeConversations(from: self),
             consent: consent,
             resortByActivity: true
         )
+        if unpinned.count > limit {
+            unpinned.removeLast(unpinned.count - limit)
+        }
         return ConversationsPage(
             pinned: pinned,
             unpinned: unpinned,
@@ -483,6 +485,14 @@ extension Database {
         let currentInboxId = try DBInbox.currentInboxId(self) ?? ""
         let contactNameResolver = try ContactsRepository.contactNameResolverInTransaction(db: self)
         return details.hydrateConversation(currentInboxId: currentInboxId, contactNameResolver: contactNameResolver)
+    }
+
+    /// How many rows beyond the requested window `composeConversationsPage`
+    /// fetches as re-sort candidates. Bounds the extra hydration each page
+    /// compose costs; a group would only be missed if agent-DM activity
+    /// should lift it more than this many positions past the window edge.
+    private enum Constant {
+        static let agentDmFoldMargin: Int = 20
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -304,6 +304,10 @@ extension Database {
     func composeListConversation(id: String, consent: [Consent]) throws -> Conversation? {
         let details = try baseListConversationsRequest(consent: consent)
             .filter(DBConversation.Columns.id == id)
+            // Same kind predicate as composeConversationsPage: the list
+            // renders groups only, so the by-id fallback must not resolve
+            // a join-request DM the paged list would never show.
+            .filter([ConversationKind.group].contains(DBConversation.Columns.kind))
             .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
             .detailedConversationQuery()
             .fetchOne(self)

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -64,10 +64,19 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
 
     let conversationsPublisher: AnyPublisher<[Conversation], Never>
 
-    init(dbReader: any DatabaseReader, consent: [Consent]) {
+    /// `throttleInterval` coalesces delivery during write bursts (catch-up,
+    /// stream replay). Leading-edge with `latest: true`, so the first value
+    /// passes through immediately and the trailing value always lands -
+    /// the list is never stale by more than one interval. Pass `0` to
+    /// disable (tests that count emissions rely on this).
+    init(dbReader: any DatabaseReader, consent: [Consent], throttleInterval: TimeInterval = 0.3) {
         self.dbReader = dbReader
         self.consent = consent
-        self.conversationsPublisher = ValueObservation
+        // The tracked region spans every conversation-related table (and the
+        // contact table via the name resolver), so without removeDuplicates
+        // an unrelated write would re-emit an identical list. Same guard as
+        // conversationsPublisher(withAgentTemplateId:) below.
+        let basePublisher: AnyPublisher<[Conversation], Never> = ValueObservation
             .tracking { db in
                 do {
                     return try db.composeAllConversations(consent: consent)
@@ -76,9 +85,17 @@ final class ConversationsRepository: ConversationsRepositoryProtocol {
                     throw error
                 }
             }
+            .removeDuplicates()
             .publisher(in: dbReader)
             .replaceError(with: [])
             .eraseToAnyPublisher()
+        if throttleInterval > 0 {
+            self.conversationsPublisher = basePublisher
+                .throttle(for: .seconds(throttleInterval), scheduler: DispatchQueue.main, latest: true)
+                .eraseToAnyPublisher()
+        } else {
+            self.conversationsPublisher = basePublisher
+        }
     }
 
     func fetchAll() throws -> [Conversation] {
@@ -199,9 +216,15 @@ extension Array where Element == DBConversationDetails {
     }
 }
 
-fileprivate extension Database {
-    func composeAllConversations(consent: [Consent]) throws -> [Conversation] {
-        let dbConversationDetails = try DBConversation
+extension Database {
+    /// Shared filter set for every list-shaped conversations read (the full
+    /// list, the paged window, and the 1:1 lookup below): non-draft (unless
+    /// invite-tagged), consented, unexpired, used, and never an agent DM
+    /// (those render as a page inside their origin conversation). Callers
+    /// add the `localState` join with their own conditions - GRDB merges
+    /// repeated `joining(required:)` calls on the same association.
+    fileprivate func baseListConversationsRequest(consent: [Consent]) -> QueryInterfaceRequest<DBConversation> {
+        DBConversation
             .filter(
                 !DBConversation.Columns.id.like("draft-%")
                 || (DBConversation.Columns.inviteTag != nil
@@ -210,18 +233,35 @@ fileprivate extension Database {
             .filter(consent.contains(DBConversation.Columns.consent))
             .filter(DBConversation.Columns.expiresAt == nil || DBConversation.Columns.expiresAt > Date())
             .filter(DBConversation.Columns.isUnused == false)
-            // Agent DMs render as a page inside their origin conversation,
-            // never as their own row in the conversations list.
             .filter(DBConversation.Columns.isAgentDm == false)
+    }
+
+    fileprivate func composeAllConversations(consent: [Consent]) throws -> [Conversation] {
+        let dbConversationDetails = try baseListConversationsRequest(consent: consent)
             .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
             .detailedConversationQuery()
             .fetchAll(self)
         let conversations = try dbConversationDetails.composeConversations(from: self)
-        // Fold each group's separate agent DM into its row so the list can
-        // render a combined preview and a DM-aware unread indicator. Only
-        // groups with a verified-agent member resolve a DM; the extra
-        // `composeOneToOne` read runs inside this same `db` transaction so
-        // GRDB's ValueObservation tracks the DM and keeps the list reactive.
+        return try foldAgentDms(into: conversations, consent: consent, resortByActivity: true)
+    }
+
+    /// Fold each group's separate agent DM into its row so the list can
+    /// render a combined preview and a DM-aware unread indicator. Only
+    /// groups with a verified-agent member resolve a DM; the extra
+    /// `composeOneToOne` read runs inside this same `db` transaction so
+    /// GRDB's ValueObservation tracks the DM and keeps the list reactive.
+    ///
+    /// `resortByActivity`: the SQL order only knows each group's own
+    /// messages; a reply in the folded DM lane must float the origin
+    /// conversation just like a group message would. Re-sort in memory by
+    /// the newer of the two lanes, keeping the SQL order for ties so rows
+    /// without a DM are unaffected. Callers that re-sort by another key
+    /// anyway (the pinned lane uses `pinnedOrder`) skip it.
+    fileprivate func foldAgentDms(
+        into conversations: [Conversation],
+        consent: [Consent],
+        resortByActivity: Bool
+    ) throws -> [Conversation] {
         let folded = try conversations.map { (conversation: Conversation) -> Conversation in
             guard let agentMember = conversation.members.first(where: { $0.isVerifiedAgent }) else {
                 return conversation
@@ -243,11 +283,7 @@ fileprivate extension Database {
             )
             return row
         }
-        // The SQL order only knows each group's own messages; a reply in the
-        // folded DM lane must float the origin conversation just like a group
-        // message would. Re-sort in memory by the newer of the two lanes,
-        // keeping the SQL order for ties so rows without a DM are unaffected.
-        guard folded.contains(where: { $0.agentDm != nil }) else { return folded }
+        guard resortByActivity, folded.contains(where: { $0.agentDm != nil }) else { return folded }
         return folded
             .enumerated()
             .sorted { (lhs: EnumeratedSequence<[Conversation]>.Element, rhs: EnumeratedSequence<[Conversation]>.Element) -> Bool in
@@ -259,7 +295,104 @@ fileprivate extension Database {
             .map(\.element)
     }
 
-    func composeAgentTemplateConversations(templateId: String, consent: [Consent]) throws -> AgentTemplateConversations {
+    /// A single conversation by id under the same eligibility filters as
+    /// the list (consent scope, unexpired, not removed, not an agent DM),
+    /// with the agent-DM fold applied. The pager's by-id fallback for
+    /// navigation targets outside the current window: nil here means the
+    /// conversation is genuinely gone from the list's perspective, not
+    /// merely out-of-window.
+    func composeListConversation(id: String, consent: [Consent]) throws -> Conversation? {
+        let details = try baseListConversationsRequest(consent: consent)
+            .filter(DBConversation.Columns.id == id)
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
+            .detailedConversationQuery()
+            .fetchOne(self)
+        guard let details else { return nil }
+        return try foldAgentDms(
+            into: [details].composeConversations(from: self),
+            consent: consent,
+            resortByActivity: false
+        ).first
+    }
+
+    /// One windowed read for the conversations list: all pinned rows (small
+    /// by the pin-limit invariant), a filtered LIMIT window of unpinned
+    /// rows, and the two booleans the list's empty states need. Runs inside
+    /// a single read so a ValueObservation tracks every region it touches.
+    func composeConversationsPage(
+        consent: [Consent],
+        filter: ConversationsListFilter,
+        limit: Int
+    ) throws -> ConversationsPage {
+        // The list renders groups only (join-request DMs and agent DMs are
+        // not rows); matching the view model's predicate here keeps the
+        // window budget spent entirely on rows that actually render.
+        let base = baseListConversationsRequest(consent: consent)
+            .filter([ConversationKind.group].contains(DBConversation.Columns.kind))
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
+
+        let pinnedDetails = try base
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.isPinned == true))
+            .detailedConversationQuery()
+            .fetchAll(self)
+
+        var unpinnedRequest = base
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.isPinned == false))
+        switch filter {
+        case .all:
+            break
+        case .unread:
+            // Matches the in-memory filter's semantics: the group's own
+            // unread flag only - a conversation unread solely in its folded
+            // agent-DM lane does not qualify, same as today.
+            unpinnedRequest = unpinnedRequest
+                .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.isUnread == true))
+        case .exploding:
+            // scheduledExplosionDate's contract: expiring, in the future
+            // (base request already enforces that), and inside one year.
+            let oneYearFromNow = Date().addingTimeInterval(365 * 24 * 60 * 60)
+            unpinnedRequest = unpinnedRequest
+                .filter(DBConversation.Columns.expiresAt != nil && DBConversation.Columns.expiresAt < oneYearFromNow)
+        }
+
+        // limit+1 answers hasMore; the surplus row is dropped before
+        // hydration and the DM fold so the fold's re-sort cannot leak it
+        // into the window.
+        var unpinnedDetails = try unpinnedRequest
+            .detailedConversationQuery()
+            .limit(limit + 1)
+            .fetchAll(self)
+        let hasMore = unpinnedDetails.count > limit
+        if hasMore {
+            unpinnedDetails.removeLast()
+        }
+
+        // Unfiltered existence check for the filter-empty states: "you have
+        // conversations, none match this filter" must not depend on the
+        // filtered window.
+        let hasAnyUnpinned = try !base
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.isPinned == false))
+            .isEmpty(self)
+
+        let pinned = try foldAgentDms(
+            into: pinnedDetails.composeConversations(from: self),
+            consent: consent,
+            resortByActivity: false
+        )
+        let unpinned = try foldAgentDms(
+            into: unpinnedDetails.composeConversations(from: self),
+            consent: consent,
+            resortByActivity: true
+        )
+        return ConversationsPage(
+            pinned: pinned,
+            unpinned: unpinned,
+            hasMore: hasMore,
+            hasAnyUnpinned: hasAnyUnpinned
+        )
+    }
+
+    fileprivate func composeAgentTemplateConversations(templateId: String, consent: [Consent]) throws -> AgentTemplateConversations {
         // Filter and partition in Swift over the hydrated conversations:
         // `member.profile.agentTemplateId` is the trusted accessor over the
         // profile metadata, and `invitedBy` already carries the agent's
@@ -288,7 +421,7 @@ fileprivate extension Database {
         )
     }
 
-    func composeOneToOne(
+    fileprivate func composeOneToOne(
         with otherInboxId: String,
         excluding excludedConversationId: String?,
         consent: [Consent],

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -82,6 +82,13 @@ class MessagesRepository: MessagesRepositoryProtocol {
     private let conversationIdSubject: CurrentValueSubject<String, Never>
     private var conversationIdCancellable: AnyCancellable?
 
+    /// Coalesces observation re-emissions during write bursts (catch-up
+    /// sync) so the transcript reprocesses at most once per interval
+    /// instead of once per landed message. Leading-edge, so a message
+    /// sent into a quiet conversation still echoes immediately. Pass 0
+    /// to disable (tests that need synchronous emissions).
+    private let throttleInterval: TimeInterval
+
     // Pagination properties
     private let pageSize: Int
     private let currentLimitSubject: CurrentValueSubject<Int, Never>
@@ -146,13 +153,15 @@ class MessagesRepository: MessagesRepositoryProtocol {
         dbReader: any DatabaseReader,
         conversationId: String,
         currentInboxId: String,
-        pageSize: Int = 50
+        pageSize: Int = 50,
+        throttleInterval: TimeInterval = 0.3
     ) {
         self.dbReader = dbReader
         self.conversationIdSubject = .init(conversationId)
         self.currentInboxId = currentInboxId
         self.pageSize = pageSize
         self.currentLimitSubject = .init(pageSize)
+        self.throttleInterval = throttleInterval
     }
 
     init(
@@ -160,13 +169,15 @@ class MessagesRepository: MessagesRepositoryProtocol {
         conversationId: String,
         currentInboxId: String,
         conversationIdPublisher: AnyPublisher<String, Never>,
-        pageSize: Int = 25
+        pageSize: Int = 25,
+        throttleInterval: TimeInterval = 0.3
     ) {
         self.dbReader = dbReader
         self.conversationIdSubject = .init(conversationId)
         self.currentInboxId = currentInboxId
         self.pageSize = pageSize
         self.currentLimitSubject = .init(pageSize)
+        self.throttleInterval = throttleInterval
         conversationIdCancellable = conversationIdPublisher
             .dropFirst()
             .sink { [weak self] conversationId in
@@ -351,7 +362,7 @@ class MessagesRepository: MessagesRepositoryProtocol {
     lazy var conversationMessagesResultPublisher: AnyPublisher<ConversationMessagesResult, Never> = {
         let dbReader = dbReader
         let stateQueue = stateQueue
-        return Publishers.CombineLatest(
+        let base: AnyPublisher<ConversationMessagesResult, Never> = Publishers.CombineLatest(
             conversationIdSubject.removeDuplicates(),
             currentLimitSubject.removeDuplicates()
         )
@@ -421,6 +432,10 @@ class MessagesRepository: MessagesRepositoryProtocol {
         }
         .switchToLatest()
         .eraseToAnyPublisher()
+        guard throttleInterval > 0 else { return base }
+        return base
+            .throttle(for: .seconds(throttleInterval), scheduler: DispatchQueue.main, latest: true)
+            .eraseToAnyPublisher()
     }()
 
     static func fetchMemberProfiles(_ db: Database, conversationId: String) throws -> [String: MemberProfileInfo] {

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/PinnedConversationsCountRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/PinnedConversationsCountRepository.swift
@@ -15,6 +15,9 @@ class PinnedConversationsCountRepository: PinnedConversationsCountRepositoryProt
             .tracking { db in
                 try db.composePinnedConversationsCount()
             }
+            // Unrelated localState writes (unread, mute) would otherwise
+            // re-emit an identical count.
+            .removeDuplicates()
             .publisher(in: databaseReader)
             .replaceError(with: 0)
             .eraseToAnyPublisher()

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -260,12 +260,23 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
 
     /// Async, network-bound, transaction-free. Safe to call concurrently for
     /// many conversations.
+    ///
+    /// `syncFirst` controls the per-group network `conversation.sync()`.
+    /// Callers with no other freshness source (the NSE message paths, the
+    /// stream processor) must leave it on: it is the only thing pulling new
+    /// commits before the group's roster and metadata are read. The batch
+    /// catch-up path passes `false` because it runs a client-wide
+    /// `syncAllConversations` first - the per-group sync would be redundant
+    /// network work multiplied by every conversation in the batch.
     func prepare(
         conversation: XMTPiOS.Group,
         inboxId: String,
-        clientConversationId: String? = nil
+        clientConversationId: String? = nil,
+        syncFirst: Bool = true
     ) async throws -> PreparedConversation {
-        try await conversation.sync()
+        if syncFirst {
+            try await conversation.sync()
+        }
         try await denyConsentIfInviteWasLocallyDeleted(for: conversation)
         let metadata = try await extractConversationMetadata(from: conversation)
         let members = try await conversation.members

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -265,9 +265,10 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
     /// Callers with no other freshness source (the NSE message paths, the
     /// stream processor) must leave it on: it is the only thing pulling new
     /// commits before the group's roster and metadata are read. The batch
-    /// catch-up path passes `false` because it runs a client-wide
-    /// `syncAllConversations` first - the per-group sync would be redundant
-    /// network work multiplied by every conversation in the batch.
+    /// catch-up path passes `false` when its client-wide
+    /// `syncAllConversations` completed - the per-group sync would be
+    /// redundant network work multiplied by every conversation in the
+    /// batch - and `true` when that sync failed or timed out.
     func prepare(
         conversation: XMTPiOS.Group,
         inboxId: String,

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -23,10 +23,12 @@ struct BatchCatchUpPrepareTimeout: Error {}
 /// traffic. Replaces N writes / N observer fires / N SwiftUI re-renders
 /// with one of each (for the regular-message path).
 ///
-/// Flow:
+/// Flow (the caller runs one client-wide `syncAllConversations` first -
+/// see `SyncingManager.runGlobalSync` - so everything below reads local
+/// libxmtp state):
 /// 1. `client.conversationsProvider.listGroups(lastActivityAfterNs:)`
 ///    discovers conversations that had activity since the cursor.
-/// 2. Per conversation, in parallel:
+/// 2. Per conversation, in bounded parallel (sliding window):
 ///    - Read the local catch-up cursor (`DBConversationCatchUpCursor`,
 ///      falling back to `MAX(message.dateNs)` pre-cursor)
 ///    - `Group.messages(afterNs:)` to fetch the backlog from XMTP
@@ -77,14 +79,11 @@ struct BatchCatchUp {
     private let perConversationPrepareTimeout: TimeInterval
 
     /// `perConversationPrepareTimeout` bounds each conversation's prepare
-    /// phase (XMTP group sync + backlog fetch + message prepare). Field
-    /// logs show a single hung group sync stalling a whole batch for
-    /// 35-150s while processing nothing; the budget converts that hang
-    /// into a skip whose cursor is retried on the next catch-up. 30s is
-    /// deliberately generous: prepare runs in parallel across
-    /// conversations, so the budget caps batch wall-clock at roughly one
-    /// budget rather than serializing, and a genuinely slow-but-working
-    /// initial sync on a large group stays under it.
+    /// phase (local backlog fetch + message prepare; the network sync
+    /// happens once, client-wide, before the batch). The budget converts
+    /// a hang into a skip whose cursor is retried on the next catch-up.
+    /// 30s is deliberately generous for what is now local work; it mostly
+    /// guards against libxmtp database contention under a heavy backlog.
     init(
         conversationWriter: ConversationWriter,
         messageWriter: IncomingMessageWriter,
@@ -350,6 +349,12 @@ struct BatchCatchUp {
     /// entry is dropped (`skipped`), its cursor stays put, and the next
     /// catch-up retries it. Before this isolation, a single throwing
     /// prepare cancelled every sibling task and failed the whole batch.
+    ///
+    /// A sliding window caps concurrent prepares. Prepare is local work
+    /// (the network sync happens once, client-wide, before the batch), so
+    /// the bound exists to keep N conversations from stampeding the GRDB
+    /// reader pool and libxmtp's SQLite connections at boot; same pattern
+    /// as `ConversationConsentReconciler.reconcileBatch`.
     private func prepareAll(
         groups: [XMTPiOS.Group],
         inboxId: String,
@@ -357,42 +362,50 @@ struct BatchCatchUp {
     ) async -> (entries: [PreparedEntry], skipped: Int) {
         let timeout = perConversationPrepareTimeout
         return await withTaskGroup(of: PreparedEntry?.self) { [conversationWriter, messageWriter, databaseWriter] taskGroup in
-            for group in groups {
-                taskGroup.addTask {
-                    do {
-                        return try await Self.withTimeout(seconds: timeout) {
-                            try await Self.prepareEntry(
-                                group: group,
-                                inboxId: inboxId,
-                                fetchFromBeginning: fetchFromBeginning,
-                                conversationWriter: conversationWriter,
-                                messageWriter: messageWriter,
-                                databaseWriter: databaseWriter
-                            )
-                        }
-                    } catch is BatchCatchUpPrepareTimeout {
-                        Log.warning("[PERF] catchup.conversation.skipped: \(group.id) prepare exceeded \(Int(timeout))s; cursor not advanced, retrying next catch-up")
-                        return nil
-                    } catch is CancellationError {
-                        return nil
-                    } catch {
-                        // A conversation that fails for a non-transient reason
-                        // retries on every catch-up. That is bounded (one
-                        // prepare per batch) and the skipped counter surfaces
-                        // it; a retry-attempt cap is deliberate future work.
-                        Log.error("catchup.conversation.skipped: \(group.id) prepare failed: \(error.localizedDescription); cursor not advanced, retrying next catch-up")
-                        return nil
+            @Sendable func prepareTask(for group: XMTPiOS.Group) async -> PreparedEntry? {
+                do {
+                    return try await Self.withTimeout(seconds: timeout) {
+                        try await Self.prepareEntry(
+                            group: group,
+                            inboxId: inboxId,
+                            fetchFromBeginning: fetchFromBeginning,
+                            conversationWriter: conversationWriter,
+                            messageWriter: messageWriter,
+                            databaseWriter: databaseWriter
+                        )
                     }
+                } catch is BatchCatchUpPrepareTimeout {
+                    Log.warning("[PERF] catchup.conversation.skipped: \(group.id) prepare exceeded \(Int(timeout))s; cursor not advanced, retrying next catch-up")
+                    return nil
+                } catch is CancellationError {
+                    return nil
+                } catch {
+                    // A conversation that fails for a non-transient reason
+                    // retries on every catch-up. That is bounded (one
+                    // prepare per batch) and the skipped counter surfaces
+                    // it; a retry-attempt cap is deliberate future work.
+                    Log.error("catchup.conversation.skipped: \(group.id) prepare failed: \(error.localizedDescription); cursor not advanced, retrying next catch-up")
+                    return nil
                 }
+            }
+
+            var iterator = groups.makeIterator()
+            var inFlight = 0
+            while inFlight < Constant.maxConcurrentPrepares, let group = iterator.next() {
+                taskGroup.addTask { await prepareTask(for: group) }
+                inFlight += 1
             }
 
             var results: [PreparedEntry] = []
             var skipped = 0
-            for await entry in taskGroup {
+            while let entry = await taskGroup.next() {
                 if let entry {
                     results.append(entry)
                 } else {
                     skipped += 1
+                }
+                if let group = iterator.next() {
+                    taskGroup.addTask { await prepareTask(for: group) }
                 }
             }
             return (results, skipped)
@@ -407,9 +420,13 @@ struct BatchCatchUp {
         messageWriter: IncomingMessageWriter,
         databaseWriter: any DatabaseWriter
     ) async throws -> PreparedEntry {
+        // No per-group network sync: the caller runs a client-wide
+        // syncAllConversations before the batch (see
+        // SyncingManager.runGlobalSync), so the backlog is already local.
         let preparedConv = try await conversationWriter.prepare(
             conversation: group,
-            inboxId: inboxId
+            inboxId: inboxId,
+            syncFirst: false
         )
 
         let perConvCursorNs: Int64
@@ -544,6 +561,14 @@ struct BatchCatchUp {
             """, arguments: [conversationId])
             return value ?? 0
         }
+    }
+
+    private enum Constant {
+        /// Sliding-window width for the prepare fan-out. Prepare is
+        /// local-only (the network sync happens once, client-wide, before
+        /// the batch), so this is a database-contention bound, not a
+        /// network one; matches ConversationConsentReconciler's window.
+        static let maxConcurrentPrepares: Int = 6
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -25,7 +25,8 @@ struct BatchCatchUpPrepareTimeout: Error {}
 ///
 /// Flow (the caller runs one client-wide `syncAllConversations` first -
 /// see `SyncingManager.runGlobalSync` - so everything below reads local
-/// libxmtp state):
+/// libxmtp state; when that sync fails or times out the caller sets
+/// `syncPerConversation` and each prepare syncs its own group instead):
 /// 1. `client.conversationsProvider.listGroups(lastActivityAfterNs:)`
 ///    discovers conversations that had activity since the cursor.
 /// 2. Per conversation, in bounded parallel (sliding window):
@@ -108,12 +109,22 @@ struct BatchCatchUp {
     /// pairing time, and the import emits no stream events — a forward-
     /// only fetch would never see them. Redelivery of already-persisted
     /// rows is free (no-op diff short-circuit + primary-key upserts).
+    ///
+    /// `syncPerConversation` restores the per-group network sync inside
+    /// each prepare. Callers pass true when the client-wide sync that
+    /// normally precedes the batch did not complete: fetching from an
+    /// unsynced local store could advance a cursor past backlog messages
+    /// that the still-running sync materializes later, and a forward-only
+    /// fetch would then never see them. The per-conversation timeout
+    /// bounds each fallback sync, same as before the client-wide sync
+    /// existed.
     func run(
         client: any XMTPClientProvider,
         inboxId: String,
         since: Date?,
         activeConversationId: String?,
-        fetchFromBeginning: Bool = false
+        fetchFromBeginning: Bool = false,
+        syncPerConversation: Bool = false
     ) async throws -> BatchCatchUpResult {
         let started = CFAbsoluteTimeGetCurrent()
         let cursorNs: Int64? = since.map { Int64($0.nanosecondsSince1970) }
@@ -140,7 +151,10 @@ struct BatchCatchUp {
         let (prepared, skippedCount) = await prepareAll(
             groups: groups,
             inboxId: inboxId,
-            fetchFromBeginning: fetchFromBeginning
+            mode: PrepareMode(
+                fetchFromBeginning: fetchFromBeginning,
+                syncPerConversation: syncPerConversation
+            )
         )
 
         // Phase 2: single-transaction persist of conversations + regular
@@ -260,6 +274,14 @@ struct BatchCatchUp {
 
     // MARK: - Private
 
+    /// The two prepare-phase switches `run` accepts, bundled so they travel
+    /// through the prepare fan-out as one value. See `run` for what each
+    /// flag means and when callers set it.
+    private struct PrepareMode: Sendable {
+        let fetchFromBeginning: Bool
+        let syncPerConversation: Bool
+    }
+
     private struct PreparedEntry {
         let group: XMTPiOS.Group
         let conversation: ConversationWriter.PreparedConversation
@@ -350,15 +372,16 @@ struct BatchCatchUp {
     /// catch-up retries it. Before this isolation, a single throwing
     /// prepare cancelled every sibling task and failed the whole batch.
     ///
-    /// A sliding window caps concurrent prepares. Prepare is local work
-    /// (the network sync happens once, client-wide, before the batch), so
-    /// the bound exists to keep N conversations from stampeding the GRDB
-    /// reader pool and libxmtp's SQLite connections at boot; same pattern
-    /// as `ConversationConsentReconciler.reconcileBatch`.
+    /// A sliding window caps concurrent prepares. Prepare is normally
+    /// local work (the network sync happens once, client-wide, before the
+    /// batch), so the bound exists to keep N conversations from stampeding
+    /// the GRDB reader pool and libxmtp's SQLite connections at boot; same
+    /// pattern as `ConversationConsentReconciler.reconcileBatch`. On the
+    /// `syncPerConversation` fallback it also caps the network fan-out.
     private func prepareAll(
         groups: [XMTPiOS.Group],
         inboxId: String,
-        fetchFromBeginning: Bool
+        mode: PrepareMode
     ) async -> (entries: [PreparedEntry], skipped: Int) {
         let timeout = perConversationPrepareTimeout
         return await withTaskGroup(of: PreparedEntry?.self) { [conversationWriter, messageWriter, databaseWriter] taskGroup in
@@ -368,7 +391,7 @@ struct BatchCatchUp {
                         try await Self.prepareEntry(
                             group: group,
                             inboxId: inboxId,
-                            fetchFromBeginning: fetchFromBeginning,
+                            mode: mode,
                             conversationWriter: conversationWriter,
                             messageWriter: messageWriter,
                             databaseWriter: databaseWriter
@@ -415,22 +438,24 @@ struct BatchCatchUp {
     private static func prepareEntry(
         group: XMTPiOS.Group,
         inboxId: String,
-        fetchFromBeginning: Bool,
+        mode: PrepareMode,
         conversationWriter: ConversationWriter,
         messageWriter: IncomingMessageWriter,
         databaseWriter: any DatabaseWriter
     ) async throws -> PreparedEntry {
-        // No per-group network sync: the caller runs a client-wide
-        // syncAllConversations before the batch (see
+        // The per-group network sync is normally skipped: the caller runs
+        // a client-wide syncAllConversations before the batch (see
         // SyncingManager.runGlobalSync), so the backlog is already local.
+        // When that sync failed or timed out, syncPerConversation restores
+        // it so the cursor cannot advance past a not-yet-synced backlog.
         let preparedConv = try await conversationWriter.prepare(
             conversation: group,
             inboxId: inboxId,
-            syncFirst: false
+            syncFirst: mode.syncPerConversation
         )
 
         let perConvCursorNs: Int64
-        if fetchFromBeginning {
+        if mode.fetchFromBeginning {
             perConvCursorNs = 0
         } else {
             perConvCursorNs = try await Self.readCatchUpCursorNs(

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -304,8 +304,8 @@ actor SyncingManager: SyncingManagerProtocol {
     /// actor. The stream-resume that follows is unaffected because it goes
     /// through the actor's normal `enqueueAction(.resume)` path.
     nonisolated func runBatchCatchUp(client: AnyClientProvider, since: Date?) async {
-        await runGlobalSync(client: client)
-        await runMessageBatch(client: client, since: since)
+        let globalSyncCompleted = await runGlobalSync(client: client)
+        await runMessageBatch(client: client, since: since, syncPerConversation: !globalSyncCompleted)
         await runInviteBatch(client: client, since: since)
     }
 
@@ -315,11 +315,14 @@ actor SyncingManager: SyncingManagerProtocol {
     /// which is why the batch's prepare phase can skip its per-group
     /// `conversation.sync()` (`syncFirst: false`): the backlog is already in
     /// libxmtp's local store by the time `listGroups` + `messages(afterNs:)`
-    /// read it. Time-boxed so a hung sync cannot stall boot; on timeout or
-    /// failure the batch still runs against whatever local state exists, and
-    /// the stream-start sync plus the next catch-up are the safety net
-    /// (cursors only advance for data actually applied).
-    private nonisolated func runGlobalSync(client: AnyClientProvider) async {
+    /// read it. Time-boxed so a hung sync cannot stall boot.
+    ///
+    /// Returns whether the sync completed. On timeout or failure the batch
+    /// still runs, but with per-conversation syncs restored: fetching from
+    /// an unsynced local store could advance catch-up cursors past backlog
+    /// that the still-running sync materializes later, permanently skipping
+    /// it (streams only deliver forward from connection time).
+    private nonisolated func runGlobalSync(client: AnyClientProvider) async -> Bool {
         let box = UncheckedClientBox(client: client)
         let started = CFAbsoluteTimeGetCurrent()
         do {
@@ -330,10 +333,13 @@ actor SyncingManager: SyncingManagerProtocol {
             }
             let elapsed = CFAbsoluteTimeGetCurrent() - started
             Log.info("[PERF] catchup.global_sync: \(Int(elapsed * 1000))ms")
+            return true
         } catch is BatchCatchUpPrepareTimeout {
-            Log.warning("[PERF] catchup.global_sync timed out after \(Int(Constant.globalSyncTimeout))s; running batch on local state")
+            Log.warning("[PERF] catchup.global_sync timed out after \(Int(Constant.globalSyncTimeout))s; running batch with per-conversation syncs")
+            return false
         } catch {
-            Log.error("catchup.global_sync failed: \(error.localizedDescription); running batch on local state")
+            Log.error("catchup.global_sync failed: \(error.localizedDescription); running batch with per-conversation syncs")
+            return false
         }
     }
 
@@ -347,11 +353,17 @@ actor SyncingManager: SyncingManagerProtocol {
         }
     }
 
+    /// `syncPerConversation` is passed through to `BatchCatchUp.run`; see
+    /// its doc for the cursor-safety contract. Callers other than
+    /// `runBatchCatchUp` leave it off because their paths sync beforehand
+    /// (the agent-join poll syncs every tick) or read data that never came
+    /// from the network (the history-archive backfill).
     @discardableResult
     private nonisolated func runMessageBatch(
         client: AnyClientProvider,
         since: Date?,
-        fetchFromBeginning: Bool = false
+        fetchFromBeginning: Bool = false,
+        syncPerConversation: Bool = false
     ) async -> BatchCatchUpResult? {
         do {
             guard let identity = try await identityStore.load() else {
@@ -375,7 +387,8 @@ actor SyncingManager: SyncingManagerProtocol {
                 inboxId: identity.inboxId,
                 since: since,
                 activeConversationId: await activeConversationId,
-                fetchFromBeginning: fetchFromBeginning
+                fetchFromBeginning: fetchFromBeginning,
+                syncPerConversation: syncPerConversation
             )
         } catch {
             Log.error("catchup.batch.messages failed: \(error.localizedDescription)")

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -58,6 +58,13 @@ public struct SyncClientParams: @unchecked Sendable {
     }
 }
 
+/// Carries the non-Sendable client across the `withTimeout` task boundary in
+/// `runGlobalSync`. Same rationale as `SyncClientParams` above; scoped down
+/// because that path has no API client in hand.
+private struct UncheckedClientBox: @unchecked Sendable {
+    let client: AnyClientProvider
+}
+
 /// Manages real-time synchronization of conversations and messages
 ///
 /// SyncingManager coordinates continuous synchronization between the local database
@@ -297,8 +304,37 @@ actor SyncingManager: SyncingManagerProtocol {
     /// actor. The stream-resume that follows is unaffected because it goes
     /// through the actor's normal `enqueueAction(.resume)` path.
     nonisolated func runBatchCatchUp(client: AnyClientProvider, since: Date?) async {
+        await runGlobalSync(client: client)
         await runMessageBatch(client: client, since: since)
         await runInviteBatch(client: client, since: since)
+    }
+
+    /// One client-wide `syncAllConversations` before the local batch. libxmtp
+    /// makes a single batched newest-message-metadata call and then syncs
+    /// only the groups with new server activity, capped at 10 concurrent -
+    /// which is why the batch's prepare phase can skip its per-group
+    /// `conversation.sync()` (`syncFirst: false`): the backlog is already in
+    /// libxmtp's local store by the time `listGroups` + `messages(afterNs:)`
+    /// read it. Time-boxed so a hung sync cannot stall boot; on timeout or
+    /// failure the batch still runs against whatever local state exists, and
+    /// the stream-start sync plus the next catch-up are the safety net
+    /// (cursors only advance for data actually applied).
+    private nonisolated func runGlobalSync(client: AnyClientProvider) async {
+        let box = UncheckedClientBox(client: client)
+        let started = CFAbsoluteTimeGetCurrent()
+        do {
+            try await BatchCatchUp.withTimeout(seconds: Constant.globalSyncTimeout) {
+                _ = try await box.client.conversationsProvider.syncAllConversations(
+                    consentStates: [.allowed, .unknown]
+                )
+            }
+            let elapsed = CFAbsoluteTimeGetCurrent() - started
+            Log.info("[PERF] catchup.global_sync: \(Int(elapsed * 1000))ms")
+        } catch is BatchCatchUpPrepareTimeout {
+            Log.warning("[PERF] catchup.global_sync timed out after \(Int(Constant.globalSyncTimeout))s; running batch on local state")
+        } catch {
+            Log.error("catchup.global_sync failed: \(error.localizedDescription); running batch on local state")
+        }
     }
 
     nonisolated func runHistoryBackfill(client: AnyClientProvider) async {
@@ -608,15 +644,57 @@ actor SyncingManager: SyncingManagerProtocol {
                 return Set(ids)
             }
 
-            var discoveredCount: Int = 0
-            for group in groups where !existingIds.contains(group.id) {
-                do {
-                    let creatorInboxId = try await group.creatorInboxId()
-                    let memberCount = try await group.members.count
-                    if creatorInboxId == params.client.inboxId && memberCount <= 1 {
-                        Log.debug("Skipping self-created single-member group: \(group.id)")
-                        continue
+            let missingGroups = groups.filter { !existingIds.contains($0.id) }
+            guard !missingGroups.isEmpty else { return 0 }
+
+            // The self-created-single-member pre-check costs two FFI calls
+            // per group; run those in a bounded window. Processing stays
+            // sequential below: `streamProcessor` is an actor, so concurrent
+            // calls would serialize there anyway, and its per-conversation
+            // writes are better off not contending for the GRDB writer.
+            let currentInboxId = params.client.inboxId
+            let groupsToProcess: [XMTPiOS.Group] = await withTaskGroup(
+                of: (index: Int, group: XMTPiOS.Group)?.self
+            ) { taskGroup in
+                @Sendable func precheckTask(index: Int, group: XMTPiOS.Group) async -> (index: Int, group: XMTPiOS.Group)? {
+                    do {
+                        let creatorInboxId = try await group.creatorInboxId()
+                        let memberCount = try await group.members.count
+                        if creatorInboxId == currentInboxId && memberCount <= 1 {
+                            Log.debug("Skipping self-created single-member group: \(group.id)")
+                            return nil
+                        }
+                        return (index, group)
+                    } catch {
+                        Log.error("Failed pre-checking discovered conversation \(group.id): \(error)")
+                        return nil
                     }
+                }
+
+                var iterator = missingGroups.enumerated().makeIterator()
+                var inFlight = 0
+                while inFlight < Constant.maxConcurrentDiscoverPrechecks, let (index, group) = iterator.next() {
+                    taskGroup.addTask { await precheckTask(index: index, group: group) }
+                    inFlight += 1
+                }
+
+                var passed: [(index: Int, group: XMTPiOS.Group)] = []
+                while let result = await taskGroup.next() {
+                    if let result {
+                        passed.append(result)
+                    }
+                    if let (index, group) = iterator.next() {
+                        taskGroup.addTask { await precheckTask(index: index, group: group) }
+                    }
+                }
+                return passed
+                    .sorted { $0.index < $1.index }
+                    .map(\.group)
+            }
+
+            var discoveredCount: Int = 0
+            for group in groupsToProcess {
+                do {
                     try await streamProcessor.processConversation(group, params: params)
                     discoveredCount += 1
                 } catch {
@@ -1131,6 +1209,14 @@ extension SyncingManager {
     }
 
     private enum Constant {
+        /// Budget for the client-wide sync that precedes a batch catch-up.
+        /// Generous: libxmtp syncs changed groups 10 at a time, so even a
+        /// heavy backlog normally finishes well inside this; a hung sync
+        /// becomes a skip rather than an indefinite boot stall.
+        static let globalSyncTimeout: TimeInterval = 60
+        /// Sliding-window width for the per-group FFI pre-checks in
+        /// `discoverNewConversations`.
+        static let maxConcurrentDiscoverPrechecks: Int = 4
         /// How often the temporary agent-join poll checks for unprocessed
         /// join requests.
         static let agentJoinPollInterval: TimeInterval = 5

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -66,8 +66,11 @@ struct BatchCatchUpIntegrationTests {
         for i in 1...messageCount {
             _ = try await group.send(content: "Batch msg \(i)")
         }
-        // Critically: do NOT sync B again. The next sync runs inside
-        // `BatchCatchUp.run` and feeds messages into the batched persist.
+        // Pull the backlog into B's local libxmtp store the way production
+        // does: one client-wide sync before the batch (see
+        // `SyncingManager.runGlobalSync`). The batch's prepare phase reads
+        // local state only and no longer syncs per group.
+        _ = try await clientB.conversations.syncAllConversations(consentStates: nil)
 
         // Wire writers + coordinator the way SyncingManager does for the
         // foreground hook (commit d09e7639). Stateless wrappers around the
@@ -173,6 +176,10 @@ struct BatchCatchUpIntegrationTests {
         for i in 1...messageCount {
             _ = try await group.send(content: "Backfill msg \(i)")
         }
+        // Land the messages in B's local libxmtp store (the batch reads
+        // local state only) - the analog of the history-archive import
+        // having populated the store.
+        _ = try await clientB.conversations.syncAllConversations(consentStates: nil)
         // Cursor comes from the actual max message timestamp, not the host
         // wall clock - libxmtp stamps sentNs server-side, and clock skew on
         // CI put wall-clock cursors behind freshly sent messages.
@@ -240,6 +247,7 @@ struct BatchCatchUpIntegrationTests {
         for i in 1...messageCount {
             _ = try await group.send(content: "Active msg \(i)")
         }
+        _ = try await clientB.conversations.syncAllConversations(consentStates: nil)
 
         let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
         let conversationWriter = ConversationWriter(
@@ -315,6 +323,7 @@ struct BatchCatchUpIntegrationTests {
         let thinkingMessageId = try await group.send(
             encodedContent: try ThinkingCodec().encode(content: thinking)
         )
+        _ = try await clientB.conversations.syncAllConversations(consentStates: nil)
 
         let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
         let conversationWriter = ConversationWriter(
@@ -421,6 +430,7 @@ struct BatchCatchUpIntegrationTests {
         // Seed: one message from A, then a first catch-up so the
         // conversation, members, and catch-up cursor all exist locally.
         _ = try await group.send(content: "seed")
+        _ = try await clientB.conversations.syncAllConversations(consentStates: nil)
 
         let messageWriter = IncomingMessageWriter(databaseWriter: fixtures.databaseManager.dbWriter)
         let conversationWriter = ConversationWriter(
@@ -447,6 +457,7 @@ struct BatchCatchUpIntegrationTests {
         // MAX(message.dateNs) and skipped the receipt forever.
         _ = try await group.send(encodedContent: ReadReceiptCodec().encode(content: ReadReceipt()))
         _ = try await group.send(content: "newer than the receipt")
+        _ = try await clientB.conversations.syncAllConversations(consentStates: nil)
 
         let pushedDate = Date(timeIntervalSinceNow: 60)
         try await fixtures.databaseManager.dbWriter.write { db in

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/SessionStateMachineTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/SessionStateMachineTests.swift
@@ -647,8 +647,10 @@ struct SessionStateMachineTests {
         // Simulate network reconnection
         await mockNetworkMonitor.simulateConnection(type: .wifi)
 
-        // Wait for resume to take effect
-        try await Task.sleep(for: .seconds(1))
+        // Wait for resume to take effect. Reconnects are debounced (a
+        // flapping link must not restart streams per blip), so wait past
+        // the debounce interval before asserting.
+        try await Task.sleep(for: .seconds(3))
 
         // Verify sync was resumed
         let resumeCount = await mockSync.resumeCallCount
@@ -761,6 +763,15 @@ struct SessionStateMachineTests {
         let resumeCount = await mockSync.resumeCallCount
         #expect(resumeCount > 0, "SyncingManager should have been resumed after foregrounding")
         #expect(!(await mockSync.isPaused), "SyncingManager should not be paused after foregrounding")
+
+        // The cold-boot authorize already ran the batch catch-up moments ago,
+        // so this foreground lands inside the skip window: streams resume but
+        // the batch must not re-run.
+        let catchUpCount = await mockSync.runBatchCatchUpCallCount
+        #expect(
+            catchUpCount == 1,
+            "Foregrounding within the skip window must not re-run the batch catch-up (got \(catchUpCount) runs)"
+        )
 
         Log.info("App foregrounded, sync resumed successfully")
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
@@ -19,14 +19,15 @@ struct ConversationsPagerTests {
         isUnread: Bool = false,
         expiresAt: Date? = nil,
         wasRemoved: Bool = false,
-        isAgentDm: Bool = false
+        isAgentDm: Bool = false,
+        kind: ConversationKind = .group
     ) throws {
         try DBConversation(
             id: id,
             clientConversationId: "client-\(id)",
             inviteTag: "tag-\(id)",
             creatorId: "me",
-            kind: .group,
+            kind: kind,
             consent: .allowed,
             createdAt: createdAt,
             name: nil,
@@ -316,12 +317,14 @@ struct ConversationsPagerTests {
             try self.seedBase(db)
             try self.seedConversation(db, id: "eligible", createdAt: Date(timeIntervalSince1970: 10_000))
             try self.seedConversation(db, id: "removed", createdAt: Date(timeIntervalSince1970: 10_001), wasRemoved: true)
+            try self.seedConversation(db, id: "join-request-dm", createdAt: Date(timeIntervalSince1970: 10_002), kind: .dm)
         }
 
         let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
 
         #expect(try pager.fetchConversation(id: "eligible")?.id == "eligible")
         #expect(try pager.fetchConversation(id: "removed") == nil, "A removed conversation is gone from the list's perspective")
+        #expect(try pager.fetchConversation(id: "join-request-dm") == nil, "A DM is never a list row, so the by-id fallback must not resolve it")
         #expect(try pager.fetchConversation(id: "missing") == nil)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
@@ -18,7 +18,8 @@ struct ConversationsPagerTests {
         pinnedOrder: Int? = nil,
         isUnread: Bool = false,
         expiresAt: Date? = nil,
-        wasRemoved: Bool = false
+        wasRemoved: Bool = false,
+        isAgentDm: Bool = false
     ) throws {
         try DBConversation(
             id: id,
@@ -42,7 +43,8 @@ struct ConversationsPagerTests {
             conversationEmoji: nil,
             imageLastRenewed: nil,
             isUnused: false,
-            hasHadVerifiedAgent: false
+            hasHadVerifiedAgent: false,
+            isAgentDm: isAgentDm
         ).insert(db)
 
         try ConversationLocalState(
@@ -179,6 +181,89 @@ struct ConversationsPagerTests {
 
         #expect(Set(page.unpinned.map(\.id)) == ["unread-1", "unread-2"])
         #expect(page.hasAnyUnpinned, "hasAnyUnpinned ignores the filter")
+    }
+
+    @Test("Agent DM activity lifts its group into the window past the SQL cutoff")
+    func agentDmActivityLiftsGroupIntoWindow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        let agentInboxId = "agent-inbox"
+        try await writer.write { db in
+            try self.seedBase(db)
+            try DBMember(inboxId: agentInboxId).save(db, onConflict: .ignore)
+            try DBProfile(
+                inboxId: agentInboxId,
+                name: "Agent",
+                memberKind: .verifiedConvos,
+                profileSource: .profileUpdate,
+                updatedAt: Date()
+            ).save(db)
+
+            // Enough newer groups that "origin" ranks beyond the SQL window
+            // on its own group-only activity.
+            for i in 0..<70 {
+                try self.seedConversation(
+                    db,
+                    id: "conv-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 10_000 + Double(i))
+                )
+            }
+            try self.seedConversation(db, id: "origin", createdAt: Date(timeIntervalSince1970: 1_000))
+            try DBConversationMember(
+                conversationId: "origin",
+                inboxId: agentInboxId,
+                role: .member,
+                consent: .allowed,
+                createdAt: Date(timeIntervalSince1970: 1_000),
+                invitedByInboxId: nil
+            ).insert(db)
+
+            // The group's agent DM holds the newest message in the database.
+            try self.seedConversation(
+                db,
+                id: "origin-dm",
+                createdAt: Date(timeIntervalSince1970: 1_001),
+                isAgentDm: true
+            )
+            try DBConversationMember(
+                conversationId: "origin-dm",
+                inboxId: agentInboxId,
+                role: .member,
+                consent: .allowed,
+                createdAt: Date(timeIntervalSince1970: 1_001),
+                invitedByInboxId: nil
+            ).insert(db)
+            try DBMessage(
+                id: "dm-message",
+                clientMessageId: "dm-message",
+                conversationId: "origin-dm",
+                senderId: agentInboxId,
+                dateNs: 100_000_000_000_000,
+                date: Date(timeIntervalSince1970: 100_000),
+                sortId: 100_000_000_000_000,
+                status: .published,
+                messageType: .original,
+                contentType: .text,
+                text: "newest activity",
+                emoji: nil,
+                invite: nil,
+                linkPreview: nil,
+                sourceMessageId: nil,
+                attachmentUrls: [],
+                update: nil
+            ).insert(db)
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        let page = try pager.fetchInitialPage()
+
+        #expect(page.unpinned.count == 60)
+        #expect(page.hasMore)
+        #expect(!page.unpinned.contains { $0.id == "origin-dm" }, "The agent DM itself never renders as a list row")
+        #expect(
+            page.unpinned.first?.id == "origin",
+            "The folded DM's newest message should float its group to the top of the window"
+        )
     }
 
     @Test("Exploding filter honors the one-year cap")

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
@@ -1,0 +1,287 @@
+@testable import ConvosCore
+import Combine
+import Foundation
+import GRDB
+import Testing
+
+/// Covers the windowed conversations page: pinned rows never consume the
+/// LIMIT budget, the window grows on loadMore, filters run in SQL with the
+/// same semantics as the view model's in-memory filters, and the by-id
+/// fallback applies the list's eligibility rules.
+@Suite("ConversationsPager", .serialized)
+struct ConversationsPagerTests {
+    private func seedConversation(
+        _ db: Database,
+        id: String,
+        createdAt: Date,
+        isPinned: Bool = false,
+        pinnedOrder: Int? = nil,
+        isUnread: Bool = false,
+        expiresAt: Date? = nil,
+        wasRemoved: Bool = false
+    ) throws {
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "tag-\(id)",
+            creatorId: "me",
+            kind: .group,
+            consent: .allowed,
+            createdAt: createdAt,
+            name: nil,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: expiresAt,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false
+        ).insert(db)
+
+        try ConversationLocalState(
+            conversationId: id,
+            isPinned: isPinned,
+            isUnread: isUnread,
+            isUnreadUpdatedAt: Date(),
+            isMuted: false,
+            pinnedOrder: pinnedOrder,
+            hidesInviteCard: false,
+            leftHostedInviteSession: false,
+            wasRemoved: wasRemoved,
+            hasHadOtherMembers: false,
+            hasSharedInvite: false
+        ).insert(db)
+
+        try DBConversationMember(
+            conversationId: id,
+            inboxId: "me",
+            role: .superAdmin,
+            consent: .allowed,
+            createdAt: createdAt,
+            invitedByInboxId: nil
+        ).insert(db)
+    }
+
+    private func seedBase(_ db: Database) throws {
+        try DBMember(inboxId: "me").save(db, onConflict: .ignore)
+        try DBInbox(inboxId: "me", clientId: "client-me", createdAt: Date()).save(db, onConflict: .ignore)
+    }
+
+    @Test("Pinned rows are unlimited and excluded from the unpinned LIMIT")
+    func pinnedExcludedFromWindow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            for i in 0..<9 {
+                try self.seedConversation(
+                    db,
+                    id: "pin-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 5_000 + Double(i)),
+                    isPinned: true,
+                    pinnedOrder: i
+                )
+            }
+            for i in 0..<100 {
+                try self.seedConversation(
+                    db,
+                    id: "conv-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 10_000 + Double(i))
+                )
+            }
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        let page = try pager.fetchInitialPage()
+
+        #expect(page.pinned.count == 9)
+        #expect(page.unpinned.count == 60)
+        #expect(page.hasMore)
+        #expect(page.hasAnyUnpinned)
+        #expect(page.unpinned.allSatisfy { !$0.isPinned })
+        // Newest-first ordering by createdAt when no messages exist.
+        #expect(page.unpinned.first?.id == "conv-99")
+    }
+
+    @Test("loadMore grows the window until exhaustion")
+    func loadMoreGrowsWindow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            for i in 0..<100 {
+                try self.seedConversation(
+                    db,
+                    id: "conv-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 10_000 + Double(i))
+                )
+            }
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        let first = try pager.fetchInitialPage()
+        #expect(first.unpinned.count == 60)
+        #expect(first.hasMore)
+
+        pager.loadMore()
+        let second = try pager.fetchInitialPage()
+        #expect(second.unpinned.count == 100)
+        #expect(!second.hasMore)
+    }
+
+    @Test("Changing the filter resets the window to the first page")
+    func filterChangeResetsWindow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            for i in 0..<80 {
+                try self.seedConversation(
+                    db,
+                    id: "conv-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 10_000 + Double(i)),
+                    isUnread: true
+                )
+            }
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        pager.loadMore()
+        #expect(try pager.fetchInitialPage().unpinned.count == 80)
+
+        pager.filter = .unread
+        let filtered = try pager.fetchInitialPage()
+        #expect(filtered.unpinned.count == 60, "Filter change should reset the window to one page")
+        #expect(filtered.hasMore)
+    }
+
+    @Test("Unread filter matches the localState flag only")
+    func unreadFilterSemantics() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            try self.seedConversation(db, id: "unread-1", createdAt: Date(timeIntervalSince1970: 10_000), isUnread: true)
+            try self.seedConversation(db, id: "read-1", createdAt: Date(timeIntervalSince1970: 10_001))
+            try self.seedConversation(db, id: "unread-2", createdAt: Date(timeIntervalSince1970: 10_002), isUnread: true)
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        pager.filter = .unread
+        let page = try pager.fetchInitialPage()
+
+        #expect(Set(page.unpinned.map(\.id)) == ["unread-1", "unread-2"])
+        #expect(page.hasAnyUnpinned, "hasAnyUnpinned ignores the filter")
+    }
+
+    @Test("Exploding filter honors the one-year cap")
+    func explodingFilterSemantics() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        let soon = Date().addingTimeInterval(3_600)
+        let beyondOneYear = Date().addingTimeInterval(2 * 365 * 24 * 60 * 60)
+        try await writer.write { db in
+            try self.seedBase(db)
+            try self.seedConversation(db, id: "exploding", createdAt: Date(timeIntervalSince1970: 10_000), expiresAt: soon)
+            try self.seedConversation(db, id: "far-future", createdAt: Date(timeIntervalSince1970: 10_001), expiresAt: beyondOneYear)
+            try self.seedConversation(db, id: "forever", createdAt: Date(timeIntervalSince1970: 10_002))
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        let all = try pager.fetchInitialPage()
+        #expect(all.unpinned.count == 3, "All three are list-eligible under .all")
+
+        pager.filter = .exploding
+        let exploding = try pager.fetchInitialPage()
+        #expect(
+            exploding.unpinned.map(\.id) == ["exploding"],
+            "Only the within-one-year expiry matches scheduledExplosionDate's contract"
+        )
+    }
+
+    @Test("Filtered-empty window still reports hasAnyUnpinned")
+    func filteredEmptyWindowKeepsHasAnyUnpinned() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            try self.seedConversation(db, id: "read-only", createdAt: Date(timeIntervalSince1970: 10_000))
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        pager.filter = .unread
+        let page = try pager.fetchInitialPage()
+
+        #expect(page.unpinned.isEmpty)
+        #expect(page.hasAnyUnpinned, "Conversations exist; only the filter excludes them")
+    }
+
+    @Test("fetchConversation applies the list's eligibility filters")
+    func fetchConversationByIdFilters() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            try self.seedConversation(db, id: "eligible", createdAt: Date(timeIntervalSince1970: 10_000))
+            try self.seedConversation(db, id: "removed", createdAt: Date(timeIntervalSince1970: 10_001), wasRemoved: true)
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+
+        #expect(try pager.fetchConversation(id: "eligible")?.id == "eligible")
+        #expect(try pager.fetchConversation(id: "removed") == nil, "A removed conversation is gone from the list's perspective")
+        #expect(try pager.fetchConversation(id: "missing") == nil)
+    }
+
+    @Test("Page publisher emits the grown window after loadMore")
+    func pagePublisherEmitsGrownWindow() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in
+            try self.seedBase(db)
+            for i in 0..<70 {
+                try self.seedConversation(
+                    db,
+                    id: "conv-\(i)",
+                    createdAt: Date(timeIntervalSince1970: 10_000 + Double(i))
+                )
+            }
+        }
+
+        let pager = ConversationsPager(dbReader: writer, consent: [.allowed], pageSize: 60, throttleInterval: 0)
+        let collector = PageCollector()
+        let cancellable = pager.pagePublisher.sink { page in collector.append(page) }
+        defer { cancellable.cancel() }
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(collector.latest?.unpinned.count == 60)
+        #expect(collector.latest?.hasMore == true)
+
+        pager.loadMore()
+        try await Task.sleep(nanoseconds: 800_000_000)
+        #expect(collector.latest?.unpinned.count == 70)
+        #expect(collector.latest?.hasMore == false)
+    }
+}
+
+private final class PageCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pages: [ConversationsPage] = []
+    func append(_ page: ConversationsPage) {
+        lock.lock()
+        pages.append(page)
+        lock.unlock()
+    }
+    var latest: ConversationsPage? {
+        lock.lock()
+        defer { lock.unlock() }
+        return pages.last
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsPagerTests.swift
@@ -269,6 +269,38 @@ struct ConversationsPagerTests {
         #expect(collector.latest?.unpinned.count == 70)
         #expect(collector.latest?.hasMore == false)
     }
+
+    @Test("An observation error never blanks the list and the pager recovers")
+    func observationErrorRecovers() async throws {
+        // A bare queue without the schema: every page fetch throws until
+        // the migrations run, standing in for a transient read failure.
+        let queue = try DatabaseQueue()
+        let pager = ConversationsPager(
+            dbReader: queue,
+            consent: [.allowed],
+            pageSize: 60,
+            throttleInterval: 0,
+            observationRetryDelay: 0.1
+        )
+        let collector = PageCollector()
+        let cancellable = pager.pagePublisher.sink { page in collector.append(page) }
+        defer { cancellable.cancel() }
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(collector.latest == nil, "An errored observation must not substitute an empty page")
+
+        try SharedDatabaseMigrator.shared.migrate(database: queue)
+        try await queue.write { db in
+            try self.seedBase(db)
+            try self.seedConversation(db, id: "conv-1", createdAt: Date(timeIntervalSince1970: 10_000))
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        #expect(
+            collector.latest?.unpinned.map(\.id) == ["conv-1"],
+            "A scheduled retry should resubscribe once the database heals"
+        )
+    }
 }
 
 private final class PageCollector: @unchecked Sendable {

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationsRepositoryAvatarObservationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationsRepositoryAvatarObservationTests.swift
@@ -92,7 +92,7 @@ struct ConversationsRepositoryAvatarObservationTests {
         try await writer.write { db in try self.seedGroup(db) }
 
         let counter = EmissionCounter()
-        let repo = ConversationsRepository(dbReader: writer, consent: [.allowed])
+        let repo = ConversationsRepository(dbReader: writer, consent: [.allowed], throttleInterval: 0)
         let cancellable = repo.conversationsPublisher.sink { _ in counter.increment() }
         defer { cancellable.cancel() }
 
@@ -124,7 +124,7 @@ struct ConversationsRepositoryAvatarObservationTests {
         try await writer.write { db in try self.seedGroup(db) }
 
         let counter = EmissionCounter()
-        let repo = ConversationsRepository(dbReader: writer, consent: [.allowed])
+        let repo = ConversationsRepository(dbReader: writer, consent: [.allowed], throttleInterval: 0)
         let cancellable = repo.conversationsPublisher.sink { _ in counter.increment() }
         defer { cancellable.cancel() }
 
@@ -141,6 +141,36 @@ struct ConversationsRepositoryAvatarObservationTests {
         #expect(
             counter.count > afterInitial,
             "Control failed: the observation did not re-emit even for a direct conversation change"
+        )
+    }
+
+    @Test("does not re-emit when a write leaves the composed value unchanged")
+    func suppressesIdenticalRecompose() async throws {
+        let dbManager = MockDatabaseManager.makeTestDatabase()
+        let writer = dbManager.dbWriter
+        try await writer.write { db in try self.seedGroup(db) }
+
+        let counter = EmissionCounter()
+        let repo = ConversationsRepository(dbReader: writer, consent: [.allowed], throttleInterval: 0)
+        let cancellable = repo.conversationsPublisher.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        let afterInitial = counter.count
+        #expect(afterInitial >= 1, "Observation should deliver an initial value")
+
+        // Re-save the row unchanged: the UPDATE touches the tracked region
+        // (the observation refetches) but the composed value is identical,
+        // so removeDuplicates must swallow the emission.
+        try await writer.write { db in
+            guard let conversation = try DBConversation.fetchOne(db, key: "c1") else { return }
+            try conversation.save(db)
+        }
+
+        try await Task.sleep(nanoseconds: 800_000_000)
+        #expect(
+            counter.count == afterInitial,
+            "A value-identical recompose must not reach subscribers (removeDuplicates)"
         )
     }
 }

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -11,8 +11,8 @@
     },
     "identity_share" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJpc3N1ZWRBdCI6MTc1MDAwMDEwMCwiaW5pdGlhdG9yRGV2aWNlTmFtZSI6IkNhbWVyb24ncyBpUGhvbmUiLCJwcml2YXRlS2V5RGF0YSI6IklpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUk9IiwiaW5ib3hJZCI6IjNmOWExYzBlNWI3ZDI4NDZhMWYzMGM5ZTRkOGI2NzUyZTBhNGM5MTM3ZmI1NjI4ZDBlM2E3YzE0YjlkNWY2ODIiLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwic2NoZW1hVmVyc2lvbiI6MX0=",
-      "contentJSON" : "{\"issuedAt\":1750000100,\"initiatorDeviceName\":\"Cameron's iPhone\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"displayName\":\"Cameron\",\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"schemaVersion\":1}",
+      "contentBase64" : "eyJpbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInNjaGVtYVZlcnNpb24iOjEsImRpc3BsYXlOYW1lIjoiQ2FtZXJvbiIsImlzc3VlZEF0IjoxNzUwMDAwMTAwLCJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIn0=",
+      "contentJSON" : "{\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"schemaVersion\":1,\"displayName\":\"Cameron\",\"issuedAt\":1750000100,\"initiatorDeviceName\":\"Cameron's iPhone\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\"}",
       "contentType" : "convos.org/identity_share:1.0",
       "typeId" : "identity_share",
       "versionMajor" : 1,
@@ -20,8 +20,8 @@
     },
     "pairing_join_request" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJkZXZpY2VOYW1lIjoiUGl4ZWwgOSBQcm8iLCJqb2luZXJJbmJveElkIjoiOGMyZDQwYjZlMWY5N2EzNWMwZDgyYjRlNmYxOWE3ZDM1YzBlMjhiNGY2YTE5ZDczYzU4ZTAyYjRmNmExOWQ3MyIsInNsdWciOiJleUpwYzNOMVpXUkJkQ0k2TVRjMU1EQXdNREF3TUN3aWMyTm9aVzFoVm1WeWMybHZiaUk2TVN3aWFXNXBkR2xoZEc5eVFXUmtjbVZ6Y3lJNklqQjRNVGxsTjJVek56WmxOMk15TVROaU4yVTNaVGRsTkRaall6Y3dZVFZrWkRBNE5tUmhabVl5WVNJc0ltVjRjR2x5WlhOQmRDSTZNVGMxTURBd01ERXlNQ3dpYm05dVkyVWlPaUpCUWtWcFRUQlNWbHB1WlVsdFlYRTNlazR6ZFZ3dmR6MDlJaXdpYzJsbmJtRjBkWEpsSWpvaUsxaG1ZemxRTVcxSE9VNWhNVnd2WW5SVFNGVlpXbFZ2VHprMldIY3pSR0pRT1docldHbEdXRE4xVVdOT1Rsd3ZWMDFLT0Z3dk1tOXdRMDV1VTFsamNFUkhVRUZLYzI0NFEwaG9kRU5yYURCbk1XTXpNMnMwZG1oM1BTSXNJbWx1YVhScFlYUnZja2x1WW05NFNXUWlPaUl6WmpsaE1XTXdaVFZpTjJReU9EUTJZVEZtTXpCak9XVTBaRGhpTmpjMU1tVXdZVFJqT1RFek4yWmlOVFl5T0dRd1pUTmhOMk14TkdJNVpEVm1Oamd5SW4wIn0=",
-      "contentJSON" : "{\"schemaVersion\":1,\"deviceName\":\"Pixel 9 Pro\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"slug\":\"eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwic2NoZW1hVmVyc2lvbiI6MSwiaW5pdGlhdG9yQWRkcmVzcyI6IjB4MTllN2UzNzZlN2MyMTNiN2U3ZTdlNDZjYzcwYTVkZDA4NmRhZmYyYSIsImV4cGlyZXNBdCI6MTc1MDAwMDEyMCwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09Iiwic2lnbmF0dXJlIjoiK1hmYzlQMW1HOU5hMVwvYnRTSFVZWlVvTzk2WHczRGJQOWhrWGlGWDN1UWNOTlwvV01KOFwvMm9wQ05uU1ljcERHUEFKc244Q0hodENraDBnMWMzM2s0dmh3PSIsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0\"}",
+      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJzbHVnIjoiZXlKcGJtbDBhV0YwYjNKSmJtSnZlRWxrSWpvaU0yWTVZVEZqTUdVMVlqZGtNamcwTm1FeFpqTXdZemxsTkdRNFlqWTNOVEpsTUdFMFl6a3hNemRtWWpVMk1qaGtNR1V6WVRkak1UUmlPV1ExWmpZNE1pSXNJbWx6YzNWbFpFRjBJam94TnpVd01EQXdNREF3TENKdWIyNWpaU0k2SWtGQ1JXbE5NRkpXV201bFNXMWhjVGQ2VGpOMVhDOTNQVDBpTENKbGVIQnBjbVZ6UVhRaU9qRTNOVEF3TURBeE1qQXNJbk5qYUdWdFlWWmxjbk5wYjI0aU9qRXNJbk5wWjI1aGRIVnlaU0k2SWl0WVptTTVVREZ0UnpsT1lURmNMMkowVTBoVldWcFZiMDg1TmxoM00wUmlVRGxvYTFocFJsZ3pkVkZqVGs1Y0wxZE5TamhjTHpKdmNFTk9ibE5aWTNCRVIxQkJTbk51T0VOSWFIUkRhMmd3WnpGak16TnJOSFpvZHowaUxDSnBibWwwYVdGMGIzSkJaR1J5WlhOeklqb2lNSGd4T1dVM1pUTTNObVUzWXpJeE0ySTNaVGRsTjJVME5tTmpOekJoTldSa01EZzJaR0ZtWmpKaEluMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIn0=",
+      "contentJSON" : "{\"schemaVersion\":1,\"slug\":\"eyJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsImlzc3VlZEF0IjoxNzUwMDAwMDAwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJleHBpcmVzQXQiOjE3NTAwMDAxMjAsInNjaGVtYVZlcnNpb24iOjEsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIn0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\"}",
       "contentType" : "convos.org/pairing_join_request:1.0",
       "typeId" : "pairing_join_request",
       "versionMajor" : 1,
@@ -47,8 +47,8 @@
     },
     "pairing_message_pin_echo" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJwYXlsb2FkIjoiMTIzNDU2IiwidHlwZSI6InBpbl9lY2hvIn0=",
-      "contentJSON" : "{\"payload\":\"123456\",\"type\":\"pin_echo\"}",
+      "contentBase64" : "eyJ0eXBlIjoicGluX2VjaG8iLCJwYXlsb2FkIjoiMTIzNDU2In0=",
+      "contentJSON" : "{\"type\":\"pin_echo\",\"payload\":\"123456\"}",
       "contentType" : "convos.org/pairing_message:1.0",
       "typeId" : "pairing_message",
       "versionMajor" : 1,
@@ -241,7 +241,7 @@
     "signatureRecoveryByte" : 28,
     "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
     "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
-    "slug" : "eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwic2NoZW1hVmVyc2lvbiI6MSwiaW5pdGlhdG9yQWRkcmVzcyI6IjB4MTllN2UzNzZlN2MyMTNiN2U3ZTdlNDZjYzcwYTVkZDA4NmRhZmYyYSIsImV4cGlyZXNBdCI6MTc1MDAwMDEyMCwibm9uY2UiOiJBQkVpTTBSVlpuZUltYXE3ek4zdVwvdz09Iiwic2lnbmF0dXJlIjoiK1hmYzlQMW1HOU5hMVwvYnRTSFVZWlVvTzk2WHczRGJQOWhrWGlGWDN1UWNOTlwvV01KOFwvMm9wQ05uU1ljcERHUEFKc244Q0hodENraDBnMWMzM2s0dmh3PSIsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0",
+    "slug" : "eyJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsImlzc3VlZEF0IjoxNzUwMDAwMDAwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJleHBpcmVzQXQiOjE3NTAwMDAxMjAsInNjaGVtYVZlcnNpb24iOjEsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIn0",
     "verifyAtUnixSeconds" : 1750000001
   },
   "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",

--- a/ConvosTests/BootSettlementMonitorTests.swift
+++ b/ConvosTests/BootSettlementMonitorTests.swift
@@ -1,0 +1,87 @@
+import ConvosCore
+import XCTest
+@testable import Convos
+
+@MainActor
+final class BootSettlementMonitorTests: XCTestCase {
+    func testSettlesImmediatelyWhenAlreadyReadyAtBind() async throws {
+        let manager = MockSessionStateManager()
+        let readyResult = try await manager.waitForInboxReadyResult()
+        manager.setState(.ready(readyResult))
+
+        let monitor = BootSettlementMonitor()
+        monitor.bind(to: manager)
+
+        XCTAssertTrue(monitor.isSettled)
+    }
+
+    func testSettlesWhenReadyArrivesAfterBind() async throws {
+        let manager = MockSessionStateManager(initialState: .authorizing(inboxId: "inbox"))
+        let monitor = BootSettlementMonitor()
+        monitor.bind(to: manager)
+
+        XCTAssertFalse(monitor.isSettled)
+
+        let readyResult = try await manager.waitForInboxReadyResult()
+        manager.setState(.ready(readyResult))
+        await waitFor { monitor.isSettled }
+
+        XCTAssertTrue(monitor.isSettled)
+    }
+
+    func testSettlesViaFallbackTimeoutWhenReadyNeverArrives() async {
+        let manager = MockSessionStateManager(initialState: .authorizing(inboxId: "inbox"))
+        let monitor = BootSettlementMonitor()
+        monitor.bind(to: manager, fallbackTimeout: 0.05)
+
+        XCTAssertFalse(monitor.isSettled)
+
+        await waitFor { monitor.isSettled }
+        XCTAssertTrue(monitor.isSettled)
+    }
+
+    func testStaysSettledAfterLaterNonReadyStates() async throws {
+        let manager = MockSessionStateManager(initialState: .authorizing(inboxId: "inbox"))
+        let monitor = BootSettlementMonitor()
+        monitor.bind(to: manager)
+
+        let readyResult = try await manager.waitForInboxReadyResult()
+        manager.setState(.ready(readyResult))
+        await waitFor { monitor.isSettled }
+
+        manager.setState(.backgrounded(readyResult))
+        manager.setState(.authorizing(inboxId: "inbox"))
+        await Task.yield()
+
+        XCTAssertTrue(monitor.isSettled)
+    }
+
+    func testRebindBeforeSettlingReplacesObservation() async throws {
+        let first = MockSessionStateManager(initialState: .authorizing(inboxId: "inbox"))
+        let second = MockSessionStateManager(initialState: .authorizing(inboxId: "inbox"))
+        let monitor = BootSettlementMonitor()
+        monitor.bind(to: first)
+        monitor.bind(to: second)
+
+        let readyResult = try await first.waitForInboxReadyResult()
+        first.setState(.ready(readyResult))
+        await waitFor(timeout: 0.2) { monitor.isSettled }
+        XCTAssertFalse(monitor.isSettled, "A replaced observation must not settle the monitor")
+
+        second.setState(.ready(readyResult))
+        await waitFor { monitor.isSettled }
+        XCTAssertTrue(monitor.isSettled)
+    }
+
+    /// Polls until the condition holds, yielding the main actor between
+    /// checks so state-stream handlers can run.
+    private func waitFor(
+        timeout: TimeInterval = 2,
+        _ condition: () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+}

--- a/ConvosTests/ConversationsViewModelDeleteTests.swift
+++ b/ConvosTests/ConversationsViewModelDeleteTests.swift
@@ -265,6 +265,10 @@ private final class TestSessionManager: SessionManagerProtocol, @unchecked Senda
         base.conversationsRepository(for: consent)
     }
 
+    func conversationsPager(for consent: [Consent]) -> any ConversationsPagerProtocol {
+        base.conversationsPager(for: consent)
+    }
+
     func conversationsCountRepo(for consent: [Consent], kinds: [ConversationKind]) -> any ConversationsCountRepositoryProtocol {
         base.conversationsCountRepo(for: consent, kinds: kinds)
     }

--- a/docs/investigations/2026-08-04-startup-performance.md
+++ b/docs/investigations/2026-08-04-startup-performance.md
@@ -1,0 +1,481 @@
+# Startup Performance for Heavy Users - Investigation and Ranked Recommendations
+
+Date: 2026-08-04
+Scope: cold-start and foreground catch-up for heavy users (hundreds of conversations,
+thousands of backlogged messages), plus conversation-list invalidation behavior during
+those windows. Covers the app (ConvosCore + Convos targets) and libxmtp internals
+(local checkout at `~/workspace/libxmtp`, same 4.12.0 line as the pinned
+`ios-4.12.0-nightly.20260804.0f01ea1`).
+
+## TL;DR
+
+The hypothesis is confirmed on both fronts, with one important refinement each:
+
+1. **Catch-up concurrency is unbounded, and it duplicates work libxmtp already does
+   bounded.** `BatchCatchUp.prepareAll` spawns one task per conversation with no
+   concurrency cap (`BatchCatchUp.swift:359`), and each task performs a full network
+   `conversation.sync()` (`ConversationWriter.swift:265`). For N conversations that is
+   up to N simultaneous group syncs contending on libxmtp's single SQLite writer.
+   Meanwhile libxmtp's own `syncAllConversations` - which the app calls right
+   afterwards anyway - does the same job with a batched "which groups changed" check
+   and a fixed 10-way concurrency cap. The app runs the expensive unbounded shape
+   first and the efficient bounded shape second.
+
+2. **The conversation list does not thrash at the cell layer; it thrashes at the
+   query/hydration layer.** The list query has no pagination and hydrates every
+   conversation with its full association graph, the entire contact table, and an
+   N+1 per-agent-conversation subquery - and the `ValueObservation` driving it has
+   no `removeDuplicates`, no debounce, and a tracked region so broad that nearly any
+   database write re-runs the whole thing. The UIKit diffable layer downstream is
+   already well optimized, so the fix belongs in the repository, not the view.
+
+The single highest-impact change is restructuring catch-up to "sync once via libxmtp,
+then read locally with bounded concurrency" (recommendation R1). The best
+effort-to-impact ratio is adding debounce + dedup to the list observation (R2), which
+is a few lines. Full ranked list below.
+
+---
+
+## Part 1: What actually happens at boot
+
+### 1.1 Boot sequence (cold start, existing identity)
+
+All pre-first-frame work runs synchronously on the main thread in `ConvosApp.init`
+(`Convos/ConvosApp.swift:24-165`): Sentry (`:55`), Firebase (`:85`),
+`ConvosClient.client(...)` (`:108`) - which opens GRDB and runs migrations
+synchronously (`DatabaseManager.swift:30-41`, `:85`) - and
+`ConversationsViewModel.init` (`:127`), which primes the list via a bounded read that
+blocks main for up to 50ms (`BoundedInitialRead.swift:49-70`).
+
+The async session chain is strictly serial (`SessionManager.swift:156-204`):
+
+```
+registerDeviceIfNeeded()          network call, gates everything after it
+  -> prewarmUnusedConversation()  builds the XMTP client (Client.build)
+     -> SessionStateMachine.authorize
+        -> authenticateBackend()  SIWE + App Check round trip, up to 3 retries
+        -> handleAuthorized:
+             runBatchCatchUp()          <- the heavy part, blocks .ready
+             syncingManager.start()     <- streams + syncAllConversations
+             emitStateChange(.ready)
+```
+
+(`SessionStateMachine.swift:819-845`; catch-up call at `:828`.)
+
+The UI renders from the local DB before `.ready`, so the app is not visually blank -
+but the catch-up storm saturates CPU, the libxmtp SQLite writer, and the GRDB reader
+pool while the user is trying to scroll, which is what "unusable" looks like in
+practice.
+
+### 1.2 The catch-up fan-out (the core problem)
+
+`runBatchCatchUp` (`SessionStateMachine.swift:1053-1066`) reads the cursor from
+UserDefaults key `convos.pushNotifications.lastWelcomeProcessed.<inboxId>` - the same
+key the NSE advances - and hands it to `BatchCatchUp.run`
+(`ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift:112`):
+
+- `listGroups(lastActivityAfterNs: cursor)` - one FFI call. With a nil cursor
+  (fresh install, pushes disabled, or NSE never ran) this returns **every**
+  conversation.
+- `prepareAll` (`BatchCatchUp.swift:353-400`) then fans out:
+
+```swift
+return await withTaskGroup(of: PreparedEntry?.self) { taskGroup in
+    for group in groups {          // N groups -> N tasks, no concurrency bound
+        taskGroup.addTask {
+            try await Self.withTimeout(seconds: timeout) {   // 30s per conversation
+                try await Self.prepareEntry(group: group, ...)
+            }
+        }
+    }
+    ...
+}
+```
+
+- Each `prepareEntry` (`:402-448`) calls `conversationWriter.prepare`, whose first
+  line is `try await conversation.sync()` (`ConversationWriter.swift:265`) - a
+  network round trip per conversation - followed by metadata extraction, a member
+  fetch, a DB cursor read, and `group.messages(afterNs:)`.
+
+The only guard is the per-conversation 30-second timeout. There is no semaphore, no
+window, no chunking. Elsewhere in the same codebase the equivalent loops are bounded:
+`ConversationConsentReconciler` uses a 6-wide sliding window
+(`ConversationConsentReconciler.swift:85`), and push-topic reconcile chunks at 100
+topics per request (`PushTopicSubscriptionManager.swift:116`).
+
+To BatchCatchUp's credit, the write side is already excellent: one big transaction
+for all conversations and regular messages (`:167-176`), one cursor-advance
+transaction (`:230-235`), supplementals in small per-type transactions, and side
+effects on a detached background task. The problem is purely the prepare-phase
+network fan-out.
+
+**Answer to "how many tasks concurrently catch up for N conversations": up to N,
+unbounded, each performing a network group sync - and the whole thing re-runs on
+every foregrounding and every network reconnect** (`SessionStateMachine.swift:982`,
+`:1488-1501`), followed each time by another `syncAllConversations` inside
+`SyncingManager.resume()` (`SyncingManager.swift:760`).
+
+### 1.3 What libxmtp does underneath (why the fan-out is redundant)
+
+From the local checkout (`crates/xmtp_mls/src/groups/welcome_sync.rs`):
+
+- `sync_all_welcomes_and_groups` (the FFI `syncAllConversations`) pulls welcomes
+  serially, then makes **one batched** `get_newest_message_metadata(group_ids)` call
+  and compares against local per-group cursors, so only groups with genuinely new
+  server messages get synced (`welcome_sync.rs:219, 439`). Quiet groups are nearly
+  free.
+- Groups that do need sync are processed with a **fixed 10-way concurrency cap**
+  (`sync_groups_in_batches(filtered, 10)`, `welcome_sync.rs:377-392`).
+- `conversation.sync()` per group takes a per-group mutex, makes ~1-2 network round
+  trips, and processes each message as **one SQLite write transaction** (MLS decrypt
+  + cursor + insert; `mls_sync.rs:2321`). SQLite is WAL with a 25-connection pool,
+  but WAL still means **one writer at a time** (`xmtp_configuration/src/common/db.rs`,
+  `pool.rs:37-38`). Concurrent group syncs serialize at the writer; extra app-side
+  concurrency buys decrypt CPU parallelism at best and lock contention at worst.
+- Cold-boot extra: the per-group `maybe_update_installations` throttle (30 min) has
+  always expired at boot, so every actively-synced group also issues per-member
+  identity-update network queries (`mls_sync.rs:4066`) - a per-group-times-members
+  network burst the app cannot see but pays for.
+- libxmtp also ships `catch_up_to_live(timeout_ms)` (XIP-83 bounded bidi catch-up,
+  `bindings/mobile/src/mls.rs:786`, `subscriptions/catch_up.rs`): one multiplexed
+  stream over all owned topics from durable cursors, chunked so a large account gets
+  a bounded first frame, with a timeout that returns a partial summary. The app does
+  not use it (it is d14n-gated; the `XMTP_BIDI_STREAMS_ENABLED` env hook already
+  exists at `ConvosApp.swift:45-48`).
+
+So the net effect on a heavy cold boot: N unbounded app-side `conversation.sync()`
+calls race each other into a single-writer SQLite funnel, then `syncAllConversations`
+re-checks everything (cheaply, but still), then `discoverNewConversations`
+(`SyncingManager.swift:569-613`) lists all groups again and - for any group missing
+from the app DB - processes them **sequentially** with two awaited FFI calls per
+group (`creatorInboxId()`, `members.count`). On a fresh install/pairing, where the
+app DB is empty, that discover loop is the dominant cost: ~N sequential
+per-conversation stores.
+
+### 1.4 The stream path per-message cost
+
+Once streams are live, every incoming group message runs
+`StreamProcessor.processMessage` (`StreamProcessor.swift:231-340`), which calls
+`conversationWriter.store(conversation:)` (`:285`) before storing the message.
+`store` = `prepare` + persist, and `prepare` starts with `conversation.sync()` - so
+**every streamed message triggers another network group sync plus a full
+conversation/member reconciliation write, then a second write transaction for the
+message itself, plus a possible third for unread state** (`:316`, `:328`). The no-op
+diff short-circuit (#857) makes the conversation persist cheap when nothing changed,
+but the sync round trip and the 2-3 write transactions per message remain. During a
+stream burst this both floods the writer and (see Part 2) fires the list observation
+per transaction.
+
+## Part 2: The conversation list pipeline
+
+### 2.1 The query: unpaginated, everything hydrated
+
+`ConversationsRepository.composeAllConversations`
+(`ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift:147-204`)
+fetches **all** non-draft, consented, non-expired conversations - no LIMIT anywhere
+in the pipeline (verified: no limit/prefix/page machinery exists in the repository,
+view model, or view controller). Per row, `detailedConversationQuery()` (`:311-375`)
+loads: all invites, creator member with 5 nested optional joins (profile, avatar
+slot, inviter identity, my-profile identity, inviter-my-profile identity), local
+state, agent-builder summary, last message via CTE, latest agent join request via
+CTE, and **all members** each with the same 5 nested joins. The two CTEs are cheap
+(pointer-based PK lookups with substr-capped text, `DBConversation.swift:239-266`).
+
+On top of the main query, each fire also runs:
+
+- A **whole-contact-table read**: `contactNameResolverInTransaction` does
+  `DBContact.fetchAll(db)` (`ContactsRepository.swift:265-274`), pulling every
+  contact into a dictionary and adding `contact` to the tracked region.
+- An **N+1 agent-DM fold**: for every conversation with a verified agent member, a
+  full extra `composeOneToOne` detailed query runs inside the same transaction
+  (`ConversationsRepository.swift:169-189`).
+
+### 2.2 The invalidation storm
+
+The publisher (`ConversationsRepository.swift:51-62`) is:
+
+```swift
+ValueObservation
+    .tracking { db in try db.composeAllConversations(consent: consent) }
+    .publisher(in: dbReader)
+    .replaceError(with: [])
+```
+
+No `.removeDuplicates()`, no debounce, no throttle. The auto-tracked region is the
+union of every table the read touches: conversation, message (via CTEs), contact,
+conversation_members, profile, avatar slots, localState, invite,
+agent_builder_summary, inbox. The message-insert trigger
+`conversation_pointer_message_insert` (`SharedDatabaseMigrator.swift:439-448`)
+updates `conversation.lastMessageId` on every eligible message insert, so **a single
+message insert anywhere re-runs the entire compose**. During catch-up/stream bursts
+- where the stream path produces 2-3 transactions per message and supplementals run
+one small transaction each - the full query + full-contact read + N+1 fold + full
+re-hydration re-executes per commit.
+
+The sibling agent-template publisher in the same file added `.removeDuplicates()`
+with a comment explaining exactly this hazard (`ConversationsRepository.swift:113-115`).
+The main list publisher and the count publisher
+(`ConversationsCountRepository.swift:15-25`) never got the same guard.
+
+Multiplier: every `sink` on a ValueObservation publisher starts an independent
+observation. `ConversationsViewModel` (`ConversationsViewModel.swift:638`) and
+`ThingsOverviewViewModel` (`ThingsOverviewViewModel.swift:68`) both subscribe (and
+`AgentDmPageView` adds another while open), so the full compose typically runs 2-3
+times per fire. `ThingsOverviewViewModel` additionally holds one
+`agentFilesLinksRepository` observation **per conversation** (`:84-92`).
+
+### 2.3 The in-memory side
+
+`ConversationsViewModel` receives the full `[Conversation]` on main and replaces the
+array wholesale (`ConversationsViewModel.swift:644-646`), then re-runs
+`ShareSuggestionDonator.donate` over the whole list per emission (`:648`). Because
+the type is `@Observable`, derived properties (`pinnedConversations`,
+`unpinnedConversations`, etc., `:219-256`) re-filter/re-sort the full array on the
+main thread on every access with no memoization. The view controller then does an
+O(N) changed-id diff per emission (`ConversationsViewController.swift:161-198`).
+
+Importantly, the downstream is already good: the list is a UICollectionView with an
+id-keyed diffable data source that only reconfigures rows whose displayed fields
+changed (`ConversationsViewController.swift:436-473`), and cells update in place via
+an observable wrapper (`ConversationListItemCell.swift:24-63`). The wasted work is
+above the snapshot: SQL, hydration, main-thread delivery, and diffing - all O(full
+list), all per commit, times the number of subscribers.
+
+### 2.4 Per-row costs at first render
+
+- Every DM row's avatar starts its **own per-inbox GRDB ValueObservation**
+  (`InboxProfileAvatarView.swift:47-49, 71-74`;
+  `ProfilesRepository.profilePublisher`, `ProfilesRepository.swift:68-86`). 50
+  visible-ish DMs = 50 extra observations against a reader pool capped at **5
+  connections** (`DatabaseManager.swift:58`), all re-firing during sync writes.
+- Avatar views seed synchronously in `init` via `ImageCache.shared.image(for:)`
+  (`ConversationAvatarViews.swift:27`), which can fall through to a synchronous disk
+  read + decode once per identity on the main thread; DM rows pay it twice
+  (conversation + profile).
+- Encrypted-avatar prefetch fires per stored conversation during sync
+  (`ConversationWriter.swift:1451` -> `EncryptedImagePrefetcher`, 4-wide), competing
+  with interactive fetches on a shared serial disk queue that also runs a full
+  cache-directory enumeration at launch (`ImageCache.swift:196, 218, 805-866`).
+
+## Part 3: Ranked recommendations
+
+One unified ranking by estimated impact on heavy-user boot/foreground. The three
+candidates under evaluation are marked **[candidate]**; the rest are the additional
+alternatives requested. Impact estimates assume a heavy user (300-500 conversations,
+1k+ message backlog).
+
+### R1. Restructure catch-up: sync once via libxmtp, then read locally, bounded - **[candidate: catch-up concurrency]**
+
+Impact: **very high** (likely 5-20x reduction in boot network calls and writer
+contention). Effort: medium. Risk: low - data flow is unchanged, only ordering and
+concurrency.
+
+Three coordinated changes:
+
+- Run **one** `syncAllConversations` first (it is activity-filtered and internally
+  capped at 10-way concurrency), then run BatchCatchUp's prepare phase **without**
+  the per-conversation `conversation.sync()` - after the global sync,
+  `group.messages(afterNs:)` is a local read. This deletes N network round trips
+  and lets libxmtp's own batched metadata check decide which groups need work.
+  (Prepare would need a sync-free variant of `ConversationWriter.prepare`;
+  `conversation.sync()` at `ConversationWriter.swift:265` is the line to bypass.)
+- Bound whatever concurrency remains in `prepareAll` to ~4-8 (mirror
+  `ConversationConsentReconciler`'s sliding window at
+  `ConversationConsentReconciler.swift:112-129`). Local-only prepares are
+  reader-pool-bound; more than that just contends.
+- Parallelize (bounded) and batch `discoverNewConversations`
+  (`SyncingManager.swift:590-603`) - it is currently strictly sequential with two
+  awaited FFI calls per new group, which dominates fresh-install/pairing boot.
+
+Also fold in: skip the duplicate `syncAllConversations` in `resume()` when
+`runBatchCatchUp` just ran one (foreground currently pays batch + sync + discover +
+push reconcile back-to-back; `SessionStateMachine.swift:982` +
+`SyncingManager.swift:760`).
+
+### R2. Debounce + dedupe the conversation list observation - **[candidate: invalidation/thrashing]** (cheapest big win)
+
+Impact: **high** (collapses hundreds of full recomposes into a handful during any
+burst). Effort: **trivial to small**. Risk: minimal.
+
+- Add `.removeDuplicates()` to `conversationsPublisher`
+  (`ConversationsRepository.swift:60`) - the agent-template publisher already does
+  this for exactly this reason - and to `ConversationsCountRepository`.
+  Note: dedup happens after the query runs, so this fixes main-thread churn, not
+  query cost; pair with a debounce for the query itself.
+- Throttle emissions (e.g. `.throttle(for: .milliseconds(250), latest: true)`) or
+  schedule the observation on a dedicated queue with coalescing. GRDB runs the
+  fetch per impactful commit; a debounce between commit and fetch is the lever that
+  actually cuts query executions during a catch-up burst.
+- Share one observation between `ConversationsViewModel` and
+  `ThingsOverviewViewModel` (`.share()`/`.multicast` on the publisher, or route both
+  through one repository instance) so the compose runs once per fire, not 2-3 times.
+
+### R3. Paginate / limit the conversation list query - **[candidate: pagination]**
+
+Impact: **high** for heavy users (per-fire cost becomes O(page) instead of O(N);
+first paint faster; memory down). Effort: medium (repository + view model + data
+source incremental load). Risk: medium - ordering with the in-memory agent-DM
+re-sort and pinned handling needs care.
+
+Concretely: `composeAllConversations` gains a `limit`/`after` cursor keyed on the
+existing sort key `COALESCE(lastMessage.date, createdAt) DESC`; the collection view
+requests the next page near the end of scroll. Two subtleties found in this
+investigation:
+
+- Pinned conversations are a separate small set - query them separately (a
+  `PinnedConversationsCountRepository` already exists) so the paged query is pure.
+- The unread filter and the "float on agent-DM reply" re-sort currently operate on
+  the full in-memory array; both are expressible in SQL (unread via localState join,
+  DM lane via a max over the folded DM date) once R5/R6 land.
+
+Even a blunt `LIMIT 100` with "show more" would deliver most of the win for the
+worst-affected users.
+
+### R4. Stop per-message `conversation.sync()` + conversation persist on the stream path
+
+Impact: **high** during any message burst (removes a network round trip and 1-2
+write transactions per incoming message). Effort: low-medium. Risk: low.
+
+`StreamProcessor.processMessage` calls `conversationWriter.store` for every group
+message (`StreamProcessor.swift:285`), which re-syncs and re-reconciles the group.
+Gate it: only run the full store when the conversation is unknown locally or a
+group-updated/commit message arrived; plain application messages should write just
+the message row. The existing no-op diff short-circuit proves the persist is usually
+redundant - the point is to skip the sync and member fetch that precede it.
+
+### R5. Remove the N+1 agent-DM fold and whole-contact-table read from compose
+
+Impact: medium-high (directly multiplies R2/R3 savings; the contact fetch also
+broadens the tracked region to every contact write). Effort: low-medium.
+
+- Fold the agent-DM summary in SQL (a lateral-style join on the agent member's DM
+  conversation) or cache the DM ids so the per-conversation `composeOneToOne`
+  (`ConversationsRepository.swift:173`) disappears.
+- Resolve contact names only for the inboxes actually present in the page
+  (`WHERE inboxId IN (...)`) instead of `DBContact.fetchAll`
+  (`ContactsRepository.swift:266`).
+
+### R6. In-memory conversation list with incremental updates - **[candidate: in-memory list]**
+
+Impact: medium-high, **but largely subsumed by R2+R3+R5 at much lower risk**.
+Effort: high. Risk: high (cache-invalidation correctness, the exact bug class GRDB
+observation currently absorbs for free).
+
+Maintaining the hydrated list in memory and applying row-level deltas (per-table
+DatabaseRegionObservation, or diffing snapshots) eliminates re-query cost entirely,
+which R2/R3 only reduce. Recommended sequencing: do R2/R3/R5 first and re-measure;
+adopt R6 only if a profile still shows compose dominating. If pursued, the shape is
+a repository-level actor cache keyed by conversation id, invalidated per-table, with
+the existing publisher emitting from the cache - the view layer needs no changes
+(it already diffs by id).
+
+### R7. Coalesce the foreground/reconnect re-sync avalanche
+
+Impact: medium-high for users who app-switch often or ride flaky networks. Effort:
+low-medium.
+
+Every foreground runs: `assertInstallationActive` (blocking network probe,
+`SessionStateMachine.swift:975`) -> full `runBatchCatchUp` -> `resume()` (stream
+restart + another `syncAllConversations` + discover + push reconcile). Every network
+up-transition triggers `resume()` too (`:1488-1501`). Suggestions: skip catch-up when
+the last one completed within a short window (e.g. 30-60s); make
+`assertInstallationActive` non-blocking (verify concurrently, tear down on failure);
+debounce network-flap resumes; after R1, `resume()` needs no extra
+`syncAllConversations` at all.
+
+### R8. Batch the per-DM-row profile observations
+
+Impact: medium (removes 50+ concurrent observations competing for 5 reader
+connections during boot; fixes avatar-driven read contention). Effort: medium.
+
+`InboxProfileAvatarView` starts one `profilePublisher` per row
+(`InboxProfileAvatarView.swift:47`). The list hydration already loads every member's
+profile in the main query - pass the hydrated profile/avatar down instead of
+re-observing per row, or introduce one shared observation keyed by the set of
+visible inbox ids. Related cheap fix: make the synchronous `ImageCache.image(for:)`
+seed in avatar `init`s (`ConversationAvatarViews.swift:27`) async-first so first
+render never does main-thread disk I/O.
+
+### R9. Take non-critical work off the serial boot chain
+
+Impact: medium for time-to-interactive (hundreds of ms to seconds, variance-heavy).
+Effort: low per item.
+
+- `registerDeviceIfNeeded()` (network) currently gates the XMTP client build
+  (`SessionManager.swift:156-204`) - build the client first, register concurrently.
+- `authenticateBackend()` (SIWE, up to 3 retries) sits between client build and
+  `.ready` (`SessionStateMachine.swift:1349-1420`) - evaluate whether catch-up and
+  streams can start on cached credentials while it refreshes.
+- Migrations run synchronously pre-first-frame (`ConvosApp.swift:108` ->
+  `DatabaseManager.swift:85`); releases that add full-table backfills
+  (`SharedDatabaseMigrator.swift:388, 606, 1026`) make heavy users pay them on the
+  launch frame. Consider an async migration gate with a lightweight splash.
+- Cold-launch niceties already exist (libxmtp log writer detached, profile backfill
+  post-ready) - this extends the same pattern.
+
+### R10. Adopt libxmtp `catch_up_to_live` (XIP-83 bounded catch-up) - strategic
+
+Impact: potentially the biggest long-term win (bounded first frame regardless of
+account size, partial-progress timeouts, one multiplexed stream instead of per-group
+round trips). Effort: high; gated on d14n availability per environment. The
+`XMTP_BIDI_STREAMS_ENABLED` hook already exists (`ConvosApp.swift:45-48`). Track it
+as the eventual replacement for the R1 shape rather than an immediate fix. Also
+worth raising upstream: the cold-boot `maybe_update_installations` storm (30-minute
+throttle always expired at boot; per-member identity queries per active group,
+`mls_sync.rs:4066`) - a boot-time grace or lazy path would benefit every client.
+
+### Smaller items noticed (not ranked, worth tickets)
+
+- DEBUG builds trace **every SQL statement** (`DatabaseManager.swift:78-80`), and
+  DEBUG covers Dev and PR TestFlight - skews any profiling done on those builds;
+  measure on Release-configuration or gate the trace.
+- `ImageCache` runs a full disk-cache enumeration at init on the same serial queue
+  as interactive reads (`ImageCache.swift:196, 218`) - head-of-line blocking at
+  first render; delay it or use a concurrent queue with a barrier.
+- `IncomingMessageWriter.chronologicalSortId` does an O(n) `UPDATE ... sortId + 1`
+  shift for out-of-order inserts (`IncomingMessageWriter.swift:541-569`) - backlog
+  replay after pairing can hit this repeatedly.
+- `ShareSuggestionDonator.donate` runs over the full list on every emission
+  (`ConversationsViewModel.swift:648`) - throttle to once per few minutes.
+- The temporary agent-join poll re-runs `syncAllConversations` every 5s for 150s
+  after joins (`SyncingManager.swift:1111-1123`) - fine once R1 lands, but worth
+  remembering it exists when reading boot traces.
+
+## Measurement plan
+
+`[PERF]` logs already cover the key spans: `sync.all_conversations`
+(`SyncingManager.swift:503`), `catchup.batch.messages` with conv/message/skip counts
+(`BatchCatchUp.swift:253`), `message.process` (`StreamProcessor.swift:332`),
+`catchup.batch.invites` (`SyncingManager.swift:336`). Missing and cheap to add
+before starting: a counter/timer on `composeAllConversations` executions (count per
+minute is the thrash metric R2/R3 must drive down), a gauge for
+`BatchCatchUp.prepareAll` peak in-flight tasks, and time-to-first-list-render.
+Baseline on a heavy account with a Release-config build (see DEBUG trace caveat),
+then re-measure after each of R1/R2/R3 independently.
+
+## Appendix: where each conclusion comes from
+
+- Unbounded fan-out: `BatchCatchUp.swift:353-400`; per-conversation network sync:
+  `ConversationWriter.swift:260-281`; boot trigger: `SessionStateMachine.swift:828`;
+  foreground trigger: `:982`; network-flap trigger: `:1488-1501`.
+- libxmtp bounded sync + activity filter: `welcome_sync.rs:219, 377-392, 439`;
+  single-writer SQLite: `xmtp_configuration/src/common/db.rs`, `pool.rs:37-38`;
+  per-message write transaction: `mls_sync.rs:2321`; installation-update storm:
+  `mls_sync.rs:4066`; unused bounded catch-up API: `bindings/mobile/src/mls.rs:786`.
+- List query and observation: `ConversationsRepository.swift:42-204, 311-375`;
+  contact-table read: `ContactsRepository.swift:265-274`; message-insert trigger:
+  `SharedDatabaseMigrator.swift:439-448`; missing dedup vs the sibling publisher:
+  `ConversationsRepository.swift:113-115`.
+- View model / view: `ConversationsViewModel.swift:638-662, 219-256`;
+  `ConversationsViewController.swift:161-198, 436-473`;
+  `ThingsOverviewViewModel.swift:67-92`.
+- Per-row profile observations and image seeds: `InboxProfileAvatarView.swift:47-89`;
+  `ProfilesRepository.swift:68-86`; `ConversationAvatarViews.swift:27`;
+  `ImageCache.swift:196-245, 805-866`; reader pool cap: `DatabaseManager.swift:58`.
+- Boot chain and main-thread work: `ConvosApp.swift:24-165`;
+  `SessionManager.swift:156-204, 323-460`; `SessionStateMachine.swift:521-584,
+  1349-1420`; `BoundedInitialRead.swift:49-70`.
+- Prior art this builds on: #857 (stream write-storm fixes),
+  `docs/plans/batch-catchup-since-last-background.md` (the batch catch-up design),
+  `docs/plans/conversations-uicollectionview.md` (the landed list rendering
+  migration).


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789304357&installation_model_id=20076&pr_number=1320&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1320&signature=0f96b56c2b6930d5fdb80508d878d0be6c7528646701b1ec694b2db423de88e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve startup performance with windowed conversation paging and bounded catch-up parallelism
> - Replaces the flat `conversationsPublisher` with a windowed `ConversationsPager` that emits `ConversationsPage` (pinned + limited unpinned), supports infinite scroll via `loadMore()`, and persists selection for rows outside the current window.
> - Adds `BootSettlementMonitor` to defer diffed/animated list updates until the session reaches `.ready` state (or a fallback timeout), avoiding jank during cold start.
> - Bounds `BatchCatchUp` prepare-phase parallelism to 6 concurrent conversations and adds a client-wide `syncAllConversations` call before per-conversation syncs, with per-conversation sync skipped when the global sync succeeds.
> - Adds a 30s skip window for redundant batch catch-ups and a 2s debounce before resuming sync after network reconnect in `SessionStateMachine`.
> - Adds `removeDuplicates()` and optional `throttleInterval` to `ConversationsRepository` and `MessagesRepository` publishers to suppress redundant emissions during write bursts.
> - Risk: the conversations list now operates on a LIMIT-bounded window; navigation and selection outside the window require async pager fetches, which can return `nil` if the conversation is not list-eligible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dec82c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->