### PR TITLE
Expire the variant registry cache so a fresh variant is selectable

### DIFF
--- a/Convos/Agent Builder/AgentVariantRegistry.swift
+++ b/Convos/Agent Builder/AgentVariantRegistry.swift
@@ -1,13 +1,21 @@
 import ConvosCore
 import SwiftUI
 
-/// App-lifetime cache of the dev variant registry (`GET /v2/agent-variants`).
+/// Short-lived cache of the dev variant registry (`GET /v2/agent-variants`).
 ///
 /// The fetch deliberately does not live in a view's `.task`: the debug picker
 /// and the new-convo picker both sit inside a `Form`/sheet whose rows are
 /// recreated as state changes, which cancels an in-flight view-scoped task and
 /// restarts it from a fresh `.loading` -- a loop that never settles. Holding the
 /// load here means view churn re-reads a cached result instead of refetching.
+///
+/// The cache expires, because a variant is usually registered minutes before
+/// someone goes looking for it. Cached for the process's lifetime, a variant
+/// that CI registered after this app last loaded the list is invisible until
+/// the app is killed -- and worse than invisible: `reconcileSelection` and the
+/// new-convo sheet both drop a selected slug that the (stale) list does not
+/// contain, so the tester's pick is silently cleared and their agent quietly
+/// builds on the default runtime.
 @MainActor
 @Observable
 final class AgentVariantRegistry {
@@ -23,17 +31,30 @@ final class AgentVariantRegistry {
     private(set) var variants: [ConvosAPI.AgentVariant] = []
     private(set) var loadState: LoadState = .idle
 
+    /// How long a loaded list stays fresh. Long enough that Form row churn
+    /// re-reads the cache rather than refetching, short enough that reopening
+    /// a picker after CI registers a variant shows it.
+    private static let freshnessWindow: TimeInterval = 30.0
+
     private var loadTask: Task<Void, Never>?
+    private var loadedAt: Date?
     private let apiClient: any ConvosAPIClientProtocol
 
     init(apiClient: any ConvosAPIClientProtocol = ConvosAPIClientFactory.client(environment: ConfigManager.shared.currentEnvironment)) {
         self.apiClient = apiClient
     }
 
-    /// Loads once and caches. Re-entrant: concurrent callers await the same
-    /// task, and an already-loaded registry returns immediately.
+    /// Loads and caches for `freshnessWindow`. Re-entrant: concurrent callers
+    /// await the same task, and a registry loaded within the window returns
+    /// immediately. Past the window the next call refetches, so a picker opened
+    /// after CI registered a variant sees it without an app restart.
     func loadIfNeeded() async {
-        if loadState == .loaded { return }
+        if loadState == .loaded, let loadedAt,
+           Date().timeIntervalSince(loadedAt) < Self.freshnessWindow {
+            return
+        }
+        // An in-flight load is awaited rather than restarted -- that guard, not
+        // the absence of expiry, is what keeps view churn from looping.
         if let loadTask {
             await loadTask.value
             return
@@ -52,6 +73,7 @@ final class AgentVariantRegistry {
                 let fetched = try await self.apiClient.getAgentVariants()
                 self.variants = fetched
                 self.reconcileSelection(against: fetched)
+                self.loadedAt = Date()
                 self.loadState = .loaded
             } catch {
                 Log.error("AgentVariantRegistry: failed to load variants: \(error.localizedDescription)")


### PR DESCRIPTION
This is the client half of the "I picked a variant and the agent ignored it" failure. The backend half landed in convos-assistants#3460; that PR made the failure visible, this one removes the cause.

### The cause

`AgentVariantRegistry` cached the dev variant list for the whole life of the app process:

```swift
func loadIfNeeded() async {
    if loadState == .loaded { return }   // no expiry
    ...
}
```

The only caller of `reload()` is the debug picker's Retry button, which renders solely in the `.failed` state — so after a *successful* load there was no path back to the network short of killing the app.

A variant CI registered after the app last opened a picker therefore never appeared in one. And the pick was not merely absent: `reconcileSelection` clears `FeatureFlags.selectedAgentVariant` when the fetched list lacks the saved slug, and `AgentVariantPickerSheet` nulls its own selection under the same condition. Both are correct intentions — don't route to a retired variant — reading a stale list as if it were live, so the tester's choice was silently dropped.

Downstream, `effectiveAgentVariantSlug` resolved to nil, the join went out with no `variantId`, the backend routed to the default worker, and the agent came back indistinguishable from a varianted one. It bites hardest immediately after registering a variant — which is exactly when a PR gets tested, and why this reads as "variants randomly don't work".

### The fix

The list stays fresh for 30 seconds instead of forever.

The type's doc comment explains that the fetch lives here, not in a view's `.task`, because `Form` row churn cancels and restarts a view-scoped load in a loop that never settles. That protection is the re-entrancy guard — a concurrent caller awaits the existing `loadTask` rather than starting a new one — not the absence of expiry, so a short window does not bring the loop back: churn happens on a millisecond timescale, well inside the window, and an in-flight load is awaited either way. `variants` is also not cleared during a refetch, so an open picker doesn't flicker empty while one runs.

### Verification — please read

**I could not build or test this.** The environment I'm running in is Linux with no Swift toolchain, so nothing here has been compiled, SwiftLint has not run, and no test was executed. That is the reason this is a draft: I'd like CI to be the first thing that compiles it.

What I did check by hand: the diff is four small edits to one file (a stored `loadedAt`, a static window, the guard in `loadIfNeeded`, and stamping `loadedAt` on success); lines are far inside the 200-char limit; no force-unwraps; no blank line after an opening brace. I did not add a unit test — `AgentVariantRegistry` takes a `ConvosAPIClientProtocol` and the app test target has no stub conforming to it, so writing one meant a large new file I could not compile. Existing `AgentVariantResolutionTests` covers `FeatureFlags` resolution and is untouched.

If you'd rather the window were a different length, or lived on `ConfigManager`, say so — the value is the only judgement call in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQyDQjA1jrkdwPNoG25krY

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQyDQjA1jrkdwPNoG25krY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789739338&installation_model_id=20076&pr_number=1346&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1346&signature=890901860e47a08f890515ccfbfabae5a45268b5a985635b191cb7aae6d2a706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expire `AgentVariantRegistry` cache after 30 seconds so a fresh variant is selectable
> - Adds a `freshnessWindow` of 30 seconds to `AgentVariantRegistry`; a successful load is now considered stale after that window elapses.
> - `loadIfNeeded` replaces its loaded-once short-circuit with an expiry check, triggering a refetch when the cache is stale.
> - In-flight `loadTask` requests are still awaited rather than duplicated, preventing view churn loops.
> - `reload` now records a `loadedAt` timestamp on successful fetch to support the freshness check.
> - Behavioral Change: the registry previously cached indefinitely; it now refetches on the next `loadIfNeeded` call after 30 seconds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d06c2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->