### PR TITLE
Make the connect sheet resilient to a null redirectUrl on /initiate

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -2104,7 +2104,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let registry = session.capabilityProviderRegistry()
         let manager = session.cloudConnectionManager(callbackURLScheme: ConfigManager.shared.appUrlScheme)
         Task { [weak self] in
-            let allLinked = await Self.connectUnlinkedProviders(
+            let outcome = await Self.connectUnlinkedProviders(
                 unlinked,
                 authorizer: authorizer,
                 registry: registry,
@@ -2113,8 +2113,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 self.connectOnApproveInFlightRequestId = nil
-                if allLinked {
-                    // Always approve the *captured* request — a newer request
+                switch outcome {
+                case .linked:
+                    // Always approve the *captured* request -- a newer request
                     // might have arrived during the connect step and replaced
                     // the picker layout's request, and we must not approve it
                     // on the old tap's behalf. The captured conversationId
@@ -2129,7 +2130,10 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                         bundleSelection: bundleSelection,
                         conversationId: conversationId
                     )
-                } else {
+                case .interrupted:
+                    self.recomputeCapabilityPickerLayout(for: request, conversationId: conversationId)
+                case .failed(let message):
+                    self.capabilityApprovalErrorMessage = message
                     self.recomputeCapabilityPickerLayout(for: request, conversationId: conversationId)
                 }
             }
@@ -2339,7 +2343,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let registry = session.capabilityProviderRegistry()
         let manager = session.cloudConnectionManager(callbackURLScheme: ConfigManager.shared.appUrlScheme)
         Task { [weak self] in
-            let allLinked = await Self.connectUnlinkedProviders(
+            let outcome = await Self.connectUnlinkedProviders(
                 providers,
                 authorizer: authorizer,
                 registry: registry,
@@ -2348,7 +2352,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 self.connectOnApproveInFlightRequestId = nil
-                guard allLinked else {
+                guard case .linked = outcome else {
                     self.capabilityApprovalErrorMessage = Constant.capabilityApprovalFailedMessage
                     return
                 }
@@ -2758,38 +2762,49 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// when EVERY provider ends up linked; the caller must not send the
     /// approval otherwise (fail closed — granting an unlinked provider would
     /// persist a resolution that can't deliver data).
+    /// Outcome of the connect-on-approve step. Distinguishes a clean link
+    /// (approve), a user-driven interruption that should leave the sheet up
+    /// with no error banner (OAuth cancel, an ungranted device permission),
+    /// and a genuine failure whose message must show so the Connect button
+    /// stops looking inert.
+    enum ConnectOnApproveOutcome: Equatable {
+        case linked
+        case interrupted
+        case failed(message: String)
+    }
+
     static func connectUnlinkedProviders(
         _ providerIds: [ProviderID],
         authorizer: any DeviceConnectionAuthorizer,
         registry: any CapabilityProviderRegistry,
         cloudConnectionManager: any CloudConnectionManagerProtocol
-    ) async -> Bool {
+    ) async -> ConnectOnApproveOutcome {
         for providerId in providerIds {
             if let kind = ConnectionKind.fromDeviceProviderId(providerId) {
                 guard await linkDeviceProvider(kind: kind, authorizer: authorizer, registry: registry) else {
-                    return false
+                    return .interrupted
                 }
             } else if let serviceId = providerId.cloudServiceId {
                 do {
                     _ = try await cloudConnectionManager.connect(serviceId: serviceId)
                 } catch let oauthError as OAuthError {
                     if case .cancelled = oauthError {
-                        // User backed out of the OAuth sheet — the approval
+                        // User backed out of the OAuth sheet; the approval
                         // sheet stays up so they can retry or swipe down.
-                    } else {
-                        Log.error("OAuth failed for \(serviceId): \(oauthError.localizedDescription)")
+                        return .interrupted
                     }
-                    return false
+                    Log.error("OAuth failed for \(serviceId): \(oauthError.localizedDescription)")
+                    return .failed(message: Constant.capabilityApprovalFailedMessage)
                 } catch {
                     Log.error("Cloud connect failed for \(serviceId): \(error.localizedDescription)")
-                    return false
+                    return .failed(message: Constant.capabilityApprovalFailedMessage)
                 }
             } else {
                 Log.warning("Unsupported provider for connect-on-approve: \(providerId.rawValue)")
-                return false
+                return .interrupted
             }
         }
-        return true
+        return .linked
     }
 
     private static func linkDeviceProvider(

--- a/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/API/CloudConnectionsAPI.swift
@@ -3,7 +3,33 @@ import Foundation
 public enum CloudConnectionsAPI {
     public struct InitiateResponse: Codable, Sendable {
         public let connectionRequestId: String
-        public let redirectUrl: String
+        /// The OAuth URL to open, or nil when the backend signals that no
+        /// browser step is needed. Optional so a null (or omitted) value
+        /// decodes cleanly instead of throwing and stalling the connect sheet.
+        public let redirectUrl: String?
+        /// Authoritative "the account already authorized this service, no OAuth
+        /// needed" signal that accompanies a null redirectUrl. Backends
+        /// predating this field omit it; an absent value decodes to false.
+        public let alreadyConnected: Bool
+
+        public init(connectionRequestId: String, redirectUrl: String?, alreadyConnected: Bool = false) {
+            self.connectionRequestId = connectionRequestId
+            self.redirectUrl = redirectUrl
+            self.alreadyConnected = alreadyConnected
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            connectionRequestId = try container.decode(String.self, forKey: .connectionRequestId)
+            redirectUrl = try container.decodeIfPresent(String.self, forKey: .redirectUrl)
+            alreadyConnected = try container.decodeIfPresent(Bool.self, forKey: .alreadyConnected) ?? false
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case connectionRequestId
+            case redirectUrl
+            case alreadyConnected
+        }
     }
 
     public struct CompleteResponse: Codable, Sendable {

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -42,17 +42,56 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
             redirectUri: redirectUri
         )
 
-        guard let oauthURL = URL(string: initiation.redirectUrl) else {
+        guard let redirectUrlString = initiation.redirectUrl else {
+            return try await resolveConnectionWithoutOAuth(serviceId: serviceId, initiation: initiation)
+        }
+
+        guard let oauthURL = URL(string: redirectUrlString) else {
             throw CloudConnectionManagerError.invalidOAuthURL
         }
 
         _ = try await oauthProvider.authenticate(url: oauthURL, callbackURLScheme: callbackURLScheme)
 
         let completion = try await apiClient.completeCloudConnection(connectionRequestId: initiation.connectionRequestId)
+        return try await persistCompletedConnection(completion, fallbackServiceId: serviceId)
+    }
 
+    /// Resolves a connect whose `/initiate` came back with a null redirectUrl,
+    /// meaning no OAuth step. The backend's authoritative signal is
+    /// `alreadyConnected`: when true, the account already authorized this
+    /// service, so the connection is finalized without a browser -- returning a
+    /// cached live local connection when present, otherwise completing the
+    /// request to materialize it. When the field is false or absent (backends
+    /// predating it), a cached live local connection is still accepted as a
+    /// transitional fallback; with neither signal the service is not connected
+    /// here, so a typed error surfaces instead of the sheet hanging.
+    private func resolveConnectionWithoutOAuth(
+        serviceId: String,
+        initiation: CloudConnectionsAPI.InitiateResponse
+    ) async throws -> CloudConnection {
+        if initiation.alreadyConnected {
+            if let existing = try await existingActiveConnection(serviceId: serviceId) {
+                return existing
+            }
+            let completion = try await apiClient.completeCloudConnection(connectionRequestId: initiation.connectionRequestId)
+            return try await persistCompletedConnection(completion, fallbackServiceId: serviceId)
+        }
+        if let existing = try await existingActiveConnection(serviceId: serviceId) {
+            return existing
+        }
+        throw CloudConnectionManagerError.oauthUrlUnavailable
+    }
+
+    /// Builds and persists a `CloudConnection` from a completion response.
+    /// `fallbackServiceId` is used only when the backend echoes an empty
+    /// service id.
+    private func persistCompletedConnection(
+        _ completion: CloudConnectionsAPI.CompleteResponse,
+        fallbackServiceId: String
+    ) async throws -> CloudConnection {
         // Backend echoes Composio's slug. Fall back to the original arg only if
         // the response somehow comes back with no service id at all.
-        let finalServiceId = completion.serviceId.isEmpty ? serviceId : completion.serviceId
+        let finalServiceId = completion.serviceId.isEmpty ? fallbackServiceId : completion.serviceId
 
         let connection = CloudConnection(
             id: completion.connectionId,
@@ -71,6 +110,21 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
         }
 
         return connection
+    }
+
+    /// The most recently connected active local connection for `serviceId`, or
+    /// nil when none exists. Reads the same store that feeds a provider's
+    /// `linked` state and grant confirmation, so a null-redirect initiate can
+    /// resolve to success without a further backend round-trip.
+    private func existingActiveConnection(serviceId: String) async throws -> CloudConnection? {
+        try await databaseWriter.read { db in
+            try DBCloudConnection
+                .filter(DBCloudConnection.Columns.serviceId == serviceId)
+                .filter(DBCloudConnection.Columns.status == CloudConnectionStatus.active.rawValue)
+                .order(DBCloudConnection.Columns.connectedAt.desc)
+                .fetchOne(db)?
+                .toConnection()
+        }
     }
 
     public func disconnect(connectionId: String) async throws {
@@ -326,11 +380,14 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
 
 enum CloudConnectionManagerError: LocalizedError {
     case invalidOAuthURL
+    case oauthUrlUnavailable
 
     var errorDescription: String? {
         switch self {
         case .invalidOAuthURL:
             "Invalid OAuth URL received from server"
+        case .oauthUrlUnavailable:
+            "Couldn't start sign-in for this service. Please try again."
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -474,6 +474,110 @@ struct ConnectionManagerTests {
         }
         #expect(connectionRow == nil)
     }
+
+    // MARK: - Null redirectUrl on /initiate
+
+    @Test("InitiateResponse decodes a null redirectUrl with alreadyConnected true")
+    func initiateResponseDecodesNullRedirectAlreadyConnected() throws {
+        let json = Data(#"{"connectionRequestId":"ca_stuck","redirectUrl":null,"alreadyConnected":true}"#.utf8)
+        let response = try JSONDecoder().decode(CloudConnectionsAPI.InitiateResponse.self, from: json)
+        #expect(response.connectionRequestId == "ca_stuck")
+        #expect(response.redirectUrl == nil)
+        #expect(response.alreadyConnected == true)
+    }
+
+    @Test("InitiateResponse decodes the mint case with alreadyConnected false and a present redirectUrl")
+    func initiateResponseDecodesMintCase() throws {
+        let json = Data(#"{"connectionRequestId":"ca_ok","redirectUrl":"https://example.com/oauth","alreadyConnected":false}"#.utf8)
+        let response = try JSONDecoder().decode(CloudConnectionsAPI.InitiateResponse.self, from: json)
+        #expect(response.redirectUrl == "https://example.com/oauth")
+        #expect(response.alreadyConnected == false)
+    }
+
+    @Test("InitiateResponse decodes an absent alreadyConnected as false without throwing")
+    func initiateResponseDecodesAbsentAlreadyConnectedAsFalse() throws {
+        let json = Data(#"{"connectionRequestId":"ca_legacy","redirectUrl":null}"#.utf8)
+        let response = try JSONDecoder().decode(CloudConnectionsAPI.InitiateResponse.self, from: json)
+        #expect(response.redirectUrl == nil)
+        #expect(response.alreadyConnected == false)
+    }
+
+    @Test("connect resolves alreadyConnected true from the cached local connection without completing")
+    func connectAlreadyConnectedUsesCachedConnection() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        apiClient.stubbedInitiateRedirectUrl = nil
+        apiClient.stubbedInitiateAlreadyConnected = true
+        let grantWriter = RecordingGrantWriter()
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConnection(id: "conn-live", serviceId: "googlecalendar").insert(db)
+        }
+
+        let connection = try await manager.connect(serviceId: "googlecalendar")
+
+        #expect(connection.id == "conn-live")
+        #expect(connection.status == .active)
+        #expect(apiClient.completeCallCount == 0, "A cached live connection needs no completion round-trip")
+    }
+
+    @Test("connect materializes alreadyConnected true via completion when nothing is cached")
+    func connectAlreadyConnectedMaterializesViaCompletion() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        apiClient.stubbedInitiateRedirectUrl = nil
+        apiClient.stubbedInitiateAlreadyConnected = true
+        let grantWriter = RecordingGrantWriter()
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        let connection = try await manager.connect(serviceId: "googlecalendar")
+
+        #expect(connection.id == "stub-conn")
+        #expect(connection.status == .active)
+        #expect(apiClient.completeCallCount == 1, "With no cached connection, completion finalizes the already-authorized account")
+
+        let saved = try await fixtures.dbReader.read { db in
+            try DBCloudConnection.fetchOne(db, key: "stub-conn")
+        }
+        #expect(saved != nil, "The materialized connection must be persisted so the grant can confirm")
+    }
+
+    @Test("connect accepts a cached connection when alreadyConnected is absent (transitional fallback)")
+    func connectNullRedirectFallsBackToCachedConnection() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        apiClient.stubbedInitiateRedirectUrl = nil
+        // alreadyConnected defaults to false, standing in for a backend that
+        // predates the field.
+        let grantWriter = RecordingGrantWriter()
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        try await fixtures.dbWriter.write { db in
+            try makeDBConnection(id: "conn-live", serviceId: "googlecalendar").insert(db)
+        }
+
+        let connection = try await manager.connect(serviceId: "googlecalendar")
+
+        #expect(connection.id == "conn-live")
+        #expect(apiClient.completeCallCount == 0)
+    }
+
+    @Test("connect surfaces an error for a null redirectUrl with no signal and nothing cached")
+    func connectNullRedirectWithoutConnectionThrows() async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        apiClient.stubbedInitiateRedirectUrl = nil
+        let grantWriter = RecordingGrantWriter()
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        do {
+            _ = try await manager.connect(serviceId: "googlecalendar")
+            Issue.record("Expected connect to throw when no local connection backs a null redirectUrl")
+        } catch CloudConnectionManagerError.oauthUrlUnavailable {
+            // expected: the sheet surfaces this instead of hanging
+        }
+    }
 }
 
 // MARK: - Helpers
@@ -571,6 +675,9 @@ private extension ConnectionManagerTests {
 
 private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable {
     var stubbedConnections: [CloudConnectionsAPI.ConnectionResponse] = []
+    var stubbedInitiateRedirectUrl: String? = "https://example.com/oauth"
+    var stubbedInitiateAlreadyConnected: Bool = false
+    private(set) var completeCallCount: Int = 0
     private(set) var revokedConnectionIds: [String] = []
 
     func request(for path: String, method: String, queryParameters: [String: String]?) throws -> URLRequest {
@@ -627,11 +734,16 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
     }
 
     func initiateCloudConnection(serviceId: String, redirectUri: String) async throws -> CloudConnectionsAPI.InitiateResponse {
-        .init(connectionRequestId: "stub-request", redirectUrl: "https://example.com/oauth")
+        .init(
+            connectionRequestId: "stub-request",
+            redirectUrl: stubbedInitiateRedirectUrl,
+            alreadyConnected: stubbedInitiateAlreadyConnected
+        )
     }
 
     func completeCloudConnection(connectionRequestId: String) async throws -> CloudConnectionsAPI.CompleteResponse {
-        .init(
+        completeCallCount += 1
+        return .init(
             connectionId: "stub-conn",
             serviceId: "googlecalendar",
             serviceName: "Google Calendar",

--- a/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
+++ b/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
@@ -153,36 +153,50 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
     }
 
     func testConnectUnlinkedProvidersSucceedsThroughOAuth() async {
-        let linked = await ConversationViewModel.connectUnlinkedProviders(
+        let outcome = await ConversationViewModel.connectUnlinkedProviders(
             [ProviderID(rawValue: "composio.googlecalendar")],
             authorizer: StubDeviceAuthorizer(),
             registry: InMemoryCapabilityProviderRegistry(),
             cloudConnectionManager: MockCloudConnectionManager()
         )
 
-        XCTAssertTrue(linked)
+        XCTAssertEqual(outcome, .linked)
     }
 
-    func testConnectUnlinkedProvidersFailsClosedWhenOAuthCancelled() async {
-        let linked = await ConversationViewModel.connectUnlinkedProviders(
+    func testConnectUnlinkedProvidersInterruptsWhenOAuthCancelled() async {
+        let outcome = await ConversationViewModel.connectUnlinkedProviders(
             [ProviderID(rawValue: "composio.googlecalendar")],
             authorizer: StubDeviceAuthorizer(),
             registry: InMemoryCapabilityProviderRegistry(),
             cloudConnectionManager: CancelledCloudConnectionManager()
         )
 
-        XCTAssertFalse(linked, "A cancelled OAuth must never let the approval proceed")
+        XCTAssertEqual(outcome, .interrupted, "A cancelled OAuth must never let the approval proceed, and must not surface an error banner")
     }
 
-    func testConnectUnlinkedProvidersFailsClosedForUnknownProvider() async {
-        let linked = await ConversationViewModel.connectUnlinkedProviders(
+    func testConnectUnlinkedProvidersInterruptsForUnknownProvider() async {
+        let outcome = await ConversationViewModel.connectUnlinkedProviders(
             [ProviderID(rawValue: "bogus.provider")],
             authorizer: StubDeviceAuthorizer(),
             registry: InMemoryCapabilityProviderRegistry(),
             cloudConnectionManager: MockCloudConnectionManager()
         )
 
-        XCTAssertFalse(linked, "Providers with no connect path must fail closed")
+        XCTAssertEqual(outcome, .interrupted, "Providers with no connect path must not let the approval proceed")
+    }
+
+    func testConnectUnlinkedProvidersSurfacesErrorWhenConnectFails() async {
+        let outcome = await ConversationViewModel.connectUnlinkedProviders(
+            [ProviderID(rawValue: "composio.googlecalendar")],
+            authorizer: StubDeviceAuthorizer(),
+            registry: InMemoryCapabilityProviderRegistry(),
+            cloudConnectionManager: FailingCloudConnectionManager()
+        )
+
+        guard case .failed = outcome else {
+            XCTFail("A genuine connect failure must surface an error so the sheet stops looking inert")
+            return
+        }
     }
 
     // MARK: - Helpers
@@ -260,6 +274,13 @@ private struct StubDeviceAuthorizer: DeviceConnectionAuthorizer {
 
 private struct CancelledCloudConnectionManager: CloudConnectionManagerProtocol {
     func connect(serviceId: String) async throws -> CloudConnection { throw OAuthError.cancelled }
+    func disconnect(connectionId: String) async throws {}
+    func refreshConnections() async throws -> [CloudConnection] { [] }
+}
+
+private struct FailingCloudConnectionManager: CloudConnectionManagerProtocol {
+    enum StubError: Error { case connectFailed }
+    func connect(serviceId: String) async throws -> CloudConnection { throw StubError.connectFailed }
     func disconnect(connectionId: String) async throws {}
     func refreshConnections() async throws -> [CloudConnection] { [] }
 }


### PR DESCRIPTION
## What & why

This is the **client-side resilience half** of the "stuck on Connect" bug. The
backend `POST /api/v2/connections/initiate` returning `redirectUrl: null` is the
root cause and is fixed separately in convos-assistants; this PR makes iOS robust
to that response so a null can never again present as a silent dead-end.

**The bug:** when `/initiate` returned `redirectUrl: null`, `InitiateResponse`
decoded it into a non-optional `String`, so `JSONDecoder` threw `valueNotFound`
before any OAuth could open. The throw was swallowed (`Log.error`, return false)
and the failure branch only recomputed layout, so the approval sheet stayed up
with an inert Connect button. A user tapped Connect ~21 times, then gave up.

## Changes

- **Decode the backend contract.** `CloudConnectionsAPI.InitiateResponse.redirectUrl`
  is now `String?`, and the response decodes a new `alreadyConnected: Bool` flag.
  An absent flag decodes to `false` (backends predating it), so old and new
  responses both decode cleanly instead of throwing.
- **Resolve a null redirectUrl without OAuth, keyed on `alreadyConnected`.** In
  `CloudConnectionManager`:
  - `alreadyConnected == true` -> finalize without a browser: return the cached
    live local connection when present, otherwise complete the request to
    materialize + persist it so the subsequent grant can confirm.
  - `alreadyConnected` false/absent -> **transitional fallback**: a cached live
    local connection is still accepted as success (for backends predating the
    flag); with no connection at all, throw the new `oauthUrlUnavailable` error.
- **Surface real failures instead of hanging.** `connectUnlinkedProviders` now
  returns a `ConnectOnApproveOutcome` (`linked` / `interrupted` / `failed`).
  Genuine failures set `capabilityApprovalErrorMessage`, which renders through
  the `isApproving:` / `approvalErrorMessage:` wiring restored in #1327 (button
  becomes "Try Again"). User-driven interruptions (OAuth cancel, an ungranted
  device permission) still leave the sheet up quietly, as before.

## How "already connected" is decided

`alreadyConnected` from `/initiate` is the authoritative signal for the success
branch. The local connection store (`DBCloudConnection` with `status == active`,
the same source that feeds a provider's `linked` state) is used only to reuse a
cached connection and as the transitional fallback for backends that do not yet
send the flag. No new backend endpoint is introduced.

## Tests

- Decode: null redirect + `alreadyConnected: true`; the mint case
  (`alreadyConnected: false` + present url); an absent flag decodes to `false`.
- `connect` branches: `alreadyConnected` true uses the cached connection (no
  completion) / materializes via completion when nothing is cached; a cached
  connection is accepted when the flag is absent (fallback); a bare null with no
  signal and nothing cached throws `oauthUrlUnavailable`.
- App-target `connectUnlinkedProviders` tests updated to the new outcome, plus a
  case asserting a genuine failure surfaces an error.

## Gates

- `swiftlint --strict` on changed files: clean.
- `swiftformat --lint` on changed files: clean.
- Build `Convos (Dev)` -configuration Dev, iPhone 17 simulator: BUILD SUCCEEDED.
- `swift test --package-path ConvosCore`: 1892 tests / 254 suites, 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789669477&installation_model_id=20076&pr_number=1334&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1334&signature=376de001567b6ce6f83454bc5a512b72a0720a95b970e49c428d719032d668be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the connect sheet resilient to a null `redirectUrl` on `/initiate`
> - [`CloudConnectionsAPI.InitiateResponse`](https://github.com/xmtplabs/convos-ios/pull/1334/files#diff-bb1d31bc10edb27be4fe69ecf77f8a2104697f02c7327113b39aef337c287e12) now decodes a null or absent `redirectUrl` and defaults `alreadyConnected` to `false` instead of failing.
> - [`CloudConnectionManager.connect`](https://github.com/xmtplabs/convos-ios/pull/1334/files#diff-bba902fb32a5fc70863b0d4644fccc337c80592645ee676c1f568f72852ca2c4) handles a null `redirectUrl` by returning an existing active connection, completing via `alreadyConnected`, or throwing `oauthUrlUnavailable`.
> - `connectUnlinkedProviders` in [`ConversationViewModel`](https://github.com/xmtplabs/convos-ios/pull/1334/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) now returns a typed `ConnectOnApproveOutcome` (`.linked`, `.interrupted`, `.failed`) instead of a `Bool`, so the connect sheet stays open without an error banner on user-driven interruptions (e.g. OAuth cancel) and shows an error only on genuine failures.
> - Behavioral Change: OAuth cancellations and unsupported providers no longer surface an error banner; only hard failures do.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42a0b64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->