### PR TITLE
Re-wire approval feedback on the capability approval sheet

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -954,6 +954,8 @@ private extension ConversationView {
             CapabilityApprovalSheetView(
                 layout: layout,
                 agentName: viewModel.askerDisplayName(for: layout.request),
+                isApproving: viewModel.capabilityApprovalInFlight,
+                approvalErrorMessage: viewModel.capabilityApprovalErrorMessage,
                 onApprove: { providerIds, bundleSelection in
                     viewModel.onCapabilityApprove(
                         providerIds: providerIds,


### PR DESCRIPTION
## Summary

The conversation-view restructure (#1311) re-added the extracted `capabilityApprovalSheet` builder in `Convos/Conversation Detail/ConversationView.swift` without the `isApproving:` and `approvalErrorMessage:` arguments. `CapabilityApprovalSheetView` defaults them to `false`/`nil`, so the sheet still presented and approvals still worked, but the in-flight spinner and the approval error message were dead. The view model properties (`capabilityApprovalInFlight`, `capabilityApprovalErrorMessage`) still exist and update.

This restores the exact pre-#1311 wiring at the call site: two argument lines, nothing else.

## Verification

- SwiftLint `--strict` on the changed file: clean
- `xcodebuild build -scheme "Convos (Dev)" -configuration Dev` against an iPhone 17 simulator: build succeeded
- `swift test --package-path ConvosCore`: 1878 tests in 254 suites, all passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789659008&installation_model_id=20076&pr_number=1327&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1327&signature=c3163670618d230463a65ff8f00fce139e04602ad49048cdff99128c0962920b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `isApproving` and `approvalErrorMessage` into `CapabilityApprovalSheetView`
> Passes `capabilityApprovalInFlight` and `capabilityApprovalErrorMessage` from the view model into `CapabilityApprovalSheetView` in [ConversationView.swift](https://github.com/xmtplabs/convos-ios/pull/1327/files#diff-8d85226aa6385ce7a0aca11596c32eb20e3c3e89b37f51651c35fceb5e28f6bc), so the sheet can reflect approval loading state and surface error messages to the user.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d34806.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->