### PR TITLE
fix: couple Abilities v2 to its live backend so they cannot disagree

### DIFF
--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -36,10 +36,11 @@ struct AbilitiesSelection {
 /// app-wide so state changes carry across surfaces (connecting an ability
 /// in settings is immediately visible in conversation info).
 ///
-/// `configure(...)` wires the live transport at app start; the Debug menu's
-/// mock/live sub-toggle (default live) picks which pair `selection`
-/// serves. Previews and tests never call `configure`, so they fall back to
-/// the mock, mirroring `CreditsServices`.
+/// `configure(...)` wires the live transport at app start; `useLiveBackend`
+/// (always true whenever `FeatureFlags.isAbilitiesV2Enabled` is on, see
+/// below) picks which pair `selection` serves. Previews and tests never
+/// call `configure`, so they fall back to the mock, mirroring
+/// `CreditsServices`.
 enum AbilitiesServices {
     /// Set once during `ConvosApp.init` before any surface can read them;
     /// the actor-based service handles its own concurrency.
@@ -58,6 +59,7 @@ enum AbilitiesServices {
     /// The atomic (service, authorizer) pair for the current mode. Resolve
     /// once per screen/view-model lifetime and pass the whole value down;
     /// never read the halves at different times.
+    @MainActor
     static var selection: AbilitiesSelection {
         guard let liveService, useLiveBackend else {
             return AbilitiesSelection(service: mockService, escalation: escalationService)
@@ -102,6 +104,7 @@ enum AbilitiesServices {
     /// before touching the network or the cache, so a cold-launch call
     /// simply waits for identity instead of writing an accountless
     /// catalog. No-op in mock mode or before `configure`.
+    @MainActor
     static func refreshCatalogInBackground() async {
         guard useLiveBackend, let liveService else { return }
         await liveService.refreshCatalog()
@@ -119,21 +122,37 @@ enum AbilitiesServices {
     }
 
     /// Debug sub-toggle under the Abilities V2 flag: live backend versus
-    /// the in-memory mock. Defaults to live; production always reads live
-    /// (the stored override is only writable from the Debug menu, which
-    /// dev/local builds alone can reach -- runtime-gated rather than
-    /// `#if DEBUG` for the same reason documented on `CreditsServices`).
+    /// the in-memory mock. Coupled to `FeatureFlags.isAbilitiesV2Enabled` in
+    /// both directions so the two can never disagree: enabling V2 forces
+    /// this on (write-time, in the flag's setter); turning this off forces
+    /// V2 off (write-time, below). This getter also reports live whenever
+    /// V2 is on regardless of what is stored, so a combination saved before
+    /// this coupling existed self-heals on the next read instead of
+    /// resurfacing after a relaunch -- there is no user-visible control for
+    /// this flag on its own; the Debug menu exposes a single "Abilities v2"
+    /// toggle. Defaults to live; production always reads live (the stored
+    /// override is only writable from the Debug menu, which dev/local
+    /// builds alone can reach -- runtime-gated rather than `#if DEBUG` for
+    /// the same reason documented on `CreditsServices`).
+    @MainActor
     static var useLiveBackend: Bool {
         guard !ConfigManager.shared.currentEnvironment.isProduction else { return true }
+        if FeatureFlags.shared.isAbilitiesV2Enabled {
+            return true
+        }
         if let stored = UserDefaults.standard.object(forKey: Constant.useLiveBackendKey) as? Bool {
             return stored
         }
         return true
     }
 
+    @MainActor
     static func setUseLiveBackend(_ value: Bool) {
         guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
         UserDefaults.standard.set(value, forKey: Constant.useLiveBackendKey)
+        if !value {
+            FeatureFlags.shared.isAbilitiesV2Enabled = false
+        }
     }
 
     /// Debug sub-toggle for the V1 awareness shim (ProfileUpdate metadata

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -118,6 +118,14 @@ final class FeatureFlags {
     /// App Settings -> Debug. Hard-locked off in production so the V1
     /// connections UI stays the default until the live transport ships;
     /// public enablement is a default flip in a client release.
+    ///
+    /// Coupled to `AbilitiesServices.useLiveBackend` in both directions so
+    /// V2 running against the mock (instead of the live backend) can never
+    /// be reached: turning this on forces the live backend on too
+    /// (write-time, below). `AbilitiesServices.useLiveBackend`'s getter
+    /// enforces the same invariant independent of what is in storage, which
+    /// is what actually keeps a value restored from persistence at launch
+    /// from resurfacing the invalid combination.
     var isAbilitiesV2Enabled: Bool {
         get {
             access(keyPath: \.isAbilitiesV2Enabled)
@@ -128,6 +136,9 @@ final class FeatureFlags {
             guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
             withMutation(keyPath: \.isAbilitiesV2Enabled) {
                 UserDefaults.standard.set(newValue, forKey: Constant.abilitiesV2EnabledKey)
+            }
+            if newValue {
+                AbilitiesServices.setUseLiveBackend(true)
             }
         }
     }

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -49,7 +49,6 @@ struct DebugViewSection: View {
     @State private var creditsPresetSelection: CreditsStatePreset = FeatureFlags.shared.mockCreditsPreset
     @State private var useRealStoreKit: Bool = SubscriptionServices.useRealStoreKit
     @State private var useRealCredits: Bool = CreditsServices.useRealBackend
-    @State private var useLiveAbilities: Bool = AbilitiesServices.useLiveBackend
     @State private var abilitiesV1ShimEnabled: Bool = AbilitiesServices.isV1AwarenessShimEnabled
     @State private var abilitiesEscalationMockEnabled: Bool = AbilitiesServices.isEscalationMockEnabled
     @State private var identity: DeviceIdentitySnapshot?
@@ -103,19 +102,18 @@ struct DebugViewSection: View {
         }
     }
 
-    /// The Abilities V2 flag with its sub-toggles: mock/live backend
-    /// selection (default live), the V1 awareness shim (default off), and
-    /// the mock consent flow (default on). Sub-toggles only render while
-    /// the flag is on; all take effect on the next read (no relaunch
-    /// needed).
+    /// The Abilities V2 flag with its sub-toggles: the V1 awareness shim
+    /// (default off) and the mock consent flow (default on). There is
+    /// deliberately no separate mock/live backend toggle here -- enabling
+    /// V2 always enables the live backend (`FeatureFlags.isAbilitiesV2Enabled`
+    /// and `AbilitiesServices.useLiveBackend` are coupled in both directions
+    /// so that combination can't be split), so "Abilities v2" is the single
+    /// control for both. Sub-toggles only render while the flag is on; all
+    /// take effect on the next read (no relaunch needed).
     @ViewBuilder
     private var abilitiesFeatureToggles: some View {
         Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
         if FeatureFlags.shared.isAbilitiesV2Enabled {
-            Toggle("Abilities: live backend", isOn: $useLiveAbilities)
-                .onChange(of: useLiveAbilities) { _, newValue in
-                    AbilitiesServices.setUseLiveBackend(newValue)
-                }
             Toggle("Abilities: v1 awareness shim", isOn: $abilitiesV1ShimEnabled)
                 .onChange(of: abilitiesV1ShimEnabled) { _, newValue in
                     AbilitiesServices.setV1AwarenessShimEnabled(newValue)


### PR DESCRIPTION
## Summary

The Debug menu exposed "Abilities v2" and "Abilities: live backend" as two independent toggles. Turning V2 on while leaving live backend off (or flipping live backend off afterward, while V2 stayed on) left the abilities surfaces rendering against `MockAbilitiesService` with no separate control pointing that out -- and that combination survived a relaunch, since both flags are plain `UserDefaults` reads with no cross-check.

This couples the two in the model, not just the UI:

- `FeatureFlags.isAbilitiesV2Enabled`'s setter forces the live backend on whenever V2 is turned on (`Convos/Config/FeatureFlags.swift`).
- `AbilitiesServices.setUseLiveBackend` forces V2 off whenever the live backend is turned off (`Convos/Abilities/AbilitiesServices.swift`).
- `AbilitiesServices.useLiveBackend`'s **getter** reports live unconditionally whenever V2 is on, regardless of what's in storage. This is the part that actually matters: a combination saved by an older build (or any future direct write) self-heals on the next read instead of resurfacing after a relaunch.

The Debug menu collapses to a single "Abilities v2" toggle (`Convos/Debug View/DebugView.swift`); the separate "Abilities: live backend" row is gone since it can no longer independently vary while V2 is on. The v1-awareness-shim and consent-flow-mock sub-toggles are unrelated to this invariant and are unchanged.

## Answering "why is mock on by default -- is it?"

It is not, today. Concretely, before this change:

1. **What a user gets when they flip "Abilities v2" on**: the live backend, via `LiveAbilitiesService` -- not mock. The selecting branch is `AbilitiesServices.selection` (`Convos/Abilities/AbilitiesServices.swift:61-70` pre-change):
   ```swift
   static var selection: AbilitiesSelection {
       guard let liveService, useLiveBackend else {
           return AbilitiesSelection(service: mockService, escalation: escalationService)
       }
       return AbilitiesSelection(service: liveService, authorizer: ..., escalation: escalationService)
   }
   ```
   `liveService` is always non-nil by the time any UI can read this (`configure()` runs unconditionally in `ConvosApp.init`), and `useLiveBackend` defaults to `true` (below), so the `else` branch runs and `LiveAbilitiesService` is what gets constructed. The V2 flag itself does not select mock vs. live -- that's the independent `useLiveBackend` flag's job, and its own default is what actually decides the outcome.

2. **Default of every flag in the selection path**:
   - `FeatureFlags.isAbilitiesV2Enabled` (gates whether the V2 surfaces render at all): default **off**, `Convos/Config/FeatureFlags.swift:124-125` pre-change (`UserDefaults.bool(forKey:)` returns `false` for an unset key). Hard-locked `false` in production.
   - `AbilitiesServices.useLiveBackend` (selects live vs. mock once V2 is on): default **on** in every build, `Convos/Abilities/AbilitiesServices.swift:126-133` pre-change -- production hard-locks `true`; non-production falls through to `return true` when nothing is stored. Only an explicit debug-menu flip to off ever made it read `false`.

3. **Deliberate or leftover?** Deliberate, and not from the original "mock-first" commit. `a5ca46867` ("Abilities v2 mock-first UI behind debug feature flag", #1227) shipped *only* mock -- there was no live service yet, so "mock-first" meant the only implementation, not a preference. The very next PR, `f0849f148` ("Abilities v2: mock-first UI + live backend service (debug-feature-flagged)", #1259), added `LiveAbilitiesService` and its own commit message says explicitly: *"AbilitiesServices becomes a CreditsServices-style holder: ... shared picks live or mock per read. The Debug menu's Abilities V2 flag gains two sub-toggles, live backend (default on) and the V1 awareness shim (default off)..."* -- "live default" is literally in that commit's subject. One stale doc comment on `isAbilitiesV2Enabled` (still saying "currently backed by `MockAbilitiesService`" and "until the live transport ships") never got updated after #1259 landed; it's corrected in this PR and is the likely source of confusion about which is default.

4. **Does this differ across Debug / Dev / TestFlight / Release?** No -- Debug (simulator), `Convos (Dev)` (which is also what ships to TestFlight, per `ENVIRONMENTS.md`), and `Convos (Local)` are all `isProduction == false` and behave identically (V2 off by default until toggled, live-backend on by default). Only the App Store `Convos (Prod)` build (`AppEnvironment.production`) differs, and it's unaffected by this change: both flags stay hard-locked (V2 `false`, live backend `true`) exactly as before.

## Behavior change

For the *default* path (fresh install, or any dev user who never touched the separate live-backend toggle), nothing changes -- live was already the outcome of turning V2 on. The only users affected are the minority who had explicitly flipped "Abilities: live backend" off while leaving V2 on, to preview the mock-only UI without hitting the network. That combination is no longer reachable; turning V2 on now always re-forces live, and there's no more standalone control to turn live off independently. If anyone relies on that mock-preview path (e.g. designers), they've lost it with this change -- flagging loudly since it's a real, if narrow, capability regression.

## Verification

- `swiftlint --strict` clean on the three changed files.
- Clean build: `xcodebuild ... -scheme "Convos (Dev)" -configuration Dev` against a concrete arm64 `iPhone 17` simulator, 0 warnings/errors.
- On-device, via the Debug menu: toggled V2 off -> on -> off, confirmed the sub-toggles (v1 awareness shim, consent flow mock) show/hide correctly and there is no more separate live-backend row to desync.
- **Persistence test** (the one a UI-only guard would miss): force-quit, then directly wrote the pre-fix invalid combination (`featureFlags.abilitiesV2Enabled = true`, `abilitiesServices.useLiveBackend = false`) into the app's persisted `UserDefaults` plist to simulate a value saved by an older build, then relaunched. The Abilities screen rendered the real two-item live catalog (Gmail, Google Calendar, both "Available") -- not the six-item mock fixture (which would show Google Calendar as already "Connected" plus Spotify/Coinbase/YouTube/Shopify) -- confirming the getter-level self-heal survives persistence, not just interactive toggling.

## Test plan

- [x] SwiftLint strict, clean
- [x] Clean Dev build on simulator
- [x] Manual: V2 off/on toggling in Debug menu, sub-toggles behave
- [x] Manual: invalid persisted combination self-heals across relaunch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789321639&installation_model_id=20076&pr_number=1323&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1323&signature=004fb81310af9f5d02e2e77ed4ee4e9c2af20212515edc082f8529b288e763cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Couple Abilities v2 flag to live backend so they cannot disagree
> - When `FeatureFlags.isAbilitiesV2Enabled` is set to `true`, `AbilitiesServices.useLiveBackend` always returns `true`, ignoring any stored UserDefaults override.
> - When `AbilitiesServices.setUseLiveBackend(false)` is called, it now also sets `isAbilitiesV2Enabled = false`, keeping both in sync.
> - The separate "Abilities: live backend" toggle is removed from the Debug UI in [DebugView.swift](https://github.com/xmtplabs/convos-ios/pull/1323/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa); enabling Abilities v2 is now the single control.
> - `AbilitiesServices` methods involved in this coupling are annotated with `@MainActor`.
> - Behavioral Change: callers accessing `AbilitiesServices.selection` or `refreshCatalogInBackground` from off-main contexts will now incur a main-actor hop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 813b895.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->