### PR TITLE
fix: route per-conversation agent calls by the conversation's variant

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1462,7 +1462,7 @@ private extension ConversationView {
         let mode = viewModel.conversation.participationMode
         let store = AgentParticipationStore(
             conversationId: viewModel.conversation.id,
-            variantId: FeatureFlags.shared.effectiveAgentVariantSlug,
+            variantId: viewModel.conversationAgentVariantSlug,
             service: ConversationAppDataParticipationService(
                 metadataWriter: viewModel.conversationMetadataWriter,
                 mode: mode

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4302,20 +4302,24 @@ extension ConversationViewModel {
     /// the flow that created it, so later joins in the same convo keep that
     /// variant even after the global default moves on.
     /// With no per-conversation assignment this falls back to
-    /// `FeatureFlags.effectiveAgentVariantSlug`. The store is consulted only
-    /// while the selector flag is on, so a stale assignment can't silently
-    /// route joins once the dev toggle is off.
+    /// `FeatureFlags.effectiveAgentVariantSlug`. A conversation's binding is
+    /// authoritative for the life of that conversation and is honored even when
+    /// the selector UI is later toggled off — the agent was created on that
+    /// variant's runtime, so every later call (join, participation, power) must
+    /// keep reaching it; only the *global* default follows the selector. Still
+    /// dev-only: assignments are never written in production (the selector can't
+    /// be enabled there) and the API client strips any variant on prod.
     @MainActor
     private static func selectedAgentVariantSlug(for conversationId: String) -> String? {
-        guard FeatureFlags.shared.isAgentVariantSelectorEnabled else {
+        guard !ConfigManager.shared.currentEnvironment.isProduction else {
             return FeatureFlags.shared.effectiveAgentVariantSlug
         }
         if let assigned = AgentVariantAssignmentStore.shared.slug(for: conversationId) {
-            Log.info("AgentVariant: join for \(conversationId) routing to assigned variant \(assigned)")
+            Log.info("AgentVariant: \(conversationId) routing to assigned variant \(assigned)")
             return assigned
         }
         let fallback = FeatureFlags.shared.effectiveAgentVariantSlug
-        Log.info("AgentVariant: join for \(conversationId) has no assignment, using \(fallback ?? "none")")
+        Log.info("AgentVariant: \(conversationId) has no assignment, using \(fallback ?? "none")")
         return fallback
     }
 

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1578,7 +1578,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             )
             let response = try await client.getAgentParticipation(
                 conversationId: conversation.id,
-                variantId: FeatureFlags.shared.effectiveAgentVariantSlug
+                variantId: conversationAgentVariantSlug
             )
             // A newer refresh started while this one was in flight; its
             // response is the fresher truth, so this one must not land.
@@ -4317,6 +4317,17 @@ extension ConversationViewModel {
         let fallback = FeatureFlags.shared.effectiveAgentVariantSlug
         Log.info("AgentVariant: join for \(conversationId) has no assignment, using \(fallback ?? "none")")
         return fallback
+    }
+
+    /// The agent-variant slug bound to THIS conversation — the per-conversation
+    /// pick, falling back to the global default. Every per-conversation agent
+    /// call (join, participation, power) must use this rather than the global
+    /// `FeatureFlags.effectiveAgentVariantSlug`; reading the global slug routes
+    /// the call by whatever variant happens to be selected now, which can
+    /// disagree with the one this conversation was actually created with, and
+    /// the backend then silently provisions/queries against the wrong runtime.
+    var conversationAgentVariantSlug: String? {
+        Self.selectedAgentVariantSlug(for: conversation.id)
     }
 
     private static func performAgentJoinCall(


### PR DESCRIPTION
Two agent calls read the **global** `FeatureFlags.effectiveAgentVariantSlug` instead of the conversation's own per-conversation binding:

- `ConversationViewModel.refreshAgentPowerStatus` (agent-power read) — line ~1581
- `ConversationView.prepareParticipation` (participation store) — line ~1465

Both then route by whatever variant is globally selected *now*, which can disagree with the one the conversation was created with. So a conversation bound to a per-PR variant silently queries/participates against the wrong runtime — and on the backend the join falls back to the default worker with no user-facing error. This surfaced from a dev agent that was "in a variant" per the picker but actually provisioned on the default dev runtime.

## Change

- Add `ConversationViewModel.conversationAgentVariantSlug`, which resolves the per-conversation assignment via the existing `selectedAgentVariantSlug(for:)` helper (already used by the join path) with the same global fallback.
- Point both call sites at it.

The create/join path was already correct (it threads the per-flow `agentVariantSlug`); this brings the two sibling reads in line with the per-conversation promise. The one remaining global read — `ConvosApp.wireDefaultAgentVariantProvider` — is intentionally global (a session-level default-agent join with no conversation in scope) and is left as-is.

Companion backend PR that makes a dropped variant visible instead of silently falling back: xmtplabs/convos-assistants#3437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011vPraNJqmmX99ckik99jLA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789673613&installation_model_id=20076&pr_number=1336&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1336&signature=30119c6fd580997651b051b00691587955772cd2a042a8b805d0a98c0d53c29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route per-conversation agent calls by the conversation's assigned variant
> - `ConversationViewModel` adds a `conversationAgentVariantSlug` computed property that resolves the agent variant for a specific conversation, falling back to the global default.
> - In non-production environments, `selectedAgentVariantSlug(for:)` consults `AgentVariantAssignmentStore` for a per-conversation assignment; in production it always uses the global effective slug.
> - Agent power fetches and participation store creation in `ConversationView` and `ConversationViewModel` now pass the conversation-scoped variant instead of `FeatureFlags.shared.effectiveAgentVariantSlug`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1082aa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->