### PR TITLE
fix: route escalation card icon through the ability catalog

### DIFF
--- a/Convos/Abilities/AbilityEscalationPromptCard.swift
+++ b/Convos/Abilities/AbilityEscalationPromptCard.swift
@@ -16,6 +16,12 @@ struct AbilityEscalationPromptCard: View {
     /// Display name resolved from the catalog; falls back to the raw
     /// ability id only if the fixture and catalog ever diverge.
     let abilityDisplayName: String
+    /// The catalog entry backing this ask, when it has resolved. Nil in
+    /// the brief window between the card appearing and the async catalog
+    /// lookup completing, and whenever the catalog carries no `icon` for
+    /// this ability -- either way, `pillContent` falls back to the local
+    /// symbol.
+    let ability: AbilitiesAPI.Ability?
     let onTap: () -> Void
 
     var body: some View {
@@ -45,10 +51,7 @@ struct AbilityEscalationPromptCard: View {
 
     private var pillContent: some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
-            Image(systemName: AbilityIconView.symbolName(for: request.abilityId))
-                .font(.body)
-                .foregroundStyle(.colorTextPrimary)
-                .frame(width: Constant.iconSize, height: Constant.iconSize)
+            pillIcon
 
             Text(abilityDisplayName)
                 .font(.callout)
@@ -66,6 +69,21 @@ struct AbilityEscalationPromptCard: View {
                 .fill(Color.colorFillMinimal)
         )
         .contentShape(.rect)
+    }
+
+    /// The catalog icon once resolved, matching `AbilityEscalationApprovalSheet`'s
+    /// header; falls back to today's local SF Symbol otherwise -- including
+    /// while the backend has not yet populated `icon.iosUrl` for any ability.
+    @ViewBuilder
+    private var pillIcon: some View {
+        if let ability {
+            AbilityIconView(ability: ability, iconSize: Constant.iconSize, showsBackground: false)
+        } else {
+            Image(systemName: AbilityIconView.symbolName(for: request.abilityId))
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+                .frame(width: Constant.iconSize, height: Constant.iconSize)
+        }
     }
 
     private enum Constant {
@@ -87,6 +105,7 @@ struct AbilityEscalationPromptSurface: View {
                 AbilityEscalationPromptCard(
                     request: request,
                     abilityDisplayName: abilityDisplayName(for: request),
+                    ability: matchedAbility(for: request),
                     onTap: handleCardTap
                 )
             }
@@ -97,10 +116,19 @@ struct AbilityEscalationPromptSurface: View {
     }
 
     private func abilityDisplayName(for request: AbilityDelegationRequest) -> String {
-        guard let ability = viewModel.pendingAbility, ability.id == request.abilityId else {
+        guard let ability = matchedAbility(for: request) else {
             return request.abilityId
         }
         return ability.displayName.resolved()
+    }
+
+    /// The resolved catalog entry for `request`, or nil if the async
+    /// catalog lookup hasn't landed yet (or resolved a different ask).
+    private func matchedAbility(for request: AbilityDelegationRequest) -> AbilitiesAPI.Ability? {
+        guard let ability = viewModel.pendingAbility, ability.id == request.abilityId else {
+            return nil
+        }
+        return ability
     }
 
     private func handleCardTap() {
@@ -125,11 +153,50 @@ struct AbilityEscalationPromptSurface: View {
     }
 }
 
-#Preview("Prompt card") {
+#Preview("Prompt card - symbol fallback") {
     AbilityEscalationPromptCard(
         request: MockAbilityEscalationService.scriptedRequest(conversationId: "mock-conversation-1"),
         abilityDisplayName: "Google Calendar",
+        ability: nil,
         onTap: {}
     )
     .padding(DesignConstants.Spacing.step4x)
+}
+
+#Preview("Prompt card - catalog icon") {
+    // Constructed inline with a self-contained data: URI rather than a
+    // shared fixture: the backend does not populate `icon.iosUrl` yet (see
+    // MockAbilitiesService's googlecalendar entry), so this is preview-only
+    // stand-in data for the day it does, kept off the shared catalog to
+    // avoid changing every other mock-mode surface's rendering.
+    let previewIcon: AbilitiesAPI.AbilityIcon? = try? AbilitiesAPI.AbilityIcon(
+        iosUrl: PreviewData.calendarIconDataUrl,
+        androidUrl: PreviewData.calendarIconDataUrl
+    )
+    let ability: AbilitiesAPI.Ability? = try? AbilitiesAPI.Ability(
+        id: "googlecalendar",
+        version: 1,
+        displayName: AbilitiesAPI.LocalizedText(en: "Google Calendar"),
+        subtitle: AbilitiesAPI.LocalizedText(en: "View and edit events"),
+        icon: previewIcon,
+        auth: AbilitiesAPI.AbilityAuth(type: .oauth),
+        bundles: []
+    )
+    if let ability {
+        AbilityEscalationPromptCard(
+            request: MockAbilityEscalationService.scriptedRequest(conversationId: "mock-conversation-1"),
+            abilityDisplayName: ability.displayName.resolved(),
+            ability: ability,
+            onTap: {}
+        )
+        .padding(DesignConstants.Spacing.step4x)
+    }
+}
+
+/// Self-contained preview fixtures: a data: URI so `AsyncImage` has a real
+/// image to decode without any network dependency.
+private enum PreviewData {
+    static let calendarIconDataUrl: String = """
+    data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAKklEQVR42mOQKn5BU8QwasGoBaMWjFowasGoBaMWjFowasGoBaMWDBULACYM1EwIDQXQAAAAAElFTkSuQmCC
+    """
 }

--- a/Convos/Abilities/AbilityRowComponents.swift
+++ b/Convos/Abilities/AbilityRowComponents.swift
@@ -6,6 +6,10 @@ import SwiftUI
 /// ability id (the backend omits icons until its asset story lands).
 struct AbilityIconView: View {
     let ability: AbilitiesAPI.Ability
+    /// Defaults preserve every existing call site's 40pt chip.
+    var iconSize: CGFloat = Constant.iconSize
+    /// Defaults preserve every existing call site's filled background.
+    var showsBackground: Bool = true
 
     var body: some View {
         Group {
@@ -21,11 +25,16 @@ struct AbilityIconView: View {
                 symbolImage
             }
         }
-        .frame(width: Constant.iconSize, height: Constant.iconSize)
-        .background(
+        .frame(width: iconSize, height: iconSize)
+        .background(backgroundChip)
+    }
+
+    @ViewBuilder
+    private var backgroundChip: some View {
+        if showsBackground {
             RoundedRectangle(cornerRadius: DesignConstants.CornerRadius.regular)
                 .fill(Color.colorFillMinimal)
-        )
+        }
     }
 
     private var iconUrl: URL? {


### PR DESCRIPTION
## Summary

- `AbilityEscalationPromptCard`'s pill hardcoded `Image(systemName: AbilityIconView.symbolName(...))` instead of going through the catalog-resolved icon that `AbilityEscalationApprovalSheet`'s header already uses one screen deeper.
- Threads the already-resolved `AbilitiesAPI.Ability?` from `ConversationEscalationViewModel.pendingAbility` through `AbilityEscalationPromptSurface` into the card.
- Gives `AbilityIconView` two new parameters (`iconSize`, `showsBackground`), both defaulted to preserve its existing 40pt-chip-with-background rendering at all six other call sites. The new call site asks for a bare 24pt icon to match the pill's existing symbol sizing.
- Falls back to today's SF Symbol rendering whenever `ability` is nil -- the brief window before the async catalog lookup resolves, and (until a parallel backend change lands) every request, since the backend does not populate `icon.iosUrl` yet. That fallback path is what runs in production today and is unchanged by this diff.

## Test plan

- [x] `swiftlint lint --strict` clean on both changed files
- [x] `swiftformat --lint` clean on both changed files
- [x] `xcodebuild build` (Dev configuration, iPhone 17 Pro simulator) succeeds with zero warnings/errors
- [x] Verified both render states on-device: nil `ability` renders the SF Symbol exactly as before; a resolved `ability` with a populated `icon.iosUrl` renders through `AsyncImage` as a bare 24pt icon with no background chip
- [x] Added a second `#Preview` variant so both states are reviewable without a device

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789312689&installation_model_id=20076&pr_number=1321&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1321&signature=54a80bc19abfe0fe4e1471f4231e3bb5ea34b8d72e35f8f7f17dd9f76c498b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route escalation card icon through the ability catalog in `AbilityEscalationPromptCard`
> - `AbilityEscalationPromptCard` gains an optional `ability` property; when set, the pill renders the catalog icon via `AbilityIconView` (24pt, no background) instead of the local SF Symbol fallback.
> - `AbilityEscalationPromptSurface` resolves the ability via a new `matchedAbility(for:)` helper and passes it to the card, also reusing that helper for display name resolution.
> - `AbilityIconView` is extended with configurable `iconSize` and `showsBackground` parameters (defaults preserved) to support the new usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 402b0d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->