### PR TITLE
Rename user-visible Abilities copy to Connections

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -54,7 +54,7 @@ struct AbilitiesListView: View {
 
     var body: some View {
         catalogList
-            .searchable(text: $viewModel.searchText, prompt: "Search abilities")
+            .searchable(text: $viewModel.searchText, prompt: "Search connections")
             .overlay { listOverlay }
             .task { await viewModel.refresh() }
             .selfSizingSheet(item: $viewModel.pendingAuthorization, onDismiss: handleAuthorizationDismissed) { context in
@@ -85,7 +85,7 @@ struct AbilitiesListView: View {
     private var headerSection: some View {
         Section {
             VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
-                Text("Abilities")
+                Text("Connections")
                     .font(.convosTitle)
                     .tracking(Font.convosTitleTracking)
                     .foregroundStyle(.colorTextPrimary)
@@ -111,7 +111,7 @@ struct AbilitiesListView: View {
             HStack(spacing: DesignConstants.Spacing.step2x) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.colorLava)
-                Text("Can't check ability status right now. Showing the last-known state.")
+                Text("Can't check connection status right now. Showing the last-known state.")
                     .font(.footnote)
                     .foregroundStyle(.colorTextSecondary)
             }
@@ -174,7 +174,7 @@ struct AbilitiesListView: View {
                     unknownStateRow(ability)
                 }
             } header: {
-                sectionHeader("Abilities")
+                sectionHeader("Connections")
             }
         }
     }

--- a/Convos/Abilities/ConversationAbilitiesSection.swift
+++ b/Convos/Abilities/ConversationAbilitiesSection.swift
@@ -35,7 +35,7 @@ struct ConversationAbilitiesSection: View {
                 abilityRow(row)
             }
         } header: {
-            Text("Abilities")
+            Text("Connections")
                 .font(.footnote.weight(.medium))
                 .foregroundStyle(.colorTextSecondary)
         }

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -274,7 +274,7 @@ struct AppSettingsView: View {
     @ViewBuilder
     private var connectionsRowLabel: some View {
         let isAbilitiesV2: Bool = FeatureFlags.shared.isAbilitiesV2Enabled
-        let title: String = isAbilitiesV2 ? "Abilities" : "Connections"
+        let title: String = "Connections"
         let connectionsCount: Int = viewModel.connectionsListViewModel.connections.count
         let showsCount: Bool = !isAbilitiesV2 && connectionsCount > 0
         HStack {

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -112,13 +112,13 @@ struct DebugViewSection: View {
     /// take effect on the next read (no relaunch needed).
     @ViewBuilder
     private var abilitiesFeatureToggles: some View {
-        Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
+        Toggle("Connections v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
         if FeatureFlags.shared.isAbilitiesV2Enabled {
-            Toggle("Abilities: v1 awareness shim", isOn: $abilitiesV1ShimEnabled)
+            Toggle("Connections: v1 awareness shim", isOn: $abilitiesV1ShimEnabled)
                 .onChange(of: abilitiesV1ShimEnabled) { _, newValue in
                     AbilitiesServices.setV1AwarenessShimEnabled(newValue)
                 }
-            Toggle("Abilities: consent flow (mock)", isOn: $abilitiesEscalationMockEnabled)
+            Toggle("Connections: consent flow (mock)", isOn: $abilitiesEscalationMockEnabled)
                 .onChange(of: abilitiesEscalationMockEnabled) { _, newValue in
                     AbilitiesServices.setEscalationMockEnabled(newValue)
                 }

--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesEndpointsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesEndpointsAPI.swift
@@ -338,11 +338,11 @@ extension AbilitiesAPI.EndpointError: LocalizedError {
         case .authIncomplete:
             "Still finishing sign-in. Try again in a moment."
         case .entitlementsUnavailable:
-            "Abilities are updating. Try again in a moment."
+            "Connections are updating. Try again in a moment."
         case .needsEntitlement:
             "Connect this ability before sharing it with a convo."
         case .unknownAbility:
-            "This ability is no longer available."
+            "This connection is no longer available."
         case .unknownBundle:
             "This permission is out of date. Refresh and try again."
         case .connectionNotOwned:

--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesServiceProtocol.swift
@@ -73,7 +73,7 @@ extension AbilitiesServiceError: LocalizedError {
         case .needsEntitlement:
             "Connect this ability before sharing it with a convo."
         case .unknownAbility:
-            "This ability is no longer available."
+            "This connection is no longer available."
         case .accountRequired:
             "Sign in to connect abilities."
         }

--- a/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
@@ -23,7 +23,7 @@ extension LiveAbilitiesServiceError: LocalizedError {
         case .missingConnectionRequest:
             "Sign-in session expired. Try connecting again."
         case .noBundlesSelected:
-            "This ability has no permissions to share yet."
+            "This connection has no permissions to share yet."
         }
     }
 }

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -2,8 +2,8 @@
   "codecs" : {
     "device_removed" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
-      "contentJSON" : "{\"schemaVersion\":1,\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"removedAt\":1750000200}",
+      "contentBase64" : "eyJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInNjaGVtYVZlcnNpb24iOjEsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
+      "contentJSON" : "{\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"schemaVersion\":1,\"removedAt\":1750000200}",
       "contentType" : "convos.org/device_removed:1.0",
       "typeId" : "device_removed",
       "versionMajor" : 1,
@@ -11,8 +11,8 @@
     },
     "identity_share" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJpbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsInNjaGVtYVZlcnNpb24iOjEsImlzc3VlZEF0IjoxNzUwMDAwMTAwLCJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIn0=",
-      "contentJSON" : "{\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"displayName\":\"Cameron\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"schemaVersion\":1,\"issuedAt\":1750000100,\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\"}",
+      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaXNzdWVkQXQiOjE3NTAwMDAxMDAsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsImluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0=",
+      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"issuedAt\":1750000100,\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"displayName\":\"Cameron\",\"schemaVersion\":1,\"initiatorDeviceName\":\"Cameron's iPhone\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\"}",
       "contentType" : "convos.org/identity_share:1.0",
       "typeId" : "identity_share",
       "versionMajor" : 1,
@@ -20,8 +20,8 @@
     },
     "pairing_join_request" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJzbHVnIjoiZXlKbGVIQnBjbVZ6UVhRaU9qRTNOVEF3TURBeE1qQXNJbTV2Ym1ObElqb2lRVUpGYVUwd1VsWmFibVZKYldGeE4zcE9NM1ZjTDNjOVBTSXNJbWx1YVhScFlYUnZja0ZrWkhKbGMzTWlPaUl3ZURFNVpUZGxNemMyWlRkak1qRXpZamRsTjJVM1pUUTJZMk0zTUdFMVpHUXdPRFprWVdabU1tRWlMQ0p6YVdkdVlYUjFjbVVpT2lJcldHWmpPVkF4YlVjNVRtRXhYQzlpZEZOSVZWbGFWVzlQT1RaWWR6TkVZbEE1YUd0WWFVWllNM1ZSWTA1T1hDOVhUVW80WEM4eWIzQkRUbTVUV1dOd1JFZFFRVXB6YmpoRFNHaDBRMnRvTUdjeFl6TXphelIyYUhjOUlpd2ljMk5vWlcxaFZtVnljMmx2YmlJNk1Td2lhWE56ZFdWa1FYUWlPakUzTlRBd01EQXdNREFzSW1sdWFYUnBZWFJ2Y2tsdVltOTRTV1FpT2lJelpqbGhNV013WlRWaU4yUXlPRFEyWVRGbU16QmpPV1UwWkRoaU5qYzFNbVV3WVRSak9URXpOMlppTlRZeU9HUXdaVE5oTjJNeE5HSTVaRFZtTmpneUluMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIn0=",
-      "contentJSON" : "{\"schemaVersion\":1,\"slug\":\"eyJleHBpcmVzQXQiOjE3NTAwMDAxMjAsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\"}",
+      "contentBase64" : "eyJzbHVnIjoiZXlKcGMzTjFaV1JCZENJNk1UYzFNREF3TURBd01Dd2laWGh3YVhKbGMwRjBJam94TnpVd01EQXdNVEl3TENKelkyaGxiV0ZXWlhKemFXOXVJam94TENKcGJtbDBhV0YwYjNKSmJtSnZlRWxrSWpvaU0yWTVZVEZqTUdVMVlqZGtNamcwTm1FeFpqTXdZemxsTkdRNFlqWTNOVEpsTUdFMFl6a3hNemRtWWpVMk1qaGtNR1V6WVRkak1UUmlPV1ExWmpZNE1pSXNJbTV2Ym1ObElqb2lRVUpGYVUwd1VsWmFibVZKYldGeE4zcE9NM1ZjTDNjOVBTSXNJbk5wWjI1aGRIVnlaU0k2SWl0WVptTTVVREZ0UnpsT1lURmNMMkowVTBoVldWcFZiMDg1TmxoM00wUmlVRGxvYTFocFJsZ3pkVkZqVGs1Y0wxZE5TamhjTHpKdmNFTk9ibE5aWTNCRVIxQkJTbk51T0VOSWFIUkRhMmd3WnpGak16TnJOSFpvZHowaUxDSnBibWwwYVdGMGIzSkJaR1J5WlhOeklqb2lNSGd4T1dVM1pUTTNObVUzWXpJeE0ySTNaVGRsTjJVME5tTmpOekJoTldSa01EZzJaR0ZtWmpKaEluMCIsInNjaGVtYVZlcnNpb24iOjEsImRldmljZU5hbWUiOiJQaXhlbCA5IFBybyIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIn0=",
+      "contentJSON" : "{\"slug\":\"eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIn0\",\"schemaVersion\":1,\"deviceName\":\"Pixel 9 Pro\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\"}",
       "contentType" : "convos.org/pairing_join_request:1.0",
       "typeId" : "pairing_join_request",
       "versionMajor" : 1,
@@ -241,7 +241,7 @@
     "signatureRecoveryByte" : 28,
     "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
     "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
-    "slug" : "eyJleHBpcmVzQXQiOjE3NTAwMDAxMjAsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0",
+    "slug" : "eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIn0",
     "verifyAtUnixSeconds" : 1750000001
   },
   "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -2,8 +2,8 @@
   "codecs" : {
     "device_removed" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInNjaGVtYVZlcnNpb24iOjEsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
-      "contentJSON" : "{\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"schemaVersion\":1,\"removedAt\":1750000200}",
+      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
+      "contentJSON" : "{\"schemaVersion\":1,\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"removedAt\":1750000200}",
       "contentType" : "convos.org/device_removed:1.0",
       "typeId" : "device_removed",
       "versionMajor" : 1,
@@ -11,8 +11,8 @@
     },
     "identity_share" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaXNzdWVkQXQiOjE3NTAwMDAxMDAsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsImluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0=",
-      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"issuedAt\":1750000100,\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"displayName\":\"Cameron\",\"schemaVersion\":1,\"initiatorDeviceName\":\"Cameron's iPhone\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\"}",
+      "contentBase64" : "eyJpbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsInNjaGVtYVZlcnNpb24iOjEsImlzc3VlZEF0IjoxNzUwMDAwMTAwLCJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIn0=",
+      "contentJSON" : "{\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"displayName\":\"Cameron\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"schemaVersion\":1,\"issuedAt\":1750000100,\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\"}",
       "contentType" : "convos.org/identity_share:1.0",
       "typeId" : "identity_share",
       "versionMajor" : 1,
@@ -20,8 +20,8 @@
     },
     "pairing_join_request" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzbHVnIjoiZXlKcGMzTjFaV1JCZENJNk1UYzFNREF3TURBd01Dd2laWGh3YVhKbGMwRjBJam94TnpVd01EQXdNVEl3TENKelkyaGxiV0ZXWlhKemFXOXVJam94TENKcGJtbDBhV0YwYjNKSmJtSnZlRWxrSWpvaU0yWTVZVEZqTUdVMVlqZGtNamcwTm1FeFpqTXdZemxsTkdRNFlqWTNOVEpsTUdFMFl6a3hNemRtWWpVMk1qaGtNR1V6WVRkak1UUmlPV1ExWmpZNE1pSXNJbTV2Ym1ObElqb2lRVUpGYVUwd1VsWmFibVZKYldGeE4zcE9NM1ZjTDNjOVBTSXNJbk5wWjI1aGRIVnlaU0k2SWl0WVptTTVVREZ0UnpsT1lURmNMMkowVTBoVldWcFZiMDg1TmxoM00wUmlVRGxvYTFocFJsZ3pkVkZqVGs1Y0wxZE5TamhjTHpKdmNFTk9ibE5aWTNCRVIxQkJTbk51T0VOSWFIUkRhMmd3WnpGak16TnJOSFpvZHowaUxDSnBibWwwYVdGMGIzSkJaR1J5WlhOeklqb2lNSGd4T1dVM1pUTTNObVUzWXpJeE0ySTNaVGRsTjJVME5tTmpOekJoTldSa01EZzJaR0ZtWmpKaEluMCIsInNjaGVtYVZlcnNpb24iOjEsImRldmljZU5hbWUiOiJQaXhlbCA5IFBybyIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIn0=",
-      "contentJSON" : "{\"slug\":\"eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIn0\",\"schemaVersion\":1,\"deviceName\":\"Pixel 9 Pro\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\"}",
+      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJzbHVnIjoiZXlKbGVIQnBjbVZ6UVhRaU9qRTNOVEF3TURBeE1qQXNJbTV2Ym1ObElqb2lRVUpGYVUwd1VsWmFibVZKYldGeE4zcE9NM1ZjTDNjOVBTSXNJbWx1YVhScFlYUnZja0ZrWkhKbGMzTWlPaUl3ZURFNVpUZGxNemMyWlRkak1qRXpZamRsTjJVM1pUUTJZMk0zTUdFMVpHUXdPRFprWVdabU1tRWlMQ0p6YVdkdVlYUjFjbVVpT2lJcldHWmpPVkF4YlVjNVRtRXhYQzlpZEZOSVZWbGFWVzlQT1RaWWR6TkVZbEE1YUd0WWFVWllNM1ZSWTA1T1hDOVhUVW80WEM4eWIzQkRUbTVUV1dOd1JFZFFRVXB6YmpoRFNHaDBRMnRvTUdjeFl6TXphelIyYUhjOUlpd2ljMk5vWlcxaFZtVnljMmx2YmlJNk1Td2lhWE56ZFdWa1FYUWlPakUzTlRBd01EQXdNREFzSW1sdWFYUnBZWFJ2Y2tsdVltOTRTV1FpT2lJelpqbGhNV013WlRWaU4yUXlPRFEyWVRGbU16QmpPV1UwWkRoaU5qYzFNbVV3WVRSak9URXpOMlppTlRZeU9HUXdaVE5oTjJNeE5HSTVaRFZtTmpneUluMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIn0=",
+      "contentJSON" : "{\"schemaVersion\":1,\"slug\":\"eyJleHBpcmVzQXQiOjE3NTAwMDAxMjAsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\"}",
       "contentType" : "convos.org/pairing_join_request:1.0",
       "typeId" : "pairing_join_request",
       "versionMajor" : 1,
@@ -241,7 +241,7 @@
     "signatureRecoveryByte" : 28,
     "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
     "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
-    "slug" : "eyJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsInNpZ25hdHVyZSI6IitYZmM5UDFtRzlOYTFcL2J0U0hVWVpVb085Nlh3M0RiUDloa1hpRlgzdVFjTk5cL1dNSjhcLzJvcENOblNZY3BER1BBSnNuOENIaHRDa2gwZzFjMzNrNHZodz0iLCJpbml0aWF0b3JBZGRyZXNzIjoiMHgxOWU3ZTM3NmU3YzIxM2I3ZTdlN2U0NmNjNzBhNWRkMDg2ZGFmZjJhIn0",
+    "slug" : "eyJleHBpcmVzQXQiOjE3NTAwMDAxMjAsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0",
     "verifyAtUnixSeconds" : 1750000001
   },
   "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",


### PR DESCRIPTION
## Summary

Product-copy rename: the user-visible term **"Abilities"** becomes **"Connections"** ("Ability"/"ability" -> "Connection"/"connection"). This touches display strings only. No code identifiers change, so the code stays fully greppable under "Ability".

13 user-visible strings changed across 7 files.

## What changed (user-visible copy)

**Account-level list screen** (`AbilitiesListView.swift`)
- Title `Abilities` -> `Connections`
- Search placeholder `Search abilities` -> `Search connections`
- Outage banner: `Can't check ability status...` -> `Can't check connection status...`
- Outage-fallback section header `Abilities` -> `Connections` (see Gray area 1)

Resulting main screen: title **Connections**, subtitle **Give agents new powers in your convos** (unchanged), placeholder **Search connections**, section headers **Connected / Available / Connections**.

**Conversation info** (`ConversationAbilitiesSection.swift`)
- Section header `Abilities` -> `Connections` (V2 path; the V1 section already reads "Connections" and the two never render together, so this simply unifies them).

**App Settings** (`AppSettingsView.swift`)
- Connections row title now reads `Connections` in both flag branches (was `Abilities` under the V2 flag).

**Debug menu** (`DebugView.swift`) - developer-only, see Gray area 2
- `Abilities v2` -> `Connections v2`
- `Abilities: v1 awareness shim` -> `Connections: v1 awareness shim`
- `Abilities: consent flow (mock)` -> `Connections: consent flow (mock)`

**ConvosCore user-visible error descriptions** (`LocalizedError`)
- `Abilities are updating. Try again in a moment.` -> `Connections are updating...`
- `This ability is no longer available.` -> `This connection is no longer available.` (two sites)
- `This ability has no permissions to share yet.` -> `This connection has no permissions to share yet.`

## What was deliberately NOT changed (internal vocabulary stays "Ability")

- Type/struct/enum names, function/variable names, file names.
- The `isAbilitiesV2Enabled` feature flag and all flag/service keys (`featureFlags.abilitiesV2Enabled`, `abilitiesServices.*`).
- Enum case identifiers, backend error codes (`unknown_ability`, `ability_mismatch`), API path segments (`v2/abilities/...`), `Codable` debug descriptions, disk cache dir name.
- All `accessibilityIdentifier` test hooks (`ability-*`, `abilities-*`) - not shown to users or VoiceOver.
- All `Log.*` strings and `[Abilities]` log prefixes.
- Code comments.
- All `capability` / `availability` / `variability` occurrences - different concepts, out of scope.

## Gray areas - flagged for a separate decision (left as-is unless noted)

1. **Outage-fallback section header** (`AbilitiesListView.swift`). Renamed to "Connections" to honor "a user must never see Abilities", but this yields **Connected / Available / Connections** headers on one screen - a "Connections" bucket next to a "Connected" bucket that also duplicates the screen title. Rare outage-only state (rows there read "Status unavailable"). You may prefer a different header for this bucket.

2. **Debug-menu toggles** (`DebugView.swift`). Renamed per the "Abilities V2 in debug/settings menus" extension, but these are developer-only and never seen by end users. Easy to revert to internal "Abilities" wording if you'd rather keep them internal.

3. **"connect"/"connected" collisions - LEFT UNCHANGED** (still say "ability") because a literal swap reads awkwardly; wording is your call:
   - `Connect this ability before sharing it with a convo.` (AbilitiesServiceProtocol + AbilitiesEndpointsAPI) -> literal swap is "Connect this connection...". Suggested: "Set up this connection before sharing it with a convo."
   - `Sign in to connect abilities.` -> literal swap "Sign in to connect connections.". Suggested: "Sign in to add connections."
   - `This sign-in doesn't match the ability being connected.` -> literal swap "...the connection being connected.". Suggested: "This sign-in doesn't match the connection you're adding."

4. **Agent-visible / assistant copy** (SKILL.md, denial guidance): none in this repo - it lives in convos-assistants. Out of scope here.

5. Minor: one doc comment in `AppSettingsView.swift` still describes the row title as "Abilities" under the flag. Left untouched per the no-comment-edits rule; now slightly stale.

## Gates
- `swiftlint --strict` on changed files: pass
- Build `Convos (Dev)` (-configuration Dev, iPhone 17, worktree .derivedData): BUILD SUCCEEDED
- `swift test --package-path ConvosCore`: 1885 tests / 254 suites passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789665528&installation_model_id=20076&pr_number=1330&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1330&signature=ae3de2766bd51dba2dbaa428d574b104c5e5be23ba21dfbe12fac4d8100dd69c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename user-visible "Abilities" copy to "Connections" across the app
> Updates all user-facing strings that referred to "Abilities" or "ability" to use "Connections" or "connection" instead. Affected surfaces include the abilities list view (search prompt, headers, outage banner), conversation info section, app settings row, debug menu toggles, and localized error messages in the core service layer. Internal code identifiers and logic are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cc49d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->