### PR TITLE
Connections v1 cleanup foundation: cleanup map + catalog-driven provider registry

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesAPI.swift
@@ -163,6 +163,28 @@ public enum AbilitiesAPI {
         }
     }
 
+    /// Optional per-manifest provider registration fields. When present,
+    /// the client builds its capability-provider registration from the
+    /// catalog instead of the hardcoded per-service tables, making a new
+    /// ability a backend-manifest-only addition. Raw strings by design:
+    /// an unknown subject or capability added backend-side must not break
+    /// catalog decode on older clients -- mapping to typed values (and
+    /// dropping unknowns) happens in `CloudProviderDescriptor`.
+    public struct AbilityProviderInfo: Codable, Sendable, Hashable {
+        /// Fully-qualified provider id, e.g. "composio.googledocs".
+        public let providerId: String
+        /// A `CapabilitySubject` raw value, e.g. "calendar".
+        public let subject: String
+        /// `ConnectionCapability` raw values, e.g. ["read", "write_create"].
+        public let capabilities: [String]
+
+        public init(providerId: String, subject: String, capabilities: [String]) {
+            self.providerId = providerId
+            self.subject = subject
+            self.capabilities = capabilities
+        }
+    }
+
     /// One user-facing permission bundle inside an ability ("Events").
     public struct AbilityBundle: Codable, Sendable, Hashable, Identifiable {
         public let id: String
@@ -268,6 +290,9 @@ public enum AbilitiesAPI {
         public let icon: AbilityIcon?
         public let auth: AbilityAuth
         public let bundles: [AbilityBundle]
+        /// Optional provider registration fields; absent on backends that
+        /// predate them (clients then fall back to hardcoded tables).
+        public let provider: AbilityProviderInfo?
         /// The decoded `entitlement` key, with null-vs-absent preserved.
         public let entitlementState: EntitlementState
 
@@ -287,6 +312,7 @@ public enum AbilitiesAPI {
             icon: AbilityIcon? = nil,
             auth: AbilityAuth,
             bundles: [AbilityBundle],
+            provider: AbilityProviderInfo? = nil,
             entitlementState: EntitlementState = .notEntitled
         ) throws {
             guard version >= 0 else {
@@ -299,6 +325,7 @@ public enum AbilitiesAPI {
             self.icon = icon
             self.auth = auth
             self.bundles = bundles
+            self.provider = provider
             self.entitlementState = entitlementState
         }
 
@@ -319,6 +346,7 @@ public enum AbilitiesAPI {
             self.icon = try container.decodeIfPresent(AbilityIcon.self, forKey: .icon)
             self.auth = try container.decode(AbilityAuth.self, forKey: .auth)
             self.bundles = try container.decode([AbilityBundle].self, forKey: .bundles)
+            self.provider = try container.decodeIfPresent(AbilityProviderInfo.self, forKey: .provider)
             if container.contains(.entitlement) {
                 if try container.decodeNil(forKey: .entitlement) {
                     self.entitlementState = .notEntitled
@@ -339,6 +367,7 @@ public enum AbilitiesAPI {
             try container.encodeIfPresent(icon, forKey: .icon)
             try container.encode(auth, forKey: .auth)
             try container.encode(bundles, forKey: .bundles)
+            try container.encodeIfPresent(provider, forKey: .provider)
             switch entitlementState {
             case .entitled(let entitlement):
                 try container.encode(entitlement, forKey: .entitlement)
@@ -360,6 +389,7 @@ public enum AbilitiesAPI {
             self.icon = other.icon
             self.auth = other.auth
             self.bundles = other.bundles
+            self.provider = other.provider
             self.entitlementState = entitlementState
         }
 
@@ -376,6 +406,7 @@ public enum AbilitiesAPI {
             case icon
             case auth
             case bundles
+            case provider
             case entitlement
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
@@ -65,6 +65,9 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
     /// same shape as V1: `<scheme>://connections/callback`.
     private let redirectUri: String?
     private let cache: AbilitiesCatalogDiskCache?
+    /// Bridges catalog-derived provider registrations to the capability
+    /// registry (see `CloudProviderDescriptor`).
+    private let descriptorStore: CloudProviderDescriptorStore
     /// The caller's own inbox id: the disk-cache scope, and the PUT's
     /// optional `extendedByInboxId`. Nil (or a nil resolution) omits the
     /// wire field and bypasses the disk cache.
@@ -119,7 +122,8 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         cache: AbilitiesCatalogDiskCache?,
         myInboxIdProvider: (@Sendable () async -> String?)? = nil,
         shimWriter: (any AbilityV1AwarenessShimWriting)? = nil,
-        isShimEnabled: @escaping @Sendable () -> Bool = { false }
+        isShimEnabled: @escaping @Sendable () -> Bool = { false },
+        descriptorStore: CloudProviderDescriptorStore = .shared
     ) {
         self.apiClient = apiClient
         self.redirectUri = callbackURLScheme.map { "\($0)://connections/callback" }
@@ -127,6 +131,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         self.myInboxIdProvider = myInboxIdProvider
         self.shimWriter = shimWriter
         self.isShimEnabled = isShimEnabled
+        self.descriptorStore = descriptorStore
     }
 
     // MARK: - AbilitiesServiceProtocol
@@ -157,6 +162,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         if catalogScope == scope && sequence > committedFetchSequence && wipeCount == wipeMark {
             committedFetchSequence = sequence
             lastKnownCatalog = catalog
+            descriptorStore.update(CloudProviderDescriptor.descriptors(from: catalog))
             if let scope {
                 cache?.save(catalog, scope: scope)
             }
@@ -354,6 +360,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         lastKnownCatalog = nil
         catalogScope = nil
         hasLoadedCache = false
+        descriptorStore.clear()
         cache?.clearAll()
     }
 
@@ -374,6 +381,9 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         catalogScope = scope
         if let scope {
             lastKnownCatalog = cache?.load(scope: scope)
+            if let loaded = lastKnownCatalog {
+                descriptorStore.update(CloudProviderDescriptor.descriptors(from: loaded))
+            }
         } else {
             lastKnownCatalog = nil
         }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityProviderBootstrap.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityProviderBootstrap.swift
@@ -47,9 +47,16 @@ public enum CapabilityProviderBootstrap {
     ///
     /// Call this after every cloud-side state change: a fresh `connect`, a `disconnect`,
     /// a `refreshConnections` that observed a status flip.
+    /// `descriptors` carries catalog-derived registration data (see
+    /// `CloudProviderDescriptor`). A service with a descriptor is registered
+    /// from it -- the hardcoded tables are not consulted -- and every
+    /// descriptor service is implicitly seeded, so a backend-manifest-only
+    /// ability gets its placeholder without an iOS change. Services without a
+    /// descriptor fall back to the tables exactly as before.
     public static func syncCloudProviders(
         connections: [CloudConnection],
         seedServiceIds: Set<String> = [],
+        descriptors: [CloudProviderDescriptor] = [],
         registry: any CapabilityProviderRegistry
     ) async {
         // Compute the desired set of provider ids from the current connections list.
@@ -60,8 +67,12 @@ public enum CapabilityProviderBootstrap {
         var seenIds: Set<ProviderID> = []
         var seenServiceIds: Set<String> = []
         var desiredProviders: [(ProviderID, CloudCapabilityProvider)] = []
+        let descriptorsByServiceId: [String: CloudProviderDescriptor] = Dictionary(
+            descriptors.map { ($0.serviceId, $0) }
+        ) { _, last in last }
         for connection in connections {
-            guard let provider = CloudCapabilityProvider.from(connection) else {
+            let descriptor = descriptorsByServiceId[connection.serviceId]
+            guard let provider = CloudCapabilityProvider.from(connection, descriptor: descriptor) else {
                 // The user linked a service this build can't route to a subject. Without a
                 // provider the service is invisible to every agent ask, so say so rather
                 // than dropping it silently.
@@ -76,8 +87,10 @@ public enum CapabilityProviderBootstrap {
             seenServiceIds.insert(connection.serviceId)
         }
 
-        for serviceId in seedServiceIds where !seenServiceIds.contains(serviceId) {
-            guard let placeholder = CloudCapabilityProvider.placeholder(serviceId: serviceId) else { continue }
+        let allSeedIds = seedServiceIds.union(descriptorsByServiceId.keys)
+        for serviceId in allSeedIds.sorted() where !seenServiceIds.contains(serviceId) {
+            let descriptor = descriptorsByServiceId[serviceId]
+            guard let placeholder = CloudCapabilityProvider.placeholder(serviceId: serviceId, descriptor: descriptor) else { continue }
             guard seenIds.insert(placeholder.id).inserted else { continue }
             desiredProviders.append((placeholder.id, placeholder))
         }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CloudCapabilityProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CloudCapabilityProvider.swift
@@ -87,18 +87,33 @@ public extension CloudCapabilityProvider {
         "gmail": "Gmail",
     ]
 
-    /// Build a provider from a `CloudConnection`, or `nil` if its `serviceId` isn't in
-    /// the subject map (in which case it's not surfaced to agents).
+    /// Build a provider from a `CloudConnection`. A catalog-derived `descriptor`
+    /// wins when present; otherwise the hardcoded tables apply, and `nil` comes
+    /// back if the `serviceId` isn't in the subject map (in which case it's not
+    /// surfaced to agents).
     ///
     /// Display name resolution: prefer the slug-keyed `serviceDisplayNames` lookup
     /// so brand capitalisation stays consistent regardless of what the server happens
     /// to return for `serviceName`. Falls through to title-casing via
     /// `CloudConnectionServiceNaming.displayName(for:)` when no entry exists.
-    static func from(_ connection: CloudConnection) -> CloudCapabilityProvider? {
-        guard let subject = serviceSubjectMap[connection.serviceId] else { return nil }
-        let capabilities = serviceCapabilitiesMap[connection.serviceId] ?? [.read]
-        let displayName = serviceDisplayNames[connection.serviceId]
-            ?? CloudConnectionServiceNaming.displayName(for: connection.serviceName, fallbackFrom: connection.serviceId)
+    static func from(
+        _ connection: CloudConnection,
+        descriptor: CloudProviderDescriptor? = nil
+    ) -> CloudCapabilityProvider? {
+        let subject: CapabilitySubject
+        let capabilities: Set<ConnectionCapability>
+        let displayName: String
+        if let descriptor {
+            subject = descriptor.subject
+            capabilities = descriptor.capabilities
+            displayName = descriptor.displayName
+        } else {
+            guard let mappedSubject = serviceSubjectMap[connection.serviceId] else { return nil }
+            subject = mappedSubject
+            capabilities = serviceCapabilitiesMap[connection.serviceId] ?? [.read]
+            displayName = serviceDisplayNames[connection.serviceId]
+                ?? CloudConnectionServiceNaming.displayName(for: connection.serviceName, fallbackFrom: connection.serviceId)
+        }
         return CloudCapabilityProvider(
             id: ProviderID(rawValue: "composio.\(connection.serviceId)"),
             serviceId: connection.serviceId,
@@ -117,10 +132,23 @@ public extension CloudCapabilityProvider {
     /// at session start so agents can target a cloud provider via `preferredProviders`
     /// even before the user has run OAuth — the picker then offers a connect-and-approve
     /// path that triggers OAuth on tap.
-    static func placeholder(serviceId: String) -> CloudCapabilityProvider? {
-        guard let subject = serviceSubjectMap[serviceId] else { return nil }
-        let capabilities = serviceCapabilitiesMap[serviceId] ?? [.read]
-        let displayName = serviceDisplayNames[serviceId] ?? serviceId
+    static func placeholder(
+        serviceId: String,
+        descriptor: CloudProviderDescriptor? = nil
+    ) -> CloudCapabilityProvider? {
+        let subject: CapabilitySubject
+        let capabilities: Set<ConnectionCapability>
+        let displayName: String
+        if let descriptor {
+            subject = descriptor.subject
+            capabilities = descriptor.capabilities
+            displayName = descriptor.displayName
+        } else {
+            guard let mappedSubject = serviceSubjectMap[serviceId] else { return nil }
+            subject = mappedSubject
+            capabilities = serviceCapabilitiesMap[serviceId] ?? [.read]
+            displayName = serviceDisplayNames[serviceId] ?? serviceId
+        }
         return CloudCapabilityProvider(
             id: ProviderID(rawValue: "composio.\(serviceId)"),
             serviceId: serviceId,

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CloudProviderDescriptor.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CloudProviderDescriptor.swift
@@ -1,0 +1,115 @@
+import Combine
+import ConvosConnections
+import Foundation
+
+/// Typed, catalog-derived registration data for one cloud provider: the
+/// resolution of a manifest's optional `provider` fields plus its display
+/// name. When a descriptor exists for a service, provider registration is
+/// built from it; the hardcoded per-service tables in
+/// `CloudCapabilityProvider` remain the fallback for backends that predate
+/// the fields (see docs/plans/connections-v1-cleanup-map.md).
+public struct CloudProviderDescriptor: Sendable, Hashable {
+    /// The cloud service slug, parsed from `providerId` ("composio.<serviceId>").
+    public let serviceId: String
+    public let subject: CapabilitySubject
+    public let capabilities: Set<ConnectionCapability>
+    public let displayName: String
+
+    public init(
+        serviceId: String,
+        subject: CapabilitySubject,
+        capabilities: Set<ConnectionCapability>,
+        displayName: String
+    ) {
+        self.serviceId = serviceId
+        self.subject = subject
+        self.capabilities = capabilities
+        self.displayName = displayName
+    }
+
+    /// Maps a manifest's raw provider fields, or nil when they cannot route
+    /// a provider: a non-`composio.` provider id (no other namespace has a
+    /// cloud-connection backing) or a subject this build does not know
+    /// (registering an unrouted provider would only confuse the picker --
+    /// same conservatism as the hardcoded subject table). Unknown capability
+    /// strings are dropped; a set left empty collapses to `[.read]`,
+    /// matching the table fallback's default.
+    public init?(providerInfo: AbilitiesAPI.AbilityProviderInfo, displayName: String) {
+        let prefix = "composio."
+        guard providerInfo.providerId.hasPrefix(prefix) else { return nil }
+        let serviceId = String(providerInfo.providerId.dropFirst(prefix.count))
+        guard !serviceId.isEmpty else { return nil }
+        guard let subject = CapabilitySubject(rawValue: providerInfo.subject) else { return nil }
+        let capabilities = Set(providerInfo.capabilities.compactMap(ConnectionCapability.init(rawValue:)))
+        self.init(
+            serviceId: serviceId,
+            subject: subject,
+            capabilities: capabilities.isEmpty ? [.read] : capabilities,
+            displayName: displayName
+        )
+    }
+
+    /// Every routable descriptor in a catalog. Manifests without `provider`
+    /// fields, and manifests whose fields fail to route, contribute nothing
+    /// (their services stay on the hardcoded fallback).
+    public static func descriptors(from catalog: AbilitiesCatalog) -> [CloudProviderDescriptor] {
+        catalog.abilities.compactMap { (ability: AbilitiesAPI.Ability) -> CloudProviderDescriptor? in
+            guard let providerInfo = ability.provider else { return nil }
+            return CloudProviderDescriptor(
+                providerInfo: providerInfo,
+                displayName: ability.displayName.resolved()
+            )
+        }
+    }
+}
+
+/// Process-wide holder for the latest catalog-derived descriptors, bridging
+/// the abilities catalog (fetched by `LiveAbilitiesService`) to capability
+/// provider registration (run by `SessionManager`'s bootstrap) without
+/// coupling the two directly. `updatesPublisher` fires after each change so
+/// the bootstrap can re-sync the registry.
+public final class CloudProviderDescriptorStore: @unchecked Sendable {
+    public static let shared: CloudProviderDescriptorStore = CloudProviderDescriptorStore()
+
+    private let lock: NSLock = NSLock()
+    private var descriptorsByServiceId: [String: CloudProviderDescriptor] = [:]
+    private let updatesSubject: PassthroughSubject<Void, Never> = PassthroughSubject()
+
+    public init() {}
+
+    public var updatesPublisher: AnyPublisher<Void, Never> {
+        updatesSubject.eraseToAnyPublisher()
+    }
+
+    public var current: [CloudProviderDescriptor] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Array(descriptorsByServiceId.values)
+    }
+
+    public func descriptor(for serviceId: String) -> CloudProviderDescriptor? {
+        lock.lock()
+        defer { lock.unlock() }
+        return descriptorsByServiceId[serviceId]
+    }
+
+    /// Replaces the stored set. Publishes only on an actual change so
+    /// repeated identical catalog fetches don't thrash registry syncs.
+    public func update(_ descriptors: [CloudProviderDescriptor]) {
+        let new = Dictionary(descriptors.map { ($0.serviceId, $0) }) { _, last in last }
+        lock.lock()
+        let changed = new != descriptorsByServiceId
+        descriptorsByServiceId = new
+        lock.unlock()
+        if changed {
+            updatesSubject.send(())
+        }
+    }
+
+    /// Account-wipe hygiene: drops catalog-derived registrations so a
+    /// re-paired account starts from the hardcoded fallback until its own
+    /// catalog arrives.
+    public func clear() {
+        update([])
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift
@@ -54,6 +54,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
     /// empty keychain after teardown if left to fire.
     private var profileServicesTask: Task<Void, Never>?
     private var cloudConnectionsCancellable: AnyCancellable?
+    private var providerDescriptorsCancellable: AnyCancellable?
     private var activeConversationObserver: NSObjectProtocol?
     private var activeDmConversationObserver: NSObjectProtocol?
     private var staleStrangerGCTask: Task<Void, Never>?
@@ -235,6 +236,7 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         serviceBootstrapTask?.cancel()
         profileServicesTask?.cancel()
         cloudConnectionsCancellable?.cancel()
+        providerDescriptorsCancellable?.cancel()
         if let activeConversationObserver {
             NotificationCenter.default.removeObserver(activeConversationObserver)
         }
@@ -1036,17 +1038,33 @@ public final class SessionManager: SessionManagerProtocol, @unchecked Sendable {
         )
 
         cloudConnectionsCancellable?.cancel()
-        let publisher = cloudConnectionRepository().connectionsPublisher()
+        providerDescriptorsCancellable?.cancel()
+        let repository = cloudConnectionRepository()
+        let publisher = repository.connectionsPublisher()
         let seedServiceIds = SupportedConnections.supportedCloudServiceIds
+        let descriptorStore = CloudProviderDescriptorStore.shared
+        let sync: @Sendable ([CloudConnection]) async -> Void = { [registry] connections in
+            await CapabilityProviderBootstrap.syncCloudProviders(
+                connections: connections,
+                seedServiceIds: seedServiceIds,
+                descriptors: descriptorStore.current,
+                registry: registry
+            )
+        }
         // GRDB's `.immediate` scheduler requires subscription on the main thread.
         await MainActor.run {
             self.cloudConnectionsCancellable = publisher.sink { connections in
-                Task { [registry] in
-                    await CapabilityProviderBootstrap.syncCloudProviders(
-                        connections: connections,
-                        seedServiceIds: seedServiceIds,
-                        registry: registry
-                    )
+                Task {
+                    await sync(connections)
+                }
+            }
+            // A catalog update can add or reshape descriptors without any
+            // cloud-connection change, so re-sync from a fresh connections
+            // read whenever the store publishes.
+            self.providerDescriptorsCancellable = descriptorStore.updatesPublisher.sink { _ in
+                Task {
+                    let connections = (try? await repository.connections()) ?? []
+                    await sync(connections)
                 }
             }
         }

--- a/ConvosCore/Tests/ConvosCoreTests/AbilitiesCatalogContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilitiesCatalogContractTests.swift
@@ -627,3 +627,80 @@ struct MockAbilitiesServiceTests {
         #expect(catalog.abilities.first { $0.id == "googlecalendar" }?.entitlement?.extensionCount == 1)
     }
 }
+
+@Suite("AbilityProviderInfo wire contract")
+struct AbilityProviderInfoContractTests {
+    private func decodeCatalog(_ json: String) throws -> AbilitiesAPI.CatalogResponse {
+        let data = try #require(json.data(using: .utf8))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(AbilitiesAPI.CatalogResponse.self, from: data)
+    }
+
+    private let providerJSON = """
+    {
+      "catalogVersion": 5,
+      "abilities": [
+        {
+          "id": "googledocs",
+          "version": 1,
+          "displayName": { "en": "Google Docs" },
+          "subtitle": { "en": "Create and share docs" },
+          "auth": { "type": "oauth" },
+          "bundles": [],
+          "provider": {
+            "providerId": "composio.googledocs",
+            "subject": "photos",
+            "capabilities": ["read", "write_create", "write_update"]
+          },
+          "entitlement": null
+        },
+        {
+          "id": "spotify",
+          "version": 1,
+          "displayName": { "en": "Spotify" },
+          "subtitle": { "en": "Control playback" },
+          "auth": { "type": "oauth" },
+          "bundles": [],
+          "entitlement": null
+        }
+      ]
+    }
+    """
+
+    @Test("provider fields decode when present and stay nil when absent")
+    func providerDecodes() throws {
+        let response = try decodeCatalog(providerJSON)
+        let docs = try #require(response.abilities.first { $0.id == "googledocs" })
+        #expect(docs.provider?.providerId == "composio.googledocs")
+        #expect(docs.provider?.subject == "photos")
+        #expect(docs.provider?.capabilities == ["read", "write_create", "write_update"])
+        let spotify = try #require(response.abilities.first { $0.id == "spotify" })
+        #expect(spotify.provider == nil)
+    }
+
+    @Test("unknown subject and capability strings survive decode — mapping drops them later")
+    func unknownVocabularyDecodes() throws {
+        let json = providerJSON.replacingOccurrences(of: "\"photos\"", with: "\"finance\"")
+        let response = try decodeCatalog(json)
+        let docs = try #require(response.abilities.first { $0.id == "googledocs" })
+        #expect(docs.provider?.subject == "finance")
+        // The typed mapping is where the unknown subject falls out.
+        let descriptor = docs.provider.flatMap { (info: AbilitiesAPI.AbilityProviderInfo) -> CloudProviderDescriptor? in
+            CloudProviderDescriptor(providerInfo: info, displayName: docs.displayName.resolved())
+        }
+        #expect(descriptor == nil)
+    }
+
+    @Test("provider fields round-trip through encode")
+    func providerRoundTrips() throws {
+        let response = try decodeCatalog(providerJSON)
+        let encoded = try JSONEncoder().encode(response)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(AbilitiesAPI.CatalogResponse.self, from: encoded)
+        let docs = try #require(decoded.abilities.first { $0.id == "googledocs" })
+        #expect(docs.provider?.providerId == "composio.googledocs")
+        #expect(docs.provider?.capabilities == ["read", "write_create", "write_update"])
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityProviderRegistrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityProviderRegistrationTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import ConvosConnections
 @testable import ConvosCore
 import Foundation
@@ -233,5 +234,219 @@ struct CapabilityProviderBootstrapTests {
         await CapabilityProviderBootstrap.syncCloudProviders(connections: [], registry: registry)
         let fitness = await registry.providers(for: .fitness)
         #expect(fitness.map(\.id.rawValue) == ["device.health"])
+    }
+}
+
+@Suite("Catalog-driven providers")
+struct CatalogDrivenProviderTests {
+    private func makeConnection(
+        serviceId: String,
+        status: CloudConnectionStatus = .active
+    ) -> CloudConnection {
+        CloudConnection(
+            id: "conn-\(serviceId)",
+            serviceId: serviceId,
+            serviceName: serviceId.capitalized,
+            provider: .composio,
+            composioEntityId: "entity",
+            composioConnectionId: "conn",
+            status: status,
+            connectedAt: Date()
+        )
+    }
+
+    private func makeProviderInfo(
+        providerId: String = "composio.notion",
+        subject: String = "tasks",
+        capabilities: [String] = ["read", "write_create"]
+    ) -> AbilitiesAPI.AbilityProviderInfo {
+        AbilitiesAPI.AbilityProviderInfo(
+            providerId: providerId,
+            subject: subject,
+            capabilities: capabilities
+        )
+    }
+
+    @Test("descriptor maps providerId, subject, and capabilities")
+    func descriptorMapsFields() {
+        let descriptor = CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(),
+            displayName: "Notion"
+        )
+        #expect(descriptor?.serviceId == "notion")
+        #expect(descriptor?.subject == .tasks)
+        #expect(descriptor?.capabilities == [.read, .writeCreate])
+        #expect(descriptor?.displayName == "Notion")
+    }
+
+    @Test("non-composio provider ids do not map")
+    func nonComposioIsNil() {
+        let descriptor = CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(providerId: "device.calendar"),
+            displayName: "Calendar"
+        )
+        #expect(descriptor == nil)
+    }
+
+    @Test("an empty serviceId does not map")
+    func emptyServiceIdIsNil() {
+        let descriptor = CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(providerId: "composio."),
+            displayName: "Nameless"
+        )
+        #expect(descriptor == nil)
+    }
+
+    @Test("an unknown subject does not map — unrouted providers stay out of the picker")
+    func unknownSubjectIsNil() {
+        let descriptor = CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(subject: "finance"),
+            displayName: "Notion"
+        )
+        #expect(descriptor == nil)
+    }
+
+    @Test("unknown capability strings are dropped; an all-unknown list collapses to read")
+    func unknownCapabilitiesDrop() {
+        let mixed = CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(capabilities: ["read", "teleport"]),
+            displayName: "Notion"
+        )
+        #expect(mixed?.capabilities == [.read])
+        let allUnknown = CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(capabilities: ["teleport"]),
+            displayName: "Notion"
+        )
+        #expect(allUnknown?.capabilities == [.read])
+    }
+
+    @Test("placeholder built from a descriptor for a service absent from every hardcoded table")
+    func placeholderFromDescriptorOnly() throws {
+        let descriptor = try #require(CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(),
+            displayName: "Notion"
+        ))
+        // Guard the premise: the hardcoded tables know nothing about this id,
+        // so any registration below can only come from the catalog.
+        #expect(CloudCapabilityProvider.serviceSubjectMap["notion"] == nil)
+        #expect(CloudCapabilityProvider.placeholder(serviceId: "notion") == nil)
+
+        let placeholder = try #require(CloudCapabilityProvider.placeholder(serviceId: "notion", descriptor: descriptor))
+        #expect(placeholder.id.rawValue == "composio.notion")
+        #expect(placeholder.subject == .tasks)
+        #expect(placeholder.capabilities == [.read, .writeCreate])
+        #expect(placeholder.displayName == "Notion")
+        #expect(placeholder.linkedSnapshot == false)
+    }
+
+    @Test("descriptor wins over the hardcoded tables for a table-known service")
+    func descriptorOverridesTables() throws {
+        let descriptor = try #require(CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(
+                providerId: "composio.googlecalendar",
+                subject: "calendar",
+                capabilities: ["read"]
+            ),
+            displayName: "Calendar (Catalog)"
+        ))
+        let provider = try #require(CloudCapabilityProvider.from(
+            makeConnection(serviceId: "googlecalendar"),
+            descriptor: descriptor
+        ))
+        // The hardcoded table grants the full verb set; the catalog narrowed
+        // it to read, and the catalog must win.
+        #expect(provider.capabilities == [.read])
+        #expect(provider.displayName == "Calendar (Catalog)")
+    }
+
+    @Test("sync registers a catalog-only service as a placeholder without a seed entry")
+    func syncSeedsFromDescriptors() async throws {
+        let registry = InMemoryCapabilityProviderRegistry()
+        let descriptor = try #require(CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(),
+            displayName: "Notion"
+        ))
+        await CapabilityProviderBootstrap.syncCloudProviders(
+            connections: [],
+            seedServiceIds: [],
+            descriptors: [descriptor],
+            registry: registry
+        )
+        let tasks = await registry.providers(for: .tasks)
+        #expect(tasks.map(\.id.rawValue) == ["composio.notion"])
+    }
+
+    @Test("sync without descriptors falls back to the hardcoded tables")
+    func syncFallsBackWithoutDescriptors() async {
+        let registry = InMemoryCapabilityProviderRegistry()
+        await CapabilityProviderBootstrap.syncCloudProviders(
+            connections: [makeConnection(serviceId: "googlecalendar")],
+            seedServiceIds: [],
+            registry: registry
+        )
+        let calendar = await registry.providers(for: .calendar)
+        let provider = calendar.first { $0.id.rawValue == "composio.googlecalendar" }
+        #expect((provider as? CloudCapabilityProvider)?.capabilities == [.read, .writeCreate, .writeUpdate, .writeDelete])
+    }
+
+    @Test("descriptors(from:) skips manifests without provider fields")
+    func descriptorsFromCatalog() throws {
+        let withProvider = try AbilitiesAPI.Ability(
+            id: "notion",
+            version: 1,
+            displayName: AbilitiesAPI.LocalizedText(en: "Notion"),
+            subtitle: AbilitiesAPI.LocalizedText(en: "Tasks and notes"),
+            auth: AbilitiesAPI.AbilityAuth(type: .oauth),
+            bundles: [],
+            provider: makeProviderInfo()
+        )
+        let withoutProvider = try AbilitiesAPI.Ability(
+            id: "spotify",
+            version: 1,
+            displayName: AbilitiesAPI.LocalizedText(en: "Spotify"),
+            subtitle: AbilitiesAPI.LocalizedText(en: "Playback"),
+            auth: AbilitiesAPI.AbilityAuth(type: .oauth),
+            bundles: []
+        )
+        let catalog = AbilitiesCatalog(catalogVersion: 1, abilities: [withProvider, withoutProvider])
+        let descriptors = CloudProviderDescriptor.descriptors(from: catalog)
+        #expect(descriptors.map(\.serviceId) == ["notion"])
+        #expect(descriptors.first?.displayName == "Notion")
+    }
+
+    @Test("store publishes on change and only on change")
+    func storePublishesOnChange() throws {
+        let store = CloudProviderDescriptorStore()
+        let counter = UpdateCounter()
+        let cancellable = store.updatesPublisher.sink { _ in counter.increment() }
+        defer { cancellable.cancel() }
+        let descriptor = try #require(CloudProviderDescriptor(
+            providerInfo: makeProviderInfo(),
+            displayName: "Notion"
+        ))
+        store.update([descriptor])
+        #expect(counter.count == 1)
+        #expect(store.descriptor(for: "notion") != nil)
+        // Identical update: no publish.
+        store.update([descriptor])
+        #expect(counter.count == 1)
+        store.clear()
+        #expect(counter.count == 2)
+        #expect(store.current.isEmpty)
+    }
+
+    private final class UpdateCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Int = 0
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+        func increment() {
+            lock.lock()
+            defer { lock.unlock() }
+            value += 1
+        }
     }
 }

--- a/docs/plans/connections-v1-cleanup-map.md
+++ b/docs/plans/connections-v1-cleanup-map.md
@@ -1,0 +1,231 @@
+# Connections v1 -> v2 cleanup map
+
+**Goal:** adding an ability becomes backend-manifest-only. Today every new
+service needs an ~8-line iOS PR touching up to six hand-maintained per-service
+tables. This map classifies each table and its consumers, records what this
+foundation PR migrates, and states the unblockers gating each remaining
+deletion. Constraint: the v1 `capability_request` transcript card is still the
+live consent path (including MCP abilities), so this is a staged migration, not
+a big-bang deletion.
+
+Buckets:
+
+- **deletable-now** — genuinely dead, removable in this PR.
+- **migratable** — a catalog-driven replacement exists or is introduced by this
+  PR; the table degrades to a fallback and is deleted once the backend ships
+  the manifest fields and the fallback window closes.
+- **kept-until-\<unblocker\>** — load-bearing for a surface that has no v2
+  replacement yet; the named unblocker is what retires it.
+
+## The per-service tables
+
+### 1. `SupportedConnections.supportedCloudServiceIds` — migratable
+
+`ConvosCore/Sources/ConvosCore/CapabilityResolution/SupportedConnections.swift:20`
+
+Consumers:
+
+- `SessionManager.bootstrapCapabilityProviders` (`ConvosCore/Sources/ConvosCore/Sessions/SessionManager.swift:1040`) — seeds unlinked placeholder providers so the consent picker can offer connect-and-approve pre-OAuth.
+- `ConnectionsListViewModel` (`Convos/App Settings/ConnectionsListViewModel.swift`) — filters the App Settings v1 connections list.
+- `ConversationConnectionsSection` (`Convos/Conversation Detail/ConversationConnectionsSection.swift`) — same filter for conversation info.
+- `AutoEnableAbilitiesService` (`ConvosCore/Sources/ConvosCore/CloudConnections/AutoEnableAbilitiesService.swift`) — v1 mirror; stands down when v2 is active.
+
+Migration in this PR: the placeholder seed set becomes the union of this table
+and the serviceIds of catalog manifests carrying `provider` fields, so a
+backend-only manifest addition registers a provider with no iOS change. The
+table remains the fallback for backends that predate the fields. Delete once
+the backend ships `provider` on every cloud manifest and the v1 settings
+surfaces retire (see kept-until entries below).
+
+### 2. `CloudCapabilityProvider.serviceSubjectMap` — migratable
+
+`ConvosCore/Sources/ConvosCore/CapabilityResolution/CloudCapabilityProvider.swift:45`
+
+Consumers: `placeholder(serviceId:)` (nil without an entry — the seed is
+silently skipped) and `from(_:)` (post-OAuth registration). Routes the consent
+sheet: no subject, no card.
+
+Migration in this PR: `CloudProviderDescriptor.subject` (from the manifest
+`provider.subject`) wins when present; this table is the fallback. Delete with
+the same condition as table 1.
+
+### 3. `CloudCapabilityProvider.serviceCapabilitiesMap` — migratable
+
+Same file, line 61. Absent entry defaults to `[.read]`, which silently drops
+any write ask (`computeLayout` filters on `supportsCapability`).
+
+Migration in this PR: `CloudProviderDescriptor.capabilities` (from
+`provider.capabilities`) wins when present; table fallback. Delete with table 1.
+
+### 4. `CloudCapabilityProvider.serviceDisplayNames` — migratable
+
+Same file, line 77. Placeholder display names for the consent surfaces.
+
+Migration in this PR: the manifest `displayName` (already localized, already
+served) rides the descriptor; table fallback. Delete with table 1.
+
+### 5. `CloudConnectionServiceNaming.displayNameOverrides` — kept-until-CON-773
+
+`ConvosCore/Sources/ConvosCore/CloudConnections/CloudConnectionServiceNaming.swift:14`
+
+Consumers: transcript summary lines for legacy connection events
+(`ConnectionMessageSummaryFormatter`), `CloudConnectionManager.displayName`
+persistence fallback. These format *historical* XMTP messages whose payloads
+carry only a slug — a catalog lookup cannot rename messages already rendered on
+other members' devices.
+
+Unblocker: CON-773 (XMTP connections-metadata drain). Once legacy connection
+events stop flowing and historical rendering is no longer required, delete the
+override table and derive names purely from the catalog.
+
+### 6. `CloudConnectionServiceCatalog` — kept-until-CON-802 + deep-link gate move
+
+`ConvosCore/Sources/ConvosComposer/CloudConnectionServiceCatalog.swift:14`
+
+Consumers:
+
+- `DeepLinkHandler.swift:63` (`ConvosCore/Sources/ConvosComposer/DeepLinkHandler.swift`) — **load-bearing security gate**: connection-grant deep links referencing a service not in this catalog are dropped. Deleting an entry silently breaks that service's OAuth/grant deep-link return.
+- `ConnectionsListViewModel` / `ConversationConnectionsSection` — v1 surfaces swapped out under `isAbilitiesV2Enabled` (`AppSettingsView.swift`, `ConversationInfoView.swift`).
+- Legacy `CloudConnectionGrantRequest` card + settings grant sheet (older content type, still decoded).
+
+Unblockers: (a) the deep-link gate must validate against the backend catalog
+(or the descriptor store) instead of this table; (b) CON-802 (legacy path
+retire) removes the v1 surfaces. Both, then delete.
+
+### 7. `ConnectionServiceIcon` — kept-until-#1321-path-covers-v1-sheet
+
+`ConvosCore/Sources/ConvosComposer/ConnectionServiceIcon.swift:18`
+
+Consumer: `CapabilityApprovalSheetView.swift:261` (v1 approval sheet branded
+icons; SF-symbol fallback otherwise). The v2 catalog already serves per-ability
+icon URLs (`icon.iosUrl`, consumed by `AbilityRowComponents` via the #1321
+ability-catalog icon path). Unblocker: route the v1 approval sheet's icon
+through the catalog icon (or retire the sheet per the end-state below), then
+delete the asset switch.
+
+## Bucket summary
+
+| Bucket | Count | Entries |
+|---|---|---|
+| deletable-now | 0 | — (verified: every table row feeds a live surface, the deep-link gate, or historical-message rendering; the sweep found no dead rows) |
+| migratable (this PR starts) | 4 | supportedCloudServiceIds (seed role), serviceSubjectMap, serviceCapabilitiesMap, serviceDisplayNames |
+| kept-until | 3 | displayNameOverrides (CON-773), CloudConnectionServiceCatalog (CON-802 + gate move), ConnectionServiceIcon (#1321 path coverage) |
+
+Also kept, not a table: `AutoEnableAbilitiesService` (v1 mirror, already
+flag-stood-down under v2; retires with CON-802).
+
+## What this PR builds (the keystone)
+
+Catalog-driven provider registration with hardcoded fallback:
+
+- `AbilitiesAPI.Ability` decodes an optional `provider` object (`providerId`,
+  `subject`, `capabilities`). Absent field: nil — old backends keep working.
+- `CloudProviderDescriptor` is the typed resolution of those fields;
+  `CloudProviderDescriptorStore` holds the latest catalog-derived set and
+  publishes updates.
+- `CloudCapabilityProvider.placeholder`/`from` and
+  `CapabilityProviderBootstrap.syncCloudProviders` consult descriptors first
+  and fall back to the hardcoded tables when absent.
+- `LiveAbilitiesService` feeds the store on every committed catalog;
+  `SessionManager` re-syncs the registry on store updates.
+
+Backend manifest fields needed (sketch, convos-assistants — not part of this
+PR):
+
+```json
+{
+  "id": "googledocs",
+  "version": 4,
+  "displayName": { "en": "Google Docs" },
+  "provider": {
+    "providerId": "composio.googledocs",
+    "subject": "photos",
+    "capabilities": ["read", "write_create", "write_update"]
+  }
+}
+```
+
+Semantics: `provider` optional (absence = client fallback tables);
+`providerId` must be `composio.<serviceId>`; `subject` one of the
+`CapabilitySubject` raw values (`calendar`, `contacts`, `tasks`, `mail`,
+`photos`, `fitness`, `music`, `location`, `home`, `screen_time`); `capabilities`
+subset of `read`, `write_create`, `write_update`, `write_delete`; any change
+bumps the manifest `version` (existing staleness contract). Unknown subject or
+capability strings are tolerated on the wire and dropped at mapping time, so
+the backend can add vocabulary ahead of old clients.
+
+## End-state: the Entitlement Actor Model target
+
+Product direction (Louis, grounded in the "Entitlement Actor Model" design
+doc, draft 2026-07-31): consent moves out of the shared group surface and into
+the member's 1:1 agent conversation, with authorization computed backend-side
+per call.
+
+Target model:
+
+- **Connections are managed in the 1:1 agent conversation (Agent tab).**
+  Connecting a calendar or mail account happens there, not via a shared group
+  pill. The group is never the connect surface.
+- **Escalation (cross-member use) is also negotiated in the 1:1 agent tab**,
+  materializing backend-side as bounded delegations per the actor-model doc:
+  six roles (trigger / actor / requester / credential-owner / beneficiary /
+  approver); requester and credential-owner are platform-resolved, never
+  model-supplied; ambiguity fails closed; the turn entitlement set is computed
+  per call backend-side and never cached for the length of a turn; the consent
+  prompt is an app surface, not chat text; delegations are bounded and
+  auditable in the ability UI. The authorization matrix behind this is not
+  yet implemented -- the phasing below accounts for that.
+- **Group conversations carry at most a status pointer** (e.g. "waiting on
+  \<member\>"). Anti-enumeration invariant: the group learns that an action is
+  escalation-gated, never the owner's connection inventory.
+- **All ability metadata is backend-driven.** The client may cache the catalog
+  at a short TTL (deployment-scoped data), but never authorization state
+  (turn-scoped -- live per call).
+
+The catalog-driven registry this PR builds is the keystone regardless: it is
+transport- and surface-agnostic (it feeds whatever surface renders consent),
+and it is what makes the client's ability metadata backend-driven.
+
+### Phasing (this rewrites the kept-until bucket's unblockers)
+
+- **Phase 0 -- this draft.** Catalog-driven provider registration with
+  hardcoded fallback; catalog stays the only client-cached ability metadata
+  (short-TTL deployment scope; the existing last-known-catalog cache already
+  matches this shape). No authorization state is cached today on the v2 path;
+  keep it that way.
+- **Phase 1 -- connection management moves to the 1:1 agent tab.** Doable on
+  the current entitlements backend (begin/complete/revoke already exist).
+  iOS surfaces this needs: an abilities/connections section in the agent DM
+  (today the Agent tab has no connect affordance -- the v2 abilities list
+  lives in App Settings and conversation info), the #1321 catalog icon path
+  reused there, and deep-link routing for the OAuth return into the DM
+  context.
+- **Phase 2 -- escalation negotiated in the 1:1 per the actor model.**
+  Blocked on the backend authorization matrix and the meta-tool family
+  (`abilities_status` / `abilities_request` / `abilities_escalate`). The group
+  side gains only the status-pointer surface (see dependency (b) below).
+- **Phase 3 -- delete the v1 card and the per-service tables.** CON-802
+  (legacy path retire) removes `CapabilityConnectPromptView`,
+  `CapabilityApprovalSheetView`, the resolution pipeline behind them, and the
+  kept-until tables (the deep-link gate moves to the catalog/descriptor
+  store first); CON-773 (XMTP connections-metadata drain) releases the
+  transcript-naming table.
+
+### Two dependencies this phasing surfaces
+
+- **(a) DM delivery reliability becomes consent-critical.** Once consent rides
+  the 1:1 lane, a dead agent-DM stream, missing backfill, or a stale
+  conversation binding (CON-803) silently breaks consent itself -- not a
+  papercut but a prerequisite for phase 1. The reliability work must land
+  before consent depends on the lane.
+- **(b) The group-side "pending consent" state is an unbuilt product
+  surface.** "Waiting on \<member\>" (without enumerating what the member has
+  or hasn't connected) has no design or implementation today; phase 2 cannot
+  ship without it, and it needs the anti-enumeration invariant designed in
+  from the start.
+
+Until phase 3 lands, the v1 card stays live, which is why the kept-until
+bucket exists: migratable tables shrink to fallbacks now (this PR), fallbacks
+delete when the backend ships `provider` fields on every cloud manifest, and
+the v1 card plus its remaining tables delete at CON-802 with the deep-link
+gate moved to the catalog and transcript naming resolved per CON-773.


### PR DESCRIPTION
## DO NOT MERGE — draft foundation for the connections v1 -> v2 cleanup

This draft charts the removal of hardcoded per-service client code and lands
the keystone that makes ability additions backend-manifest-only. It must not
merge until: (1) the backend ships the `provider` manifest fields sketched
below (convos-assistants), and (2) the map's phasing is agreed. The v1
`capability_request` card is still the live consent path (including MCP
abilities), so nothing here deletes it — this is a staged migration.

Based on origin/dev before #1337 (googledocs capability card) merged; if #1337
lands first, its three registration lines become one more row in the map's
migratable bucket and this branch rebases cleanly (no file overlap outside the
tables it documents).

## Commit 1 — the cleanup map (half the deliverable)

`docs/plans/connections-v1-cleanup-map.md` classifies every hand-maintained
per-service table with consumers and file references:

| Bucket | Count | Entries |
|---|---|---|
| deletable-now | 0 | independently verified: every row feeds a live surface, the deep-link security gate, or historical-message rendering |
| migratable (this PR starts) | 4 | `supportedCloudServiceIds` (seed role), `serviceSubjectMap`, `serviceCapabilitiesMap`, `serviceDisplayNames` |
| kept-until | 3 | `CloudConnectionServiceNaming` (CON-773 drain), `CloudConnectionServiceCatalog` (CON-802 + deep-link gate move), `ConnectionServiceIcon` (catalog icon path coverage) |

Kept pieces are tombstoned in the map with file:line and their unblocker
(no inline comment noise, per repo conventions).

The map's end-state section follows the **Entitlement Actor Model** design doc
(draft 2026-07-31) and the product decision that consent moves to the 1:1
agent conversation: connections managed in the Agent tab; escalation
negotiated there too, materializing as bounded backend-side delegations
(six-role model, platform-resolved requester/credential-owner, fail-closed,
per-call turn entitlements, consent as an app surface); groups carry only an
anti-enumeration-safe status pointer. Phasing: 0 = this draft, 1 = connection
management in the agent tab (current entitlements backend suffices; the DM
needs new iOS surfaces), 2 = actor-model escalation (blocked on the
authorization matrix + `abilities_status`/`abilities_request`/
`abilities_escalate` meta-tools), 3 = delete the v1 card and tables (CON-802,
CON-773). Two named dependencies: DM delivery reliability (CON-803 et al.)
becomes consent-critical in phase 1, and the group-side "pending consent"
status surface is unbuilt.

## Commit 2 — catalog-driven provider registry (the keystone)

- `AbilitiesAPI.Ability` decodes an optional `provider` object; absent keeps
  today's behavior byte-for-byte.
- `CloudProviderDescriptor` resolves the raw fields to typed values
  (unknown vocabulary tolerated on the wire, dropped at mapping).
- `CloudCapabilityProvider` + `CapabilityProviderBootstrap` consult
  descriptors first, hardcoded tables as fallback; descriptor services are
  implicitly seeded, so a backend-only manifest addition registers a
  connect-and-approve placeholder with zero iOS change.
- `CloudProviderDescriptorStore` bridges catalog fetches
  (`LiveAbilitiesService`) to registry syncs (`SessionManager`) and clears on
  account wipe. The catalog remains the only client-cached ability metadata
  (short-TTL deployment scope); no authorization state is cached.

## Safe deletions

None. Independently re-verified beyond the earlier classification: the
`CloudConnectionServiceCatalog` entries gate connection-grant deep links
(`DeepLinkHandler.swift:63`), the naming tables format historical transcript
messages, and every icon/name helper has live callers. Forced deletions would
change behavior, so this commit intentionally does not exist.

## Backend manifest fields needed (convos-assistants, not in this PR)

```json
{
  "id": "googledocs",
  "version": 4,
  "displayName": { "en": "Google Docs" },
  "provider": {
    "providerId": "composio.googledocs",
    "subject": "photos",
    "capabilities": ["read", "write_create", "write_update"]
  }
}
```

`provider` optional (absence = client fallback); `providerId` must be
`composio.<serviceId>`; `subject` one of the client's `CapabilitySubject` raw
values; `capabilities` a subset of `read`/`write_create`/`write_update`/
`write_delete`; any change bumps the manifest `version` (existing staleness
contract). Unknown subject/capability strings must not be considered a client
error — older clients drop them at mapping time.

## What must land before un-drafting

1. Backend `provider` fields on the cloud manifests (or agreement to ship
   them), so the fallback window has an end.
2. Review of the map's phasing and the two named dependencies.
3. #1337 rebase if it merges first.

## Tests and gates

- New: wire decode (present/absent/unknown vocabulary/round-trip), descriptor
  mapping edges, catalog-only registration with the hardcoded tables provably
  unconsulted, table fallback without descriptors, store change-only
  publishing.
- Existing consent-sheet and registration tests: unchanged, passing.
- swiftlint --strict on changed files: clean. swiftformat --lint: clean.
- Build `Convos (Dev)` -configuration Dev, iPhone 17 simulator: BUILD SUCCEEDED.
- `swift test --package-path ConvosCore`: 1907 tests / 256 suites, 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789679843&installation_model_id=20076&pr_number=1338&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1338&signature=d9555a8234d69a1c1a06dfdd78f5989c00ce10f5422c69d53397f7a24b1a2755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add catalog-driven provider registry to replace hardcoded per-service tables
> - Introduces `CloudProviderDescriptor` and `CloudProviderDescriptorStore` to hold catalog-derived provider registration data (subject, capabilities, displayName) keyed by serviceId, sourced from a new `provider` field on `AbilitiesAPI.Ability`.
> - Updates `CloudCapabilityProvider.from` and `.placeholder` to accept an optional descriptor, using catalog values when present and falling back to existing hardcoded maps otherwise.
> - Updates `CapabilityProviderBootstrap.syncCloudProviders` to accept descriptors and seed placeholders for catalog-declared services even without explicit `seedServiceIds`.
> - Re-wires `SessionManager` to subscribe to `CloudProviderDescriptorStore.updatesPublisher` so the capability provider registry re-syncs whenever the abilities catalog changes.
> - Adds a [planning doc](https://github.com/xmtplabs/convos-ios/pull/1338/files#diff-8c572099a8c914ce8ee2c789cd8ff5e08304ee13d2585f3e263580a28ea01aa0) outlining the phased migration from v1 per-service tables to catalog-driven registration.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c5e13a3. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->