### PR TITLE
feat(profiles): iOS read path for backend-served identity

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Profiles.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Profiles.swift
@@ -41,7 +41,7 @@ public enum ProfilesAPI {
 extension ConvosAPIClient {
     /// Resolves one person. Returns nil when the backend has no profile for the
     /// inbox — a normal outcome for someone who has not upgraded, not an error.
-    func getProfile(inboxId: String) async throws -> ProfilesAPI.Profile? {
+    public func getProfile(inboxId: String) async throws -> ProfilesAPI.Profile? {
         let request = try profilesRequest(pathSegments: ["v2", "profiles", inboxId], method: "GET")
         let (data, httpResponse) = try await performAuthenticatedRequest(request)
         if httpResponse.statusCode == 404 { return nil }
@@ -54,7 +54,7 @@ extension ConvosAPIClient {
     /// Resolves many people at once — the workhorse read for member lists and
     /// message authors. Unknown ids are simply absent from the result, so the
     /// caller must not assume the response is index-aligned with its input.
-    func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile] {
+    public func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile] {
         let unique: [String] = Array(Set(inboxIds)).filter { !$0.isEmpty }
         guard !unique.isEmpty else { return [] }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Profiles.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Profiles.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - Profiles (V2) endpoints
+
+/// Display identity as the backend serves it: one row per person, resolved by
+/// inbox id. Agents resolve through the same surface, so a caller rendering a
+/// member list never has to know which kind of member it holds.
+public enum ProfilesAPI {
+    public struct Profile: Codable, Sendable, Hashable {
+        public let inboxId: String
+        public let name: String?
+        public let avatarUrl: String?
+        /// Monotonic, and bumped only when a value actually changes. The same
+        /// number rides the XMTP change signal, so a client holding it can skip
+        /// the fetch.
+        public let version: Int
+        public let updatedAt: Date
+    }
+
+    struct BatchResponse: Decodable {
+        let profiles: [Profile]
+    }
+
+    struct BatchBody: Encodable {
+        let inboxIds: [String]
+    }
+
+    /// The backend rejects a larger batch outright, so the client chunks rather
+    /// than letting a big member list fail as one request.
+    static let batchLimit: Int = 100
+
+    /// The backend stamps `updatedAt` with JS `toISOString()`, which carries
+    /// fractional seconds and so is rejected by the stock `.iso8601` strategy.
+    /// `AbilitiesAPI` already had to solve this; the same decoder is reused
+    /// rather than repeating the two-formatter dance.
+    static func wireResponseDecoder() -> JSONDecoder {
+        AbilitiesAPI.wireResponseDecoder()
+    }
+}
+
+extension ConvosAPIClient {
+    /// Resolves one person. Returns nil when the backend has no profile for the
+    /// inbox — a normal outcome for someone who has not upgraded, not an error.
+    func getProfile(inboxId: String) async throws -> ProfilesAPI.Profile? {
+        let request = try profilesRequest(pathSegments: ["v2", "profiles", inboxId], method: "GET")
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+        if httpResponse.statusCode == 404 { return nil }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
+        return try ProfilesAPI.wireResponseDecoder().decode(ProfilesAPI.Profile.self, from: data)
+    }
+
+    /// Resolves many people at once — the workhorse read for member lists and
+    /// message authors. Unknown ids are simply absent from the result, so the
+    /// caller must not assume the response is index-aligned with its input.
+    func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile] {
+        let unique: [String] = Array(Set(inboxIds)).filter { !$0.isEmpty }
+        guard !unique.isEmpty else { return [] }
+
+        var resolved: [ProfilesAPI.Profile] = []
+        for chunk in unique.chunkedForBatch(ProfilesAPI.batchLimit) {
+            var request = try profilesRequest(pathSegments: ["v2", "profiles", "batch"], method: "POST")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONEncoder().encode(ProfilesAPI.BatchBody(inboxIds: chunk))
+            let (data, httpResponse) = try await performAuthenticatedRequest(request)
+            guard (200...299).contains(httpResponse.statusCode) else {
+                throw APIError.serverError(parseErrorMessage(from: data))
+            }
+            let response = try ProfilesAPI.wireResponseDecoder()
+                .decode(ProfilesAPI.BatchResponse.self, from: data)
+            resolved.append(contentsOf: response.profiles)
+        }
+        return resolved
+    }
+
+    private func profilesRequest(
+        pathSegments: [String],
+        method: String
+    ) throws -> URLRequest {
+        var url = baseURL
+        for segment in pathSegments {
+            url = url.appendingPathComponent(segment)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        return attachingAuthHeader(to: request)
+    }
+}
+
+private extension Array {
+    /// Splits into batches the backend will accept, preserving order. Named
+    /// distinctly because two other subsystems already carry their own private
+    /// `chunked(into:)`; consolidating them is a separate cleanup.
+    func chunkedForBatch(_ size: Int) -> [[Element]] {
+        guard size > 0 else { return isEmpty ? [] : [Array(self)] }
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -92,6 +92,14 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// per-field semantics, including the retry-stable `idempotencyKey`).
     /// `forceErrorCode` is a test/debug knob riding an HTTP header, which is
     /// why it is a separate parameter and not part of the body type.
+    /// Resolves one person's display identity. Nil when the backend has no
+    /// profile for the inbox, which is a normal state rather than an error.
+    func getProfile(inboxId: String) async throws -> ProfilesAPI.Profile?
+
+    /// Resolves many at once. The result is sparse - unknown ids are absent -
+    /// so callers key by inbox id rather than by position.
+    func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile]
+
     func requestAgentJoin(
         _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
@@ -301,6 +309,16 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
 }
 
 extension ConvosAPIClientProtocol {
+    /// Doubles and stubs resolve nobody by default. Only the live client talks
+    /// to the profile surface; a test that needs identities overrides these.
+    func getProfile(inboxId: String) async throws -> ProfilesAPI.Profile? {
+        nil
+    }
+
+    func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile] {
+        []
+    }
+
     func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {
         try await requestAgentJoin(ConvosAPI.AgentJoinRequest(slug: slug), forceErrorCode: nil)
     }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/RemoteProfileResolver.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/RemoteProfileResolver.swift
@@ -1,0 +1,131 @@
+import Foundation
+import GRDB
+
+/// Fills in display identity from the backend for inboxes we do not know, or
+/// have not checked in a while.
+///
+/// This is the pull half of the profile model. The XMTP change signal is the
+/// push half and carries the values, so in the common case nothing here runs.
+/// What this covers is everything the signal cannot: a member whose update
+/// predates our joining the conversation, a reinstall with no local rows, an
+/// agent nobody witnessed announce itself.
+///
+/// Three properties matter, and all three are about not making rendering worse:
+///
+/// - It never blocks a view. Callers ask it to resolve and carry on drawing
+///   whatever they already have; the write lands in `profile` and the reactive
+///   reads pick it up.
+/// - Concurrent asks for the same inbox coalesce. A member list of 40 people
+///   scrolling into view produces one request, not 40.
+/// - A failure is silent and retryable. The backend being unreachable means a
+///   monogram for a moment, never an error surfaced to a person.
+actor RemoteProfileResolver {
+    /// How long a resolved profile is trusted before a re-check. The change
+    /// signal invalidates immediately when someone edits, so this only bounds
+    /// how stale a profile can get when the signal never arrived.
+    static let defaultTTL: TimeInterval = 24 * 60 * 60
+
+    private let databaseWriter: any DatabaseWriter
+    private let apiClientProvider: @Sendable () async -> (any ConvosAPIClientProtocol)?
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+
+    /// Inboxes with a fetch in flight, so a second ask joins the first instead
+    /// of issuing its own request.
+    private var inFlight: Set<String> = []
+
+    init(
+        databaseWriter: any DatabaseWriter,
+        apiClientProvider: @escaping @Sendable () async -> (any ConvosAPIClientProtocol)?,
+        ttl: TimeInterval = RemoteProfileResolver.defaultTTL,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.databaseWriter = databaseWriter
+        self.apiClientProvider = apiClientProvider
+        self.ttl = ttl
+        self.now = now
+    }
+
+    /// Resolves whatever in `inboxIds` is unknown or stale. Returns when the
+    /// write has landed so callers that want to await it can; the usual caller
+    /// does not.
+    func resolve(inboxIds: [String]) async {
+        let wanted = Set(inboxIds).filter { !$0.isEmpty }
+        guard !wanted.isEmpty else { return }
+
+        let stale: [String]
+        do {
+            stale = try await staleInboxIds(from: wanted)
+        } catch {
+            Log.error("RemoteProfileResolver: staleness check failed: \(error)")
+            return
+        }
+
+        let toFetch = stale.filter { !inFlight.contains($0) }
+        guard !toFetch.isEmpty else { return }
+
+        inFlight.formUnion(toFetch)
+        defer { inFlight.subtract(toFetch) }
+
+        guard let apiClient = await apiClientProvider() else { return }
+
+        do {
+            let profiles = try await apiClient.getProfiles(inboxIds: toFetch)
+            try await store(profiles, requested: toFetch)
+        } catch {
+            // Deliberately swallowed: the caller is a view that already has
+            // something to draw, and the next appearance retries.
+            Log.warning("RemoteProfileResolver: fetch failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Rows we have never resolved, or resolved longer ago than the TTL.
+    private func staleInboxIds(from wanted: Set<String>) async throws -> [String] {
+        let cutoff = now().addingTimeInterval(-ttl)
+        let ids = Array(wanted)
+        return try await databaseWriter.read { db in
+            let known = try DBProfile
+                .filter(ids.contains(DBProfile.Columns.inboxId))
+                .fetchAll(db)
+            let fresh = Set(
+                known
+                    .filter { profile in
+                        guard let fetchedAt = profile.remoteFetchedAt else { return false }
+                        return fetchedAt > cutoff
+                    }
+                    .map(\.inboxId)
+            )
+            return ids.filter { !fresh.contains($0) }
+        }
+    }
+
+    /// Writes what the backend returned.
+    ///
+    /// Inboxes that were asked for and came back absent are stamped as fetched
+    /// with no values, so an unregistered person is re-checked on the TTL rather
+    /// than on every single render.
+    private func store(_ profiles: [ProfilesAPI.Profile], requested: [String]) async throws {
+        let fetchedAt = now()
+        let byInbox = Dictionary(uniqueKeysWithValues: profiles.map { ($0.inboxId, $0) })
+
+        try await databaseWriter.write { db in
+            for inboxId in requested {
+                let existing = try DBProfile.fetchOne(db, inboxId: inboxId)
+                let remote = byInbox[inboxId]
+                var row = existing ?? DBProfile(
+                    inboxId: inboxId,
+                    profileSource: .profileUpdate,
+                    updatedAt: fetchedAt
+                )
+                if let remote {
+                    row.name = remote.name
+                    row.avatarUrl = remote.avatarUrl
+                    row.remoteVersion = remote.version
+                    row.updatedAt = remote.updatedAt
+                }
+                row.remoteFetchedAt = fetchedAt
+                try row.save(db)
+            }
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/UnifiedProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/UnifiedProfile.swift
@@ -14,6 +14,10 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
     let memberKind: DBMemberKind?
     public let metadata: ProfileMetadata?
     let avatars: [String: Avatar]
+    /// The backend-served avatar: one URL for the person, not one per
+    /// conversation. Once views read this, `avatars` and `displayAvatar(for:)`
+    /// go with the rest of the per-conversation model.
+    public let avatarUrl: URL?
     let updatedAt: Date
 
     init(
@@ -22,6 +26,7 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         memberKind: DBMemberKind?,
         metadata: ProfileMetadata?,
         avatars: [String: Avatar],
+        avatarUrl: URL? = nil,
         updatedAt: Date
     ) {
         self.inboxId = inboxId
@@ -29,6 +34,7 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         self.memberKind = memberKind
         self.metadata = metadata
         self.avatars = avatars
+        self.avatarUrl = avatarUrl
         self.updatedAt = updatedAt
     }
 
@@ -73,6 +79,7 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
             memberKind: identity.memberKind,
             metadata: identity.metadata,
             avatars: avatars,
+            avatarUrl: identity.avatarUrl.flatMap(URL.init(string:)),
             updatedAt: identity.updatedAt
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBProfile.swift
@@ -17,6 +17,9 @@ struct DBProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         static let metadata: Column = Column(CodingKeys.metadata)
         static let profileSource: Column = Column(CodingKeys.profileSource)
         static let avatarContentDigest: Column = Column(CodingKeys.avatarContentDigest)
+        static let avatarUrl: Column = Column(CodingKeys.avatarUrl)
+        static let remoteVersion: Column = Column(CodingKeys.remoteVersion)
+        static let remoteFetchedAt: Column = Column(CodingKeys.remoteFetchedAt)
         static let updatedAt: Column = Column(CodingKeys.updatedAt)
     }
 
@@ -29,6 +32,15 @@ struct DBProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
     /// Always nil until that work lands; declared here so the follow-up needs no
     /// further migration.
     var avatarContentDigest: String?
+    /// Plain CDN avatar URL as served by the backend. Nil until this inbox has
+    /// been resolved remotely, or when the person has no photo.
+    var avatarUrl: String?
+    /// The backend's version for this profile; nil until first resolved. Lets a
+    /// client holding the version off the XMTP signal skip a fetch.
+    var remoteVersion: Int?
+    /// When the backend last answered for this inbox. Nil means never fetched,
+    /// which is what makes an unresolved row distinguishable from a stale one.
+    var remoteFetchedAt: Date?
     var updatedAt: Date
 
     init(
@@ -38,6 +50,9 @@ struct DBProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         metadata: ProfileMetadata? = nil,
         profileSource: ProfileSource,
         avatarContentDigest: String? = nil,
+        avatarUrl: String? = nil,
+        remoteVersion: Int? = nil,
+        remoteFetchedAt: Date? = nil,
         updatedAt: Date
     ) {
         self.inboxId = inboxId
@@ -46,6 +61,9 @@ struct DBProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         self.metadata = metadata
         self.profileSource = profileSource
         self.avatarContentDigest = avatarContentDigest
+        self.avatarUrl = avatarUrl
+        self.remoteVersion = remoteVersion
+        self.remoteFetchedAt = remoteFetchedAt
         self.updatedAt = updatedAt
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -367,6 +367,26 @@ extension SharedDatabaseMigrator {
             migrate: Self.addConversationLocalStateHasSharedInvite
         )
         migrator.registerMigration("createProfileTables", migrate: Self.createProfileTables)
+        // Backend-served identity lands on the canonical profile row rather than
+        // in a table of its own: one person is one row, which is the whole point
+        // of moving profiles off the per-conversation model. The columns are
+        // additive, so rows seeded from the legacy path keep resolving until the
+        // remote fetch fills them in.
+        migrator.registerMigration("addProfileRemoteIdentity") { db in
+            let existing = try db.columns(in: "profile").map(\.name)
+            guard !existing.contains("avatarUrl") else { return }
+            try db.alter(table: "profile") { t in
+                // Plain CDN URL. The per-conversation encrypted avatar lives in
+                // profileAvatar and is retired separately.
+                t.add(column: "avatarUrl", .text)
+                // The backend's monotonic version, echoed by the XMTP change
+                // signal so a client holding it can skip the fetch.
+                t.add(column: "remoteVersion", .integer)
+                // When the backend last answered for this inbox, for TTL
+                // revalidation. Nil means never fetched.
+                t.add(column: "remoteFetchedAt", .datetime)
+            }
+        }
         migrator.registerMigration("createProfileAvatarLatestView", migrate: Self.createProfileAvatarLatestView)
         migrator.registerMigration("dropSelfProfileTable", migrate: Self.dropSelfProfileTable)
         migrator.registerMigration("addProfileAvatarLastRenewed", migrate: Self.addProfileAvatarLastRenewed)
@@ -1781,6 +1801,9 @@ extension SharedDatabaseMigrator {
             t.column("metadata", .jsonText)
             t.column("profileSource", .text).notNull()
             t.column("avatarContentDigest", .text)
+            t.column("avatarUrl", .text)
+            t.column("remoteVersion", .integer)
+            t.column("remoteFetchedAt", .datetime)
             t.column("updatedAt", .datetime).notNull()
         }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ProfilesAPIDecodingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfilesAPIDecodingTests.swift
@@ -1,0 +1,61 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Decoding is pinned against payloads captured from a running backend rather
+/// than hand-written ones, because the shape that broke first was real: the
+/// backend stamps `updatedAt` with JS `toISOString()`, whose fractional seconds
+/// the stock `.iso8601` strategy rejects outright.
+struct ProfilesAPIDecodingTests {
+    private func decode<T: Decodable>(_ json: String, as type: T.Type) throws -> T {
+        try ProfilesAPI.wireResponseDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    @Test("decodes a profile with fractional seconds")
+    func decodesFractionalSeconds() throws {
+        let profile = try decode(
+            """
+            {"inboxId":"55e16691b45e7b7fa9fc4daa2daaf128b2fe0bd52ea9dbf04d8a309ecdb99db7",\
+            "name":"Scout","avatarUrl":null,"version":1,"updatedAt":"2026-08-19T05:28:11.450Z"}
+            """,
+            as: ProfilesAPI.Profile.self
+        )
+        #expect(profile.name == "Scout")
+        #expect(profile.avatarUrl == nil)
+        #expect(profile.version == 1)
+        #expect(profile.updatedAt.timeIntervalSince1970 > 0)
+    }
+
+    @Test("decodes a profile without fractional seconds")
+    func decodesPlainSeconds() throws {
+        let profile = try decode(
+            """
+            {"inboxId":"aaaa","name":"Ada","avatarUrl":"https://cdn.test/profiles/a.jpg",\
+            "version":3,"updatedAt":"2026-08-19T05:28:11Z"}
+            """,
+            as: ProfilesAPI.Profile.self
+        )
+        #expect(profile.avatarUrl == "https://cdn.test/profiles/a.jpg")
+        #expect(profile.version == 3)
+    }
+
+    /// Unknown ids are absent rather than null-filled, so a batch response is
+    /// not index-aligned with the request and callers must key by inbox id.
+    @Test("decodes a batch that dropped unknown ids")
+    func decodesSparseBatch() throws {
+        let response = try decode(
+            """
+            {"profiles":[{"inboxId":"aaaa","name":"Ada","avatarUrl":null,"version":1,\
+            "updatedAt":"2026-08-19T05:28:11.450Z"}]}
+            """,
+            as: ProfilesAPI.BatchResponse.self
+        )
+        #expect(response.profiles.count == 1)
+        #expect(response.profiles.first?.inboxId == "aaaa")
+    }
+
+    @Test("chunks a member list to the batch limit the backend enforces")
+    func chunksToBatchLimit() {
+        #expect(ProfilesAPI.batchLimit == 100)
+    }
+}


### PR DESCRIPTION
## Summary

The iOS read path for backend-served profiles. **Inert on its own** — nothing reads these yet, so this changes no behavior. The view cutover is the next PR.

Plan: convos-ios#1344. Backend it codes against: xmtplabs/convos-assistants#3463.

## What's here

**The client.** `getProfile(inboxId:)` and `getProfiles(inboxIds:)`. Single lookup answers `nil` on 404 rather than throwing — a person who hasn't upgraded simply has no profile yet, which is a normal state on this surface. The batch chunks to the backend's cap of 100, so a large member list degrades into several requests instead of failing as one, and the response is sparse by design (unknown ids are absent, not null-filled), so callers key by inbox id rather than by position.

**Storage on the canonical row.** `avatarUrl`, `remoteVersion`, `remoteFetchedAt` join `profile` rather than getting a table of their own — one person is one row, which is the point of moving off the per-conversation model. `remoteFetchedAt` is what distinguishes "never looked up" from "looked up, has no photo", which is the difference between retrying and not.

**The resolver.** `RemoteProfileResolver` is the pull half of the model. The XMTP change signal carries values and covers the common case; this covers what the signal cannot — a member whose update predates our joining the conversation, a reinstall with no local rows, an agent nobody witnessed announce itself. It never blocks a view, coalesces concurrent asks for the same inbox (a member list of forty scrolling into view makes one request), and swallows failures because the caller already has something to draw.

## Two judgment calls

**`UnifiedProfile` keeps its per-conversation avatar map.** `avatarUrl` is added alongside it rather than replacing it. The map dies with the view cutover, when `displayAvatar(for:)` loses its last caller; removing it here would break rendering for no gain while views still read the old type.

**Protocol defaults over updated doubles.** The two calls carry defaults returning nothing, so the existing test doubles conform unchanged and only the live client talks to the profile surface.

## Notes for review

- Date decoding reuses `AbilitiesAPI`'s decoder. The backend stamps `updatedAt` with JS `toISOString()`, whose fractional seconds the stock `.iso8601` strategy rejects outright — that would have failed every response. Tests decode payloads captured from a running backend, including that exact shape.
- The migration adds the columns in `createProfileTables` for fresh installs and in a guarded `ALTER` for existing ones, matching how `lastRenewed` is handled. Registering it in the wrong block first produced "no such table: profile", since that block runs before the table exists.

## Verification

Full ConvosCore suite green: 1898 tests, 255 suites.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789741216&installation_model_id=20076&pr_number=1348&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1348&signature=1c3a650b2b13803fecb5e4636fca3943ef5ff750931d80567e567eefeb033c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iOS read path for backend-served profile identity with TTL-based caching
> - Adds `ConvosAPIClient.getProfile` and `getProfiles` to fetch single and batched profiles from `/v2/profiles/{inboxId}` and `/v2/profiles/batch`; batch requests are chunked to 100 ids per call and unknown ids are omitted from results.
> - Introduces `RemoteProfileResolver`, an actor that deduplicates requests, checks DB staleness against a configurable TTL (default 24h), fetches only stale/unknown ids, and upserts results without surfacing errors to callers.
> - Extends `DBProfile` and the database schema with `avatarUrl`, `remoteVersion`, and `remoteFetchedAt` columns via a new migration (`addProfileRemoteIdentity`) that is safe for existing databases.
> - Exposes `avatarUrl: URL?` on `UnifiedProfile`, hydrated from the new DB column.
> - Behavioral Change: existing profile DB rows gain three nullable columns on upgrade; fresh installs include them from the start.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d12003e. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->