### PR TITLE
Docs: make "Listen mode" == mentions-only (wire `mention`) explicit

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -21,6 +21,9 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
     /// The levels the menu offers — every level there is.
     public static var selectableCases: [AgentParticipationLevel] { allCases }
 
+    /// User-visible name of the level. `.mentionsOnly` (wire value `"mention"`)
+    /// reads as "Listen mode" — the label and the wire value are the same mode
+    /// under two names; there is no separate `listen` mode.
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
@@ -18,6 +18,12 @@ import Foundation
 /// mirror the agent runtime reads.
 public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendable {
     case speakFreely = "speak"
+    /// The quiet-but-listening mode: the agent keeps working but only speaks
+    /// when it is addressed (an @mention or its name). Its wire value is
+    /// `"mention"` and its user-facing name is "Listen mode" (see `title`) —
+    /// they are the SAME mode. There is no separate `listen` wire value; if you
+    /// see "listen" in a transcript, screenshot, or product copy, it means this
+    /// case.
     case mentionsOnly = "mention"
     case paused
 
@@ -37,7 +43,9 @@ public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendab
     }
 
     /// User-visible name of the mode, as it reads in the participation menu and
-    /// in the transcript row a change leaves behind.
+    /// in the transcript row a change leaves behind. Note `.mentionsOnly`
+    /// (wire value `"mention"`) reads as "Listen mode" here — the label and the
+    /// wire vocabulary are deliberately different names for one mode.
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"


### PR DESCRIPTION
"Listen mode" and "Mentions only" are the same mode — the confusion keeps recurring because the user-facing label and the wire vocabulary don't match anywhere in the code.

The enum case is `mentionsOnly` with wire value `"mention"`, but its user-visible `title` is `"Listen mode"`. There is **no** separate `listen` wire value. When someone reads "listen mode" in a transcript or screenshot and then greps for `listen` in the runtime/appData vocabulary, they find nothing and reach for the wrong conclusion.

This PR adds clarifying doc comments at the two spots where the label diverges from the wire value (`ConversationParticipationMode` and `AgentParticipationLevel`), so the mapping is stated where a reader lands. No behavior change.

Proposed by jarod@xmtp.com via ConvosOS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789421807&installation_model_id=20076&pr_number=1324&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1324&signature=683373647942093a82b7e51bdd108ef36a444ae4ff9ad39d201440f902f8d865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document that `mentionsOnly` maps to wire value "mention" and displays as "Listen mode"
> Adds inline documentation comments to `AgentParticipationLevel.title` and `ConversationParticipationMode.mentionsOnly` clarifying the relationship between the `.mentionsOnly` case, its wire value `"mention"`, and its user-facing label "Listen mode". No executable code is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 084e6db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->