### PR TITLE
Let a resume revive sync after the streams give up

### DIFF
--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -133,11 +133,22 @@ actor SyncingManager: SyncingManagerProtocol {
     let streamProcessor: any StreamProcessorProtocol
     // Maximum consecutive stream failures before giving up. Prevents FD exhaustion when
     // XMTP service is unavailable (each failed connection attempt can leak file descriptors).
-    private let maxStreamRetries: Int = 10
+    // Injectable so tests can reach the exhausted/`.error` state without sitting through
+    // the full ~2.5 minute backoff ladder.
+    private let maxStreamRetries: Int
 
     private var messageStreamTask: Task<Void, Never>?
     private var conversationStreamTask: Task<Void, Never>?
     private var syncTask: Task<Void, Never>?
+
+    /// The params of the most recent `start`, retained so a session that has
+    /// fallen into `.error` can be restarted from a plain `.resume`.
+    ///
+    /// `.error` carries only the `Error`, so without this the state machine
+    /// had nothing to restart *with* and every recovery trigger the app sends
+    /// (foreground, network reconnect) is a `.resume` that could only be
+    /// dropped. Cleared on `stop` so a stopped session is never resurrected.
+    private var lastClientParams: SyncClientParams?
 
     /// Temporary diagnostic state for the agent-join poll. The task is the
     /// bounded polling loop; the date stamps the last message the stream
@@ -170,6 +181,15 @@ actor SyncingManager: SyncingManagerProtocol {
         if case .ready = _state { return true }
         return false
     }
+
+    /// True once the streams have exhausted their retry budget and the manager
+    /// has fallen into `.error`. Distinct from `!isSyncReady`, which is also
+    /// true for the transient `.starting` state - tests need to tell the
+    /// terminal state apart from the in-flight one.
+    var hasGivenUpOnStreams: Bool {
+        if case .error = _state { return true }
+        return false
+    }
     private var isProcessing: Bool = false
     private var currentTask: Task<Void, Never>?
 
@@ -196,7 +216,9 @@ actor SyncingManager: SyncingManagerProtocol {
          deviceRegistrationManager: (any DeviceRegistrationManagerProtocol)? = nil,
          notificationCenter: any UserNotificationCenterProtocol,
          deviceConnections: DeviceConnectionsBundle = .none,
+         maxStreamRetries: Int = 10,
          coreActions: any CoreActions) {
+        self.maxStreamRetries = maxStreamRetries
         self.identityStore = identityStore
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
@@ -471,6 +493,31 @@ actor SyncingManager: SyncingManagerProtocol {
                 // Recover from error by starting fresh
                 try await handleStart(client: params.client, apiClient: params.apiClient)
 
+            case (.error, .resume):
+                // Every recovery trigger the app has - returning to the
+                // foreground, the network monitor reconnecting - sends
+                // `.resume`, never `.start`. Dropping it here made `.error`
+                // terminal for the life of the process: streams stay
+                // cancelled, so nothing arrives over them and no further
+                // catch-up runs, while the session layer stays `.ready` and
+                // the UI keeps looking healthy. Restart from the retained
+                // params instead. If the underlying failure is still there
+                // the streams simply exhaust again, which makes this state
+                // transient rather than permanent - and the retry ladder
+                // (~2.5 minutes) rate-limits the attempts on its own.
+                guard let params = lastClientParams else {
+                    Log.warning("Sync is in error state with no retained client params - cannot recover")
+                    break
+                }
+                Log.info("Recovering sync from error state")
+                try await handleStart(client: params.client, apiClient: params.apiClient)
+
+            case (.error, .pause):
+                // Streams were already cancelled on the way into `.error`,
+                // so there is nothing to pause. Backgrounding a errored
+                // session is expected, not an invalid transition.
+                Log.debug("Pause requested while in error state - nothing to pause")
+
             case (.ready, .pause):
                 try await handlePause()
 
@@ -525,6 +572,7 @@ actor SyncingManager: SyncingManagerProtocol {
 
     private func handleStart(client: AnyClientProvider, apiClient: any ConvosAPIClientProtocol) async throws {
         let params = SyncClientParams(client: client, apiClient: apiClient)
+        lastClientParams = params
         emitStateChange(.starting(params, pauseOnComplete: false))
 
         // Setup notifications if not already done
@@ -934,6 +982,8 @@ actor SyncingManager: SyncingManagerProtocol {
 
         await cancelAndAwaitTasks()
         activeConversationId = nil
+        // A stopped session must not be revivable by a stray `.resume`.
+        lastClientParams = nil
 
         for observer in notificationObservers {
             NotificationCenter.default.removeObserver(observer)

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -110,11 +110,19 @@ class TestableMockClient: XMTPClientProvider, @unchecked Sendable {
 
 class TestableMockConversations: ConversationsProvider, @unchecked Sendable {
     let syncBehavior: TestableMockClient.SyncBehavior
-    let streamBehavior: TestableMockClient.StreamBehavior
 
     private var _syncCallCount: Int = 0
     private var _streamCallCount: Int = 0
+    private var _streamBehavior: TestableMockClient.StreamBehavior
     private let lock: OSAllocatedUnfairLock<Void> = OSAllocatedUnfairLock()
+
+    /// Settable mid-test so a test can let the streams start succeeding again,
+    /// the way they would once connectivity comes back. Read on every stream
+    /// creation rather than captured once at init.
+    var streamBehavior: TestableMockClient.StreamBehavior {
+        get { lock.withLock { _streamBehavior } }
+        set { lock.withLock { _streamBehavior = newValue } }
+    }
 
     var syncCallCount: Int {
         lock.withLock { _syncCallCount }
@@ -126,7 +134,7 @@ class TestableMockConversations: ConversationsProvider, @unchecked Sendable {
 
     init(syncBehavior: TestableMockClient.SyncBehavior, streamBehavior: TestableMockClient.StreamBehavior) {
         self.syncBehavior = syncBehavior
-        self.streamBehavior = streamBehavior
+        self._streamBehavior = streamBehavior
     }
 
     // swiftlint:disable:next function_parameter_count
@@ -1331,6 +1339,62 @@ struct SyncingManagerTests {
         // Final state should be ready
         let isReady = await syncingManager.isSyncReady
         #expect(isReady, "Should be ready after multiple cycles")
+
+        // Clean up
+        await syncingManager.stop()
+        try? await fixtures.cleanup()
+    }
+
+    /// Regression: a sync layer that exhausted its stream retries used to be
+    /// stuck in `.error` for the life of the process. Both of the app's
+    /// recovery triggers - returning to the foreground and the network
+    /// monitor reconnecting - call `resume()`, and `.resume` was only handled
+    /// from `.paused`, so it was dropped. The streams stayed cancelled while
+    /// the session layer stayed `.ready`, so the app kept looking healthy and
+    /// silently received nothing - including the join-request DMs that admit
+    /// someone into a conversation.
+    @Test("Resume recovers a sync layer that exhausted its stream retries")
+    func testResumeRecoversFromStreamRetryExhaustion() async throws {
+        let fixtures = TestFixtures()
+        let mockClient = TestableMockClient()
+        mockClient.streamBehavior = .throwImmediately
+        let mockAPIClient = TestableMockAPIClient()
+
+        // A budget of 1 exhausts on the first failure, so the error state is
+        // reached without the production backoff ladder.
+        let syncingManager = SyncingManager(
+            identityStore: fixtures.identityStore,
+            databaseWriter: fixtures.databaseManager.dbWriter,
+            databaseReader: fixtures.databaseManager.dbReader,
+            deviceRegistrationManager: nil,
+            notificationCenter: MockUserNotificationCenter(),
+            maxStreamRetries: 1,
+            coreActions: NoOpCoreActions()
+        )
+
+        await syncingManager.start(with: mockClient, apiClient: mockAPIClient)
+
+        // Streams give up and the manager lands in `.error`. Checked via the
+        // terminal state rather than `!isSyncReady`, which is also true while
+        // `.starting` and would pass before anything had actually failed.
+        try await waitUntil(timeout: .seconds(10)) {
+            await syncingManager.hasGivenUpOnStreams
+        }
+
+        // Let the streams succeed again, as they would once connectivity is back.
+        (mockClient.conversationsProvider as? TestableMockConversations)?.streamBehavior = .neverClose
+
+        // This is the call the foreground and network-reconnect paths both make.
+        await syncingManager.resume()
+
+        try await waitUntil(timeout: .seconds(10)) {
+            await syncingManager.isSyncReady
+        }
+
+        let recovered = await syncingManager.isSyncReady
+        let stillGivenUp = await syncingManager.hasGivenUpOnStreams
+        #expect(recovered, "Resume should restart a sync layer stuck in the error state")
+        #expect(!stillGivenUp, "Sync should no longer be in the error state after recovering")
 
         // Clean up
         await syncingManager.stop()


### PR DESCRIPTION
## The bug

A sync layer that exhausts its stream retry budget lands in `.error` and **can never leave it for the life of the process**.

`.error` only accepted `.start`. Neither of the app's recovery triggers sends one — returning to the foreground (`handleEnterForeground`) and the network monitor reconnecting (`resumeAfterNetworkDebounce`) both call `resume()`. So `.resume` arrived, matched nothing, and was dropped with `Invalid state transition: error(streamRetriesExhausted) -> resume`.

It fails quietly, which is what makes it bad:

- Both streams are cancelled on the way into `.error`, so nothing arrives over them again.
- The **session** layer stays `.ready`, so `SessionStateMachine`'s own `(.error, .enterForeground) -> handleRetryFromError()` never fires either. The two state machines fail independently and only one of them can heal.
- The UI keeps looking completely healthy.

This is not hypothetical. The Dev app's log on my simulator shows it twice, the second lasting **45 hours** with the conversations screen open the entire time (`durationSecs=182518`), logging nothing at all between the failure and the next backgrounding:

```
[2026-08-17T02:37:32Z] [error] Conversation stream: max retries (10) exceeded, giving up
[2026-08-17T02:37:32Z] [error] Streams exhausted max retries, transitioning to error state
        ── 45 hours of silence ──
[2026-08-18T23:40:29Z] [warn]  Invalid state transition: error(streamRetriesExhausted) -> pause
```

## Why users see it as "stuck in Verifying"

A join request reaches the inviter over the message stream, or through `runBatchCatchUp` — and catch-up runs **only** at session start and on background→foreground. There is no periodic re-check.

With the streams dead and no catch-up running, the join request is never processed. The joiner sits in "Verifying" until the 150s `joinWaitWindow` expires. Worse, once the request ages past `InviteJoinRequestsManager.maxCatchUpWindow` (24h), no later catch-up reaches back far enough either — **the join is missed permanently**.

Meanwhile push notifications keep arriving for conversations the user is already subscribed to. That is why an affected user still receives new messages normally while nobody can get into their conversations — the two paths are independent, and the join-request DM is a brand-new conversation they have no push subscription for. The existing code even notes this: *"with no topic subscription for the new DM there may be no second push."*

## The fix

Handle `.resume` from `.error` by restarting from the params retained at the last `start`. `.error` carries only the `Error`, so there was previously nothing to restart *with* — hence the new `lastClientParams`.

If the underlying failure is still present the streams simply exhaust again, which makes the state **transient rather than permanent**, and the ~2.5 minute backoff ladder rate-limits the attempts on its own.

Also:
- `.pause` from `.error` is now an explicit no-op — the streams are already cancelled, so backgrounding an errored session is expected, not invalid.
- `stop` clears `lastClientParams` so a stopped session can't be revived by a stray resume.

## Testing

New test `testResumeRecoversFromStreamRetryExhaustion` drives the manager to real retry exhaustion, lets the streams start succeeding again, and calls the same `resume()` the foreground and network paths call.

- **Against pre-fix code it fails** — the resume is dropped and it times out after 30s.
- With the fix it passes in ~0.2s, and the log shows `Recovering sync from error state`.
- All 27 existing SyncingManager tests pass.

Two small seams support the test: `maxStreamRetries` becomes an injectable parameter (default `10`, so no call site changes) so the test can reach the exhausted state without the full backoff ladder, and `hasGivenUpOnStreams` exposes the terminal state — `isSyncReady` alone can't distinguish `.error` from the transient `.starting`, which made an earlier version of this test pass vacuously.

## Follow-ups not in this PR

- `startAgentJoinRequestPolling` — the existing fallback for "suspected silent message-stream death" — has **no production caller**, only mocks and tests. It is also scoped to agent joins; invite joins have no equivalent safety net.
- No metric is emitted on `streamRetriesExhausted`, so the size of the affected population isn't measurable.
- Ten retries over ~2.5 minutes is a short budget for an app that may sit open for days.

> [!NOTE]
> The commit is unsigned — the 1Password CLI isn't unlocked on this machine, so signing failed. Happy to re-sign if the repo requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789694878&installation_model_id=20076&pr_number=1340&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1340&signature=72354f4067d964e935e8bede6000645bb24a4919ac7e3427e91d42567aa1536d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Let a `.resume` action revive `SyncingManager` after streams exhaust retries
> - `SyncingManager` now stores the last `SyncClientParams` on start so that a `.resume` event from the `.error` state can call `handleStart` with the retained params, restarting sync instead of being dropped.
> - A `.pause` event from `.error` is accepted as a no-op since streams are already cancelled.
> - Adds `hasGivenUpOnStreams` computed property so external observers can detect the terminal error state.
> - `maxStreamRetries` is now an injected initializer parameter (default 10) rather than a hard-coded constant, enabling tests to set a lower budget.
> - A new regression test in [SyncingManagerTests.swift](https://github.com/xmtplabs/convos-ios/pull/1340/files#diff-fed6480a9015f39aed18adeb203bd72b66c61a635afc5482a945fd06f2757a32) verifies recovery by switching mock stream behavior mid-run after the manager enters the error state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30b841d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->