### PR TITLE
Latch the short-content top slack so it cannot drive a layout loop

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/MessagesViewController.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/MessagesViewController.swift
@@ -374,8 +374,11 @@ public final class MessagesViewController: UIViewController {
     /// a safe-area change.
     var clippedTopOverflow: CGFloat = 0.0 {
         didSet {
+            // Re-measured, not just re-asserted: the slack is what is left of the
+            // visible area once this has been taken out of it, so it moves with
+            // this. The host sets this from a SwiftUI update, not a layout pass.
             guard clippedTopOverflow != oldValue, isViewLoaded else { return }
-            applyClippedTopOverflow()
+            relatchShortContentTopSlack()
         }
     }
 
@@ -383,6 +386,31 @@ public final class MessagesViewController: UIViewController {
     /// `reportContentHeightIfChanged`.
     var onContentHeightChanged: ((CGFloat) -> Void)?
     private var lastReportedContentHeight: CGFloat?
+
+    /// The slack, last measured somewhere the content height was settled.
+    ///
+    /// `shortContentTopSlack` reads `collectionView.contentSize`, and the layout
+    /// reads the resulting inset straight back out: `offsetCompensation` in
+    /// `invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)`
+    /// sums `adjustedContentInset.top` into the offset it compensates a self-sizing
+    /// cell by. Measuring the slack fresh from inside a layout pass therefore closes
+    /// a cycle - a new inset moves the compensated offset, that shows a different
+    /// visible rect, those cells self-size, the content height changes, and the
+    /// slack is different again - which UIKit caps and traps on, seven
+    /// `_updateVisibleCellsNow:` frames deep, as "stuck in a recursive layout loop".
+    /// The conversation sheet hits it on presentation, where a short transcript and
+    /// a synchronous `layoutBelowIfNeeded` from the sheet's transition put every
+    /// turn of that cycle inside one pass.
+    ///
+    /// Latching is what breaks it: the value only changes where the content height
+    /// has settled - `reportContentHeightIfChanged`'s deferred hop, and the
+    /// deferred hop for a resize - so a layout pass only ever re-asserts a constant.
+    private var latchedShortContentTopSlack: CGFloat = 0.0
+
+    /// The height this list was last laid out at, and whether a re-measure is
+    /// already queued for it.
+    private var lastTopSlackLayoutHeight: CGFloat?
+    private var isShortContentTopSlackRelatchScheduled: Bool = false
 
     private var lastKeyboardFrameChange: KeyboardInfo?
 
@@ -613,6 +641,7 @@ public final class MessagesViewController: UIViewController {
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         applyClippedTopOverflow()
+        scheduleShortContentTopSlackRelatchIfHeightChanged()
     }
 
     /// The SwiftUI bottom bar mounts into the safe area a render pass or two
@@ -1644,7 +1673,7 @@ extension MessagesViewController {
         // that fires when that changes.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            applyClippedTopOverflow()
+            relatchShortContentTopSlack()
             onContentHeightChanged?(height)
         }
     }
@@ -1652,11 +1681,42 @@ extension MessagesViewController {
     /// The list's top inset: what the host clips away, plus whatever it takes to
     /// hold short content against the bottom. See `clippedTopOverflow` and
     /// `shortContentTopSlack`.
+    ///
+    /// Safe to call from inside a layout pass. `clippedTopOverflow` is a constant
+    /// handed over by the host, and the slack is the latched value rather than a
+    /// fresh reading - so the inset this writes does not move while the pass runs,
+    /// and the pass settles after one write. See `latchedShortContentTopSlack`.
     func applyClippedTopOverflow() {
-        let target: CGFloat = clippedTopOverflow + shortContentTopSlack
+        let target: CGFloat = clippedTopOverflow + latchedShortContentTopSlack
         guard abs(collectionView.contentInset.top - target) > 0.5 else { return }
         collectionView.contentInset.top = target
         collectionView.verticalScrollIndicatorInsets.top = target
+    }
+
+    /// Re-measures the slack and applies it. Never call this from inside a layout
+    /// pass; that is the cycle `latchedShortContentTopSlack` documents.
+    func relatchShortContentTopSlack() {
+        latchedShortContentTopSlack = shortContentTopSlack
+        applyClippedTopOverflow()
+    }
+
+    /// The slack follows the list's own height as well as its content: the
+    /// conversation sheet changing detent resizes the transcript without changing a
+    /// single message, and no content height is reported for that. Re-measuring
+    /// inline would put the live geometry back inside the layout pass, so this
+    /// defers a turn and coalesces - a detent change is a run of layout passes, and
+    /// only the last one's height matters.
+    private func scheduleShortContentTopSlackRelatchIfHeightChanged() {
+        let height: CGFloat = collectionView.frame.height
+        guard lastTopSlackLayoutHeight != height else { return }
+        lastTopSlackLayoutHeight = height
+        guard !isShortContentTopSlackRelatchScheduled else { return }
+        isShortContentTopSlackRelatchScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            isShortContentTopSlackRelatchScheduled = false
+            relatchShortContentTopSlack()
+        }
     }
 
     /// Extra top inset that rests content too short to fill the visible area


### PR DESCRIPTION
Fixes the `EXC_BREAKPOINT` crash on opening a conversation sheet: UIKit's
`_UICollectionViewFeedbackLoopDebugger` trap, *"Collection view ... is stuck in a
recursive layout loop"*, seven `-[UICollectionView _updateVisibleCellsNow:]` frames deep.

## The loop

`shortContentTopSlack` is measured from `collectionView.contentSize`, and the layout reads
the resulting inset straight back out — `offsetCompensation` in
`invalidationContext(forPreferredLayoutAttributes:withOriginalAttributes:)` sums
`adjustedContentInset.top` into the offset it compensates a self-sizing cell by:

```swift
let offsetCompensation: CGFloat = min(
    controller.contentHeight(at: state) - collectionView!.frame.height
    + adjustedContentInset.bottom + adjustedContentInset.top,   // <- the slack lands here
    heightDifference
)
```

So measuring the slack fresh from inside a layout pass closed a cycle:

    new inset -> moved compensated offset -> different visible rect
      -> cells self-size -> new content height -> new slack -> new inset

The conversation sheet drives all of it synchronously — `_sheetLayoutInfoLayout:` ->
`layoutBelowIfNeeded` — so every turn landed inside a single layout pass and UIKit hit its
recursion cap and trapped.

It only bites when the transcript is short enough for the slack to be non-zero, which is
why a brand-new convo reproduces it every time and a long one never does.

## Why the previous fix did not hold

`shortContentTopSlack` was introduced to escape this exact crash — its doc comment
describes hitting it "seven `_updateVisibleCellsNow:` frames deep" and moving from
offsetting item frames to applying an inset, on the reasoning that "an inset cannot join
that cycle because it does not change where any item thinks it is."

That is true of item frames, but the inset still joins the cycle — through
`adjustedContentInset.top` in the offset compensation above, one level up from where it
was being looked for.

## The change

Latch the measurement. `latchedShortContentTopSlack` only changes where the content height
has settled:

- the deferred hop in `reportContentHeightIfChanged`
- the host handing over a new `clippedTopOverflow`
- a new deferred, coalesced hop when the list's own height changes (a detent change resizes
  the transcript without changing a message, so no content height is reported for it)

`applyClippedTopOverflow()` — still called from `viewDidLayoutSubviews` to close the
"handed over before the view loaded" gap — now writes a constant, so a layout pass settles
after one write instead of re-entering.

`clippedTopOverflow` itself stays live and synchronous; it is a constant handed in from
outside, not derived from geometry the pass is still changing.

## Verification

- Reproduced on a simulator against the pre-fix build, three times, with a stack identical
  to the device crashes (same trap, same seven nested `_updateVisibleCellsNow:` frames).
- Confirmed fixed by hand on the built build.
- Device crash logs: 6 from 2026-08-19 plus 10 matching retired ones from Aug 15–16.

## Scope

The bug arrived with #1325 and is on `dev`, not just this stack — the two frames in the
crash stack are `MessagesCollectionView.layoutSubviews()` and
`MessagesCollectionLayout.invalidateLayout(with:)`, and the capsule-sheet work touches
neither file. The first matching crash predates the capsule branch's first commit by three
days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789743398&installation_model_id=20076&pr_number=1350&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1350&signature=48dac2dff55830f1b3cb4cb69be9428e0cdd62520a6f377db0c9e45dd9509148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Latch short-content top slack to prevent layout loops in `MessagesViewController`
> - Introduces `latchedShortContentTopSlack`, a stored property that captures the last measured slack value so `applyClippedTopOverflow` never reads live content-size-based slack during an in-progress layout pass.
> - Adds `relatchShortContentTopSlack` as an explicit, safe re-measure point called from `clippedTopOverflow.didSet` and `reportContentHeightIfChanged` instead of direct slack reads.
> - Adds `scheduleShortContentTopSlackRelatchIfHeightChanged` in `viewDidLayoutSubviews` to coalesce frame-height changes and defer the relatch to the next main-queue turn.
> - Behavioral Change: top inset is now based on a stored snapshot of slack rather than a live read, so it may briefly reflect a stale value between a height change and the scheduled relatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c7424d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->