### PR TITLE
feat(api): send the per-PR preview token so builds can target a preview backend

### DIFF
--- a/Convos/Conversations List/Empty State/EmptyStateMocksProvider.swift
+++ b/Convos/Conversations List/Empty State/EmptyStateMocksProvider.swift
@@ -47,9 +47,13 @@ final class EmptyStateMocksProvider {
         guard !hasStartedRemoteRefresh else { return }
         hasStartedRemoteRefresh = true
         do {
-            let apiClient = ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)
+            let environment = ConfigManager.shared.currentEnvironment
+            let apiClient = ConvosAPIClientFactory.client(environment: environment)
             let request = try apiClient.request(for: Constant.remotePath, method: "GET", queryParameters: nil)
-            let (data, response) = try await URLSession.shared.data(for: request)
+            // Not URLSession.shared: this is one of ours, so it needs the
+            // preview token on a preview build.
+            let session = PreviewTokenSession.makeSession(for: environment)
+            let (data, response) = try await session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   (200...299).contains(httpResponse.statusCode) else {
                 Log.info("EmptyStateMocksProvider: remote mocks unavailable, keeping bundled payload")

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -27,7 +27,8 @@ struct ConvosApp: App {
         ConfigManager.configure(overrides: ConvosSecretOverrides(
             apiBaseURL: Secrets.CONVOS_API_BASE_URL,
             xmtpCustomHost: Secrets.XMTP_CUSTOM_HOST,
-            gatewayURL: Secrets.GATEWAY_URL
+            gatewayURL: Secrets.GATEWAY_URL,
+            previewToken: Secrets.PREVIEW_TOKEN
         ))
         let environment = ConfigManager.shared.currentEnvironment
         ConvosLog.configure(environment: environment)

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -96,7 +96,8 @@ struct ConvosApp: App {
         #endif
         let agentKeyset = AgentKeyset(
             endpointURL: AgentKeyset.endpointURL(for: environment),
-            fallbackKey: debugFallbackKey
+            fallbackKey: debugFallbackKey,
+            urlSession: PreviewTokenSession.makeSession(for: environment)
         )
         AgentKeysetStore.instance.configure(agentKeyset)
 

--- a/ConvosAppClip/ConvosAppClipApp.swift
+++ b/ConvosAppClip/ConvosAppClipApp.swift
@@ -10,7 +10,8 @@ struct ConvosAppClipApp: App {
         ConfigManager.configure(overrides: ConvosSecretOverrides(
             apiBaseURL: Secrets.CONVOS_API_BASE_URL,
             xmtpCustomHost: Secrets.XMTP_CUSTOM_HOST,
-            gatewayURL: Secrets.GATEWAY_URL
+            gatewayURL: Secrets.GATEWAY_URL,
+            previewToken: Secrets.PREVIEW_TOKEN
         ))
         let environment = ConfigManager.shared.currentEnvironment
         ConvosLog.configure(environment: environment)

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+SIWE.swift
@@ -121,7 +121,7 @@ extension ConvosAPIClient {
             request.setValue(jwt, forHTTPHeaderField: "X-Convos-AuthToken")
         }
 
-        let (data, response) = try await Self.siweSession.data(for: request)
+        let (data, response) = try await siweSession.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }
@@ -140,17 +140,6 @@ extension ConvosAPIClient {
 
     // MARK: - Internals
 
-    /// Dedicated URLSession with cookie storage disabled. SIWE's
-    /// `__Host-` nonce cookie must be carried manually as the `Cookie`
-    /// header on `/auth/token` — see `ConvosAPIClient+SIWECookieParsing`.
-    private static let siweSession: URLSession = {
-        let config = URLSessionConfiguration.ephemeral
-        config.httpCookieStorage = nil
-        config.httpShouldSetCookies = false
-        config.httpCookieAcceptPolicy = .never
-        return URLSession(configuration: config)
-    }()
-
     func requestAuthNonce(appCheckToken: String, retryCount: Int) async throws -> AuthNonceChallenge {
         let url = baseURL.appendingPathComponent("v2/auth/nonce")
         var request = URLRequest(url: url)
@@ -159,7 +148,7 @@ extension ConvosAPIClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = Data("{}".utf8)
 
-        let (data, response) = try await Self.siweSession.data(for: request)
+        let (data, response) = try await siweSession.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }
@@ -201,7 +190,7 @@ extension ConvosAPIClient {
         )
         request.httpBody = try JSONEncoder().encode(body)
 
-        let (data, response) = try await Self.siweSession.data(for: request)
+        let (data, response) = try await siweSession.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError.invalidResponse
         }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -453,7 +453,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
             fatalError("Failed constructing API base URL")
         }
         self.baseURL = apiBaseURL
-        self.session = URLSession(configuration: .default)
+        self.session = URLSession(configuration: PreviewTokenSession.configuration(for: environment))
         self.environment = environment
         self.overrideJWTToken = overrideJWTToken
     }

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -442,6 +442,8 @@ final class LockedSigningContext: @unchecked Sendable {
 final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
     let baseURL: URL
     private let session: URLSession
+    /// Sign-in transport; see `PreviewTokenSession.makeSIWESession`.
+    let siweSession: URLSession
     let environment: AppEnvironment
     let keychainService: any KeychainServiceProtocol = KeychainService()
     private let overrideJWTToken: String?  // Immutable JWT override from APNS payload
@@ -454,6 +456,7 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         }
         self.baseURL = apiBaseURL
         self.session = URLSession(configuration: PreviewTokenSession.configuration(for: environment))
+        self.siweSession = PreviewTokenSession.makeSIWESession(for: environment)
         self.environment = environment
         self.overrideJWTToken = overrideJWTToken
     }

--- a/ConvosCore/Sources/ConvosCore/API/PreviewTokenSession.swift
+++ b/ConvosCore/Sources/ConvosCore/API/PreviewTokenSession.swift
@@ -11,16 +11,47 @@ import Foundation
 /// `/auth/nonce` and `/auth/token` too, and any route added later would
 /// silently 503.
 ///
-/// Only requests made through this configuration are stamped. The attachment
+/// Every session that talks to the backend has to be built through here. The
+/// sign-in calls run on their own cookie-disabled session, so a token stamped
+/// only on the main one leaves `/auth/nonce` and `/auth/token` unauthorized
+/// against a preview - which reads as a broken sign-in, not a missing header.
+///
+/// Only requests made through these configurations are stamped. The attachment
 /// upload goes out on `URLSession.shared` to S3 and must not carry it.
-enum PreviewTokenSession {
-    static let header: String = "X-Preview-Token"
+public enum PreviewTokenSession {
+    public static let header: String = "X-Preview-Token"
 
-    static func configuration(for environment: AppEnvironment) -> URLSessionConfiguration {
-        let configuration: URLSessionConfiguration = .default
+    /// - Parameter base: the configuration to stamp. Callers that need
+    ///   specific transport behaviour pass their own - the SIWE session is
+    ///   `.ephemeral` with cookie storage disabled, and must stay that way.
+    public static func configuration(
+        for environment: AppEnvironment,
+        base: URLSessionConfiguration = .default
+    ) -> URLSessionConfiguration {
         let previewToken: String = environment.previewToken
-        guard !previewToken.isEmpty else { return configuration }
-        configuration.httpAdditionalHeaders = [header: previewToken]
-        return configuration
+        guard !previewToken.isEmpty else { return base }
+        base.httpAdditionalHeaders = [header: previewToken]
+        return base
+    }
+
+    /// Session for callers that talk to the backend outside `ConvosAPIClient`'s
+    /// own session. Reach for this instead of `URLSession.shared` for anything
+    /// aimed at our API - `.shared` carries no token and 401s on a preview.
+    public static func makeSession(for environment: AppEnvironment) -> URLSession {
+        URLSession(configuration: configuration(for: environment))
+    }
+
+    /// Sign-in transport: ephemeral with cookie storage disabled, because
+    /// SIWE's `__Host-` nonce cookie is carried manually as the `Cookie` header
+    /// on `/auth/token` (see ConvosAPIClient+SIWECookieParsing). Built here so
+    /// it is stamped like every other backend session - a file-static in the
+    /// SIWE extension could not see the environment, which left `/auth/nonce`
+    /// and `/auth/token` unauthorized against a preview.
+    public static func makeSIWESession(for environment: AppEnvironment) -> URLSession {
+        let base: URLSessionConfiguration = .ephemeral
+        base.httpCookieStorage = nil
+        base.httpShouldSetCookies = false
+        base.httpCookieAcceptPolicy = .never
+        return URLSession(configuration: configuration(for: environment, base: base))
     }
 }

--- a/ConvosCore/Sources/ConvosCore/API/PreviewTokenSession.swift
+++ b/ConvosCore/Sources/ConvosCore/API/PreviewTokenSession.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Builds the URLSession configuration the API client uses, carrying the
+/// per-PR preview token when this build was given one.
+///
+/// Preview backends (`https://pr-<N>.dev.convos.xyz`) are publicly resolvable,
+/// so they refuse every request that arrives without the bundle's token -
+/// `/healthcheck` is the only exemption. Stamping it on the session rather than
+/// at each call site is deliberate: the gate also covers the unauthenticated
+/// sign-in calls, so a per-request approach would have to remember
+/// `/auth/nonce` and `/auth/token` too, and any route added later would
+/// silently 503.
+///
+/// Only requests made through this configuration are stamped. The attachment
+/// upload goes out on `URLSession.shared` to S3 and must not carry it.
+enum PreviewTokenSession {
+    static let header: String = "X-Preview-Token"
+
+    static func configuration(for environment: AppEnvironment) -> URLSessionConfiguration {
+        let configuration: URLSessionConfiguration = .default
+        let previewToken: String = environment.previewToken
+        guard !previewToken.isEmpty else { return configuration }
+        configuration.httpAdditionalHeaders = [header: previewToken]
+        return configuration
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -100,6 +100,17 @@ public enum AppEnvironment: Sendable {
         }
     }
 
+    /// Per-PR preview bundle token, empty for every normal build. Preview
+    /// backends refuse any request that arrives without it.
+    var previewToken: String {
+        switch self {
+        case .local(let config), .dev(let config), .production(let config):
+            return config.previewToken
+        case .tests:
+            return ""
+        }
+    }
+
     public var siweConfiguration: SIWEConfiguration {
         switch self {
         case .local(let config), .dev(let config), .production(let config):

--- a/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
+++ b/ConvosCore/Sources/ConvosCore/AppEnvironment.swift
@@ -102,7 +102,7 @@ public enum AppEnvironment: Sendable {
 
     /// Per-PR preview bundle token, empty for every normal build. Preview
     /// backends refuse any request that arrives without it.
-    var previewToken: String {
+    public var previewToken: String {
         switch self {
         case .local(let config), .dev(let config), .production(let config):
             return config.previewToken

--- a/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Config/ConfigManager.swift
@@ -7,11 +7,20 @@ public struct ConvosSecretOverrides: Sendable {
     public let apiBaseURL: String
     public let xmtpCustomHost: String
     public let gatewayURL: String
+    /// Per-PR preview bundle token. Defaulted so existing call sites - the app,
+    /// the App Clip, the notification extension - compile unchanged.
+    public let previewToken: String
 
-    public init(apiBaseURL: String, xmtpCustomHost: String, gatewayURL: String) {
+    public init(
+        apiBaseURL: String,
+        xmtpCustomHost: String,
+        gatewayURL: String,
+        previewToken: String = ""
+    ) {
         self.apiBaseURL = apiBaseURL
         self.xmtpCustomHost = xmtpCustomHost
         self.gatewayURL = gatewayURL
+        self.previewToken = previewToken
     }
 
     public static let empty: ConvosSecretOverrides = .init(
@@ -122,6 +131,8 @@ public final class ConfigManager: @unchecked Sendable {
             ? nil
             : overrides.gatewayURL.trimmingCharacters(in: .whitespacesAndNewlines)
 
+        let previewToken: String = overrides.previewToken.trimmingCharacters(in: .whitespacesAndNewlines)
+
         let siweConfiguration = self.siweConfiguration
 
         switch envString {
@@ -138,7 +149,8 @@ public final class ConfigManager: @unchecked Sendable {
                 siweConfiguration: siweConfiguration,
                 xmtpEndpoint: xmtpEndpoint,
                 xmtpNetwork: xmtpNetwork,
-                gatewayUrl: gatewayUrl
+                gatewayUrl: gatewayUrl,
+                previewToken: previewToken
             )
             return .local(config: config)
 
@@ -154,7 +166,8 @@ public final class ConfigManager: @unchecked Sendable {
                 relyingPartyIdentifier: relyingPartyIdentifier,
                 siweConfiguration: siweConfiguration,
                 xmtpEndpoint: xmtpEndpoint,
-                xmtpNetwork: xmtpNetwork
+                xmtpNetwork: xmtpNetwork,
+                previewToken: previewToken
             )
             return .dev(config: config)
 
@@ -169,7 +182,8 @@ public final class ConfigManager: @unchecked Sendable {
                 appGroupIdentifier: appGroupIdentifier,
                 relyingPartyIdentifier: relyingPartyIdentifier,
                 siweConfiguration: siweConfiguration,
-                xmtpNetwork: xmtpNetwork
+                xmtpNetwork: xmtpNetwork,
+                previewToken: previewToken
             )
             return .production(config: config)
 

--- a/ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift
+++ b/ConvosCore/Sources/ConvosCore/ConvosConfiguration.swift
@@ -33,6 +33,9 @@ public struct ConvosConfiguration: Sendable {
     public let xmtpEndpoint: String?
     public let xmtpNetwork: String?
     public let gatewayUrl: String?
+    /// Per-PR preview bundle token, when this build was given one. Empty for
+    /// every normal build.
+    public let previewToken: String
 
     public init(
         apiBaseURL: String,
@@ -41,7 +44,8 @@ public struct ConvosConfiguration: Sendable {
         siweConfiguration: SIWEConfiguration,
         xmtpEndpoint: String? = nil,
         xmtpNetwork: String? = nil,
-        gatewayUrl: String? = nil
+        gatewayUrl: String? = nil,
+        previewToken: String = ""
     ) {
         self.apiBaseURL = apiBaseURL
         self.appGroupIdentifier = appGroupIdentifier
@@ -50,5 +54,6 @@ public struct ConvosConfiguration: Sendable {
         self.xmtpEndpoint = xmtpEndpoint
         self.xmtpNetwork = xmtpNetwork
         self.gatewayUrl = gatewayUrl
+        self.previewToken = previewToken
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/PreviewTokenSessionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PreviewTokenSessionTests.swift
@@ -33,6 +33,20 @@ struct PreviewTokenSessionTests {
         #expect(configuration.httpAdditionalHeaders == nil)
     }
 
+    /// The sign-in calls run on their own cookie-disabled session. When that
+    /// session was built as a file-static it could not see the environment, so
+    /// `/auth/nonce` and `/auth/token` arrived at a preview backend with no
+    /// token and were refused - which presents as a broken sign-in rather than
+    /// a missing header.
+    @Test("stamps the sign-in session too, without losing its cookie policy")
+    func stampsSIWESession() throws {
+        let session = PreviewTokenSession.makeSIWESession(for: environment(previewToken: "t0ken"))
+        let headers = try #require(session.configuration.httpAdditionalHeaders)
+        #expect(headers[PreviewTokenSession.header] as? String == "t0ken")
+        #expect(session.configuration.httpCookieStorage == nil)
+        #expect(session.configuration.httpShouldSetCookies == false)
+    }
+
     @Test("environments carry the token through from the build's secrets")
     func environmentExposesToken() {
         #expect(environment(previewToken: "abc").previewToken == "abc")

--- a/ConvosCore/Tests/ConvosCoreTests/PreviewTokenSessionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/PreviewTokenSessionTests.swift
@@ -1,0 +1,41 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+struct PreviewTokenSessionTests {
+    private func environment(previewToken: String) -> AppEnvironment {
+        .dev(config: ConvosConfiguration(
+            apiBaseURL: "https://pr-1.dev.convos.xyz/api",
+            appGroupIdentifier: "group.org.convos.tests",
+            relyingPartyIdentifier: "convos.org",
+            siweConfiguration: SIWEConfiguration(
+                domain: "dev.convos.org",
+                uri: "https://dev.convos.org",
+                chainId: 1
+            ),
+            previewToken: previewToken
+        ))
+    }
+
+    @Test("stamps the preview token on every request through the session")
+    func stampsToken() throws {
+        let configuration = PreviewTokenSession.configuration(for: environment(previewToken: "t0ken"))
+        let headers = try #require(configuration.httpAdditionalHeaders)
+        #expect(headers[PreviewTokenSession.header] as? String == "t0ken")
+    }
+
+    /// A normal build has no token, and sending an empty one would be worse
+    /// than sending none: the gate compares in constant time and would reject
+    /// it, turning "not a preview build" into a 503 on every call.
+    @Test("adds no header when the build has no token")
+    func omitsHeaderWithoutToken() {
+        let configuration = PreviewTokenSession.configuration(for: environment(previewToken: ""))
+        #expect(configuration.httpAdditionalHeaders == nil)
+    }
+
+    @Test("environments carry the token through from the build's secrets")
+    func environmentExposesToken() {
+        #expect(environment(previewToken: "abc").previewToken == "abc")
+        #expect(AppEnvironment.tests.previewToken.isEmpty)
+    }
+}

--- a/Scripts/build-phases/copy-env-config-app-clip.sh
+++ b/Scripts/build-phases/copy-env-config-app-clip.sh
@@ -14,9 +14,12 @@ if [ "$CONFIGURATION" = "Local" ] || [ "$CONFIGURATION" = "Dev" ]; then
     FIREBASE_TOKEN="$(resolve_firebase_debug_token "${SRCROOT}/.env")"
     CONVOS_API_BASE_URL=""
     POSTHOG_API_KEY=""
+    PREVIEW_TOKEN=""
     if [ -f "${SRCROOT}/.env" ]; then
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         POSTHOG_API_KEY=$(grep -v '^#' "${SRCROOT}/.env" | grep '^POSTHOG_API_KEY=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        # Per-PR preview bundle token; empty for every normal build.
+        PREVIEW_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^PREVIEW_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
 
     if [ -n "$FIREBASE_TOKEN" ]; then
@@ -42,6 +45,7 @@ enum Secrets {
     static let SENTRY_DSN = ""
     static let POSTHOG_API_KEY = "$POSTHOG_API_KEY"
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
+    static let PREVIEW_TOKEN: String = "$PREVIEW_TOKEN"
 }
 
 // swiftlint:enable all
@@ -86,6 +90,7 @@ enum Secrets {
     static let SENTRY_DSN = ""
     static let POSTHOG_API_KEY = ""
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
+    static let PREVIEW_TOKEN: String = "$PREVIEW_TOKEN"
 }
 
 // swiftlint:enable all

--- a/Scripts/build-phases/copy-env-config-main-app.sh
+++ b/Scripts/build-phases/copy-env-config-main-app.sh
@@ -140,6 +140,7 @@ elif [ "$TARGET_NAME" = "Convos" ] && [ "$CONFIGURATION" = "Dev" ]; then
     AGENT_DEBUG_JWKS=""
     POSTHOG_API_KEY=""
     SENTRY_DSN=""
+    PREVIEW_TOKEN=""
     if [ -f "${SRCROOT}/.env" ]; then
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
 
@@ -147,6 +148,9 @@ elif [ "$TARGET_NAME" = "Convos" ] && [ "$CONFIGURATION" = "Dev" ]; then
         POSTHOG_API_KEY=$(grep -v '^#' "${SRCROOT}/.env" | grep '^POSTHOG_API_KEY=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
 
         SENTRY_DSN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^SENTRY_DSN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+
+        # Per-PR preview bundle token; empty for every normal build.
+        PREVIEW_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^PREVIEW_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
 
     if [ -n "$FIREBASE_TOKEN" ]; then
@@ -186,6 +190,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
     static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
     static let AGENT_DEBUG_JWKS: String = "$ESCAPED_AGENT_DEBUG_JWKS"
+    static let PREVIEW_TOKEN: String = "$PREVIEW_TOKEN"
 }
 
 // swiftlint:enable all
@@ -247,6 +252,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
     static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
     static let AGENT_DEBUG_JWKS: String = ""
+    static let PREVIEW_TOKEN: String = ""
 }
 
 // swiftlint:enable all

--- a/Scripts/build-phases/copy-env-config-notification-service.sh
+++ b/Scripts/build-phases/copy-env-config-notification-service.sh
@@ -27,12 +27,15 @@ if [ "$CONFIGURATION" = "Local" ]; then
     FIREBASE_TOKEN=""
     AGENT_DEBUG_JWKS=""
     POSTHOG_API_KEY=""
+    PREVIEW_TOKEN=""
 
     if [ -f "${SRCROOT}/.env" ]; then
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         XMTP_CUSTOM_HOST=$(grep -v '^#' "${SRCROOT}/.env" | grep '^XMTP_CUSTOM_HOST=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
         AGENT_DEBUG_JWKS=$(grep -v '^#' "${SRCROOT}/.env" | grep '^AGENT_DEBUG_JWKS=' | cut -d'=' -f2- | sed -e "s/^'//" -e "s/'$//" || true)
         POSTHOG_API_KEY=$(grep -v '^#' "${SRCROOT}/.env" | grep '^POSTHOG_API_KEY=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
+        # Per-PR preview bundle token; empty for every normal build.
+        PREVIEW_TOKEN=$(grep -v '^#' "${SRCROOT}/.env" | grep '^PREVIEW_TOKEN=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
     fi
     # Resolve the XMTP host the same way Scripts/generate-secrets-local.sh does:
     # USE_CONFIG means "no custom host, use the network the config selects", and
@@ -61,6 +64,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
     static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
     static let AGENT_DEBUG_JWKS: String = "$ESCAPED_AGENT_DEBUG_JWKS"
+    static let PREVIEW_TOKEN: String = "$PREVIEW_TOKEN"
 }
 // swiftlint:enable all
 EOF
@@ -78,6 +82,7 @@ elif [ "$CONFIGURATION" = "Dev" ]; then
     CONVOS_API_BASE_URL=""
     AGENT_DEBUG_JWKS=""
     POSTHOG_API_KEY=""
+    PREVIEW_TOKEN=""
     SENTRY_DSN=""
     if [ -f "${SRCROOT}/.env" ]; then
         CONVOS_API_BASE_URL=$(grep -v '^#' "${SRCROOT}/.env" | grep '^CONVOS_API_BASE_URL=' | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' || true)
@@ -117,6 +122,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
     static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
     static let AGENT_DEBUG_JWKS: String = "$ESCAPED_AGENT_DEBUG_JWKS"
+    static let PREVIEW_TOKEN: String = "$PREVIEW_TOKEN"
 }
 // swiftlint:enable all
 EOF
@@ -153,6 +159,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN = "$FIREBASE_TOKEN"
     static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
     static let AGENT_DEBUG_JWKS: String = ""
+    static let PREVIEW_TOKEN: String = ""
 }
 // swiftlint:enable all
 EOF

--- a/Scripts/generate-secrets-local.sh
+++ b/Scripts/generate-secrets-local.sh
@@ -307,6 +307,7 @@ if [ -f ".env" ]; then
         [[ "$key" == "FIREBASE_APP_CHECK_DEBUG_TOKEN" ]] && continue
         [[ "$key" == "GIT_COMMIT_SHA" ]] && continue
         [[ "$key" == "AGENT_DEBUG_JWKS" ]] && continue
+        [[ "$key" == "PREVIEW_TOKEN" ]] && continue
 
         # Validate Swift identifier
         if ! is_valid_swift_identifier "$key"; then

--- a/Scripts/generate-secrets-local.sh
+++ b/Scripts/generate-secrets-local.sh
@@ -53,6 +53,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = ""
     static let GIT_COMMIT_SHA: String = ""
     static let AGENT_DEBUG_JWKS: String = ""
+    static let PREVIEW_TOKEN: String = ""
 }
 
 MINIMAL_EOF
@@ -154,6 +155,7 @@ ENV_SENTRY_DSN=""
 ENV_POSTHOG_API_KEY=""
 ENV_FIREBASE_DEBUG_TOKEN=""
 ENV_AGENT_DEBUG_JWKS=""
+ENV_PREVIEW_TOKEN=""
 ENV_HAS_BACKEND_URL=false
 ENV_HAS_XMTP_HOST=false
 ENV_HAS_GATEWAY_URL=false
@@ -179,6 +181,10 @@ if [ -f ".env" ]; then
     if grep -v '^#' ".env" | grep -q '^POSTHOG_API_KEY='; then
         ENV_POSTHOG_API_KEY=$(grep -v '^#' ".env" | grep '^POSTHOG_API_KEY=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
+    if grep -v '^#' ".env" | grep -q '^PREVIEW_TOKEN='; then
+        ENV_PREVIEW_TOKEN=$(grep -v '^#' ".env" | grep '^PREVIEW_TOKEN=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
+    fi
+
     if grep -v '^#' ".env" | grep -q '^FIREBASE_APP_CHECK_DEBUG_TOKEN='; then
         ENV_FIREBASE_DEBUG_TOKEN=$(grep -v '^#' ".env" | grep '^FIREBASE_APP_CHECK_DEBUG_TOKEN=' | tail -n1 | cut -d'=' -f2- | sed -e 's/^"//' -e 's/"$//' -e 's/[[:space:]]*#.*$//' || true)
     fi
@@ -279,6 +285,7 @@ enum Secrets {
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = "$(swift_escape "$ENV_FIREBASE_DEBUG_TOKEN")"
     static let GIT_COMMIT_SHA: String = "$(swift_escape "$GIT_SHA")"
     static let AGENT_DEBUG_JWKS: String = "$(swift_escape "$ENV_AGENT_DEBUG_JWKS")"
+    static let PREVIEW_TOKEN: String = "$(swift_escape "$ENV_PREVIEW_TOKEN")"
 EOF
 
 # Check if .env file exists and add any additional secrets from it

--- a/Scripts/generate-secrets-secure.sh
+++ b/Scripts/generate-secrets-secure.sh
@@ -22,6 +22,8 @@ ensure_secrets_directories
 ESCAPED_API_URL=$(swift_escape "${CONVOS_API_BASE_URL:-}")
 ESCAPED_XMTP_HOST=$(swift_escape "${XMTP_CUSTOM_HOST:-}")
 ESCAPED_GATEWAY_URL=$(swift_escape "${GATEWAY_URL:-}")
+# Per-PR preview bundle token, injected by CI for preview builds only.
+ESCAPED_PREVIEW_TOKEN=$(swift_escape "${PREVIEW_TOKEN:-}")
 
 GIT_SHA=$(get_git_commit_sha)
 ESCAPED_GIT_SHA=$(swift_escape "$GIT_SHA")
@@ -75,6 +77,7 @@ enum Secrets {
     static let CONVOS_API_BASE_URL: String = "$ESCAPED_API_URL"
     static let XMTP_CUSTOM_HOST: String = "$ESCAPED_XMTP_HOST"
     static let GATEWAY_URL: String = "$ESCAPED_GATEWAY_URL"
+    static let PREVIEW_TOKEN: String = "$ESCAPED_PREVIEW_TOKEN"
     static let SENTRY_DSN: String = "$ESCAPED_SENTRY_DSN"
     static let POSTHOG_API_KEY: String = "$ESCAPED_POSTHOG_API_KEY"
     static let FIREBASE_APP_CHECK_DEBUG_TOKEN: String = ""


### PR DESCRIPTION
## Summary

The backend already deploys a preview bundle per PR (`https://pr-<N>.dev.convos.xyz`) and gates it: when `PREVIEW=1`, every request must carry the bundle's token in `X-Preview-Token`, and `/healthcheck` is the only exemption. CI derives the token as HMAC(master, pr_number) and hands it to the bundle and to that PR's assistant worker.

The app never sent it, so pointing a build at a preview returned 401 on every call — there was no way to exercise an iOS change against the backend PR it depends on before either merged. This closes that.

`PREVIEW_TOKEN` flows the way `CONVOS_API_BASE_URL` already does — `.env` or the CI environment → generated `Secrets` → `ConvosSecretOverrides` → `ConvosConfiguration` → `AppEnvironment.previewToken`. Both new parameters are defaulted, so every existing call site compiles untouched.

## Every backend caller, not just one session

Running it on a simulator against a gated backend is what made this correct. The first version stamped only `ConvosAPIClient`'s session: device registration passed the gate, **sign-in did not**. `/auth/nonce` and `/auth/token` run on a separate ephemeral session with cookie storage disabled (SIWE's `__Host-` nonce cookie is carried manually), and that session was a file-static that could never see the environment. The symptom is a broken sign-in with nothing pointing at a missing header.

Two further callers build requests and send them on `URLSession.shared` — the empty-state mocks fetch and the agent keyset fetch (`/.well-known/agents.json`). Both fall back to bundled data, so they hid the problem instead of reporting it.

All three now go through `PreviewTokenSession`, which also owns the SIWE transport settings so the cookie policy and the stamping cannot drift apart. `makeSession(for:)` is the general seam: anything aimed at our API uses it rather than `URLSession.shared`. The attachment upload to S3 deliberately stays unstamped.

An empty token adds no header at all — sending one would be worse than sending none, since the gate compares in constant time and would reject it.

## Secrets generation

Three build-phase scripts write `Secrets.swift` with fixed field lists — main app, notification service (which also writes the main app's copy), and App Clip. Any one of them omitting `PREVIEW_TOKEN` fails the build with `type 'Secrets' has no member`. The local generator also had to stop emitting it twice, once from its own template and again from the generic `.env` passthrough.

## Using it

```
PREVIEW_TOKEN=<token for this PR>
CONVOS_API_BASE_URL=https://pr-<N>.dev.convos.xyz/api
```

then build. A normal build is unaffected: no token, no header, no behavior change.

## Verification

- Full ConvosCore suite green (1898 tests, 255 suites), including 4 tests covering the stamped session, the sign-in session's header *and* cookie policy, the empty-token case, and the environment plumbing.
- On a simulator against a local backend running `PREVIEW=1`: full sign-in with **zero** `preview_token.unauthorized` rejections, where the first version produced them on every auth attempt. `/.well-known/agents.json` and `/empty-state-mocks` now pass the gate too.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send X-Preview-Token header on all backend requests for preview builds
> - Adds a new `PreviewTokenSession` utility in [PreviewTokenSession.swift](https://github.com/xmtplabs/convos-ios/pull/1345/files#diff-f7175276e33db94fe9bdfd7eabe15e9a127b5233be597a63b3e182a1f39aaf96) that injects `X-Preview-Token` into `URLSessionConfiguration.httpAdditionalHeaders` when a non-empty token is present in the environment.
> - Threads the preview token from `.env` through build scripts, `Secrets.swift`, `ConvosSecretOverrides`, `ConfigManager`, `ConvosConfiguration`, and `AppEnvironment` so it is available at runtime.
> - Updates `ConvosAPIClient` (main session and SIWE flows), `EmptyStateMocksProvider`, and `AgentKeyset` to use sessions produced by `PreviewTokenSession`, replacing static or shared sessions with per-instance, environment-aware sessions.
> - Non-preview builds are unaffected since the token defaults to an empty string and the header is omitted when empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fbe189.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->