### PR TITLE
Resolve capability requests per member instead of conversation-wide

### DIFF
--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
@@ -4,17 +4,18 @@ import Foundation
 import GRDB
 
 /// Observes the message table for `capability_request` rows in one conversation and
-/// publishes the latest one that hasn't been resolved by a matching
-/// `capability_request_result` yet. The picker UI subscribes — when the publisher
-/// emits a non-nil `CapabilityRequest`, the conversation view model recomputes the
-/// `CapabilityPickerLayout` and surfaces the approval sheet.
+/// publishes the latest one that the viewing member hasn't resolved with a
+/// matching `capability_request_result` yet. The picker UI subscribes — when the
+/// publisher emits a non-nil `CapabilityRequest`, the conversation view model
+/// recomputes the `CapabilityPickerLayout` and surfaces the approval sheet.
 ///
 /// Resolution detection joins result rows on `requestId` and applies
 /// `CapabilityConnectPrompt.resolution` — the SAME validated rule the transcript
 /// pill derives its display state from, so "tap path open" and "pill pending"
-/// can never disagree. First decision wins, in message-time order: the earliest
-/// validated approve/deny/cancel resolves the request for the whole
-/// conversation; asker-authored rows and non-decision statuses never resolve it.
+/// can never disagree. Resolution is per viewer: only the viewer's own
+/// approve/deny/cancel rows resolve a request for them (earliest wins, in
+/// message-time order); other members' rows, asker-authored rows, and
+/// non-decision statuses never resolve it.
 public protocol CapabilityRequestRepositoryProtocol: Sendable {
     var pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> { get }
 }
@@ -22,17 +23,24 @@ public protocol CapabilityRequestRepositoryProtocol: Sendable {
 public final class CapabilityRequestRepository: CapabilityRequestRepositoryProtocol, @unchecked Sendable {
     private let dbReader: any DatabaseReader
     private let conversationId: String
+    private let viewerInboxId: String
 
-    public init(dbReader: any DatabaseReader, conversationId: String) {
+    public init(dbReader: any DatabaseReader, conversationId: String, viewerInboxId: String) {
         self.dbReader = dbReader
         self.conversationId = conversationId
+        self.viewerInboxId = viewerInboxId
     }
 
     public lazy var pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> = {
         let conversationId = self.conversationId
+        let viewerInboxId = self.viewerInboxId
         return ValueObservation
             .tracking { db -> CapabilityRequest? in
-                Self.computeLatestPendingRequest(conversationId: conversationId, db: db)
+                Self.computeLatestPendingRequest(
+                    conversationId: conversationId,
+                    viewerInboxId: viewerInboxId,
+                    db: db
+                )
             }
             .publisher(in: dbReader, scheduling: .async(onQueue: .main))
             .replaceError(with: nil)
@@ -41,12 +49,14 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
 
     /// Pure function over a `Database` (visible for testing). Walks every
     /// capability_request message for the conversation in descending date
-    /// order and returns the first one that no validated result resolves.
-    static func computeLatestPendingRequest(conversationId: String, db: Database) -> CapabilityRequest? {
+    /// order and returns the first one that no validated result from the
+    /// viewer resolves.
+    static func computeLatestPendingRequest(conversationId: String, viewerInboxId: String, db: Database) -> CapabilityRequest? {
         do {
             let resultsByRequestId = try resultRecordsByRequestId(conversationId: conversationId, db: db)
             return try computeLatestPendingRequest(
                 conversationId: conversationId,
+                viewerInboxId: viewerInboxId,
                 db: db,
                 resultsByRequestId: resultsByRequestId
             )
@@ -60,10 +70,12 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
     /// returned request to decide which unresolved pill renders `.pending`
     /// (actionable) versus `.superseded` — keeping the transcript and the tap
     /// path on one verdict. Resolution per request is
-    /// `CapabilityConnectPrompt.resolution`: the first validated decision in
-    /// message-time order wins, asker-authored rows never count.
+    /// `CapabilityConnectPrompt.resolution`: the viewer's first validated
+    /// decision in message-time order wins; other members' rows and
+    /// asker-authored rows never count.
     static func computeLatestPendingRequest(
         conversationId: String,
+        viewerInboxId: String,
         db: Database,
         resultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]]
     ) throws -> CapabilityRequest? {
@@ -80,7 +92,8 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
             }
             let resolution = CapabilityConnectPrompt.resolution(
                 results: resultsByRequestId[request.requestId] ?? [],
-                askerInboxId: request.askerInboxId
+                askerInboxId: request.askerInboxId,
+                viewerInboxId: viewerInboxId
             )
             if resolution == nil {
                 return request

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -984,7 +984,11 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     }
 
     public func capabilityRequestRepository(for conversationId: String) -> any CapabilityRequestRepositoryProtocol {
-        CapabilityRequestRepository(dbReader: databaseReader, conversationId: conversationId)
+        CapabilityRequestRepository(
+            dbReader: databaseReader,
+            conversationId: conversationId,
+            viewerInboxId: MessagesRepository.currentInboxId(from: databaseReader)
+        )
     }
 
     public func deviceConnectionAuthorizer() -> any DeviceConnectionAuthorizer {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/CapabilityConnectPrompt.swift
@@ -7,19 +7,20 @@ import Foundation
 /// Built at compose time. `status` is derived by joining
 /// `capability_request_result` rows on `requestId` (same shape as the
 /// reaction join on `sourceMessageId`) — the request row itself is never
-/// edited, so the pill stays in history and flips state on every member's
-/// device as result rows sync in.
+/// edited, so the pill stays in history. Resolution is per viewer: only the
+/// viewing member's own result rows flip the state that member sees, so one
+/// member acting leaves every other member's pill actionable.
 public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
     public enum Status: String, Hashable, Codable, Sendable {
-        /// No validated result row resolves the request yet and it is the
-        /// conversation's latest unresolved ask — tapping opens the approval
-        /// sheet.
+        /// The viewing member has no validated decision of their own on the
+        /// request yet and it is the conversation's latest ask unresolved for
+        /// them — tapping opens the approval sheet.
         case pending
-        /// The first validated result row (in message-time order, from any
-        /// member's device) was an approval.
+        /// The viewer's first validated result row (in message-time order)
+        /// was an approval.
         case connected
-        /// The first validated result row (in message-time order) was a
-        /// denial or cancellation.
+        /// The viewer's first validated result row (in message-time order)
+        /// was a denial or cancellation.
         case dismissed
         /// Still unresolved, but a newer unresolved request has taken over as
         /// the conversation's single actionable ask. Rendered inert; flips
@@ -31,7 +32,7 @@ public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
     /// needs: who sent it, what they decided, and where the row sits in
     /// message time. `sentAtNs` (the message's `dateNs`) plus `messageId` (the
     /// stable tiebreaker for identical timestamps) give
-    /// `resolution(results:askerInboxId:)` its first-decision ordering; both
+    /// `resolution(results:askerInboxId:viewerInboxId:)` its first-decision ordering; both
     /// come off the synced message row, so every device sorts identically.
     public struct ResultRecord: Hashable, Sendable {
         public let senderId: String
@@ -84,12 +85,14 @@ public struct CapabilityConnectPrompt: Hashable, Codable, Sendable {
 public extension CapabilityConnectPrompt {
     /// `isLatestUnresolvedRequest`: whether this request is the one
     /// `CapabilityRequestRepository.computeLatestPendingRequest` would surface
-    /// — i.e. the conversation's single actionable ask. Unresolved requests
-    /// that aren't it render `.superseded` instead of `.pending`, so the pill
-    /// is never tappable-looking while the tap path would refuse it.
+    /// for the viewer — i.e. their single actionable ask. Requests the viewer
+    /// hasn't resolved that aren't it render `.superseded` instead of
+    /// `.pending`, so the pill is never tappable-looking while the tap path
+    /// would refuse it.
     static func make(
         request: CapabilityRequest,
         results: [ResultRecord],
+        viewerInboxId: String,
         isLatestUnresolvedRequest: Bool
     ) -> CapabilityConnectPrompt {
         let preferredProviderId = request.preferredProviders?.first
@@ -102,6 +105,7 @@ public extension CapabilityConnectPrompt {
             status: displayStatus(
                 results: results,
                 askerInboxId: request.askerInboxId,
+                viewerInboxId: viewerInboxId,
                 isLatestUnresolvedRequest: isLatestUnresolvedRequest
             )
         )
@@ -112,31 +116,31 @@ public extension CapabilityConnectPrompt {
     /// picker layout, i.e. the tap path) — both layers must always agree on
     /// whether a request is still open.
     ///
-    /// First decision wins, in message-time order: one capability request is
-    /// one connection ask for the whole conversation, and the EARLIEST
-    /// validated result resolves it for every member — approved flips the
-    /// pill to `.connected` conversation-wide (and the grant separately
-    /// broadcasts as a `connection_event`); denied/cancelled resolves to
-    /// `.dismissed` just as finally — an agent that still needs access
-    /// re-requests under a new `requestId`. Results are sorted here (sent
-    /// timestamp, then message id as the stable tiebreaker) rather than
-    /// trusting callers to pass them ordered, so the temporal guarantee
-    /// holds in every call path.
+    /// Resolution is per viewer: a result row only counts toward the status
+    /// the viewing member sees when its XMTP-attested sender (the envelope's
+    /// `senderInboxId`, persisted as the row's `senderId`) is the viewer
+    /// themselves. Each member answers the same request independently — one
+    /// member approving grants their own connection (broadcast separately as
+    /// a `connection_event`) and leaves every other member's pill actionable;
+    /// a denial or cancellation dismisses the ask for its author alone. Among
+    /// the viewer's own rows the first decision wins, in message-time order
+    /// (sent timestamp, then message id as the stable tiebreaker); results
+    /// are sorted here rather than trusting callers to pass them ordered, so
+    /// the temporal guarantee holds in every call path.
     ///
-    /// Validation: a result only counts when its XMTP-attested sender (the
-    /// envelope's `senderInboxId`, persisted as the row's `senderId`) is not
-    /// the request's asker — the requesting agent can't approve, deny, or
-    /// cancel its own ask. This mirrors the attested-sender posture of
+    /// The request's asker can never resolve its own ask, even as the viewer
+    /// — the requesting agent can't approve, deny, or cancel what it asked
+    /// for. This mirrors the attested-sender posture of
     /// `validateConnectionGrantRequest`; the result payload carries no sender
     /// claim of its own, so the envelope identity is the only trusted input.
     /// `staleResource` and forward-compat `unknown` statuses are not user
-    /// decisions, so they are skipped, never resolving. Returns nil while
-    /// unresolved.
-    static func resolution(results: [ResultRecord], askerInboxId: String) -> Status? {
+    /// decisions, so they are skipped, never resolving. Returns nil while the
+    /// viewer hasn't decided.
+    static func resolution(results: [ResultRecord], askerInboxId: String, viewerInboxId: String) -> Status? {
         let ordered = results.sorted {
             ($0.sentAtNs, $0.messageId) < ($1.sentAtNs, $1.messageId)
         }
-        for record in ordered where record.senderId != askerInboxId {
+        for record in ordered where record.senderId == viewerInboxId && record.senderId != askerInboxId {
             switch record.status {
             case .approved:
                 return .connected
@@ -149,16 +153,18 @@ public extension CapabilityConnectPrompt {
         return nil
     }
 
-    /// Folds the validated resolution (see `resolution(results:askerInboxId:)`)
-    /// into the pill's display state. Unresolved requests are `.pending` only
-    /// when they are the conversation's latest unresolved ask; older ones are
+    /// Folds the viewer's validated resolution (see
+    /// `resolution(results:askerInboxId:viewerInboxId:)`) into the pill's
+    /// display state. Requests the viewer hasn't resolved are `.pending` only
+    /// when they are the conversation's latest such ask; older ones are
     /// `.superseded` (visible but inert).
     static func displayStatus(
         results: [ResultRecord],
         askerInboxId: String,
+        viewerInboxId: String,
         isLatestUnresolvedRequest: Bool
     ) -> Status {
-        if let resolution = resolution(results: results, askerInboxId: askerInboxId) {
+        if let resolution = resolution(results: results, askerInboxId: askerInboxId, viewerInboxId: viewerInboxId) {
             return resolution
         }
         return isLatestUnresolvedRequest ? .pending : .superseded

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -587,6 +587,7 @@ extension Array where Element == DBMessage {
             return resolveCapabilityConnectContent(
                 jsonText: dbMessage.text,
                 resultsByRequestId: capabilityResultsByRequestId,
+                viewerInboxId: currentInboxId,
                 latestPendingRequestId: latestPendingCapabilityRequestId
             )
         case .capabilityRequestResult:
@@ -612,6 +613,7 @@ extension Array where Element == DBMessage {
     private static func resolveCapabilityConnectContent(
         jsonText: String?,
         resultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]],
+        viewerInboxId: String,
         latestPendingRequestId: String?
     ) -> MessageContent? {
         guard let jsonText,
@@ -621,6 +623,7 @@ extension Array where Element == DBMessage {
         let prompt = CapabilityConnectPrompt.make(
             request: request,
             results: resultsByRequestId[request.requestId] ?? [],
+            viewerInboxId: viewerInboxId,
             isLatestUnresolvedRequest: request.requestId == latestPendingRequestId
         )
         return .capabilityConnect(prompt: prompt)
@@ -1165,13 +1168,13 @@ fileprivate extension Database {
         // ValueObservation: the main message query already tracks the table,
         // so a late-arriving result row still re-fires composition.
         //
-        // First decision wins, in message-time order: one capability request
-        // is one connection ask for the whole conversation — the earliest
-        // validated (non-asker) result flips the pill for every member; the
-        // agent re-requests under a new requestId if it needs more. Both the
-        // resolution rule and the latest-pending computation are shared with
-        // CapabilityRequestRepository (the tap path), so a pill rendered
-        // `.pending` is always the request the approval sheet would open for.
+        // Resolution is per viewer: only the current member's own validated
+        // (non-asker) result rows flip the pill they see — the earliest of
+        // their decisions wins, and other members' decisions leave their pill
+        // actionable. Both the resolution rule and the latest-pending
+        // computation are shared with CapabilityRequestRepository (the tap
+        // path), so a pill rendered `.pending` is always the request the
+        // approval sheet would open for.
         var capabilityResultsByRequestId: [String: [CapabilityConnectPrompt.ResultRecord]] = [:]
         var latestPendingCapabilityRequestId: String?
         if rawMessages.contains(where: { $0.contentType == .capabilityRequest }) {
@@ -1181,6 +1184,7 @@ fileprivate extension Database {
             )
             latestPendingCapabilityRequestId = try CapabilityRequestRepository.computeLatestPendingRequest(
                 conversationId: conversationId,
+                viewerInboxId: currentInboxId,
                 db: self,
                 resultsByRequestId: capabilityResultsByRequestId
             )?.requestId

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -641,11 +641,11 @@ extension XMTPiOS.DecodedMessage {
 
     /// Result rows are persisted verbatim; legitimacy is enforced at derivation
     /// time by `CapabilityConnectPrompt.resolution`, which only lets a result
-    /// resolve a request when the row's XMTP-attested sender differs from the
-    /// request's asker. Unlike `CloudConnectionGrantRequest` (validated above
+    /// resolve a request for the member who authored it (never the request's
+    /// asker). Unlike `CloudConnectionGrantRequest` (validated above
     /// via `validateConnectionGrantRequest`), the result payload carries no
     /// sender claim to cross-check here — and the matching request row may not
-    /// have synced yet, so the asker comparison can only happen at the join.
+    /// have synced yet, so the sender comparisons can only happen at the join.
     private func handleCapabilityRequestResultContent() throws -> DBMessageComponents {
         let content = try content() as Any
         guard let result = content as? CapabilityRequestResult else {

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
@@ -47,42 +47,68 @@ struct CapabilityConnectTranscriptTests {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .pending)
     }
 
-    @Test("an approved result row flips the prompt to connected")
+    @Test("the viewer's own approval flips the prompt to connected")
     func connectedOnApproval() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [record(from: approver, .approved)],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .connected)
     }
 
-    @Test("an earlier denial dismisses even when an approval lands later")
+    @Test("another member's approval leaves the prompt pending for the viewer")
+    func otherMemberApprovalKeepsViewerPending() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [record(from: "another-member", .approved)],
+            askerInboxId: asker,
+            viewerInboxId: approver,
+            isLatestUnresolvedRequest: true
+        )
+        #expect(status == .pending)
+    }
+
+    @Test("another member's denial leaves the prompt pending for the viewer")
+    func otherMemberDenialKeepsViewerPending() {
+        let status = CapabilityConnectPrompt.displayStatus(
+            results: [record(from: "another-member", .denied)],
+            askerInboxId: asker,
+            viewerInboxId: approver,
+            isLatestUnresolvedRequest: true
+        )
+        #expect(status == .pending)
+    }
+
+    @Test("the viewer's earlier denial dismisses even when their approval lands later")
     func earlierDenialWinsOverLaterApproval() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [
                 record(from: approver, .denied, at: 1),
-                record(from: "another-member", .approved, at: 2),
+                record(from: approver, .approved, at: 2),
             ],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .dismissed)
     }
 
-    @Test("an earlier approval connects even when a denial lands later")
+    @Test("the viewer's earlier approval connects even when their denial lands later")
     func earlierApprovalWinsOverLaterDenial() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [
                 record(from: approver, .approved, at: 1),
-                record(from: "another-member", .denied, at: 2),
+                record(from: approver, .denied, at: 2),
             ],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .connected)
@@ -94,16 +120,17 @@ struct CapabilityConnectTranscriptTests {
         // earlier denial must still win.
         let status = CapabilityConnectPrompt.displayStatus(
             results: [
-                record(from: "another-member", .approved, at: 2),
+                record(from: approver, .approved, at: 2),
                 record(from: approver, .denied, at: 1),
             ],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .dismissed)
     }
 
-    @Test("an asker denial earlier than a valid approval still connects")
+    @Test("an asker denial earlier than the viewer's approval still connects")
     func askerDenialSkippedBeforeValidApproval() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [
@@ -111,6 +138,7 @@ struct CapabilityConnectTranscriptTests {
                 record(from: approver, .approved, at: 2),
             ],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .connected)
@@ -120,16 +148,18 @@ struct CapabilityConnectTranscriptTests {
     func identicalTimestampsUseMessageIdTiebreaker() {
         let results = [
             record(from: approver, .denied, at: 5, id: "message-b"),
-            record(from: "another-member", .approved, at: 5, id: "message-a"),
+            record(from: approver, .approved, at: 5, id: "message-a"),
         ]
         let status = CapabilityConnectPrompt.displayStatus(
             results: results,
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         let reversedStatus = CapabilityConnectPrompt.displayStatus(
             results: results.reversed(),
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         // "message-a" (the approval) sorts first regardless of array order.
@@ -137,27 +167,30 @@ struct CapabilityConnectTranscriptTests {
         #expect(reversedStatus == .connected)
     }
 
-    @Test("denied and cancelled results dismiss the prompt")
+    @Test("the viewer's denied and cancelled results dismiss the prompt")
     func dismissedOnDenyOrCancel() {
         let denied = CapabilityConnectPrompt.displayStatus(
             results: [record(from: approver, .denied)],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         let cancelled = CapabilityConnectPrompt.displayStatus(
             results: [record(from: approver, .cancelled)],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(denied == .dismissed)
         #expect(cancelled == .dismissed)
     }
 
-    @Test("the asker cannot resolve its own request")
+    @Test("the asker cannot resolve its own request, even as the viewer")
     func askerResultsIgnored() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [record(from: asker, .approved)],
             askerInboxId: asker,
+            viewerInboxId: asker,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .pending)
@@ -171,6 +204,7 @@ struct CapabilityConnectTranscriptTests {
                 record(from: approver, .unknown, at: 2),
             ],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(status == .pending)
@@ -181,16 +215,18 @@ struct CapabilityConnectTranscriptTests {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: false
         )
         #expect(status == .superseded)
     }
 
-    @Test("a resolved request stays resolved even when a newer request exists")
+    @Test("a request the viewer resolved stays resolved even when a newer request exists")
     func resolutionWinsOverSupersession() {
         let status = CapabilityConnectPrompt.displayStatus(
             results: [record(from: approver, .approved)],
             askerInboxId: asker,
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: false
         )
         #expect(status == .connected)
@@ -203,6 +239,7 @@ struct CapabilityConnectTranscriptTests {
         let prompt = CapabilityConnectPrompt.make(
             request: makeRequest(),
             results: [],
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(prompt.serviceName == "Google Calendar")
@@ -217,6 +254,7 @@ struct CapabilityConnectTranscriptTests {
         let prompt = CapabilityConnectPrompt.make(
             request: makeRequest(preferredProviders: nil),
             results: [],
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(prompt.serviceName == "Calendar")
@@ -229,6 +267,7 @@ struct CapabilityConnectTranscriptTests {
         let prompt = CapabilityConnectPrompt.make(
             request: makeRequest(preferredProviders: [ProviderID(rawValue: "device.calendar")]),
             results: [],
+            viewerInboxId: approver,
             isLatestUnresolvedRequest: true
         )
         #expect(prompt.serviceName == "Apple Calendar")
@@ -248,14 +287,24 @@ struct CapabilityConnectTranscriptTests {
         #expect(prompt.serviceName == "Google Calendar")
     }
 
-    @Test("approved result row from another member hydrates the prompt as connected")
+    @Test("the viewer's own approved result row hydrates the prompt as connected")
     func hydratesConnectedPrompt() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 2)
+
+        let prompt = try #require(try harness.fetchPrompt())
+        #expect(prompt.status == .connected)
+    }
+
+    @Test("another member's approved result row leaves the viewer's prompt pending")
+    func hydrationKeepsViewerPendingAfterOtherMemberApproval() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
         try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
 
         let prompt = try #require(try harness.fetchPrompt())
-        #expect(prompt.status == .connected)
+        #expect(prompt.status == .pending)
     }
 
     @Test("approved result row from the asker leaves the prompt pending")
@@ -272,7 +321,7 @@ struct CapabilityConnectTranscriptTests {
     func hydrationJoinsByRequestId() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
-        try harness.insertResultRow(requestId: "req-other", senderId: approver, status: .approved, sortId: 2)
+        try harness.insertResultRow(requestId: "req-other", senderId: harness.currentInboxId, status: .approved, sortId: 2)
 
         let prompt = try #require(try harness.fetchPrompt())
         #expect(prompt.status == .pending)
@@ -303,14 +352,62 @@ struct CapabilityConnectTranscriptTests {
     // the same database so the pill can never look actionable while the tap
     // path would refuse it, or vice versa.
 
-    @Test("non-asker approval resolves the request in both layers")
-    func agreementOnNonAskerApproval() throws {
+    @Test("the viewer's approval resolves the request in both layers")
+    func agreementOnViewerApproval() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 2)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == nil)
+    }
+
+    // The multi-member contract: every member sees the pill, and it grays out
+    // only for a member who has used it themselves. The harness models user 1
+    // as `currentInboxId` and user 2 as `approver`, alongside the agent asker.
+
+    @Test("one member's approval consumes the pill only for that member")
+    func otherMemberApprovalKeepsViewerActionable() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
         try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
 
+        #expect(try harness.fetchPrompt(requestId: "req-1", as: approver)?.status == .connected)
+        #expect(try harness.latestPendingRequestId(as: approver) == nil)
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-1")
+    }
+
+    @Test("each member's own approval completes the request for them")
+    func bothMembersConnectedAfterBothApprove() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
+
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
         #expect(try harness.latestPendingRequestId() == nil)
+        #expect(try harness.fetchPrompt(requestId: "req-1", as: approver)?.status == .connected)
+        #expect(try harness.latestPendingRequestId(as: approver) == nil)
+    }
+
+    @Test("a denial dismisses the request only for its author")
+    func dismissalIsPerViewer() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 2)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1", as: approver)?.status == .dismissed)
+        #expect(try harness.latestPendingRequestId(as: approver) == nil)
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-1")
+
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == nil)
+        #expect(try harness.fetchPrompt(requestId: "req-1", as: approver)?.status == .dismissed)
+        #expect(try harness.latestPendingRequestId(as: approver) == nil)
     }
 
     @Test("asker-authored approval leaves the request open in both layers")
@@ -333,46 +430,46 @@ struct CapabilityConnectTranscriptTests {
         #expect(try harness.latestPendingRequestId() == "req-1")
     }
 
-    @Test("duplicate results agree: the earliest decision wins for both layers")
-    func agreementOnDuplicateResults() throws {
+    @Test("mixed rows agree: only the viewer's earliest decision counts in both layers")
+    func agreementOnMixedMemberRows() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
         try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 2)
         try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
         try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 4)
 
-        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .dismissed)
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
         #expect(try harness.latestPendingRequestId() == nil)
     }
 
-    @Test("denial before approval dismisses in both layers")
+    @Test("the viewer's denial before their approval dismisses in both layers")
     func agreementOnDenialBeforeApproval() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .denied, sortId: 2)
         try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
 
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .dismissed)
         #expect(try harness.latestPendingRequestId() == nil)
     }
 
-    @Test("approval before denial connects in both layers")
+    @Test("the viewer's approval before their denial connects in both layers")
     func agreementOnApprovalBeforeDenial() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 2)
         try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .denied, sortId: 3)
 
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
         #expect(try harness.latestPendingRequestId() == nil)
     }
 
-    @Test("an asker denial then a valid approval connects in both layers")
+    @Test("an asker denial then the viewer's approval connects in both layers")
     func agreementOnAskerDenialThenApproval() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
         try harness.insertResultRow(requestId: "req-1", senderId: asker, status: .denied, sortId: 2)
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 3)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 3)
 
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
         #expect(try harness.latestPendingRequestId() == nil)
@@ -385,8 +482,8 @@ struct CapabilityConnectTranscriptTests {
         let sharedNs = Int64(harness.now.timeIntervalSince1970 * 1_000_000_000) + 10
         // Same dateNs on both rows; the lower message id ("message-2", the
         // approval) must win in both layers regardless of insertion order.
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .denied, sortId: 3, dateNs: sharedNs)
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .approved, sortId: 2, dateNs: sharedNs)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .denied, sortId: 3, dateNs: sharedNs)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 2, dateNs: sharedNs)
 
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .connected)
         #expect(try harness.latestPendingRequestId() == nil)
@@ -396,8 +493,8 @@ struct CapabilityConnectTranscriptTests {
     func agreementOnNonDecisionStatuses() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(), sortId: 1)
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .staleResource, sortId: 2)
-        try harness.insertResultRow(requestId: "req-1", senderId: approver, status: .unknown, sortId: 3)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .staleResource, sortId: 2)
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .unknown, sortId: 3)
 
         #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
         #expect(try harness.latestPendingRequestId() == "req-1")
@@ -414,16 +511,28 @@ struct CapabilityConnectTranscriptTests {
         #expect(try harness.latestPendingRequestId() == "req-2")
     }
 
-    @Test("resolving the newer request hands actionability back to the older one")
+    @Test("the viewer resolving the newer request hands actionability back to the older one")
     func agreementOnSupersededFlipBack() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.insertRequestRow(makeRequest(requestId: "req-1"), sortId: 1)
+        try harness.insertRequestRow(makeRequest(requestId: "req-2"), sortId: 2)
+        try harness.insertResultRow(requestId: "req-2", senderId: harness.currentInboxId, status: .approved, sortId: 3)
+
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
+        #expect(try harness.fetchPrompt(requestId: "req-2")?.status == .connected)
+        #expect(try harness.latestPendingRequestId() == "req-1")
+    }
+
+    @Test("another member resolving the newer request changes nothing for the viewer")
+    func agreementOnSupersededHeldByOtherMemberResolution() throws {
         let harness = try HydrationHarness(asker: asker, approver: approver)
         try harness.insertRequestRow(makeRequest(requestId: "req-1"), sortId: 1)
         try harness.insertRequestRow(makeRequest(requestId: "req-2"), sortId: 2)
         try harness.insertResultRow(requestId: "req-2", senderId: approver, status: .approved, sortId: 3)
 
-        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .pending)
-        #expect(try harness.fetchPrompt(requestId: "req-2")?.status == .connected)
-        #expect(try harness.latestPendingRequestId() == "req-1")
+        #expect(try harness.fetchPrompt(requestId: "req-1")?.status == .superseded)
+        #expect(try harness.fetchPrompt(requestId: "req-2")?.status == .pending)
+        #expect(try harness.latestPendingRequestId() == "req-2")
     }
 }
 
@@ -484,11 +593,14 @@ private struct HydrationHarness {
         )
     }
 
-    func fetchMessages() throws -> [AnyMessage] {
+    /// `viewer` defaults to `currentInboxId` (user 1's device); passing
+    /// another member's inbox id derives the transcript that member's device
+    /// would compose, so per-viewer tests can assert both sides of one store.
+    func fetchMessages(as viewer: String? = nil) throws -> [AnyMessage] {
         let repository = MessagesRepository(
             dbReader: dbManager.dbReader,
             conversationId: conversationId,
-            currentInboxId: currentInboxId
+            currentInboxId: viewer ?? currentInboxId
         )
         return try repository.fetchInitial()
     }
@@ -497,23 +609,26 @@ private struct HydrationHarness {
         try fetchPrompts().first
     }
 
-    func fetchPrompt(requestId: String) throws -> CapabilityConnectPrompt? {
-        try fetchPrompts().first { $0.requestId == requestId }
+    func fetchPrompt(requestId: String, as viewer: String? = nil) throws -> CapabilityConnectPrompt? {
+        try fetchPrompts(as: viewer).first { $0.requestId == requestId }
     }
 
     /// The repository half of the layer-agreement assertions: the request the
-    /// tap path would open the approval sheet for, nil when none is pending.
-    func latestPendingRequestId() throws -> String? {
-        try dbManager.dbReader.read { db in
+    /// tap path would open the approval sheet for, nil when none is pending
+    /// for the given viewer.
+    func latestPendingRequestId(as viewer: String? = nil) throws -> String? {
+        let viewerInboxId = viewer ?? currentInboxId
+        return try dbManager.dbReader.read { db in
             CapabilityRequestRepository.computeLatestPendingRequest(
                 conversationId: conversationId,
+                viewerInboxId: viewerInboxId,
                 db: db
             )?.requestId
         }
     }
 
-    private func fetchPrompts() throws -> [CapabilityConnectPrompt] {
-        try fetchMessages().compactMap { anyMessage in
+    private func fetchPrompts(as viewer: String? = nil) throws -> [CapabilityConnectPrompt] {
+        try fetchMessages(as: viewer).compactMap { anyMessage in
             if case .message(let message, _) = anyMessage,
                case .capabilityConnect(let prompt) = message.content {
                 return prompt


### PR DESCRIPTION
## Summary

In a multi-member group, the first validated `capability_request_result` from any member resolved the request on every device: one member approving (or denying) flipped the transcript pill to connected or dismissed for everyone else, taking away their chance to grant their own connection. Grants themselves were already per account (owner bound to the JWT), so the other members lost the affordance while holding no grant.

Intended behavior: everyone sees the pill, and it grays out only after a given member used it themselves. As long as a member hasn't consumed it, it stays tappable for them.

## Change

Resolution becomes a function of (requestId, viewing member): a result row counts toward the status a member sees only when its XMTP-attested `senderId` is that member.

- `CapabilityConnectPrompt.resolution` / `displayStatus` / `make` gain a `viewerInboxId` and filter result rows to the viewer's own (the asker exclusion and earliest-decision-wins ordering among the viewer's rows are unchanged)
- `CapabilityRequestRepository` (the tap path) takes the viewer's inbox id, injected by `SessionManager`, so "pill pending" and "approval sheet opens" keep deriving from the same rule per viewer
- `MessagesRepository`'s compose-time join threads its existing `currentInboxId` through
- superseded semantics unchanged (now per viewer, since "latest unresolved" is per viewer)

No wire or protocol change: result rows already carry `senderId`, and nothing changes agent-side - the agent's result correlation by `requestId` and its re-ask ledger are untouched. A member who hasn't acted re-taps the existing pill.

## Tests

Reworked `CapabilityConnectTranscriptTests` to the per-member contract and added the multi-member repro:

- `otherMemberApprovalKeepsViewerPending` / `otherMemberDenialKeepsViewerPending` (status derivation)
- `hydrationKeepsViewerPendingAfterOtherMemberApproval` (GRDB compose-time join)
- `otherMemberApprovalKeepsViewerActionable` - user 2 approves: user 2 connected, user 1 still pending and actionable in both layers
- `bothMembersConnectedAfterBothApprove` - user 1 then approves: both connected
- `dismissalIsPerViewer` - a denial dismisses only for its author; the other member can still approve
- `agreementOnSupersededHeldByOtherMemberResolution` - another member resolving the newer request changes nothing for the viewer

## Verification

- SwiftLint `--strict` on the six changed files: clean
- `xcodebuild build -scheme "Convos (Dev)" -configuration Dev` against an iPhone 17 simulator: build succeeded
- `swift test --package-path ConvosCore`: 1885 tests in 254 suites, all passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789661718&installation_model_id=20076&pr_number=1328&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1328&signature=f8c044156f31519624dbb0be30831d46493459826000dfa39d1f31598970ba37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve capability requests per viewer instead of conversation-wide
> - `CapabilityConnectPrompt.resolution` now filters decision rows to those authored by the viewing member, so only the viewer's own approve/deny/cancel action resolves the request for them — other members' decisions no longer affect the viewer's pill state.
> - `CapabilityRequestRepository` accepts a `viewerInboxId` and uses it when computing the latest pending request, so the pending state is per-viewer rather than shared across the conversation.
> - `CapabilityConnectPrompt.make` and `displayStatus` are updated to derive pending/connected/dismissed/superseded status from the viewer's own decisions.
> - Tests in [CapabilityConnectTranscriptTests.swift](https://github.com/xmtplabs/convos-ios/pull/1328/files#diff-13febb5a4c860784a91731639b932873d1d6729cf56becaba0a4aae256b53d99) are updated and extended with multi-member scenarios to verify per-viewer semantics.
> - Behavioral Change: a capability request now remains pending for a viewer until that specific viewer acts on it, regardless of what other conversation members have done.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa2b93c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->