### PR TITLE
Allow enabling Abilities v2 from the production debug menu

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -251,11 +251,13 @@ struct AppSettingsView: View {
     }
 
     /// The V1 connections list, or the V2 abilities list behind the
-    /// Abilities V2 feature flag (dev builds only; the flag is hard-locked
-    /// off in production). Read at push time, so flipping the flag in the
-    /// debug menu takes effect on the next visit. The V2 branch presents
-    /// `AbilitiesListScreen`, which owns its view model via `@State`, so
-    /// re-evaluations of this builder cannot replace the model mid-push.
+    /// Abilities V2 feature flag. Off by default in every environment;
+    /// reachable from the Debug menu in non-production builds and from the
+    /// curated prod debug menu in production. Read at push time, so
+    /// flipping the flag in either debug menu takes effect on the next
+    /// visit. The V2 branch presents `AbilitiesListScreen`, which owns its
+    /// view model via `@State`, so re-evaluations of this builder cannot
+    /// replace the model mid-push.
     @ViewBuilder
     private var connectionsDestination: some View {
         if FeatureFlags.shared.isAbilitiesV2Enabled {

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -114,10 +114,16 @@ final class FeatureFlags {
 
     /// Off by default -- gates the V2 abilities surfaces (the abilities
     /// catalog list in App Settings and the per-conversation abilities
-    /// section), currently backed by `MockAbilitiesService`. Toggle from
-    /// App Settings -> Debug. Hard-locked off in production so the V1
-    /// connections UI stays the default until the live transport ships;
-    /// public enablement is a default flip in a client release.
+    /// section), backed by the live abilities backend once enabled (see
+    /// `AbilitiesServices.useLiveBackend`, which reports live unconditionally
+    /// whenever this flag is on). Toggle from App Settings -> Debug in
+    /// non-production builds, or from the curated prod debug menu in
+    /// production. Deliberately not prod-locked like most flags above: the
+    /// control is reachable everywhere so V2 can be dogfooded in production,
+    /// same posture as `isListenParticipationEnabled`. Default stays off in
+    /// every environment -- enabling it in production points the client at
+    /// whatever the production abilities backend currently serves, which may
+    /// lag what dev has.
     ///
     /// Coupled to `AbilitiesServices.useLiveBackend` in both directions so
     /// V2 running against the mock (instead of the live backend) can never
@@ -125,15 +131,15 @@ final class FeatureFlags {
     /// (write-time, below). `AbilitiesServices.useLiveBackend`'s getter
     /// enforces the same invariant independent of what is in storage, which
     /// is what actually keeps a value restored from persistence at launch
-    /// from resurfacing the invalid combination.
+    /// from resurfacing the invalid combination -- and in production that
+    /// getter reports live regardless of storage, so the coupling holds
+    /// there without needing a production guard of its own.
     var isAbilitiesV2Enabled: Bool {
         get {
             access(keyPath: \.isAbilitiesV2Enabled)
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
             return UserDefaults.standard.bool(forKey: Constant.abilitiesV2EnabledKey)
         }
         set {
-            guard !ConfigManager.shared.currentEnvironment.isProduction else { return }
             withMutation(keyPath: \.isAbilitiesV2Enabled) {
                 UserDefaults.standard.set(newValue, forKey: Constant.abilitiesV2EnabledKey)
             }

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -20,14 +20,18 @@ import UserNotifications
 //
 // Hard rules enforced here:
 // - No mutating controls (no "Request Now", no "Register Device Again", no
-//   purchase / change-plan CTAs, no mock-credit toggles). Two deliberate
-//   exceptions, both flipping only a local default so a tester can opt this
+//   purchase / change-plan CTAs, no mock-credit toggles). Three deliberate
+//   exceptions, each flipping only a local default so a tester can opt this
 //   install into a feature we are dogfooding in production:
 //   - the XMTP bidi streaming opt-in, which selects the stream transport at
 //     next launch -- nothing account- or network-mutating.
 //   - the Listen opt-in, which only decides whether the participation control
 //     is built. Turning it on mutates nothing by itself; the writes happen
 //     later, in the control, when a member actually picks a level.
+//   - the Abilities v2 opt-in, which swaps the abilities catalog list and
+//     per-conversation section from the V1 connections UI to the V2 one and
+//     points them at the live abilities backend. Off by default; nothing
+//     mutates until a tester connects an ability from that surface.
 // - The live `BackendAuthProbe` (JWT minter) is never imported or instantiated
 //   here. The identity readout uses `DeviceIdentitySnapshot`, which is
 //   network-free and carries no JWT.
@@ -175,10 +179,11 @@ struct ProdDebugMenuView: View {
         let injectorEnabled: Bool = FeatureFlags.shared.isDebugInjectorEnabled
         Section("Feature flags") {
             labeledRow("Debug injector", injectorEnabled ? "On" : "Off")
-            // The two interactive controls in this curated menu; see the
+            // The interactive controls in this curated menu; see the
             // module overview for why they are allowed here.
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
+            Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesServiceProtocol.swift
@@ -83,8 +83,10 @@ extension AbilitiesServiceError: LocalizedError {
 /// Backend-owned abilities: catalog enumeration, account-level entitlement
 /// lifecycle, and extension of entitlements to agents within conversations.
 /// The backend is the only source of truth; clients read statuses, never
-/// derive them. `MockAbilitiesService` drives every V2 surface until the
-/// live transport lands.
+/// derive them. `LiveAbilitiesService` is the default implementation once
+/// the Abilities V2 flag is on; `MockAbilitiesService` only drives V2
+/// surfaces when the mock/live sub-toggle is explicitly flipped to mock in
+/// a non-production Debug menu.
 public protocol AbilitiesServiceProtocol: Sendable {
     /// Fetches the full catalog crossed with the caller's entitlement
     /// state, resolved per the availability contract: a response carrying


### PR DESCRIPTION
## Summary

- `isAbilitiesV2Enabled` (`Convos/Config/FeatureFlags.swift`) was hard-locked off in production builds, with the setter a no-op - there was no way to opt in short of a code change and App Store release. Unlocks the flag's `UserDefaults`-backed getter/setter for production; **default stays off in every environment**.
- Adds an "Abilities v2" toggle to `ProdDebugMenuView`'s curated feature-flags section, following the existing Listen / XMTP-bidi-streaming toggle precedent in that same file (the prod debug menu is a separate, reduced surface from the full dev `DebugView` - it did not previously carry this row at all).
- Traced every downstream `isProduction` guard in the abilities feature area (`AbilitiesServices.swift` is the only other file with any): `useLiveBackend`'s getter already reports live unconditionally in production regardless of storage, so the mock/live coupling invariant (V2 on => live backend, mock unreachable) holds without touching that file. The escalation-mock and v1-awareness-shim sub-toggles stay correctly locked off in prod (escalation has no live transport yet, so this avoids showing a fake scripted consent request to real users). No other consumer of the flag has a separate production gate.
- Fixes two doc comments left stale by #1323: the flag and `AbilitiesServiceProtocol` both still described the live backend as "currently backed by `MockAbilitiesService`" / dev-only, which has been inaccurate since the live transport shipped.

## This changes no default

Enabling V2 from the prod debug menu today points the client at whatever the **production** abilities backend currently serves - which lags dev. Per the current gates inventory: the prod assistant worker deploy is broken on a missing Infisical identity variable, the prod backend is several days stale (predates the owner-only enforcement / attribution work on dev), and 4 of 6 abilities are still `hidden: true` server-side (only Google Calendar and Gmail are unhidden). This toggle exists for controlled dogfooding once prod catches up - it does not itself make V2 functional or default-on for anyone.

## Test plan

- [x] Built `Convos (Prod)` scheme (Release config, `org.convos.ios`, `environment: production`) for iOS Simulator - build succeeded with zero errors.
- [x] Reached the curated prod debug menu (App Settings -> 7x version tap -> Enable -> Debug menu row), confirmed "Abilities v2" toggle present, off by default.
- [x] Flipped on: App Settings "Connections" row relabeled "Abilities", navigated into the V2 `AbilitiesListScreen`. Catalog fetch itself 403s with a Firebase App Check "App attestation failed" error - expected and unrelated to this change: App Attest has no Simulator implementation and production builds carry no debug token fallback, so this could not be verified end-to-end on Simulator (would need a physical device or a non-prod build).
- [x] Killed and relaunched the app: toggle state and "Abilities" row label both persisted.
- [x] Flipped off: row reverted to "Connections" (V1 restored).
- [x] `swiftformat` + `swiftlint --strict` clean on all changed files; pre-commit and pre-push hooks passed.
- [ ] `ConvosTests` (Xcode target) currently fails to compile on `dev` for unrelated, pre-existing reasons (a Swift 6 concurrency error in `ConversationViewModelCapabilityConnectTests.swift`, untouched by this branch) - not run. `ConvosCore`'s only change is a doc comment, so the Docker-backed `swift test --package-path ConvosCore` suite was not run either.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789593883&installation_model_id=20076&pr_number=1326&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1326&signature=e97a4596b6ddf2fe680e2561ec08bbc51dab5dfaf2819214adab80010c3fceea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow enabling Abilities V2 from the production debug menu
> - Removes production-environment guards from `FeatureFlags.isAbilitiesV2Enabled`, so the flag can now be read and written in production (previously always returned `false` and ignored writes).
> - Adds an "Abilities v2" toggle to [`ProdDebugMenuView`](https://github.com/xmtplabs/convos-ios/pull/1326/files#diff-815af3105d8d852a87268252db30020c7003096279ca94a9c908613d1bb26cef), exposing the flag in the curated prod debug menu.
> - Enabling the flag still forces the live backend via `AbilitiesServices.setUseLiveBackend(true)` at write time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48132d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->