### PR TITLE
Default the mock consent flow off in non-production

### DIFF
--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -169,15 +169,15 @@ enum AbilitiesServices {
     }
 
     /// Debug sub-toggle for the mock consent flow (agent ability-use
-    /// requests and delegations). Default on in non-production so enabling
-    /// the abilities flag is the only step needed to demo the full consent
-    /// flow; production always reads false.
+    /// requests and delegations). Default off; a dev flips this sub-toggle to
+    /// demo the full consent flow so enabling the abilities flag alone does
+    /// not inject the scripted card; production always reads false.
     static var isEscalationMockEnabled: Bool {
         guard !ConfigManager.shared.currentEnvironment.isProduction else { return false }
         if let stored = UserDefaults.standard.object(forKey: Constant.escalationMockEnabledKey) as? Bool {
             return stored
         }
-        return true
+        return false
     }
 
     static func setEscalationMockEnabled(_ value: Bool) {

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -115,7 +115,7 @@ struct DebugViewSection: View {
     }
 
     /// The Abilities V2 flag with its sub-toggles: the V1 awareness shim
-    /// (default off) and the mock consent flow (default on). There is
+    /// (default off) and the mock consent flow (default off). There is
     /// deliberately no separate mock/live backend toggle here -- enabling
     /// V2 always enables the live backend (`FeatureFlags.isAbilitiesV2Enabled`
     /// and `AbilitiesServices.useLiveBackend` are coupled in both directions


### PR DESCRIPTION
## Summary

`AbilitiesServices.isEscalationMockEnabled` (debug sub-toggle "Abilities: consent flow (mock)", key `abilitiesServices.escalationMockEnabled`) defaulted **on** in Dev and Local. This is a genuine code default, not a plist leftover: the getter returns `true` when no value is stored.

That flag gates `MockAbilityEscalationService`. The moment a dogfooder turned Abilities V2 on, the mock injected a scripted incoming consent card (agent "Caley" requesting Google Calendar) ~3s into every agent conversation, with no separate opt-in. Dev users read that as a real, intrusive ask and complained.

## Change

Flip the getter's unstored default from `true` to `false` at `AbilitiesServices.swift`, and correct the two doc comments that said the flow defaults on (`AbilitiesServices.swift`, `Convos/Debug View/DebugView.swift`).

- Enabling Abilities V2 no longer auto-fires the mock. A dev opts in explicitly via the existing debug sub-toggle to demo the consent flow.
- Production stays hard-locked `false` (the getter returns before reading storage) - that path is unchanged.
- The mock service, the sub-toggle, the prompt card, the approval sheet, and the delegations list are all untouched. The mock is still the only escalation-protocol implementation and remains available one toggle away.

## Blast radius: zero

- The `isActive` gate is the sole reader of the flag; nothing else changes behavior.
- `AbilityEscalationMockTests` construct the service with their own explicit `isActive: { true }` and scenario - unaffected.
- `AbilityDetailView` previews construct `MockAbilityEscalationService(scenario:)` directly - unaffected.

## Verification

- SwiftLint `--strict` on the two changed files: clean
- `xcodebuild build -scheme "Convos (Dev)" -configuration Dev` against an iPhone 17 simulator: build succeeded
- `swift test --package-path ConvosCore`: 1885 tests in 254 suites, all passed (MockAbilityEscalationService suite included)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789667336&installation_model_id=20076&pr_number=1332&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1332&signature=71617f43b5b9a69fcf507290f823160469ced21ee6472bbb517c391106fa0de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `isEscalationMockEnabled` to false in non-production environments
> Changes the fallback value of `AbilitiesServices.isEscalationMockEnabled` from `true` to `false` when no stored preference exists in UserDefaults. Updates the comment in [DebugView.swift](https://github.com/xmtplabs/convos-ios/pull/1332/files#diff-c45ca903f9cc34fa316deb294404f56695ab7914c8a43563ade3081b646368aa) to reflect the new default. Behavioral Change: the mock consent flow is now opt-in rather than opt-out in non-production builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b19cb90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->