### PR TITLE
Make the thinking sheet a half sheet, extendable to full height

### DIFF
--- a/Convos/Conversation Detail/ThinkingDetailView.swift
+++ b/Convos/Conversation Detail/ThinkingDetailView.swift
@@ -4,7 +4,8 @@ import ConvosMetrics
 import SwiftUI
 import UIKit
 
-/// Full-height sheet that renders the per-session thinking history for one
+/// Half-height sheet (draggable up to full height) that renders the
+/// per-session thinking history for one
 /// `convos.org/thinking:1.0` descriptor. Reuses `MessagesViewController`
 /// via `MessagesViewRepresentable` so each moment lands as a regular
 /// text-message cell — bubbles, sender resolution, scroll anchoring,
@@ -109,7 +110,7 @@ struct ThinkingDetailView: View {
                     }
             }
         }
-        .presentationDetents([.large])
+        .presentationDetents([.medium, .large])
         .presentationDragIndicator(.hidden)
         .presentationBackground(.colorBackgroundRaisedSecondary)
         .sheet(isPresented: $presentingAgentProfile) {


### PR DESCRIPTION
## What

The thinking detail sheet (`ThinkingDetailView`) opened pinned to `.large` (full height) only. This switches it to `[.medium, .large]` so it opens as a **half sheet** and can be dragged up to full height.

## Why

Half height keeps the underlying conversation partly visible and feels lighter for a glanceable "what's the agent thinking" surface, while still allowing a drag up to full height when there's a long thinking history to read.

## Details

- `.presentationDetents([.medium, .large])` — first detent (`.medium`) is the initial one, so it opens half height.
- No other layout changes needed: the floating top capsule / checkmark dismiss and the bottom Stop button already lay out off the dynamic `topBarHeight` / `bottomBarHeight` content insets, so both detents render correctly.
- Drag indicator stays hidden to preserve the existing floating chrome; the top-bar region remains draggable to resize.

## Test plan

- [ ] Open a thinking session -> sheet appears at half height
- [ ] Drag up -> expands to full height; drag down -> returns to half
- [ ] Checkmark dismiss and Stop button work at both detents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789667451&installation_model_id=20076&pr_number=1333&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1333&signature=d1d35c47219f28d238b62d7e40a4ba5d4bdb04b0e3193020f43afffaaf8c039f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `ThinkingDetailView` sheet open at half height, draggable to full height
> Changes the sheet presentation detents in [ThinkingDetailView.swift](https://github.com/xmtplabs/convos-ios/pull/1333/files#diff-b8ed965e2dc8ccf87a709b8c5fb697f32733b9633a88856a64df5c88348a2367) from `.large` only to `.medium` and `.large`, so the sheet opens at half height and can be dragged up to full height.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d01f58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->