### PR TITLE
Raise the sheet when a notification names the agent DM

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -405,6 +405,30 @@ struct ConversationView<MessagesBottomBar: View>: View {
             return
         }
         selectTab(.agent)
+        revealAgentDm()
+    }
+
+    /// Raises the sheet for a request that named the agent DM outright.
+    ///
+    /// Selecting the tab is not enough on its own. Every other route to the Agent
+    /// tab leaves the sheet where it was and lets `openCollapsedSheetIfUnread`
+    /// decide, which is right for a tab the user is browsing between: with the
+    /// sheet down they are looking at the Home, and only the unread dot makes the
+    /// switch mean "show me what arrived".
+    ///
+    /// A notification tap is not that. It named a message, so the sheet has to
+    /// come up whether or not anything is badged - and it usually is not, because
+    /// the badge needs `agentDmSession.dmViewModel` to exist and to have reported
+    /// `isUnread`, which a tap can easily beat. The tab was selected and the sheet
+    /// stayed down, so the notification landed on the Home and the message it
+    /// pointed at was never shown.
+    ///
+    /// Nothing is waited for here. The lane can be raised before the DM binds -
+    /// the transcript fills in underneath - and an empty lane for a moment is a far
+    /// better answer than the wrong screen.
+    private func revealAgentDm() {
+        guard sheetDetent == .collapsed else { return }
+        moveSheet(to: .smallestReadable)
     }
 
     /// Programmatic tab selection: keeps `visitedTabs` in sync (the


### PR DESCRIPTION
Tapping a DM notification selected the Agent tab and stopped there. Whether the sheet came up was left to `openCollapsedSheetIfUnread`, which is gated on `badgedTabs`:

```
handleSelectAgentDmPageRequest  ->  selectTab(.agent)            // and nothing else
handleSelectedTabChange         ->  openCollapsedSheetIfUnread(for:)
openCollapsedSheetIfUnread      ->  guard badgedTabs.contains(tab)
badgedTabs                      ->  agentDmSession?.dmViewModel?.conversation.isUnread == true
```

The badge needs the DM session to exist *and* to have already reported `isUnread`, which a tap can easily beat. So the tab was selected, the sheet stayed down, and the notification landed on the Home with the message it named never shown.

## Why not just fix the gate

That gate is right for a tab the user is browsing between: with the sheet down they are looking at the Home, and may be picking which lane the composer belongs to while leaving it in view. It is the unread dot that makes the switch mean "show me what arrived".

A notification tap is not that. It named a message, so the sheet comes up whether or not anything is badged — which is what `revealAgentDm()` does, on the explicit request only.

## Nothing is waited for

The lane is raised immediately rather than deferred until the DM binds. The transcript fills in underneath, and an empty lane for a moment is a far better answer than the wrong screen.

A cold open was already correct by another route — `ConversationSheetDetent.initial(hasUnread:agentDmRequested:)` covers it via `agentDmRequested` — so this only showed when the conversation was already on screen, which is the case the post site in `routeToTappedConversation` calls out.

## Testing

Verified on the simulator against the exact failure case: conversation open, sheet collapsed, Group tab selected; delivered an agent-DM push (`thread-id` = the DM's conversation id) and tapped it. The Agent tab is selected and the sheet comes up on the message.

Reported by Macroscope on #1325 and deferred from it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789686412&installation_model_id=20076&pr_number=1339&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1339&signature=a9fb4830bf17d25389da567de79f16d63fda06d6345b158adc96b14a2ec2b19e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise the sheet when a notification names the agent DM
> When a `selectAgentDmPageRequest` notification targets the current conversation, `handleSelectAgentDmPageRequest` in [ConversationView.swift](https://github.com/xmtplabs/convos-ios/pull/1339/files#diff-8d85226aa6385ce7a0aca11596c32eb20e3c3e89b37f51651c35fceb5e28f6bc) now calls the new `revealAgentDm()` helper after selecting the Agent tab. `revealAgentDm()` checks if the sheet is collapsed and, if so, moves it to the `smallestReadable` detent via `moveSheet(to: .smallestReadable)`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 945ea5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->