### PR TITLE
Fail closed when a cloud /complete returns a non-active status

### DIFF
--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -277,9 +277,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     private var latestObservedCapabilityRequest: CapabilityRequest?
     @ObservationIgnored
     private var locallyHandledCapabilityRequestIds: Set<String> = []
-    /// Request id whose connect-before-grant step (OS prompt / OAuth) is in
-    /// flight — re-entrancy guard for `onCapabilityApprove`.
-    @ObservationIgnored
+    /// Request id whose connect-before-grant step (OS prompt / OAuth / headless
+    /// completion) is in flight -- re-entrancy guard for `onCapabilityApprove`
+    /// and part of the sheet's busy state so the button shows progress while a
+    /// no-browser connect runs. Observed (not `@ObservationIgnored`) so the busy
+    /// state reacts when it changes.
     private var connectOnApproveInFlightRequestId: String?
     @ObservationIgnored
     var lastReadReceiptSentAt: Date?
@@ -953,7 +955,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// succeeds; until then the pill stays pending.
     private(set) var capabilityApprovalInFlightRequestId: String?
     var capabilityApprovalInFlight: Bool {
-        capabilityApprovalInFlightRequestId != nil
+        capabilityApprovalInFlightRequestId != nil || connectOnApproveInFlightRequestId != nil
     }
     /// Failure the approval sheet surfaces when an approval could not be
     /// completed -- the backend grant POST or the result send failed. The

--- a/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionManager.swift
@@ -93,6 +93,17 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
         // the response somehow comes back with no service id at all.
         let finalServiceId = completion.serviceId.isEmpty ? fallbackServiceId : completion.serviceId
 
+        // Only an active completion is a usable connection. A non-active status
+        // (INITIALIZING/EXPIRED/FAILED/unknown maps to .expired/.revoked) means
+        // there is no live credential behind it; persisting and returning it
+        // would read as connected while the repository still treats the service
+        // as disconnected -- a phantom-linked false success. Fail closed so the
+        // connect surfaces an actionable error instead.
+        let status = CloudConnectionStatus.from(composioStatus: completion.status)
+        guard status == .active else {
+            throw CloudConnectionManagerError.connectionNotActive
+        }
+
         let connection = CloudConnection(
             id: completion.connectionId,
             serviceId: finalServiceId,
@@ -100,7 +111,7 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
             provider: .composio,
             composioEntityId: completion.composioEntityId,
             composioConnectionId: completion.composioConnectionId,
-            status: CloudConnectionStatus.from(composioStatus: completion.status),
+            status: status,
             connectedAt: Date()
         )
 
@@ -381,6 +392,7 @@ public final class CloudConnectionManager: CloudConnectionManagerProtocol, @unch
 enum CloudConnectionManagerError: LocalizedError {
     case invalidOAuthURL
     case oauthUrlUnavailable
+    case connectionNotActive
 
     var errorDescription: String? {
         switch self {
@@ -388,6 +400,8 @@ enum CloudConnectionManagerError: LocalizedError {
             "Invalid OAuth URL received from server"
         case .oauthUrlUnavailable:
             "Couldn't start sign-in for this service. Please try again."
+        case .connectionNotActive:
+            "This service isn't finished connecting yet. Please try again."
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConnectionManagerTests.swift
@@ -543,6 +543,32 @@ struct ConnectionManagerTests {
         #expect(saved != nil, "The materialized connection must be persisted so the grant can confirm")
     }
 
+    @Test(
+        "connect fails closed when /complete returns a non-active status",
+        arguments: ["INITIALIZING", "INITIATED", "EXPIRED", "FAILED", "SOMETHING_UNKNOWN"]
+    )
+    func connectRejectsNonActiveCompletion(status: String) async throws {
+        let fixtures = try await makeTestFixtures()
+        let apiClient = StubAPIClient()
+        apiClient.stubbedInitiateRedirectUrl = nil
+        apiClient.stubbedInitiateAlreadyConnected = true
+        apiClient.stubbedCompleteStatus = status
+        let grantWriter = RecordingGrantWriter()
+        let manager = makeManager(fixtures: fixtures, apiClient: apiClient, grantWriter: grantWriter)
+
+        do {
+            _ = try await manager.connect(serviceId: "googlecalendar")
+            Issue.record("Expected connect to fail closed for a non-active /complete status \(status)")
+        } catch CloudConnectionManagerError.connectionNotActive {
+            // expected: a not-yet-live connection surfaces at connect time
+        }
+
+        let saved = try await fixtures.dbReader.read { db in
+            try DBCloudConnection.fetchOne(db, key: "stub-conn")
+        }
+        #expect(saved == nil, "A non-active completion must never persist a live connection")
+    }
+
     @Test("connect accepts a cached connection when alreadyConnected is absent (transitional fallback)")
     func connectNullRedirectFallsBackToCachedConnection() async throws {
         let fixtures = try await makeTestFixtures()
@@ -677,6 +703,7 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
     var stubbedConnections: [CloudConnectionsAPI.ConnectionResponse] = []
     var stubbedInitiateRedirectUrl: String? = "https://example.com/oauth"
     var stubbedInitiateAlreadyConnected: Bool = false
+    var stubbedCompleteStatus: String = "ACTIVE"
     private(set) var completeCallCount: Int = 0
     private(set) var revokedConnectionIds: [String] = []
 
@@ -749,7 +776,7 @@ private final class StubAPIClient: ConvosAPIClientProtocol, @unchecked Sendable 
             serviceName: "Google Calendar",
             composioEntityId: "entity",
             composioConnectionId: "ca",
-            status: "ACTIVE"
+            status: stubbedCompleteStatus
         )
     }
 


### PR DESCRIPTION
## What & why

Follow-up to #1334 (merged), from a Codex adversarial review. #1334 made the
connect sheet resilient to a null `redirectUrl` on `/initiate` and added a
no-browser `alreadyConnected` completion path. That path (and the pre-existing
OAuth path it shares) had a **phantom-linked false success**: a non-active
`/complete` result was persisted and returned as a successful connection.

`CloudConnectionStatus.from` maps `INITIALIZING`, `INITIATED`, `EXPIRED`,
`FAILED`, and unknown statuses to `.expired` / `.revoked`. `persistCompletedConnection`
built and saved the connection from that status and returned normally, so a
connection with no live credential behind it read as connected while the
repository still treated the service as disconnected. It only surfaced later, at
grant time (the backend's `connection_not_found` 409), instead of at connect.

## Changes

- **`.active` guard (primary).** `persistCompletedConnection` computes the mapped
  status once and requires `.active` before building/persisting. A non-active
  status persists nothing and throws the new `CloudConnectionManagerError.connectionNotActive`,
  so connect fails closed and surfaces an actionable error through the same path
  as `oauthUrlUnavailable` (the #1327 `capabilityApprovalErrorMessage` / "Try
  Again" wiring; Settings callers surface it via their existing `error` state).
  The guard is shared by the OAuth completion path and the no-browser
  already-connected completion path, so both benefit.
- **Busy state during the headless completion.** The connect-on-approve in-flight
  id was `@ObservationIgnored` and excluded from the sheet's busy state, so the
  button stayed enabled and inert during a no-browser `initiate`/`complete`. It
  is now observed and folded into `capabilityApprovalInFlight`, so the button
  shows progress and disables while the connect runs.

## Tests

- New parameterized ConvosCore test over `INITIALIZING`, `INITIATED`, `EXPIRED`,
  `FAILED`, and an unknown status: `connect` throws `connectionNotActive` and no
  connection is persisted. The stub's `/complete` status is now configurable
  (it previously always returned `ACTIVE`, which is exactly why this slipped).
- The existing active-completion success tests are unchanged and still pass.

## Gates

- `swiftlint --strict` on changed files: clean.
- `swiftformat --lint` on changed files: clean.
- Build `Convos (Dev)` -configuration Dev, iPhone 17 simulator: BUILD SUCCEEDED.
- `swift test --package-path ConvosCore`: 1893 tests / 254 suites, 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789671274&installation_model_id=20076&pr_number=1335&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1335&signature=bf19b7e0ad2bff65a5fba7db7b07314d40e35a8000cf164d86836067796d7056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail closed when a cloud `/complete` response returns a non-active status
> - `CloudConnectionManager.persistCompletedConnection` now throws `CloudConnectionManagerError.connectionNotActive` and skips saving to the database when the `/complete` response status is not `active`.
> - `capabilityApprovalInFlight` in `ConversationViewModel` now returns `true` during both backend grant/result and connect-before-grant operations, keeping UI state accurate throughout the flow.
> - A new parameterized test `connectRejectsNonActiveCompletion` verifies fail-closed behavior across all non-active statuses.
> - Behavioral Change: connections that previously may have been persisted with a non-active status will now fail with an error instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17e52d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->