### PR TITLE
Per-conversation agent variant, picked at new convo

### DIFF
--- a/Convos/Agent Builder/AgentVariantAssignmentStore.swift
+++ b/Convos/Agent Builder/AgentVariantAssignmentStore.swift
@@ -4,10 +4,13 @@ import Foundation
 /// Remembers which variant each conversation's agents were built under.
 ///
 /// The pick is made at new-convo creation, before a conversation id exists, so
-/// it lands in `pendingSlug` first and the conversation claims it on its first
-/// agent join (`claimPendingSlug(for:)`). Every later join in that same
-/// conversation reads the stored assignment, so a convo keeps one variant for
-/// its lifetime instead of following the global default as it changes.
+/// it rides along on the `NewConversationViewModel` that mints the
+/// conversation and is written here once that flow reaches `.ready` with an id.
+/// Deliberately not a single shared "pending" slot: two overlapping creation
+/// flows would race for it, and the second pick would bind to the first
+/// conversation. Every later join in a conversation reads its assignment, so a
+/// convo keeps one variant for its lifetime instead of following the global
+/// default as it changes.
 ///
 /// Backed by UserDefaults rather than the database: this is a dev-only testing
 /// aid gated behind `FeatureFlags.isAgentVariantSelectorEnabled`, and a schema
@@ -20,19 +23,6 @@ final class AgentVariantAssignmentStore {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-    }
-
-    /// The variant chosen for the conversation about to be created, consumed by
-    /// the first agent join that follows.
-    var pendingSlug: String? {
-        get { defaults.string(forKey: Constant.pendingSlugKey) }
-        set {
-            guard let newValue else {
-                defaults.removeObject(forKey: Constant.pendingSlugKey)
-                return
-            }
-            defaults.set(newValue, forKey: Constant.pendingSlugKey)
-        }
     }
 
     func slug(for conversationId: String) -> String? {
@@ -51,22 +41,14 @@ final class AgentVariantAssignmentStore {
         defaults.set(current, forKey: Constant.assignmentsKey)
     }
 
-    /// Binds any pending pick to this conversation and clears it, so the next
-    /// conversation starts from the default rather than inheriting this one's.
-    /// Returns the slug now in force for the conversation (existing assignment
-    /// wins, so a re-join can't be re-pointed by a later pending pick).
-    @discardableResult
-    func claimPendingSlug(for conversationId: String) -> String? {
-        guard !conversationId.isEmpty else { return nil }
-        if let existing = slug(for: conversationId) {
-            pendingSlug = nil
-            return existing
-        }
-        guard let pending = pendingSlug else { return nil }
-        assign(slug: pending, to: conversationId)
-        pendingSlug = nil
-        Log.info("AgentVariant: conversation \(conversationId) claimed variant \(pending)")
-        return pending
+    /// Records the variant a freshly created conversation was started under.
+    /// An existing assignment wins, so a conversation that already routed a
+    /// join can't be re-pointed later.
+    func assignIfUnset(slug: String?, to conversationId: String) {
+        guard let slug, !conversationId.isEmpty else { return }
+        guard self.slug(for: conversationId) == nil else { return }
+        assign(slug: slug, to: conversationId)
+        Log.info("AgentVariant: conversation \(conversationId) bound to variant \(slug)")
     }
 
     private func assignments() -> [String: String] {
@@ -75,6 +57,5 @@ final class AgentVariantAssignmentStore {
 
     private enum Constant {
         static let assignmentsKey: String = "agentVariantAssignmentsByConversation"
-        static let pendingSlugKey: String = "agentVariantPendingSlug"
     }
 }

--- a/Convos/Agent Builder/AgentVariantAssignmentStore.swift
+++ b/Convos/Agent Builder/AgentVariantAssignmentStore.swift
@@ -1,0 +1,80 @@
+import ConvosCore
+import Foundation
+
+/// Remembers which variant each conversation's agents were built under.
+///
+/// The pick is made at new-convo creation, before a conversation id exists, so
+/// it lands in `pendingSlug` first and the conversation claims it on its first
+/// agent join (`claimPendingSlug(for:)`). Every later join in that same
+/// conversation reads the stored assignment, so a convo keeps one variant for
+/// its lifetime instead of following the global default as it changes.
+///
+/// Backed by UserDefaults rather than the database: this is a dev-only testing
+/// aid gated behind `FeatureFlags.isAgentVariantSelectorEnabled`, and a schema
+/// migration would be disproportionate for it.
+@MainActor
+final class AgentVariantAssignmentStore {
+    static let shared: AgentVariantAssignmentStore = AgentVariantAssignmentStore()
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// The variant chosen for the conversation about to be created, consumed by
+    /// the first agent join that follows.
+    var pendingSlug: String? {
+        get { defaults.string(forKey: Constant.pendingSlugKey) }
+        set {
+            guard let newValue else {
+                defaults.removeObject(forKey: Constant.pendingSlugKey)
+                return
+            }
+            defaults.set(newValue, forKey: Constant.pendingSlugKey)
+        }
+    }
+
+    func slug(for conversationId: String) -> String? {
+        guard !conversationId.isEmpty else { return nil }
+        return assignments()[conversationId]
+    }
+
+    func assign(slug: String?, to conversationId: String) {
+        guard !conversationId.isEmpty else { return }
+        var current = assignments()
+        if let slug {
+            current[conversationId] = slug
+        } else {
+            current.removeValue(forKey: conversationId)
+        }
+        defaults.set(current, forKey: Constant.assignmentsKey)
+    }
+
+    /// Binds any pending pick to this conversation and clears it, so the next
+    /// conversation starts from the default rather than inheriting this one's.
+    /// Returns the slug now in force for the conversation (existing assignment
+    /// wins, so a re-join can't be re-pointed by a later pending pick).
+    @discardableResult
+    func claimPendingSlug(for conversationId: String) -> String? {
+        guard !conversationId.isEmpty else { return nil }
+        if let existing = slug(for: conversationId) {
+            pendingSlug = nil
+            return existing
+        }
+        guard let pending = pendingSlug else { return nil }
+        assign(slug: pending, to: conversationId)
+        pendingSlug = nil
+        Log.info("AgentVariant: conversation \(conversationId) claimed variant \(pending)")
+        return pending
+    }
+
+    private func assignments() -> [String: String] {
+        defaults.dictionary(forKey: Constant.assignmentsKey) as? [String: String] ?? [:]
+    }
+
+    private enum Constant {
+        static let assignmentsKey: String = "agentVariantAssignmentsByConversation"
+        static let pendingSlugKey: String = "agentVariantPendingSlug"
+    }
+}

--- a/Convos/Agent Builder/AgentVariantDebugPicker.swift
+++ b/Convos/Agent Builder/AgentVariantDebugPicker.swift
@@ -1,0 +1,84 @@
+import ConvosCore
+import SwiftUI
+
+/// Form-native variant picker for App Settings -> Debug, shown under the
+/// "Agent variant selector" toggle. Sets the default variant new conversations
+/// start from; the per-conversation picker at creation can override it.
+///
+/// Reads `AgentVariantRegistry.shared` rather than fetching itself -- a
+/// view-scoped fetch here is cancelled and restarted by Form row churn and
+/// never settles.
+struct AgentVariantDebugPicker: View {
+    @State private var registry: AgentVariantRegistry = .shared
+
+    var body: some View {
+        Group {
+            picker
+            statusRow
+        }
+        .task { await registry.loadIfNeeded() }
+    }
+
+    /// Always rendered, so the row structure stays stable across load states
+    /// and the enclosing Form does not recreate this view mid-fetch.
+    private var picker: some View {
+        Picker("Variant", selection: selectionBinding) {
+            Text("No variant").tag(String?.none)
+            ForEach(registry.variants) { variant in
+                Text(variant.label).tag(String?.some(variant.slug))
+            }
+        }
+        .disabled(registry.variants.isEmpty)
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        switch registry.loadState {
+        case .loading, .idle:
+            Text("Loading variants...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .failed:
+            retryRow
+        case .loaded:
+            whatToTestRow
+        }
+    }
+
+    /// The chosen variant's what-to-test, so the tester can confirm what they
+    /// are about to route new conversations through before leaving the screen.
+    @ViewBuilder
+    private var whatToTestRow: some View {
+        let selected: ConvosAPI.AgentVariant? = registry.variant(withSlug: FeatureFlags.shared.selectedAgentVariant?.slug)
+        if let selected, !selected.whatToTest.isEmpty {
+            Text(selected.whatToTest)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var retryRow: some View {
+        let retry: () -> Void = {
+            Task { await registry.reload() }
+        }
+        return Button(action: retry) {
+            HStack {
+                Text("Couldn't load variants")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0.0)
+                Text("Retry")
+                    .font(.caption)
+            }
+        }
+    }
+
+    private var selectionBinding: Binding<String?> {
+        Binding(
+            get: { FeatureFlags.shared.selectedAgentVariant?.slug },
+            set: { newValue in
+                FeatureFlags.shared.selectedAgentVariant = registry.variant(withSlug: newValue)
+            }
+        )
+    }
+}

--- a/Convos/Agent Builder/AgentVariantPickerSheet.swift
+++ b/Convos/Agent Builder/AgentVariantPickerSheet.swift
@@ -31,6 +31,14 @@ struct AgentVariantPickerSheet: View {
         .task {
             selectedSlug = FeatureFlags.shared.selectedAgentVariant?.slug
             await registry.loadIfNeeded()
+            // The persisted default may name a variant that has since been
+            // retired -- `loadIfNeeded` clears it from FeatureFlags during
+            // reconciliation, so drop it here too rather than handing a dead
+            // slug to the new conversation. Validated against the live list so
+            // a pick made while the fetch was in flight survives.
+            if registry.loadState == .loaded, registry.variant(withSlug: selectedSlug) == nil {
+                selectedSlug = nil
+            }
         }
     }
 

--- a/Convos/Agent Builder/AgentVariantPickerSheet.swift
+++ b/Convos/Agent Builder/AgentVariantPickerSheet.swift
@@ -6,12 +6,11 @@ import SwiftUI
 /// `FeatureFlags.isAgentVariantSelectorEnabled` is on, ahead of the
 /// new-conversation flow.
 ///
-/// The pick is written to `AgentVariantAssignmentStore.pendingSlug`; the
-/// conversation claims it on its first agent join and keeps it from then on.
-/// Starts on the Debug default so the common case is Continue without touching
-/// the dropdown.
+/// The pick is handed to the caller, which passes it to the creation flow so it
+/// binds to that specific conversation once it has an id. Starts on the Debug
+/// default so the common case is Continue without touching the dropdown.
 struct AgentVariantPickerSheet: View {
-    let onContinue: () -> Void
+    let onContinue: (String?) -> Void
 
     @State private var registry: AgentVariantRegistry = .shared
     @State private var selectedSlug: String?
@@ -62,10 +61,10 @@ struct AgentVariantPickerSheet: View {
 
     private var continueButton: some View {
         let confirm: () -> Void = {
-            AgentVariantAssignmentStore.shared.pendingSlug = selectedSlug
-            Log.info("AgentVariant: pending pick for next conversation: \(selectedSlug ?? "none")")
+            let slug = selectedSlug
+            Log.info("AgentVariant: new conversation starting under variant \(slug ?? "none")")
             dismiss()
-            onContinue()
+            onContinue(slug)
         }
         return Button(action: confirm) {
             Text("Continue")

--- a/Convos/Agent Builder/AgentVariantPickerSheet.swift
+++ b/Convos/Agent Builder/AgentVariantPickerSheet.swift
@@ -1,0 +1,75 @@
+import ConvosCore
+import SwiftUI
+
+/// Asks which variant the conversation about to be created should build its
+/// agent under. Presented from the compose entry point while
+/// `FeatureFlags.isAgentVariantSelectorEnabled` is on, ahead of the
+/// new-conversation flow.
+///
+/// The pick is written to `AgentVariantAssignmentStore.pendingSlug`; the
+/// conversation claims it on its first agent join and keeps it from then on.
+/// Starts on the Debug default so the common case is Continue without touching
+/// the dropdown.
+struct AgentVariantPickerSheet: View {
+    let onContinue: () -> Void
+
+    @State private var registry: AgentVariantRegistry = .shared
+    @State private var selectedSlug: String?
+    @Environment(\.dismiss) private var dismiss: DismissAction
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.step4x) {
+            Text("Agent variant")
+                .font(.headline)
+            Text("The agent in this conversation builds under the variant you pick here.")
+                .font(.subheadline)
+                .foregroundStyle(.colorTextSecondary)
+            variantMenu
+            whatToTest
+            continueButton
+        }
+        .padding(DesignConstants.Spacing.step4x)
+        .task {
+            selectedSlug = FeatureFlags.shared.selectedAgentVariant?.slug
+            await registry.loadIfNeeded()
+        }
+    }
+
+    private var variantMenu: some View {
+        Picker("Variant", selection: $selectedSlug) {
+            Text(noVariantTitle).tag(String?.none)
+            ForEach(registry.variants) { variant in
+                Text(variant.label).tag(String?.some(variant.slug))
+            }
+        }
+        .pickerStyle(.menu)
+        .disabled(registry.loadState == .loading)
+    }
+
+    private var noVariantTitle: String {
+        registry.loadState == .loading ? "Loading variants..." : "No variant"
+    }
+
+    @ViewBuilder
+    private var whatToTest: some View {
+        let selected: ConvosAPI.AgentVariant? = registry.variant(withSlug: selectedSlug)
+        if let selected, !selected.whatToTest.isEmpty {
+            Text(selected.whatToTest)
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+        }
+    }
+
+    private var continueButton: some View {
+        let confirm: () -> Void = {
+            AgentVariantAssignmentStore.shared.pendingSlug = selectedSlug
+            Log.info("AgentVariant: pending pick for next conversation: \(selectedSlug ?? "none")")
+            dismiss()
+            onContinue()
+        }
+        return Button(action: confirm) {
+            Text("Continue")
+        }
+        .convosButtonStyle(.rounded(fullWidth: true))
+    }
+}

--- a/Convos/Agent Builder/AgentVariantRegistry.swift
+++ b/Convos/Agent Builder/AgentVariantRegistry.swift
@@ -1,0 +1,78 @@
+import ConvosCore
+import SwiftUI
+
+/// App-lifetime cache of the dev variant registry (`GET /v2/agent-variants`).
+///
+/// The fetch deliberately does not live in a view's `.task`: the debug picker
+/// and the new-convo picker both sit inside a `Form`/sheet whose rows are
+/// recreated as state changes, which cancels an in-flight view-scoped task and
+/// restarts it from a fresh `.loading` -- a loop that never settles. Holding the
+/// load here means view churn re-reads a cached result instead of refetching.
+@MainActor
+@Observable
+final class AgentVariantRegistry {
+    enum LoadState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed
+    }
+
+    static let shared: AgentVariantRegistry = AgentVariantRegistry()
+
+    private(set) var variants: [ConvosAPI.AgentVariant] = []
+    private(set) var loadState: LoadState = .idle
+
+    private var loadTask: Task<Void, Never>?
+    private let apiClient: any ConvosAPIClientProtocol
+
+    init(apiClient: any ConvosAPIClientProtocol = ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)) {
+        self.apiClient = apiClient
+    }
+
+    /// Loads once and caches. Re-entrant: concurrent callers await the same
+    /// task, and an already-loaded registry returns immediately.
+    func loadIfNeeded() async {
+        if loadState == .loaded { return }
+        if let loadTask {
+            await loadTask.value
+            return
+        }
+        await reload()
+    }
+
+    /// Forces a refetch, replacing any cached result. Detached from the caller's
+    /// task so a cancelled view teardown can't cancel the fetch itself.
+    func reload() async {
+        loadTask?.cancel()
+        loadState = .loading
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let fetched = try await self.apiClient.getAgentVariants()
+                self.variants = fetched
+                self.reconcileSelection(against: fetched)
+                self.loadState = .loaded
+            } catch {
+                Log.error("AgentVariantRegistry: failed to load variants: \(error.localizedDescription)")
+                self.loadState = .failed
+            }
+            self.loadTask = nil
+        }
+        loadTask = task
+        await task.value
+    }
+
+    func variant(withSlug slug: String?) -> ConvosAPI.AgentVariant? {
+        guard let slug else { return nil }
+        return variants.first { $0.slug == slug }
+    }
+
+    /// Drops a persisted selection whose slug no longer exists in the live
+    /// registry, so a retired variant can't silently keep routing builds.
+    private func reconcileSelection(against fetched: [ConvosAPI.AgentVariant]) {
+        guard let slug = FeatureFlags.shared.selectedAgentVariant?.slug else { return }
+        guard !fetched.contains(where: { $0.slug == slug }) else { return }
+        FeatureFlags.shared.selectedAgentVariant = nil
+    }
+}

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -235,6 +235,13 @@ class NewConversationViewModel: Identifiable, Hashable {
     /// leave a stale id in the cache's claim set.
     private var claimRegistrationTask: Task<Void, Never>?
 
+    /// The dev-only agent variant this conversation was started under, chosen
+    /// before the conversation existed. Carried on the flow rather than in a
+    /// shared slot so two overlapping creations can't bind each other's pick;
+    /// written to `AgentVariantAssignmentStore` once `.ready` supplies an id.
+    @ObservationIgnored
+    private let agentVariantSlug: String?
+
     private(set) var isCreatingConversation: Bool = false
     private(set) var currentError: Error?
     private(set) var conversationState: ConversationStateMachine.State = .uninitialized {
@@ -352,10 +359,12 @@ class NewConversationViewModel: Identifiable, Hashable {
         session: any SessionManagerProtocol,
         mode: NewConversationMode,
         defersInviteVisibilityUntilEntered: Bool = false,
-        coreActions: any CoreActions = NoOpCoreActions()
+        coreActions: any CoreActions = NoOpCoreActions(),
+        agentVariantSlug: String? = nil
     ) {
         self.session = session
         self.coreActions = coreActions
+        self.agentVariantSlug = agentVariantSlug
         self.qrScannerViewModel = QRScannerViewModel()
         switch mode {
         case .scanner:
@@ -457,6 +466,7 @@ class NewConversationViewModel: Identifiable, Hashable {
     ) {
         self.session = session
         self.coreActions = coreActions
+        self.agentVariantSlug = nil
         self.qrScannerViewModel = QRScannerViewModel()
         self.autoCreateConversation = autoCreateConversation
         self.startedWithFullscreenScanner = showingFullScreenScanner
@@ -1383,6 +1393,13 @@ extension NewConversationViewModel {
                     }
                 }
             }
+
+            // Bind this flow's variant pick to the conversation now that it
+            // has an id, before any agent join reads it.
+            AgentVariantAssignmentStore.shared.assignIfUnset(
+                slug: agentVariantSlug,
+                to: result.conversationId
+            )
 
             notifyDefaultAgentConversationReadyIfNeeded(result)
 

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -1395,11 +1395,17 @@ extension NewConversationViewModel {
             }
 
             // Bind this flow's variant pick to the conversation now that it
-            // has an id, before any agent join reads it.
-            AgentVariantAssignmentStore.shared.assignIfUnset(
-                slug: agentVariantSlug,
-                to: result.conversationId
-            )
+            // has an id, before any agent join reads it. Only for a
+            // conversation this flow created: a `.joined` result is somebody
+            // else's existing conversation that superseded ours, and the pick
+            // was made for the conversation we were going to create, not that
+            // one.
+            if result.origin == .created {
+                AgentVariantAssignmentStore.shared.assignIfUnset(
+                    slug: agentVariantSlug,
+                    to: result.conversationId
+                )
+            }
 
             notifyDefaultAgentConversationReadyIfNeeded(result)
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4281,9 +4281,9 @@ extension ConversationViewModel {
     /// single-flight and batched callers can share the same body without
     /// holding `self`.
     /// The agent variant slug an agent join routes to, scoped to the
-    /// conversation. The pick made at creation is claimed by this
-    /// conversation's first join and stays bound to it, so later joins in the
-    /// same convo keep that variant even after the global default moves on.
+    /// conversation. The pick made at creation is bound to the conversation by
+    /// the flow that created it, so later joins in the same convo keep that
+    /// variant even after the global default moves on.
     /// With no per-conversation assignment this falls back to
     /// `FeatureFlags.effectiveAgentVariantSlug`. The store is consulted only
     /// while the selector flag is on, so a stale assignment can't silently
@@ -4293,7 +4293,7 @@ extension ConversationViewModel {
         guard FeatureFlags.shared.isAgentVariantSelectorEnabled else {
             return FeatureFlags.shared.effectiveAgentVariantSlug
         }
-        if let assigned = AgentVariantAssignmentStore.shared.claimPendingSlug(for: conversationId) {
+        if let assigned = AgentVariantAssignmentStore.shared.slug(for: conversationId) {
             Log.info("AgentVariant: join for \(conversationId) routing to assigned variant \(assigned)")
             return assigned
         }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4055,7 +4055,7 @@ extension ConversationViewModel {
         let taskId = requestId
         let session = self.session
         let actions: any CoreActions = coreActions
-        let variantId = Self.selectedAgentVariantSlug()
+        let variantId = Self.selectedAgentVariantSlug(for: conversationId)
         agentJoinTask = Task { [weak self] in
             let outcome = await Self.performAgentJoinCall(
                 templateId: templateId,
@@ -4147,7 +4147,7 @@ extension ConversationViewModel {
         let forceErrorCode = agentJoinForceErrorCode
         let conversationId = conversation.id
         let session = self.session
-        let variantId = Self.selectedAgentVariantSlug()
+        let variantId = Self.selectedAgentVariantSlug(for: conversationId)
         Task { [weak self] in
             var failed: [AgentJoinAttempt] = []
             var anySucceeded = false
@@ -4280,10 +4280,26 @@ extension ConversationViewModel {
     /// `.noAgentsAvailable`) on error. Static + parameterized so both the
     /// single-flight and batched callers can share the same body without
     /// holding `self`.
-    /// The agent variant slug an agent join routes to. See
-    /// `FeatureFlags.effectiveAgentVariantSlug`.
-    private static func selectedAgentVariantSlug() -> String? {
-        FeatureFlags.shared.effectiveAgentVariantSlug
+    /// The agent variant slug an agent join routes to, scoped to the
+    /// conversation. The pick made at creation is claimed by this
+    /// conversation's first join and stays bound to it, so later joins in the
+    /// same convo keep that variant even after the global default moves on.
+    /// With no per-conversation assignment this falls back to
+    /// `FeatureFlags.effectiveAgentVariantSlug`. The store is consulted only
+    /// while the selector flag is on, so a stale assignment can't silently
+    /// route joins once the dev toggle is off.
+    @MainActor
+    private static func selectedAgentVariantSlug(for conversationId: String) -> String? {
+        guard FeatureFlags.shared.isAgentVariantSelectorEnabled else {
+            return FeatureFlags.shared.effectiveAgentVariantSlug
+        }
+        if let assigned = AgentVariantAssignmentStore.shared.claimPendingSlug(for: conversationId) {
+            Log.info("AgentVariant: join for \(conversationId) routing to assigned variant \(assigned)")
+            return assigned
+        }
+        let fallback = FeatureFlags.shared.effectiveAgentVariantSlug
+        Log.info("AgentVariant: join for \(conversationId) has no assignment, using \(fallback ?? "none")")
+        return fallback
     }
 
     private static func performAgentJoinCall(

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -169,6 +169,9 @@ final class ConversationsViewModel {
     }
     /// Drives the scanner sheet the home's scan button presents.
     var presentingScanner: Bool = false
+    /// Drives the dev-only agent-variant sheet shown ahead of a new
+    /// conversation while `FeatureFlags.isAgentVariantSelectorEnabled` is on.
+    var presentingVariantPicker: Bool = false
     /// Owned here so the sheet's viewfinder survives re-renders and can be
     /// re-armed between presentations.
     let scannerViewModel: QRScannerViewModel = QRScannerViewModel()
@@ -505,6 +508,21 @@ final class ConversationsViewModel {
     /// are brought in from inside it, by sharing its invite link. Picking
     /// contacts up front was a detour on the way to the same place.
     func onStartConvo() {
+        // While the dev variant selector is on, every new conversation picks
+        // the variant its agent builds under before the conversation exists.
+        // The pick is held as pending and claimed by the conversation's first
+        // agent join, so the convo keeps that variant for its lifetime.
+        guard !FeatureFlags.shared.isAgentVariantSelectorEnabled else {
+            presentingVariantPicker = true
+            return
+        }
+        startNewConversation()
+    }
+
+    /// Mints the conversation the compose button asks for. Split out of
+    /// `onStartConvo` so the variant picker can run ahead of it and then
+    /// continue into the same flow.
+    func startNewConversation() {
         newConversationViewModel = NewConversationViewModel(
             session: session,
             mode: .newConversation,

--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -522,11 +522,12 @@ final class ConversationsViewModel {
     /// Mints the conversation the compose button asks for. Split out of
     /// `onStartConvo` so the variant picker can run ahead of it and then
     /// continue into the same flow.
-    func startNewConversation() {
+    func startNewConversation(agentVariantSlug: String? = nil) {
         newConversationViewModel = NewConversationViewModel(
             session: session,
             mode: .newConversation,
-            coreActions: coreActions
+            coreActions: coreActions,
+            agentVariantSlug: agentVariantSlug
         )
     }
 

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -78,7 +78,7 @@ struct DebugViewSection: View {
     private var featuresSection: some View {
         Section("Features") {
             Toggle("Debug injector button", isOn: Bindable(FeatureFlags.shared).isDebugInjectorEnabled)
-            Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
+            agentVariantToggles
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
             abilitiesFeatureToggles
@@ -99,6 +99,18 @@ struct DebugViewSection: View {
             .sheet(isPresented: $showingSafariTestSheet) {
                 SafariTestSheet()
             }
+        }
+    }
+
+    /// The agent-variant flag with its picker. The dropdown only renders while
+    /// the flag is on, mirroring the abilities sub-toggles below. The pick is
+    /// stored globally (`FeatureFlags.selectedAgentVariant`) and read at agent-
+    /// join time, so it applies to conversations created after it is set.
+    @ViewBuilder
+    private var agentVariantToggles: some View {
+        Toggle("Agent variant selector", isOn: Bindable(FeatureFlags.shared).isAgentVariantSelectorEnabled)
+        if FeatureFlags.shared.isAgentVariantSelectorEnabled {
+            AgentVariantDebugPicker()
         }
     }
 

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -635,6 +635,15 @@ struct MainTabSheetsModifier: ViewModifier {
                     }
                 )
             }
+            // Dev-only: pick the agent variant for the conversation the
+            // compose button is about to create.
+            .selfSizingSheet(isPresented: $conversationsViewModel.presentingVariantPicker) {
+                AgentVariantPickerSheet(
+                    onContinue: {
+                        conversationsViewModel.startNewConversation()
+                    }
+                )
+            }
     }
 }
 

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -639,8 +639,8 @@ struct MainTabSheetsModifier: ViewModifier {
             // compose button is about to create.
             .selfSizingSheet(isPresented: $conversationsViewModel.presentingVariantPicker) {
                 AgentVariantPickerSheet(
-                    onContinue: {
-                        conversationsViewModel.startNewConversation()
+                    onContinue: { slug in
+                        conversationsViewModel.startNewConversation(agentVariantSlug: slug)
                     }
                 )
             }


### PR DESCRIPTION
## Why

Removing template creation left the agent variant selector in the codebase but rendered on no surface you could still reach, so there was no way to route a new conversation's agent through a variant.

This brings it back, and makes the choice **per conversation** rather than one global default.

## What

- **`AgentVariantRegistry`** caches `GET /v2/agent-variants` for the app's lifetime. The previous view-scoped `.task` fetch was cancelled and restarted by Form row churn on every state change, so it never settled — the dropdown sat on "Loading variants..." forever and never even reached its failed/retry state. Verified fixed: one clean request, and the `failed to load variants: cancelled` spam (20+ lines in a single second) is gone.
- **`AgentVariantPickerSheet`** asks which variant to use when the compose button starts a conversation, prefilled from the Debug default, showing the variant's what-to-test.
- **`AgentVariantAssignmentStore`** holds the pick as pending until a conversation id exists, then binds it to that conversation on its first agent join. Later joins in the same convo keep that variant even after the global default moves on; an existing assignment always wins, so a re-join can't be re-pointed by a later pick.
- **`ConversationViewModel.selectedAgentVariantSlug(for:)`** resolves per conversation, falling back to `FeatureFlags.effectiveAgentVariantSlug`. The store is consulted only while the selector flag is on, so a stale assignment can't silently route joins once the dev toggle is off.
- The **Debug picker** (App Settings → Debug → Features) now sets the default the sheet starts from.

Storage is UserDefaults rather than the database: this is dev-only and flag-gated, and a schema migration would be disproportionate.

## Testing

- `swift test --package-path ConvosCore` — 1878 tests in 254 suites pass.
- Built and installed on the simulator; registry load confirmed in the log with a real payload.
- SwiftLint `--strict` and SwiftFormat clean across `Convos/`.

## Known gap

The default-agent-in-every-convo path passes no `variantId` (no references under `Convos/Conversation Creation/`), so a cache-time-provisioned agent may bypass the assignment. Any join routed through `ConversationViewModel` picks it up. Happy to thread that path in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789664178&installation_model_id=20076&pr_number=1329&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1329&signature=57a64f86d62c9dd3bc68393ba3038c07efbf2ad3e5b90c15c7d5bd6d79d4d7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-conversation agent variant selection when starting new conversations
> - Introduces `AgentVariantRegistry` as an app-lifetime singleton that caches agent variants fetched from the backend, replacing per-view fetches.
> - Adds `AgentVariantAssignmentStore` to persist a conversationId → variant slug mapping in `UserDefaults`.
> - When the `isAgentVariantSelectorEnabled` dev flag is on, starting a new conversation presents `AgentVariantPickerSheet` to choose a variant before the conversation is created; the chosen slug is stored against the new conversation id.
> - `ConversationViewModel.selectedAgentVariantSlug(for:)` now resolves the variant per-conversation using the store, falling back to the global `FeatureFlags.effectiveAgentVariantSlug` when no assignment exists.
> - The Debug view gains an inline `AgentVariantDebugPicker` beneath the selector toggle to set the default variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afe94f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->