### PR TITLE
Wire the capability pill in the agent DM and scope its approval to the origin group

### DIFF
--- a/Convos/Capabilities/CapabilityApprovalSheetView.swift
+++ b/Convos/Capabilities/CapabilityApprovalSheetView.swift
@@ -30,6 +30,13 @@ struct CapabilityApprovalSheetView: View {
     /// Non-nil when the last approval attempt failed (grant POST or result
     /// send). Rendered above the primary button, which becomes a retry.
     let approvalErrorMessage: String?
+    /// Name of the conversation the grant will scope to (the origin group
+    /// for an agent DM, the conversation itself otherwise). The approve
+    /// control renders only when this is resolved -- named consent.
+    let scopeDisplayName: String?
+    /// Copy for a blocked agent-DM approval (origin unresolvable, departed,
+    /// or failed the consistency check); replaces the approve control.
+    let blockedMessage: String?
     let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
 
     init(
@@ -37,12 +44,16 @@ struct CapabilityApprovalSheetView: View {
         agentName: String?,
         isApproving: Bool = false,
         approvalErrorMessage: String? = nil,
+        scopeDisplayName: String? = nil,
+        blockedMessage: String? = nil,
         onApprove: @escaping (Set<ProviderID>, [String: Set<String>]) -> Void
     ) {
         self.layout = layout
         self.agentName = agentName
         self.isApproving = isApproving
         self.approvalErrorMessage = approvalErrorMessage
+        self.scopeDisplayName = scopeDisplayName
+        self.blockedMessage = blockedMessage
         self.onApprove = onApprove
     }
 
@@ -52,6 +63,8 @@ struct CapabilityApprovalSheetView: View {
             agentName: agentName,
             isApproving: isApproving,
             approvalErrorMessage: approvalErrorMessage,
+            scopeDisplayName: scopeDisplayName,
+            blockedMessage: blockedMessage,
             onApprove: onApprove
         )
         // Reseed the selection state if a newer request replaces the layout
@@ -113,6 +126,8 @@ private struct ApprovalSheetContent: View {
     let agentName: String?
     let isApproving: Bool
     let approvalErrorMessage: String?
+    let scopeDisplayName: String?
+    let blockedMessage: String?
     let onApprove: (Set<ProviderID>, [String: Set<String>]) -> Void
 
     @State private var selection: Set<ProviderID>
@@ -126,12 +141,16 @@ private struct ApprovalSheetContent: View {
         agentName: String?,
         isApproving: Bool,
         approvalErrorMessage: String?,
+        scopeDisplayName: String?,
+        blockedMessage: String?,
         onApprove: @escaping (Set<ProviderID>, [String: Set<String>]) -> Void
     ) {
         self.layout = layout
         self.agentName = agentName
         self.isApproving = isApproving
         self.approvalErrorMessage = approvalErrorMessage
+        self.scopeDisplayName = scopeDisplayName
+        self.blockedMessage = blockedMessage
         self.onApprove = onApprove
         _selection = State(initialValue: CapabilityApprovalSheetView.seedSelection(for: layout))
         _enabledBundleIds = State(initialValue: CapabilityApprovalSheetView.seedBundleSelection(for: layout))
@@ -406,6 +425,10 @@ private struct ApprovalSheetContent: View {
         return needsConnect ? "Connect" : "Done"
     }
 
+    /// Named-consent gate: the approve control renders only when the scope
+    /// conversation is resolved and named. A blocked scope shows its copy
+    /// instead; an unresolved one shows progress. In a plain group the scope
+    /// resolves immediately to the conversation itself.
     private var approveButton: some View {
         let approveAction: () -> Void = {
             onApprove(selection, approvedBundleSelection)
@@ -417,9 +440,21 @@ private struct ApprovalSheetContent: View {
                     .font(.caption)
                     .foregroundStyle(.colorCaution)
             }
-            Button(approveButtonTitle, action: approveAction)
-                .convosButtonStyle(.rounded(fullWidth: true))
-                .disabled(buttonDisabled)
+            if let blockedMessage {
+                Text(blockedMessage)
+                    .font(.caption)
+                    .foregroundStyle(.colorCaution)
+            } else if let scopeDisplayName {
+                Text("For use in \(scopeDisplayName)")
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+                Button(approveButtonTitle, action: approveAction)
+                    .convosButtonStyle(.rounded(fullWidth: true))
+                    .disabled(buttonDisabled)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+            }
         }
         .padding(.horizontal, DesignConstants.Spacing.step4x)
     }
@@ -527,6 +562,7 @@ private func previewRequest() -> CapabilityRequest {
             serviceBundles: previewBundles()
         ),
         agentName: "Agent",
+        scopeDisplayName: "Space Camp",
         onApprove: { _, _ in }
     )
 }
@@ -541,6 +577,7 @@ private func previewRequest() -> CapabilityRequest {
             serviceBundles: previewBundles()
         ),
         agentName: "Agent",
+        scopeDisplayName: "Space Camp",
         onApprove: { _, _ in }
     )
 }
@@ -555,6 +592,7 @@ private func previewRequest() -> CapabilityRequest {
             serviceBundles: previewBundles(grantedBundleIds: ["calendar.events"])
         ),
         agentName: "Agent",
+        scopeDisplayName: "Space Camp",
         onApprove: { _, _ in }
     )
 }
@@ -568,6 +606,7 @@ private func previewRequest() -> CapabilityRequest {
             defaultSelection: [ProviderID(rawValue: "composio.googlecalendar")]
         ),
         agentName: "Agent",
+        scopeDisplayName: "Space Camp",
         onApprove: { _, _ in }
     )
 }
@@ -589,6 +628,7 @@ private func previewRequest() -> CapabilityRequest {
             serviceBundles: previewBundles()
         ),
         agentName: "Agent",
+        scopeDisplayName: "Space Camp",
         onApprove: { _, _ in }
     )
 }

--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -355,6 +355,7 @@ struct AgentDmPageView: View {
             onAgentOutOfCredits: { dmVm.presentingPaywall = true },
             agentPowerDepletedByInboxId: dmVm.agentPowerDepletedByInboxId,
             onTapUpdateMember: { dmVm.presentingProfileForMember = $0 },
+            onTapCapabilityConnect: { prompt in handleDmCapabilityConnectTap(prompt, dmVm: dmVm) },
             onRetryMessage: dmVm.retryMessage(_:),
             onDeleteMessage: dmVm.deleteMessage(_:),
             onRetryAgentJoin: {},
@@ -409,6 +410,43 @@ struct AgentDmPageView: View {
             .sheet(isPresented: $dmVm.presentingPaywall) {
                 paywall(for: dmVm)
             }
+            .selfSizingSheet(isPresented: $dmVm.presentingCapabilityApproval) {
+                capabilityApprovalSheet(for: dmVm)
+            }
+    }
+
+    /// A pending pill in the DM transcript opens the same approval sheet the
+    /// group path uses. Read-only viewers can't answer the request (a result
+    /// message couldn't be sent on their behalf anyway).
+    private func handleDmCapabilityConnectTap(_ prompt: CapabilityConnectPrompt, dmVm: ConversationViewModel) {
+        guard !isReadOnly else { return }
+        dmVm.onTapCapabilityConnectPrompt(prompt)
+    }
+
+    /// Mirrors `ConversationView.capabilityApprovalSheet` -- including the
+    /// in-flight and error wiring and the named grant-scope disclosure. The
+    /// DM approval scopes its grant to the origin group, and the sheet names
+    /// that group before the approve control renders.
+    @ViewBuilder
+    private func capabilityApprovalSheet(for dmVm: ConversationViewModel) -> some View {
+        if let layout = dmVm.pendingCapabilityPickerLayout {
+            CapabilityApprovalSheetView(
+                layout: layout,
+                agentName: dmVm.askerDisplayName(for: layout.request),
+                isApproving: dmVm.capabilityApprovalInFlight,
+                approvalErrorMessage: dmVm.capabilityApprovalErrorMessage,
+                scopeDisplayName: dmVm.capabilityApprovalScopeName,
+                blockedMessage: dmVm.capabilityApprovalBlockedMessage,
+                onApprove: { providerIds, bundleSelection in
+                    dmVm.onCapabilityApprove(
+                        providerIds: providerIds,
+                        bundleSelection: bundleSelection
+                    )
+                }
+            )
+        } else {
+            EmptyView()
+        }
     }
 
     /// The low-balance paywall reached from the transcript's out-of-credits

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1375,6 +1375,8 @@ private extension ConversationView {
                 agentName: viewModel.askerDisplayName(for: layout.request),
                 isApproving: viewModel.capabilityApprovalInFlight,
                 approvalErrorMessage: viewModel.capabilityApprovalErrorMessage,
+                scopeDisplayName: viewModel.capabilityApprovalScopeName,
+                blockedMessage: viewModel.capabilityApprovalBlockedMessage,
                 onApprove: { providerIds, bundleSelection in
                     viewModel.onCapabilityApprove(
                         providerIds: providerIds,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -290,6 +290,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// the inner guards (or the tap ended blocked/diverged).
     @ObservationIgnored
     private var capabilityApproveTapInFlightRequestId: String?
+    /// Orders concurrent scope resolutions: each initiator (pill tap,
+    /// observe/recompute, approve) bumps the generation synchronously on the
+    /// main actor and only the latest generation may assign
+    /// `capabilityGrantScopeResolution`. This is what lets an approve-time
+    /// divergence re-present win over a pill-tap resolution still in flight
+    /// -- without it the late tap repaint could restore the stale scope and
+    /// re-diverge every retry.
+    @ObservationIgnored
+    private var capabilityScopeGeneration: UInt64 = 0
     @ObservationIgnored
     var lastReadReceiptSentAt: Date?
     @ObservationIgnored
@@ -1797,6 +1806,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
+                    self.capabilityScopeGeneration += 1
+                    let generation = self.capabilityScopeGeneration
                     let scopeResolution = await self.resolveCapabilityGrantScopeForCurrentConversation(request: request)
                     // Grant-side reads (existing grants, resolver state) key
                     // on the grant scope so a DM sheet seeds from the origin
@@ -1821,7 +1832,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     // `latestObservedCapabilityRequest`, so the staleness check above can't
                     // see that the user already answered.
                     guard !self.locallyHandledCapabilityRequestIds.contains(request.requestId) else { return }
-                    self.capabilityGrantScopeResolution = scopeResolution
+                    if generation == self.capabilityScopeGeneration {
+                        self.capabilityGrantScopeResolution = scopeResolution
+                    }
                     self.pendingCapabilityPickerLayout = layout
                 }
             }
@@ -2117,6 +2130,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let request = layout.request
         let conversationId = conversation.id
         let isAgentDm = conversation.isAgentDm
+        capabilityScopeGeneration += 1
+        let generation = capabilityScopeGeneration
         Task { @MainActor [weak self] in
             guard let self else { return }
             let resolution = await self.resolveCapabilityGrantScope(
@@ -2125,6 +2140,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 isAgentDm: isAgentDm
             )
             guard self.pendingCapabilityPickerLayout?.request.requestId == request.requestId else { return }
+            guard generation == self.capabilityScopeGeneration else { return }
             self.capabilityGrantScopeResolution = resolution
         }
     }
@@ -2159,6 +2175,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let isAgentDm = conversation.isAgentDm
         guard capabilityApproveTapInFlightRequestId != request.requestId else { return }
         capabilityApproveTapInFlightRequestId = request.requestId
+        capabilityScopeGeneration += 1
+        let approveGeneration = capabilityScopeGeneration
         capabilityApprovalErrorMessage = nil
         // The scope the sheet disclosed for this tap: consent is bound to it.
         let displayedResolution = capabilityGrantScopeResolution
@@ -2179,8 +2197,11 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 conversationId: conversationId,
                 isAgentDm: isAgentDm
             )
-            // A late completion must not repaint a newer request's sheet.
+            // A late completion must not repaint a newer request's sheet,
+            // and a newer initiator (a fresh tap or recompute) must not be
+            // repainted by this approve either.
             guard self.pendingCapabilityPickerLayout?.request.requestId == request.requestId else { return }
+            guard approveGeneration == self.capabilityScopeGeneration else { return }
             self.capabilityGrantScopeResolution = resolution
             guard let grantScopeConversationId = resolution.scope.grantScopeConversationId else {
                 if case .unresolvableOrigin(let reason) = resolution.scope {
@@ -3014,6 +3035,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let isAgentDm = conversation.isAgentDm
         Task { @MainActor [weak self] in
             guard let self else { return }
+            self.capabilityScopeGeneration += 1
+            let generation = self.capabilityScopeGeneration
             let scopeResolution = await self.resolveCapabilityGrantScope(
                 for: request,
                 conversationId: conversationId,
@@ -3037,7 +3060,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                   !self.locallyHandledCapabilityRequestIds.contains(request.requestId) else {
                 return
             }
-            self.capabilityGrantScopeResolution = scopeResolution
+            if generation == self.capabilityScopeGeneration {
+                self.capabilityGrantScopeResolution = scopeResolution
+            }
             self.pendingCapabilityPickerLayout = layout
         }
     }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -961,6 +961,24 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// completed -- the backend grant POST or the result send failed. The
     /// request stays pending and the sheet's button retries the same approval.
     private(set) var capabilityApprovalErrorMessage: String?
+    /// Where the pending request's approval will scope its grant, resolved
+    /// alongside the picker layout and re-verified at approve time. Nil while
+    /// resolving. The approval sheet's approve control renders only from a
+    /// resolved value, so consent always names the target conversation.
+    private(set) var capabilityGrantScopeResolution: CapabilityGrantScopeResolution?
+    /// The name the approval sheet shows for the conversation the grant will
+    /// scope to; nil while resolving or when the scope is blocked.
+    var capabilityApprovalScopeName: String? {
+        guard let resolution = capabilityGrantScopeResolution else { return nil }
+        guard case .unresolvableOrigin = resolution.scope else { return resolution.scopeDisplayName }
+        return nil
+    }
+    /// The blocked-approval copy for an agent DM whose origin cannot back a
+    /// grant; nil when the scope resolved (or is still resolving).
+    var capabilityApprovalBlockedMessage: String? {
+        guard case .unresolvableOrigin(let reason)? = capabilityGrantScopeResolution?.scope else { return nil }
+        return reason.userFacingMessage
+    }
     var presentingProfileForMember: ConversationMember?
     var presentingNewConversationForInvite: NewConversationViewModel? {
         didSet { oldValue?.cleanUpIfNeeded() }
@@ -1734,6 +1752,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let resolver = session.capabilityResolver()
         let handler = CapabilityRequestHandler()
         pendingCapabilityPickerLayout = nil
+        capabilityGrantScopeResolution = nil
         latestObservedCapabilityRequest = nil
         locallyHandledCapabilityRequestIds.removeAll()
         capabilityApprovalInFlightRequestId = nil
@@ -1755,10 +1774,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 self.latestObservedCapabilityRequest = request
                 guard let request else {
                     self.pendingCapabilityPickerLayout = nil
+                    self.capabilityGrantScopeResolution = nil
                     return
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
+                    let scopeResolution = await self.resolveCapabilityGrantScope(for: request)
+                    // Grant-side reads (existing grants, resolver state) key
+                    // on the grant scope so a DM sheet seeds from the origin
+                    // group's grants. A blocked scope reads the DM itself,
+                    // which is harmlessly empty -- approve is blocked anyway.
+                    let grantReadConversationId = scopeResolution.scope.grantScopeConversationId ?? conversationId
                     let layout = await Self.computeCapabilityPickerLayout(
                         request: request,
                         registry: registry,
@@ -1766,7 +1792,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                         handler: handler,
                         servicesStore: self.messagingService.connectionServicesStore(),
                         cloudConnectionRepository: self.session.cloudConnectionRepository(),
-                        conversationId: conversationId
+                        conversationId: grantReadConversationId
                     )
                     // Discard if a newer request arrived while we were computing —
                     // otherwise an out-of-order completion can stomp the latest UI.
@@ -1777,6 +1803,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     // `latestObservedCapabilityRequest`, so the staleness check above can't
                     // see that the user already answered.
                     guard !self.locallyHandledCapabilityRequestIds.contains(request.requestId) else { return }
+                    self.capabilityGrantScopeResolution = scopeResolution
                     self.pendingCapabilityPickerLayout = layout
                 }
             }
@@ -2013,6 +2040,28 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
 
     // MARK: - Capability picker
 
+    /// Resolves which conversation this request's approval must scope its
+    /// grant to: identity for a plain group, the verified origin group for an
+    /// agent DM. The live-marker fallback reads the DM's own appData through
+    /// the XMTP client and only runs when the local mirror row is absent.
+    private func resolveCapabilityGrantScope(for request: CapabilityRequest) async -> CapabilityGrantScopeResolution {
+        let repository = session.capabilityRequestRepository(for: conversation.id)
+        let conversationId = conversation.id
+        let messagingService = self.messagingService
+        return await repository.resolveGrantScope(
+            isAgentDm: conversation.isAgentDm,
+            askerInboxId: request.askerInboxId,
+            liveMarkerOrigin: {
+                guard let result = try? await messagingService.sessionStateManager.waitForInboxReadyResult(),
+                      let xmtpConversation = try? await result.client.conversation(with: conversationId),
+                      case .group(let group) = xmtpConversation else {
+                    return nil
+                }
+                return (try? group.agentDmOriginConversationId).flatMap { $0 }
+            }
+        )
+    }
+
     /// User tapped the transcript's capability connect pill. Pending pills open
     /// the approval sheet for the request they carry; connected/dismissed/
     /// superseded pills are inert. The derivation only renders `.pending` on
@@ -2063,11 +2112,49 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             providerIds: providerIds,
             bundleSelection: bundleSelection
         )
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            // Approval-time origin consistency check: re-resolve the grant
+            // scope at the moment of the tap rather than trusting the
+            // presentation-time value. A blocked scope surfaces its message
+            // and sends nothing -- no grant, no revoke, no result.
+            let resolution = await self.resolveCapabilityGrantScope(for: request)
+            self.capabilityGrantScopeResolution = resolution
+            guard let grantScopeConversationId = resolution.scope.grantScopeConversationId else {
+                if case .unresolvableOrigin(let reason) = resolution.scope {
+                    self.capabilityApprovalErrorMessage = reason.userFacingMessage
+                    CapabilityApprovalTelemetry.blockedApproval(reason: reason.telemetryValue)
+                }
+                return
+            }
+            self.continueCapabilityApprove(
+                request: request,
+                layout: layout,
+                split: split,
+                conversationId: conversationId,
+                grantScopeConversationId: grantScopeConversationId
+            )
+        }
+    }
+
+    /// The post-scope-resolution half of `onCapabilityApprove`: revokes for
+    /// all-off services, then the connect-or-approve pipeline. Grant-side
+    /// writes target `grantScopeConversationId`; the result message targets
+    /// the pill's own conversation (`conversationId`). In a plain group the
+    /// two are the same id, making every path today's exact behavior.
+    private func continueCapabilityApprove(
+        request: CapabilityRequest,
+        layout: CapabilityPickerLayout,
+        split: CapabilityApprovalSplit,
+        conversationId: String,
+        grantScopeConversationId: String
+    ) {
         if !split.uncheckedServiceIds.isEmpty {
             revokeUncheckedCapabilityGrants(
                 serviceIds: split.uncheckedServiceIds,
                 request: request,
                 conversationId: conversationId,
+                grantScopeConversationId: grantScopeConversationId,
                 recomputeLayoutAfter: split.approvedProviderIds.isEmpty
             )
         }
@@ -2094,7 +2181,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 request,
                 providerIds: providerIds,
                 bundleSelection: bundleSelection,
-                conversationId: conversationId
+                conversationId: conversationId,
+                grantScopeConversationId: grantScopeConversationId
             )
             return
         }
@@ -2130,7 +2218,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                         request,
                         providerIds: providerIds,
                         bundleSelection: bundleSelection,
-                        conversationId: conversationId
+                        conversationId: conversationId,
+                        grantScopeConversationId: grantScopeConversationId
                     )
                 case .interrupted:
                     self.recomputeCapabilityPickerLayout(for: request, conversationId: conversationId)
@@ -2190,6 +2279,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         serviceIds: [String],
         request: CapabilityRequest,
         conversationId: String,
+        grantScopeConversationId: String,
         recomputeLayoutAfter: Bool
     ) {
         let grantWriter = messagingService.connectionGrantWriter()
@@ -2201,7 +2291,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             let revoked = await Self.revokeUncheckedCloudGrants(
                 serviceIds: serviceIds,
                 grantedToInboxId: grantedToInboxId,
-                conversationId: conversationId,
+                conversationId: grantScopeConversationId,
                 grantWriter: grantWriter,
                 eventWriter: eventWriter,
                 resolver: resolver,
@@ -2283,6 +2373,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>],
         conversationId: String,
+        grantScopeConversationId: String,
         allowConnectRecovery: Bool = true
     ) {
         guard capabilityApprovalInFlightRequestId == nil else { return }
@@ -2295,7 +2386,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 status: .approved,
                 providerIds: providerIds,
                 bundleSelection: bundleSelection,
-                conversationId: conversationId
+                conversationId: conversationId,
+                grantScopeConversationId: grantScopeConversationId
             )
             // A conversation switch mid-flight resets the in-flight id and may
             // hand it to a newer approval. A late completion that no longer
@@ -2318,7 +2410,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     request: request,
                     providerIds: providerIds,
                     bundleSelection: bundleSelection,
-                    conversationId: conversationId
+                    conversationId: conversationId,
+                    grantScopeConversationId: grantScopeConversationId
                 )
             case .failed, .needsConnect:
                 self.capabilityApprovalErrorMessage = Constant.capabilityApprovalFailedMessage
@@ -2337,7 +2430,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         request: CapabilityRequest,
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>],
-        conversationId: String
+        conversationId: String,
+        grantScopeConversationId: String
     ) {
         guard connectOnApproveInFlightRequestId != request.requestId else { return }
         connectOnApproveInFlightRequestId = request.requestId
@@ -2363,6 +2457,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                     providerIds: providerIds,
                     bundleSelection: bundleSelection,
                     conversationId: conversationId,
+                    grantScopeConversationId: grantScopeConversationId,
                     allowConnectRecovery: false
                 )
             }
@@ -2386,7 +2481,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         status: CapabilityRequestResult.Status,
         providerIds: Set<ProviderID>,
         bundleSelection: [String: Set<String>] = [:],
-        conversationId: String
+        conversationId: String,
+        grantScopeConversationId: String
     ) async -> CapabilityResultSendOutcome {
         let resolver = session.capabilityResolver()
         let writer = messagingService.capabilityRequestResultWriter()
@@ -2403,7 +2499,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             previouslyApproved = await resolver.resolution(
                 subject: request.subject,
                 capability: request.capability,
-                conversationId: conversationId,
+                conversationId: grantScopeConversationId,
                 grantedToInboxId: askerInboxId
             )
         } else {
@@ -2416,7 +2512,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
             let confirmation = await Self.persistApprovedCloudCapabilities(
                 providerIds: sortedIds,
                 bundleSelection: bundleSelection,
-                conversationId: conversationId,
+                conversationId: grantScopeConversationId,
                 grantedToInboxId: askerInboxId,
                 grantWriter: messagingService.connectionGrantWriter(),
                 repository: session.cloudConnectionRepository()
@@ -2435,7 +2531,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 try await resolver.clearResolution(
                     subject: request.subject,
                     capability: request.capability,
-                    conversationId: conversationId,
+                    conversationId: grantScopeConversationId,
                     grantedToInboxId: askerInboxId
                 )
             } catch {
@@ -2467,7 +2563,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 providerIds: providerIds,
                 sortedProviderIds: sortedIds,
                 newlyApprovedProviderIds: newlyApprovedProviderIds,
-                conversationId: conversationId
+                conversationId: grantScopeConversationId
             )
         }
         return .sent
@@ -2845,6 +2941,8 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let handler = CapabilityRequestHandler()
         Task { @MainActor [weak self] in
             guard let self else { return }
+            let scopeResolution = await self.resolveCapabilityGrantScope(for: request)
+            let grantReadConversationId = scopeResolution.scope.grantScopeConversationId ?? conversationId
             let layout = await Self.computeCapabilityPickerLayout(
                 request: request,
                 registry: registry,
@@ -2852,8 +2950,9 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 handler: handler,
                 servicesStore: self.messagingService.connectionServicesStore(),
                 cloudConnectionRepository: self.session.cloudConnectionRepository(),
-                conversationId: conversationId
+                conversationId: grantReadConversationId
             )
+            self.capabilityGrantScopeResolution = scopeResolution
             // If a newer request arrived OR the user already approved/denied this one,
             // don't revive the picker with a stale layout.
             guard self.latestObservedCapabilityRequest == request,

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -283,6 +283,13 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// no-browser connect runs. Observed (not `@ObservationIgnored`) so the busy
     /// state reacts when it changes.
     private var connectOnApproveInFlightRequestId: String?
+    /// Synchronous re-entrancy latch for the approve tap. The pipeline's own
+    /// guards are taken only after the async scope-resolution hop, so without
+    /// this a double-tap could double-run the revoke pass and race a second
+    /// result send. Held from tap until the resolved continuation has taken
+    /// the inner guards (or the tap ended blocked/diverged).
+    @ObservationIgnored
+    private var capabilityApproveTapInFlightRequestId: String?
     @ObservationIgnored
     var lastReadReceiptSentAt: Date?
     @ObservationIgnored
@@ -970,8 +977,19 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// scope to; nil while resolving or when the scope is blocked.
     var capabilityApprovalScopeName: String? {
         guard let resolution = capabilityGrantScopeResolution else { return nil }
-        guard case .unresolvableOrigin = resolution.scope else { return resolution.scopeDisplayName }
-        return nil
+        switch resolution.scope {
+        case .unresolvableOrigin:
+            return nil
+        case .originGroup:
+            // The resolver blocks nameless origins, so this is always the
+            // origin group's real name.
+            return resolution.scopeDisplayName
+        case .conversation:
+            // A nameless plain group falls back to the same user-facing
+            // display name the user is already looking at -- a real
+            // identity, never a generic noun.
+            return resolution.scopeDisplayName ?? conversation.displayName
+        }
     }
     /// The blocked-approval copy for an agent DM whose origin cannot back a
     /// grant; nil when the scope resolved (or is still resolving).
@@ -1779,7 +1797,7 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    let scopeResolution = await self.resolveCapabilityGrantScope(for: request)
+                    let scopeResolution = await self.resolveCapabilityGrantScopeForCurrentConversation(request: request)
                     // Grant-side reads (existing grants, resolver state) key
                     // on the grant scope so a DM sheet seeds from the origin
                     // group's grants. A blocked scope reads the DM itself,
@@ -2044,12 +2062,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// grant to: identity for a plain group, the verified origin group for an
     /// agent DM. The live-marker fallback reads the DM's own appData through
     /// the XMTP client and only runs when the local mirror row is absent.
-    private func resolveCapabilityGrantScope(for request: CapabilityRequest) async -> CapabilityGrantScopeResolution {
-        let repository = session.capabilityRequestRepository(for: conversation.id)
-        let conversationId = conversation.id
+    private func resolveCapabilityGrantScope(
+        for request: CapabilityRequest,
+        conversationId: String,
+        isAgentDm: Bool
+    ) async -> CapabilityGrantScopeResolution {
+        let repository = session.capabilityRequestRepository(for: conversationId)
         let messagingService = self.messagingService
         return await repository.resolveGrantScope(
-            isAgentDm: conversation.isAgentDm,
+            isAgentDm: isAgentDm,
             askerInboxId: request.askerInboxId,
             liveMarkerOrigin: {
                 guard let result = try? await messagingService.sessionStateManager.waitForInboxReadyResult(),
@@ -2059,6 +2080,18 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 }
                 return (try? group.agentDmOriginConversationId).flatMap { $0 }
             }
+        )
+    }
+
+    /// Captures the conversation identity at call time so an async resolution
+    /// can never span a draft-to-real conversation swap.
+    private func resolveCapabilityGrantScopeForCurrentConversation(
+        request: CapabilityRequest
+    ) async -> CapabilityGrantScopeResolution {
+        await resolveCapabilityGrantScope(
+            for: request,
+            conversationId: conversation.id,
+            isAgentDm: conversation.isAgentDm
         )
     }
 
@@ -2077,6 +2110,23 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         // the user on a fresh open; the sheet starts clean.
         capabilityApprovalErrorMessage = nil
         presentingCapabilityApproval = true
+        // A blocked scope self-heals here: the pending publisher only tracks
+        // message rows, so origin tables syncing later re-trigger nothing --
+        // re-resolving on every tap is what makes "the same tap succeeds
+        // after sync" actually true.
+        let request = layout.request
+        let conversationId = conversation.id
+        let isAgentDm = conversation.isAgentDm
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let resolution = await self.resolveCapabilityGrantScope(
+                for: request,
+                conversationId: conversationId,
+                isAgentDm: isAgentDm
+            )
+            guard self.pendingCapabilityPickerLayout?.request.requestId == request.requestId else { return }
+            self.capabilityGrantScopeResolution = resolution
+        }
     }
 
     /// User tapped the approval sheet's primary button with this provider
@@ -2106,7 +2156,12 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         guard let layout = pendingCapabilityPickerLayout else { return }
         let request = layout.request
         let conversationId = conversation.id
+        let isAgentDm = conversation.isAgentDm
+        guard capabilityApproveTapInFlightRequestId != request.requestId else { return }
+        capabilityApproveTapInFlightRequestId = request.requestId
         capabilityApprovalErrorMessage = nil
+        // The scope the sheet disclosed for this tap: consent is bound to it.
+        let displayedResolution = capabilityGrantScopeResolution
 
         let split = Self.splitCapabilityApproval(
             providerIds: providerIds,
@@ -2114,17 +2169,34 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         )
         Task { @MainActor [weak self] in
             guard let self else { return }
+            defer { self.capabilityApproveTapInFlightRequestId = nil }
             // Approval-time origin consistency check: re-resolve the grant
             // scope at the moment of the tap rather than trusting the
             // presentation-time value. A blocked scope surfaces its message
             // and sends nothing -- no grant, no revoke, no result.
-            let resolution = await self.resolveCapabilityGrantScope(for: request)
+            let resolution = await self.resolveCapabilityGrantScope(
+                for: request,
+                conversationId: conversationId,
+                isAgentDm: isAgentDm
+            )
+            // A late completion must not repaint a newer request's sheet.
+            guard self.pendingCapabilityPickerLayout?.request.requestId == request.requestId else { return }
             self.capabilityGrantScopeResolution = resolution
             guard let grantScopeConversationId = resolution.scope.grantScopeConversationId else {
                 if case .unresolvableOrigin(let reason) = resolution.scope {
                     self.capabilityApprovalErrorMessage = reason.userFacingMessage
                     CapabilityApprovalTelemetry.blockedApproval(reason: reason.telemetryValue)
                 }
+                return
+            }
+            // Consent binding: the grant may only target the scope the sheet
+            // disclosed when the user tapped. On divergence (a rebind moved
+            // the origin between presentation and tap) nothing is written --
+            // the sheet re-presents with the fresh scope and the user
+            // re-consents to the newly named group.
+            guard displayedResolution?.scope == resolution.scope else {
+                self.capabilityApprovalErrorMessage = "This approval's destination changed. Check the group name and try again."
+                CapabilityApprovalTelemetry.blockedApproval(reason: "scope_diverged")
                 return
             }
             self.continueCapabilityApprove(
@@ -2939,9 +3011,14 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         let registry = session.capabilityProviderRegistry()
         let resolver = session.capabilityResolver()
         let handler = CapabilityRequestHandler()
+        let isAgentDm = conversation.isAgentDm
         Task { @MainActor [weak self] in
             guard let self else { return }
-            let scopeResolution = await self.resolveCapabilityGrantScope(for: request)
+            let scopeResolution = await self.resolveCapabilityGrantScope(
+                for: request,
+                conversationId: conversationId,
+                isAgentDm: isAgentDm
+            )
             let grantReadConversationId = scopeResolution.scope.grantScopeConversationId ?? conversationId
             let layout = await Self.computeCapabilityPickerLayout(
                 request: request,
@@ -2952,13 +3029,15 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
                 cloudConnectionRepository: self.session.cloudConnectionRepository(),
                 conversationId: grantReadConversationId
             )
-            self.capabilityGrantScopeResolution = scopeResolution
             // If a newer request arrived OR the user already approved/denied this one,
-            // don't revive the picker with a stale layout.
+            // don't revive the picker with a stale layout -- or repaint its
+            // scope: a stale recompute writing a transient blocked verdict
+            // would hide the newer request's approve control.
             guard self.latestObservedCapabilityRequest == request,
                   !self.locallyHandledCapabilityRequestIds.contains(request.requestId) else {
                 return
             }
+            self.capabilityGrantScopeResolution = scopeResolution
             self.pendingCapabilityPickerLayout = layout
         }
     }

--- a/Convos/Metrics/CapabilityApprovalTelemetry.swift
+++ b/Convos/Metrics/CapabilityApprovalTelemetry.swift
@@ -1,0 +1,16 @@
+import Foundation
+import PostHog
+
+/// Counter for the blocked-approval path: an agent DM whose origin could not
+/// back a grant at approve time. The residual population (a roster lane whose
+/// DM truly has no origin marker) should be empty by construction, so this
+/// counter exists to let reality contradict that claim; a sustained rate is
+/// the signal to escalate to worker-side lane invalidation.
+enum CapabilityApprovalTelemetry {
+    static func blockedApproval(reason: String) {
+        PostHogSDK.shared.capture(
+            "capability_approval_blocked",
+            properties: ["reason": reason]
+        )
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
@@ -45,12 +45,20 @@ public enum CapabilityGrantScopeBlockReason: Equatable, Sendable {
     /// The asking agent is no longer a member of the origin group (a rebind
     /// left the DM's recorded origin stale).
     case agentNotInOrigin
+    /// The recorded origin is not a group conversation: it names the DM
+    /// itself or another agent DM. The marker is member-writable, so this is
+    /// treated as untrusted input -- a DM-scoped grant authorizes nothing.
+    case originNotAGroup
+    /// The origin group carries no name, so the sheet cannot disclose which
+    /// conversation the grant would scope to. Named consent requires the
+    /// real name; a generic noun is not consent.
+    case originUnnamed
 
     public var userFacingMessage: String {
         switch self {
         case .userNotInOrigin:
             return "This request belongs to a conversation you're no longer in."
-        case .originUnknown, .originNotSynced, .agentNotInOrigin:
+        case .originUnknown, .originNotSynced, .agentNotInOrigin, .originNotAGroup, .originUnnamed:
             return "Can't approve from this chat right now — still syncing. Try again in a moment."
         }
     }
@@ -62,6 +70,8 @@ public enum CapabilityGrantScopeBlockReason: Equatable, Sendable {
         case .originNotSynced: return "origin_not_synced"
         case .userNotInOrigin: return "user_not_in_origin"
         case .agentNotInOrigin: return "agent_not_in_origin"
+        case .originNotAGroup: return "origin_not_a_group"
+        case .originUnnamed: return "origin_unnamed"
         }
     }
 }
@@ -83,9 +93,6 @@ public struct CapabilityGrantScopeResolution: Equatable, Sendable {
 }
 
 extension CapabilityGrantScopeResolution {
-    /// Shared fallback when a scope conversation row has no name of its own.
-    static let unnamedScopeFallback: String = "your group chat"
-
     /// Database-driven resolution. `liveMarkerOrigin` is consulted only when
     /// the mirror row is absent: it reads the DM's own XMTP appData marker,
     /// the authoritative source the row mirrors (covers a failed mirror write
@@ -99,13 +106,15 @@ extension CapabilityGrantScopeResolution {
         liveMarkerOrigin: @Sendable () async -> String?
     ) async -> CapabilityGrantScopeResolution {
         guard isAgentDm else {
+            // A nameless plain group keeps a nil name: the view model falls
+            // back to the conversation's own user-facing display name, which
+            // the user is already looking at -- never a generic noun.
             let name: String? = try? await dbReader.read { db in
                 try DBConversation.fetchOne(db, id: conversationId)?.name
             }
-            let displayName: String = (name?.isEmpty == false) ? (name ?? "") : Self.unnamedScopeFallback
             return CapabilityGrantScopeResolution(
                 scope: .conversation(conversationId),
-                scopeDisplayName: displayName
+                scopeDisplayName: (name?.isEmpty == false) ? name : nil
             )
         }
 
@@ -118,6 +127,11 @@ extension CapabilityGrantScopeResolution {
         }
         guard let originId, !originId.isEmpty else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originUnknown), scopeDisplayName: nil)
+        }
+        // The marker is member-writable: an origin naming the DM itself is
+        // untrusted input steering the grant back into the DM scope.
+        guard originId != conversationId else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
         }
 
         let check: OriginConsistencyCheck? = try? await dbReader.read { db in
@@ -150,8 +164,18 @@ extension CapabilityGrantScopeResolution {
         guard check.agentIsMember else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.agentNotInOrigin), scopeDisplayName: nil)
         }
-        let displayName: String = (origin.name?.isEmpty == false) ? (origin.name ?? "") : Self.unnamedScopeFallback
-        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: displayName)
+        // An origin that is itself an agent DM can never back a grant; the
+        // membership checks pass trivially for any DM the viewer and agent
+        // share, so this guard is what stops a steered marker.
+        guard !origin.isAgentDm else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
+        }
+        // Named consent requires the origin's real name; without one the
+        // sheet cannot disclose the grant target, so the approval blocks.
+        guard let originName = origin.name, !originName.isEmpty else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originUnnamed), scopeDisplayName: nil)
+        }
+        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: originName)
     }
 
     private struct OriginConsistencyCheck {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
@@ -49,16 +49,20 @@ public enum CapabilityGrantScopeBlockReason: Equatable, Sendable {
     /// itself or another agent DM. The marker is member-writable, so this is
     /// treated as untrusted input -- a DM-scoped grant authorizes nothing.
     case originNotAGroup
-    /// The origin group carries no name, so the sheet cannot disclose which
-    /// conversation the grant would scope to. Named consent requires the
-    /// real name; a generic noun is not consent.
-    case originUnnamed
+    /// The origin group's identity could not be derived at all (hydration
+    /// failed), so the sheet cannot truthfully disclose which conversation
+    /// the grant would scope to. Ordinary unnamed groups do not land here:
+    /// their identity derives from the member list, exactly as the rest of
+    /// the app names them.
+    case originUnidentifiable
 
     public var userFacingMessage: String {
         switch self {
         case .userNotInOrigin:
             return "This request belongs to a conversation you're no longer in."
-        case .originUnknown, .originNotSynced, .agentNotInOrigin, .originNotAGroup, .originUnnamed:
+        case .originUnidentifiable:
+            return "Can't identify the conversation this request belongs to."
+        case .originUnknown, .originNotSynced, .agentNotInOrigin, .originNotAGroup:
             return "Can't approve from this chat right now — still syncing. Try again in a moment."
         }
     }
@@ -71,7 +75,7 @@ public enum CapabilityGrantScopeBlockReason: Equatable, Sendable {
         case .userNotInOrigin: return "user_not_in_origin"
         case .agentNotInOrigin: return "agent_not_in_origin"
         case .originNotAGroup: return "origin_not_a_group"
-        case .originUnnamed: return "origin_unnamed"
+        case .originUnidentifiable: return "origin_unidentifiable"
         }
     }
 }
@@ -170,12 +174,23 @@ extension CapabilityGrantScopeResolution {
         guard !origin.isAgentDm else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
         }
-        // Named consent requires the origin's real name; without one the
-        // sheet cannot disclose the grant target, so the approval blocks.
-        guard let originName = origin.name, !originName.isEmpty else {
-            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originUnnamed), scopeDisplayName: nil)
+        // Named consent requires the origin's real identity. An explicit
+        // name is returned verbatim; an unnamed group derives its title from
+        // the member list -- the same derivation every other surface uses to
+        // name it -- so ordinary unnamed groups approve normally. Only a
+        // group whose identity cannot be derived at all blocks.
+        let originDisplayName: String? = try? await dbReader.read { db in
+            let details = try DBConversation
+                .filter(DBConversation.Columns.id == originId)
+                .detailedConversationQuery()
+                .fetchOne(db)
+            let currentInboxId = try DBInbox.currentInboxId(db) ?? viewerInboxId
+            return details?.hydrateConversation(currentInboxId: currentInboxId).displayName
         }
-        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: originName)
+        guard let originDisplayName, !originDisplayName.isEmpty else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originUnidentifiable), scopeDisplayName: nil)
+        }
+        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: originDisplayName)
     }
 
     private struct OriginConsistencyCheck {

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
@@ -152,15 +152,11 @@ extension CapabilityGrantScopeResolution {
                 .filter(DBConversationMember.Columns.conversationId == originId)
                 .filter(DBConversationMember.Columns.inboxId == askerInboxId)
                 .fetchCount(db) > 0
-            let memberCount = try DBConversationMember
-                .filter(DBConversationMember.Columns.conversationId == originId)
-                .fetchCount(db)
             return OriginConsistencyCheck(
                 origin: origin,
                 userIsMember: userIsMember,
                 userDeparted: userDeparted,
-                agentIsMember: agentIsMember,
-                memberCount: memberCount
+                agentIsMember: agentIsMember
             )
         }
         guard let check, let origin = check.origin else {
@@ -172,18 +168,20 @@ extension CapabilityGrantScopeResolution {
         guard check.agentIsMember else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.agentNotInOrigin), scopeDisplayName: nil)
         }
-        // A grant must scope to a real group, not a DM. `kind` cannot make
-        // that distinction here: every conversation is persisted `.group`
-        // (extraction hardcodes it, ConversationWriter -- there is no `.dm`
-        // write path), so DM-ness is carried by shape, not `kind`. A DM is
-        // exactly two members, so the member-count check is what rejects a
-        // marker steered at any 2-member conversation the viewer and asking
-        // agent share -- including one that dodged agent-DM classification
-        // (unmarked, or an unverified-agent chat that never sets isAgentDm).
-        // The isAgentDm guard stays as belt-and-braces for the marked case.
-        guard check.memberCount > 2 else {
-            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
-        }
+        // A marked agent DM can never back a grant. This is the only stable,
+        // persisted DM discriminator the schema offers: `kind` is always
+        // `.group` (extraction hardcodes it -- no `.dm` write path), the
+        // `agent_dm_origin` row is written only when `isAgentDm`, and no
+        // peer/dm-type column exists. Member count was tried and reverted: it
+        // is mutable normal-lifecycle state, so gating on it wrongly blocked a
+        // legitimate group that shrank to the viewer and agent.
+        //
+        // The residual it leaves open -- a marker steered at an unmarked
+        // 2-member (viewer + agent) conversation -- is indistinguishable in
+        // persisted state from that shrunken legit group, so no reliable guard
+        // can separate them. It is also inert: the backend keys entitlement on
+        // the agent's pinned primary conversation, so a grant scoped anywhere
+        // else authorizes nothing, and the sheet names the scope for consent.
         guard !origin.isAgentDm else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
         }
@@ -216,6 +214,5 @@ extension CapabilityGrantScopeResolution {
         let userIsMember: Bool
         let userDeparted: Bool
         let agentIsMember: Bool
-        let memberCount: Int
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
@@ -1,0 +1,163 @@
+import Foundation
+import GRDB
+
+/// Which conversation a capability approval's grant writes scope to.
+///
+/// In a plain group the pill's conversation and the grant's conversation are
+/// the same. In an agent DM they are not: the backend authorizes tool calls
+/// against the agent's primary group, so a grant scoped to the DM's own id
+/// authorizes nothing. The DM approval therefore resolves its origin group
+/// and scopes every grant-side write there, while the result message stays in
+/// the DM. An agent DM whose origin cannot be resolved is an explicit blocked
+/// case, never a silent fallthrough to the DM id.
+public enum CapabilityGrantScope: Equatable, Sendable {
+    /// Not an agent DM: today's exact behavior, scope = the conversation.
+    case conversation(String)
+    /// Agent DM with a resolved, verified origin group.
+    case originGroup(String)
+    /// Agent DM whose origin is unknown, missing, or failed the approval-time
+    /// consistency check: the approval is blocked.
+    case unresolvableOrigin(CapabilityGrantScopeBlockReason)
+
+    /// The conversation id grant-side writes target, or nil when blocked.
+    public var grantScopeConversationId: String? {
+        switch self {
+        case .conversation(let id): return id
+        case .originGroup(let id): return id
+        case .unresolvableOrigin: return nil
+        }
+    }
+}
+
+/// Why an agent-DM approval is blocked. Drives the sheet copy: a user who
+/// left the origin group gets the departed wording; every other case reads
+/// as the transient still-syncing form (the dominant blocked population is a
+/// reinstalled device whose origin group has not synced yet, and it
+/// self-heals -- the pill stays pending and the same tap succeeds later).
+public enum CapabilityGrantScopeBlockReason: Equatable, Sendable {
+    /// No `agent_dm_origin` row and no readable appData marker.
+    case originUnknown
+    /// Origin id known but the conversation is not present locally.
+    case originNotSynced
+    /// The user is no longer a member of the origin group (or has a
+    /// recorded departure).
+    case userNotInOrigin
+    /// The asking agent is no longer a member of the origin group (a rebind
+    /// left the DM's recorded origin stale).
+    case agentNotInOrigin
+
+    public var userFacingMessage: String {
+        switch self {
+        case .userNotInOrigin:
+            return "This request belongs to a conversation you're no longer in."
+        case .originUnknown, .originNotSynced, .agentNotInOrigin:
+            return "Can't approve from this chat right now — still syncing. Try again in a moment."
+        }
+    }
+
+    /// Stable identifier for the blocked-path telemetry counter.
+    public var telemetryValue: String {
+        switch self {
+        case .originUnknown: return "origin_unknown"
+        case .originNotSynced: return "origin_not_synced"
+        case .userNotInOrigin: return "user_not_in_origin"
+        case .agentNotInOrigin: return "agent_not_in_origin"
+        }
+    }
+}
+
+/// A resolved scope plus the display name the approval sheet must show.
+/// The named-consent rule: the sheet cannot render its approve control
+/// without the resolved name of the conversation the grant will scope to.
+public struct CapabilityGrantScopeResolution: Equatable, Sendable {
+    public let scope: CapabilityGrantScope
+    /// Name of the scope conversation; nil when blocked. Falls back to a
+    /// generic noun when the conversation row carries no name, so a resolved
+    /// scope always names its target.
+    public let scopeDisplayName: String?
+
+    public init(scope: CapabilityGrantScope, scopeDisplayName: String?) {
+        self.scope = scope
+        self.scopeDisplayName = scopeDisplayName
+    }
+}
+
+extension CapabilityGrantScopeResolution {
+    /// Shared fallback when a scope conversation row has no name of its own.
+    static let unnamedScopeFallback: String = "your group chat"
+
+    /// Database-driven resolution. `liveMarkerOrigin` is consulted only when
+    /// the mirror row is absent: it reads the DM's own XMTP appData marker,
+    /// the authoritative source the row mirrors (covers a failed mirror write
+    /// and a reinstalled device whose row has not been rebuilt yet).
+    static func resolve(
+        conversationId: String,
+        isAgentDm: Bool,
+        askerInboxId: String,
+        viewerInboxId: String,
+        dbReader: any DatabaseReader,
+        liveMarkerOrigin: @Sendable () async -> String?
+    ) async -> CapabilityGrantScopeResolution {
+        guard isAgentDm else {
+            let name: String? = try? await dbReader.read { db in
+                try DBConversation.fetchOne(db, id: conversationId)?.name
+            }
+            let displayName: String = (name?.isEmpty == false) ? (name ?? "") : Self.unnamedScopeFallback
+            return CapabilityGrantScopeResolution(
+                scope: .conversation(conversationId),
+                scopeDisplayName: displayName
+            )
+        }
+
+        let mirroredOrigin: String? = try? await dbReader.read { db in
+            try DBAgentDmOrigin.originConversationId(for: conversationId, in: db)
+        }
+        var originId: String? = mirroredOrigin
+        if originId == nil {
+            originId = await liveMarkerOrigin()
+        }
+        guard let originId, !originId.isEmpty else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originUnknown), scopeDisplayName: nil)
+        }
+
+        let check: OriginConsistencyCheck? = try? await dbReader.read { db in
+            let origin = try DBConversation.fetchOne(db, id: originId)
+            let userIsMember = try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == originId)
+                .filter(DBConversationMember.Columns.inboxId == viewerInboxId)
+                .fetchCount(db) > 0
+            let userDeparted = try DBMemberDeparture
+                .filter(DBMemberDeparture.Columns.conversationId == originId)
+                .filter(DBMemberDeparture.Columns.inboxId == viewerInboxId)
+                .fetchCount(db) > 0
+            let agentIsMember = try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == originId)
+                .filter(DBConversationMember.Columns.inboxId == askerInboxId)
+                .fetchCount(db) > 0
+            return OriginConsistencyCheck(
+                origin: origin,
+                userIsMember: userIsMember,
+                userDeparted: userDeparted,
+                agentIsMember: agentIsMember
+            )
+        }
+        guard let check, let origin = check.origin else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotSynced), scopeDisplayName: nil)
+        }
+        guard check.userIsMember, !check.userDeparted else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.userNotInOrigin), scopeDisplayName: nil)
+        }
+        guard check.agentIsMember else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.agentNotInOrigin), scopeDisplayName: nil)
+        }
+        let displayName: String = (origin.name?.isEmpty == false) ? (origin.name ?? "") : Self.unnamedScopeFallback
+        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: displayName)
+    }
+
+    private struct OriginConsistencyCheck {
+        let origin: DBConversation?
+        let userIsMember: Bool
+        let userDeparted: Bool
+        let agentIsMember: Bool
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
@@ -168,9 +168,14 @@ extension CapabilityGrantScopeResolution {
         guard check.agentIsMember else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.agentNotInOrigin), scopeDisplayName: nil)
         }
-        // An origin that is itself an agent DM can never back a grant; the
-        // membership checks pass trivially for any DM the viewer and agent
-        // share, so this guard is what stops a steered marker.
+        // A grant must scope to a group conversation. The positive kind
+        // check rejects a marker steered at a plain DM (which has member
+        // rows and no agent-DM flag, so it passes every other guard); the
+        // agent-DM guard stays alongside it because an agent DM is itself a
+        // 2-member group -- kind alone would let it through.
+        guard origin.kind == .group else {
+            return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
+        }
         guard !origin.isAgentDm else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
         }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityGrantScope.swift
@@ -152,11 +152,15 @@ extension CapabilityGrantScopeResolution {
                 .filter(DBConversationMember.Columns.conversationId == originId)
                 .filter(DBConversationMember.Columns.inboxId == askerInboxId)
                 .fetchCount(db) > 0
+            let memberCount = try DBConversationMember
+                .filter(DBConversationMember.Columns.conversationId == originId)
+                .fetchCount(db)
             return OriginConsistencyCheck(
                 origin: origin,
                 userIsMember: userIsMember,
                 userDeparted: userDeparted,
-                agentIsMember: agentIsMember
+                agentIsMember: agentIsMember,
+                memberCount: memberCount
             )
         }
         guard let check, let origin = check.origin else {
@@ -168,12 +172,16 @@ extension CapabilityGrantScopeResolution {
         guard check.agentIsMember else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.agentNotInOrigin), scopeDisplayName: nil)
         }
-        // A grant must scope to a group conversation. The positive kind
-        // check rejects a marker steered at a plain DM (which has member
-        // rows and no agent-DM flag, so it passes every other guard); the
-        // agent-DM guard stays alongside it because an agent DM is itself a
-        // 2-member group -- kind alone would let it through.
-        guard origin.kind == .group else {
+        // A grant must scope to a real group, not a DM. `kind` cannot make
+        // that distinction here: every conversation is persisted `.group`
+        // (extraction hardcodes it, ConversationWriter -- there is no `.dm`
+        // write path), so DM-ness is carried by shape, not `kind`. A DM is
+        // exactly two members, so the member-count check is what rejects a
+        // marker steered at any 2-member conversation the viewer and asking
+        // agent share -- including one that dodged agent-DM classification
+        // (unmarked, or an unverified-agent chat that never sets isAgentDm).
+        // The isAgentDm guard stays as belt-and-braces for the marked case.
+        guard check.memberCount > 2 else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originNotAGroup), scopeDisplayName: nil)
         }
         guard !origin.isAgentDm else {
@@ -192,10 +200,15 @@ extension CapabilityGrantScopeResolution {
             let currentInboxId = try DBInbox.currentInboxId(db) ?? viewerInboxId
             return details?.hydrateConversation(currentInboxId: currentInboxId).displayName
         }
-        guard let originDisplayName, !originDisplayName.isEmpty else {
+        // A whitespace-only name (an explicit "   " passes computedDisplayName's
+        // non-empty check verbatim) would render a blank sheet while allowing
+        // approval -- a named-consent violation. Trim before the guard and
+        // disclose the trimmed value.
+        let trimmedName = originDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedName, !trimmedName.isEmpty else {
             return CapabilityGrantScopeResolution(scope: .unresolvableOrigin(.originUnidentifiable), scopeDisplayName: nil)
         }
-        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: originDisplayName)
+        return CapabilityGrantScopeResolution(scope: .originGroup(originId), scopeDisplayName: trimmedName)
     }
 
     private struct OriginConsistencyCheck {
@@ -203,5 +216,6 @@ extension CapabilityGrantScopeResolution {
         let userIsMember: Bool
         let userDeparted: Bool
         let agentIsMember: Bool
+        let memberCount: Int
     }
 }

--- a/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/CapabilityResolution/CapabilityRequestRepository.swift
@@ -18,6 +18,17 @@ import GRDB
 /// non-decision statuses never resolve it.
 public protocol CapabilityRequestRepositoryProtocol: Sendable {
     var pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> { get }
+
+    /// Resolves which conversation an approval's grant writes must scope to
+    /// (see `CapabilityGrantScope`). `isAgentDm` is the conversation's
+    /// persisted classification; `liveMarkerOrigin` reads the DM's own XMTP
+    /// appData marker and is consulted only when the local mirror row is
+    /// absent.
+    func resolveGrantScope(
+        isAgentDm: Bool,
+        askerInboxId: String,
+        liveMarkerOrigin: @escaping @Sendable () async -> String?
+    ) async -> CapabilityGrantScopeResolution
 }
 
 public final class CapabilityRequestRepository: CapabilityRequestRepositoryProtocol, @unchecked Sendable {
@@ -29,6 +40,21 @@ public final class CapabilityRequestRepository: CapabilityRequestRepositoryProto
         self.dbReader = dbReader
         self.conversationId = conversationId
         self.viewerInboxId = viewerInboxId
+    }
+
+    public func resolveGrantScope(
+        isAgentDm: Bool,
+        askerInboxId: String,
+        liveMarkerOrigin: @escaping @Sendable () async -> String?
+    ) async -> CapabilityGrantScopeResolution {
+        await CapabilityGrantScopeResolution.resolve(
+            conversationId: conversationId,
+            isAgentDm: isAgentDm,
+            askerInboxId: askerInboxId,
+            viewerInboxId: viewerInboxId,
+            dbReader: dbReader,
+            liveMarkerOrigin: liveMarkerOrigin
+        )
     }
 
     public lazy var pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> = {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -257,8 +257,13 @@ public final class MockInboxesService: SessionManagerProtocol, @unchecked Sendab
         InMemoryCapabilityResolver(registry: mockCapabilityRegistry)
     }
 
+    /// Test hook: when set, `capabilityRequestRepository(for:)` returns this
+    /// instead of the inert mock, so view-model tests can control grant-scope
+    /// resolutions (timing included).
+    public var capabilityRequestRepositoryOverride: (any CapabilityRequestRepositoryProtocol)?
+
     public func capabilityRequestRepository(for conversationId: String) -> any CapabilityRequestRepositoryProtocol {
-        MockCapabilityRequestRepository()
+        capabilityRequestRepositoryOverride ?? MockCapabilityRequestRepository()
     }
 
     public func deviceConnectionAuthorizer() -> any DeviceConnectionAuthorizer {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/MockInboxesService.swift
@@ -288,5 +288,13 @@ private struct MockDeviceConnectionAuthorizer: DeviceConnectionAuthorizer {
 }
 
 private final class MockCapabilityRequestRepository: CapabilityRequestRepositoryProtocol, @unchecked Sendable {
+    func resolveGrantScope(
+        isAgentDm: Bool,
+        askerInboxId: String,
+        liveMarkerOrigin: @escaping @Sendable () async -> String?
+    ) async -> CapabilityGrantScopeResolution {
+        CapabilityGrantScopeResolution(scope: .conversation("mock"), scopeDisplayName: "Mock Group")
+    }
+
     let pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> = Just(nil).eraseToAnyPublisher()
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContentType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageContentType.swift
@@ -20,7 +20,6 @@ public enum MessageContentType: String, Codable, Sendable {
         case .update,
              .assistantJoinRequest,
              .connectionGrantRequest,
-             .capabilityRequest,
              .capabilityRequestResult,
              .connectionEvent,
              .connectionInvocation,
@@ -28,6 +27,9 @@ public enum MessageContentType: String, Codable, Sendable {
              .connectionPayload:
             false
         default:
+            // capabilityRequest deliberately marks unread: a connect request
+            // in the member's 1:1 agent conversation is discovered through
+            // the Agent tab's unread dot, so the pill arriving must light it.
             true
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -1358,7 +1358,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
                 senderInboxId: message.senderInboxId,
                 currentInboxId: myInboxId,
                 conversationId: conversation.id,
-                activeConversationId: nil
+                activeConversationIds: []
             ) {
                 marksConversationAsUnread = true
             }

--- a/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/BatchCatchUp.swift
@@ -122,7 +122,7 @@ struct BatchCatchUp {
         client: any XMTPClientProvider,
         inboxId: String,
         since: Date?,
-        activeConversationId: String?,
+        activeConversationIds: Set<String>,
         fetchFromBeginning: Bool = false,
         syncPerConversation: Bool = false
     ) async throws -> BatchCatchUpResult {
@@ -181,7 +181,7 @@ struct BatchCatchUp {
             try Self.persistPreparedEntries(
                 prepared,
                 inboxId: inboxId,
-                activeConversationId: activeConversationId,
+                activeConversationIds: activeConversationIds,
                 conversationWriter: conversationWriter,
                 messageWriter: messageWriter,
                 in: db
@@ -310,7 +310,7 @@ struct BatchCatchUp {
     private static func persistPreparedEntries(
         _ prepared: [PreparedEntry],
         inboxId: String,
-        activeConversationId: String?,
+        activeConversationIds: Set<String>,
         conversationWriter: ConversationWriter,
         messageWriter: IncomingMessageWriter,
         in db: Database
@@ -350,7 +350,7 @@ struct BatchCatchUp {
                     senderInboxId: preparedMessage.source.senderInboxId,
                     currentInboxId: inboxId,
                     conversationId: entry.conversation.dbConversation.id,
-                    activeConversationId: activeConversationId
+                    activeConversationIds: activeConversationIds
                 ) {
                     entryMarksUnread = true
                 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/CaughtUpMessageRouting.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/CaughtUpMessageRouting.swift
@@ -56,17 +56,19 @@ enum CaughtUpMessageKind {
 /// Whether a newly-persisted message should mark its conversation unread,
 /// applied identically by every ingest path. A message marks unread when its
 /// content type is user-visible (`marksConversationAsUnread`), it came from
-/// someone other than us, and it isn't the conversation the user is currently
-/// viewing. Pass `activeConversationId: nil` from contexts with no active
-/// conversation (push, conversation discovery).
+/// someone other than us, and it isn't a conversation the user is currently
+/// viewing. `activeConversationIds` is a set because the conversation screen
+/// can have two live surfaces at once: the group and its folded agent DM
+/// (the Agent tab); each registers separately. Pass `[]` from contexts with
+/// no active conversation (push, conversation discovery).
 func marksConversationUnread(
     contentType: MessageContentType,
     senderInboxId: String,
     currentInboxId: String,
     conversationId: String,
-    activeConversationId: String?
+    activeConversationIds: Set<String>
 ) -> Bool {
     contentType.marksConversationAsUnread
         && senderInboxId != currentInboxId
-        && conversationId != activeConversationId
+        && !activeConversationIds.contains(conversationId)
 }

--- a/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/StreamProcessor.swift
@@ -25,7 +25,7 @@ protocol StreamProcessorProtocol: Actor {
     func processMessage(
         _ message: DecodedMessage,
         params: SyncClientParams,
-        activeConversationId: String?
+        activeConversationIds: Set<String>
     ) async
 
     func reconcilePushSubscriptions(params: SyncClientParams, context: String) async
@@ -258,7 +258,7 @@ actor StreamProcessor: StreamProcessorProtocol {
     func processMessage(
         _ message: DecodedMessage,
         params: SyncClientParams,
-        activeConversationId: String?
+        activeConversationIds: Set<String>
     ) async {
         if handleFastPaths(message: message, params: params) { return }
 
@@ -350,7 +350,7 @@ actor StreamProcessor: StreamProcessorProtocol {
                         senderInboxId: message.senderInboxId,
                         currentInboxId: params.client.inboxId,
                         conversationId: conversation.id,
-                        activeConversationId: activeConversationId
+                        activeConversationIds: activeConversationIds
                     ) {
                         try await localStateWriter.setUnread(true, for: conversation.id)
                     }

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -168,6 +168,10 @@ actor SyncingManager: SyncingManagerProtocol {
     private var agentTemplateCacheCoordinator: AgentTemplateCacheCoordinator?
 
     private var activeConversationId: String?
+    /// The folded agent DM currently on screen (the Agent tab), tracked
+    /// separately: the DM is its own conversation whose id never appears in
+    /// `activeConversationChanged` (that carries the parent group id).
+    private var activeDmConversationId: String?
 
     // Stream readiness tracking - used to wait for streams to subscribe before signaling ready
     private var messageStreamReadyContinuation: AsyncStream<Void>.Continuation?
@@ -408,7 +412,7 @@ actor SyncingManager: SyncingManagerProtocol {
                 client: client,
                 inboxId: identity.inboxId,
                 since: since,
-                activeConversationId: await activeConversationId,
+                activeConversationIds: await activeConversationIds,
                 fetchFromBeginning: fetchFromBeginning,
                 syncPerConversation: syncPerConversation
             )
@@ -1069,7 +1073,7 @@ actor SyncingManager: SyncingManagerProtocol {
                     await streamProcessor.processMessage(
                         message,
                         params: params,
-                        activeConversationId: activeConversationId
+                        activeConversationIds: activeConversationIds
                     )
                 }
 
@@ -1168,6 +1172,16 @@ extension SyncingManager {
     func setActiveConversationId(_ conversationId: String?) {
         // Update the active conversation
         activeConversationId = conversationId
+    }
+
+    func setActiveDmConversationId(_ conversationId: String?) {
+        activeDmConversationId = conversationId
+    }
+
+    /// The conversations exempt from unread marking right now: the active
+    /// group and, when the Agent tab is up, its folded DM.
+    var activeConversationIds: Set<String> {
+        Set([activeConversationId, activeDmConversationId].compactMap { $0 })
     }
 
     func setInviteJoinErrorHandler(_ handler: (any InviteJoinErrorHandler)?) async {
@@ -1309,6 +1323,17 @@ extension SyncingManager {
             }
         }
         notificationObservers.append(activeConversationObserver)
+        let activeDmObserver = NotificationCenter.default.addObserver(
+            forName: .activeDmConversationChanged,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            let conversationId = notification.userInfo?["conversationId"] as? String
+            Task { [weak self] in
+                await self?.setActiveDmConversationId(conversationId)
+            }
+        }
+        notificationObservers.append(activeDmObserver)
         installPushTokenObserver()
     }
 

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/AgentVerificationDowngradeTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/AgentVerificationDowngradeTests.swift
@@ -113,7 +113,7 @@ struct AgentVerificationDowngradeTests {
         let updateMsg = try #require(messages.first {
             (try? $0.encodedContent.type) == ContentTypeProfileUpdate
         })
-        await processor.processMessage(updateMsg, params: params, activeConversationId: nil)
+        await processor.processMessage(updateMsg, params: params, activeConversationIds: [])
 
         let postMemberKind = try await fixtures.databaseManager.dbReader.read { db in
             try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: inboxIdA)?.memberKind
@@ -192,7 +192,7 @@ struct AgentVerificationDowngradeTests {
         let snapshotMsg = try #require(messages.first {
             (try? $0.encodedContent.type) == ContentTypeProfileSnapshot
         })
-        await processor.processMessage(snapshotMsg, params: params, activeConversationId: nil)
+        await processor.processMessage(snapshotMsg, params: params, activeConversationIds: [])
 
         let postMemberKind = try await fixtures.databaseManager.dbReader.read { db in
             try DBMemberProfile.fetchOne(db, conversationId: group.id, inboxId: inboxIdA)?.memberKind

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/BatchCatchUpIntegrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/Integration/BatchCatchUpIntegrationTests.swift
@@ -93,7 +93,7 @@ struct BatchCatchUpIntegrationTests {
         let counter = CommitCounter()
         fixtures.databaseManager.dbWriter.add(transactionObserver: counter)
 
-        let result = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+        let result = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationIds: [])
 
         // Headline assertions: the batch saw the conversation and at least
         // all N user messages. libxmtp emits group-membership update messages
@@ -166,7 +166,7 @@ struct BatchCatchUpIntegrationTests {
 
         // First batch persists the conversation row - the state a freshly
         // paired installation is in right after welcomes are ingested.
-        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationIds: [])
 
         // Now messages land in libxmtp's local database while the app-side
         // cursor sits ahead of their sentNs - the exact state a history-
@@ -198,7 +198,7 @@ struct BatchCatchUpIntegrationTests {
         // A forward-only batch fetches afterNs: cursor and must miss the
         // older messages entirely - this is the bug shape the backfill
         // exists for.
-        let forwardOnly = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+        let forwardOnly = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationIds: [])
         #expect(forwardOnly.messagesProcessed == 0, "Forward-only batch should see nothing behind the cursor, got \(forwardOnly.messagesProcessed)")
 
         // The backfill ignores the cursor and re-ingests everything.
@@ -206,7 +206,7 @@ struct BatchCatchUpIntegrationTests {
             client: clientB,
             inboxId: inboxIdB,
             since: nil,
-            activeConversationId: nil,
+            activeConversationIds: [],
             fetchFromBeginning: true
         )
         #expect(backfill.messagesProcessed >= messageCount, "Backfill should ingest the \(messageCount) pre-cursor messages, got \(backfill.messagesProcessed)")
@@ -271,7 +271,7 @@ struct BatchCatchUpIntegrationTests {
             client: clientB,
             inboxId: inboxIdB,
             since: nil,
-            activeConversationId: group.id
+            activeConversationIds: [group.id]
         )
 
         #expect(result.messagesProcessed >= messageCount, "Expected at least \(messageCount) messages persisted, got \(result.messagesProcessed)")
@@ -337,7 +337,7 @@ struct BatchCatchUpIntegrationTests {
             databaseWriter: fixtures.databaseManager.dbWriter
         )
 
-        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationIds: [])
 
         // The backlog thinking message lands in the thinking-session store...
         let thinkingMomentCount = try await fixtures.databaseManager.dbReader.read { db in
@@ -396,7 +396,7 @@ struct BatchCatchUpIntegrationTests {
             client: clientB,
             inboxId: inboxIdB,
             since: Date(timeIntervalSinceNow: 60),
-            activeConversationId: nil
+            activeConversationIds: []
         )
 
         #expect(result.conversationsProcessed == 0, "Expected 0 changed conversations, got \(result.conversationsProcessed)")
@@ -443,7 +443,7 @@ struct BatchCatchUpIntegrationTests {
             messageWriter: messageWriter,
             databaseWriter: fixtures.databaseManager.dbWriter
         )
-        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationIds: [])
 
         let seededCursor = try await fixtures.databaseManager.dbReader.read { db in
             try DBConversationCatchUpCursor.caughtUpToNs(for: group.id, in: db)
@@ -482,7 +482,7 @@ struct BatchCatchUpIntegrationTests {
             ).insert(db)
         }
 
-        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationId: nil)
+        _ = try await batch.run(client: clientB, inboxId: inboxIdB, since: nil, activeConversationIds: [])
 
         // The read receipt behind the pushed message must have been fetched
         // and stored.

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityConnectTranscriptTests.swift
@@ -534,6 +534,27 @@ struct CapabilityConnectTranscriptTests {
         #expect(try harness.fetchPrompt(requestId: "req-2")?.status == .pending)
         #expect(try harness.latestPendingRequestId() == "req-2")
     }
+
+    // MARK: - Agent DM fixture
+
+    @Test("a pending request in an agent DM derives per-viewer exactly like a group")
+    func dmFixtureDerivesPerViewer() throws {
+        let harness = try HydrationHarness(asker: asker, approver: approver)
+        try harness.dbManager.dbWriter.write { db in
+            try db.execute(
+                sql: "UPDATE conversation SET isAgentDm = 1 WHERE id = ?",
+                arguments: [harness.conversationId]
+            )
+        }
+        try harness.insertRequestRow(makeRequest(), sortId: 1)
+        let pending = try #require(try harness.fetchPrompt())
+        #expect(pending.status == .pending)
+        // The viewer's own approval resolves it; per-viewer rules are
+        // unchanged by the DM classification.
+        try harness.insertResultRow(requestId: "req-1", senderId: harness.currentInboxId, status: .approved, sortId: 2)
+        let connected = try #require(try harness.fetchPrompt())
+        #expect(connected.status == .connected)
+    }
 }
 
 // MARK: - GRDB harness

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
@@ -1,0 +1,293 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+/// Origin-scoping for approvals raised in an agent DM: grant-side writes
+/// must target the DM's origin group (a DM-scoped grant authorizes nothing
+/// backend-side), an unresolvable origin blocks the approval instead of
+/// silently falling through to the DM id, and a resolved scope always names
+/// its target so the sheet can disclose it.
+@Suite("Capability grant scope resolution")
+struct CapabilityGrantScopeResolutionTests {
+    private let dmId: String = "agent-dm-1"
+    private let originId: String = "origin-group-1"
+    private let viewer: String = "current-user"
+    private let agent: String = "asker-agent"
+
+    private struct Fixture {
+        let dbManager: any DatabaseManagerProtocol
+
+        var dbReader: any DatabaseReader { dbManager.dbReader }
+        var dbWriter: any DatabaseWriter { dbManager.dbWriter }
+    }
+
+    private func makeFixture() -> Fixture {
+        Fixture(dbManager: MockDatabaseManager.makeTestDatabase())
+    }
+
+    private func seedConversation(
+        _ db: Database,
+        id: String,
+        name: String?,
+        isAgentDm: Bool,
+        members: [String]
+    ) throws {
+        for inboxId in members {
+            try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
+        }
+        try DBConversation(
+            id: id,
+            clientConversationId: "client-\(id)",
+            inviteTag: "invite-\(id)",
+            creatorId: members.first ?? "creator",
+            kind: .group,
+            consent: .allowed,
+            createdAt: Date(),
+            name: name,
+            description: nil,
+            imageURLString: nil,
+            publicImageURLString: nil,
+            includeInfoInPublicPreview: false,
+            expiresAt: nil,
+            debugInfo: .empty,
+            isLocked: false,
+            imageSalt: nil,
+            imageNonce: nil,
+            imageEncryptionKey: nil,
+            conversationEmoji: nil,
+            imageLastRenewed: nil,
+            isUnused: false,
+            hasHadVerifiedAgent: false,
+            isAgentDm: isAgentDm
+        ).insert(db)
+        for (index, inboxId) in members.enumerated() {
+            try DBConversationMember(
+                conversationId: id,
+                inboxId: inboxId,
+                role: index == 0 ? .superAdmin : .member,
+                consent: .allowed,
+                createdAt: Date(),
+                invitedByInboxId: nil
+            ).insert(db)
+        }
+    }
+
+    /// Seeds the standard shape: an agent DM (viewer + agent) plus an origin
+    /// group whose membership the caller controls.
+    private func seedDmAndOrigin(
+        _ fixture: Fixture,
+        originName: String? = "Space Camp",
+        originMembers: [String]? = nil,
+        recordOriginRow: Bool = true
+    ) throws {
+        try fixture.dbWriter.write { db in
+            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
+            try seedConversation(
+                db,
+                id: originId,
+                name: originName,
+                isAgentDm: false,
+                members: originMembers ?? [viewer, agent, "other-member"]
+            )
+            if recordOriginRow {
+                try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: originId, in: db)
+            }
+        }
+    }
+
+    private func resolve(
+        _ fixture: Fixture,
+        conversationId: String,
+        isAgentDm: Bool = true,
+        liveMarkerOrigin: @escaping @Sendable () async -> String? = { nil }
+    ) async -> CapabilityGrantScopeResolution {
+        await CapabilityGrantScopeResolution.resolve(
+            conversationId: conversationId,
+            isAgentDm: isAgentDm,
+            askerInboxId: agent,
+            viewerInboxId: viewer,
+            dbReader: fixture.dbReader,
+            liveMarkerOrigin: liveMarkerOrigin
+        )
+    }
+
+    @Test("a plain group scopes to itself with its own name — today's exact behavior")
+    func plainGroupScopesToItself() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: "group-1", name: "Weekend Plans", isAgentDm: false, members: [viewer, agent])
+        }
+        let resolution = await resolve(fixture, conversationId: "group-1", isAgentDm: false)
+        #expect(resolution.scope == .conversation("group-1"))
+        #expect(resolution.scope.grantScopeConversationId == "group-1")
+        #expect(resolution.scopeDisplayName == "Weekend Plans")
+    }
+
+    @Test("an agent DM with an origin row scopes to the origin group and names it")
+    func dmWithOriginRowScopesToOrigin() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture)
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .originGroup(originId))
+        #expect(resolution.scope.grantScopeConversationId == originId)
+        #expect(resolution.scopeDisplayName == "Space Camp")
+    }
+
+    @Test("the live appData marker is not consulted when the mirror row exists")
+    func markerNotConsultedWhenRowPresent() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture)
+        let consulted = MarkerProbe()
+        _ = await resolve(fixture, conversationId: dmId, liveMarkerOrigin: {
+            consulted.trip()
+            return nil
+        })
+        #expect(consulted.tripped == false)
+    }
+
+    @Test("a missing mirror row falls back to the live appData marker")
+    func dmWithoutRowFallsBackToMarker() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture, recordOriginRow: false)
+        let originId = self.originId
+        let resolution = await resolve(fixture, conversationId: dmId, liveMarkerOrigin: { originId })
+        #expect(resolution.scope == .originGroup(originId))
+        #expect(resolution.scopeDisplayName == "Space Camp")
+    }
+
+    @Test("no row and no marker blocks the approval with the still-syncing copy")
+    func dmWithoutRowOrMarkerBlocks() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture, recordOriginRow: false)
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originUnknown))
+        #expect(resolution.scope.grantScopeConversationId == nil)
+        #expect(resolution.scopeDisplayName == nil)
+        #expect(CapabilityGrantScopeBlockReason.originUnknown.userFacingMessage.contains("still syncing"))
+    }
+
+    @Test("an origin the device has not synced blocks with the still-syncing copy")
+    func dmOriginNotSyncedBlocks() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: "never-synced", in: db)
+        }
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originNotSynced))
+        #expect(CapabilityGrantScopeBlockReason.originNotSynced.userFacingMessage.contains("still syncing"))
+    }
+
+    @Test("a departed origin blocks with the no-longer-in copy")
+    func dmDepartedOriginBlocks() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture, originMembers: [agent, "other-member"])
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.userNotInOrigin))
+        #expect(CapabilityGrantScopeBlockReason.userNotInOrigin.userFacingMessage == "This request belongs to a conversation you're no longer in.")
+    }
+
+    @Test("a recorded departure blocks even while the member row is still present")
+    func dmRecordedDepartureBlocks() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture)
+        try await fixture.dbWriter.write { [self] db in
+            try DBMemberDeparture(conversationId: originId, inboxId: viewer, dateNs: 1).insert(db)
+        }
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.userNotInOrigin))
+    }
+
+    @Test("an origin the asking agent is no longer in blocks — rebind staleness")
+    func dmAgentNotInOriginBlocks() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture, originMembers: [viewer, "other-member"])
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.agentNotInOrigin))
+        #expect(CapabilityGrantScopeBlockReason.agentNotInOrigin.userFacingMessage.contains("still syncing"))
+    }
+
+    @Test("a resolved scope is always named — a nameless origin gets the fallback noun")
+    func resolvedScopeAlwaysNamed() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture, originName: nil)
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .originGroup(originId))
+        #expect(resolution.scopeDisplayName == "your group chat")
+    }
+
+    @Test("the repository seam resolves the same DM fixture the view model hands it")
+    func repositorySeamResolvesDmFixture() async throws {
+        let fixture = makeFixture()
+        try seedDmAndOrigin(fixture)
+        let repository = CapabilityRequestRepository(
+            dbReader: fixture.dbReader,
+            conversationId: dmId,
+            viewerInboxId: viewer
+        )
+        let resolution = await repository.resolveGrantScope(
+            isAgentDm: true,
+            askerInboxId: agent,
+            liveMarkerOrigin: { nil }
+        )
+        #expect(resolution.scope == .originGroup(originId))
+        #expect(resolution.scopeDisplayName == "Space Camp")
+    }
+
+    private final class MarkerProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Bool = false
+        var tripped: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+        func trip() {
+            lock.lock()
+            defer { lock.unlock() }
+            value = true
+        }
+    }
+}
+
+/// The Agent tab's discoverability surface is the unread dot: a connect
+/// request arriving in the member's 1:1 must light it, while result rows and
+/// the member's own messages must not.
+@Suite("Capability request unread marking")
+struct CapabilityRequestUnreadTests {
+    @Test("a capability request marks the conversation unread")
+    func capabilityRequestMarksUnread() {
+        #expect(MessageContentType.capabilityRequest.marksConversationAsUnread)
+        #expect(marksConversationUnread(
+            contentType: .capabilityRequest,
+            senderInboxId: "agent",
+            currentInboxId: "me",
+            conversationId: "dm-1",
+            activeConversationId: nil
+        ))
+    }
+
+    @Test("a capability result does not mark unread")
+    func capabilityResultDoesNotMarkUnread() {
+        #expect(MessageContentType.capabilityRequestResult.marksConversationAsUnread == false)
+    }
+
+    @Test("the viewer's own messages and the active conversation stay exempt")
+    func unreadExemptionsHold() {
+        #expect(marksConversationUnread(
+            contentType: .capabilityRequest,
+            senderInboxId: "me",
+            currentInboxId: "me",
+            conversationId: "dm-1",
+            activeConversationId: nil
+        ) == false)
+        #expect(marksConversationUnread(
+            contentType: .capabilityRequest,
+            senderInboxId: "agent",
+            currentInboxId: "me",
+            conversationId: "dm-1",
+            activeConversationId: "dm-1"
+        ) == false)
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
@@ -32,6 +32,7 @@ struct CapabilityGrantScopeResolutionTests {
         name: String?,
         isAgentDm: Bool,
         members: [String],
+        kind: ConversationKind = .group,
         withLocalState: Bool = true
     ) throws {
         for inboxId in members {
@@ -42,7 +43,7 @@ struct CapabilityGrantScopeResolutionTests {
             clientConversationId: "client-\(id)",
             inviteTag: "invite-\(id)",
             creatorId: members.first ?? "creator",
-            kind: .group,
+            kind: kind,
             consent: .allowed,
             createdAt: Date(),
             name: name,
@@ -255,6 +256,22 @@ struct CapabilityGrantScopeResolutionTests {
         try await fixture.dbWriter.write { [self] db in
             try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
             try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: dmId, in: db)
+        }
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originNotAGroup))
+        #expect(resolution.scope.grantScopeConversationId == nil)
+    }
+
+    @Test("an origin that is a plain DM blocks — a grant must scope to a group")
+    func originBeingPlainDmBlocks() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
+            // An ordinary .dm the viewer and asking agent share: it has
+            // member rows and no agent-DM flag, so only the positive
+            // group-kind check can stop a marker steered at it.
+            try seedConversation(db, id: "plain-dm", name: nil, isAgentDm: false, members: [viewer, agent], kind: .dm)
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: "plain-dm", in: db)
         }
         let resolution = await resolve(fixture, conversationId: dmId)
         #expect(resolution.scope == .unresolvableOrigin(.originNotAGroup))

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
@@ -31,7 +31,8 @@ struct CapabilityGrantScopeResolutionTests {
         id: String,
         name: String?,
         isAgentDm: Bool,
-        members: [String]
+        members: [String],
+        withLocalState: Bool = true
     ) throws {
         for inboxId in members {
             try DBMember(inboxId: inboxId).save(db, onConflict: .ignore)
@@ -61,6 +62,21 @@ struct CapabilityGrantScopeResolutionTests {
             hasHadVerifiedAgent: false,
             isAgentDm: isAgentDm
         ).insert(db)
+        if withLocalState {
+            try ConversationLocalState(
+                conversationId: id,
+                isPinned: false,
+                isUnread: false,
+                isUnreadUpdatedAt: Date(),
+                isMuted: false,
+                pinnedOrder: nil,
+                hidesInviteCard: false,
+                leftHostedInviteSession: false,
+                wasRemoved: false,
+                hasHadOtherMembers: false,
+                hasSharedInvite: false
+            ).insert(db)
+        }
         for (index, inboxId) in members.enumerated() {
             try DBConversationMember(
                 conversationId: id,
@@ -208,13 +224,29 @@ struct CapabilityGrantScopeResolutionTests {
         #expect(CapabilityGrantScopeBlockReason.agentNotInOrigin.userFacingMessage.contains("still syncing"))
     }
 
-    @Test("a nameless origin blocks — consent cannot name a group that has no name")
-    func namelessOriginBlocks() async throws {
+    @Test("an unnamed origin approves with its member-derived identity — the same name the rest of the app shows")
+    func unnamedOriginApprovesWithDerivedName() async throws {
         let fixture = makeFixture()
         try seedDmAndOrigin(fixture, originName: nil)
         let resolution = await resolve(fixture, conversationId: dmId)
-        #expect(resolution.scope == .unresolvableOrigin(.originUnnamed))
-        #expect(resolution.scopeDisplayName == nil)
+        #expect(resolution.scope == .originGroup(originId))
+        let name = try #require(resolution.scopeDisplayName)
+        #expect(!name.isEmpty)
+    }
+
+    @Test("an origin whose identity cannot be derived blocks with honest copy")
+    func unidentifiableOriginBlocks() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
+            // No local-state row: the identity hydration's required join
+            // fails, modelling a partially synced origin.
+            try seedConversation(db, id: originId, name: nil, isAgentDm: false, members: [viewer, agent], withLocalState: false)
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: originId, in: db)
+        }
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originUnidentifiable))
+        #expect(CapabilityGrantScopeBlockReason.originUnidentifiable.userFacingMessage == "Can't identify the conversation this request belongs to.")
     }
 
     @Test("an origin marker naming the DM itself blocks — member-writable input must not steer the scope")

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
@@ -32,7 +32,6 @@ struct CapabilityGrantScopeResolutionTests {
         name: String?,
         isAgentDm: Bool,
         members: [String],
-        kind: ConversationKind = .group,
         withLocalState: Bool = true
     ) throws {
         for inboxId in members {
@@ -43,7 +42,10 @@ struct CapabilityGrantScopeResolutionTests {
             clientConversationId: "client-\(id)",
             inviteTag: "invite-\(id)",
             creatorId: members.first ?? "creator",
-            kind: kind,
+            // Production persists every conversation as `.group` (extraction
+            // hardcodes it; there is no `.dm` write path), so DM-shaped
+            // fixtures must be 2-member `.group` rows, never `.dm`.
+            kind: .group,
             consent: .allowed,
             createdAt: Date(),
             name: name,
@@ -240,9 +242,10 @@ struct CapabilityGrantScopeResolutionTests {
         let fixture = makeFixture()
         try await fixture.dbWriter.write { [self] db in
             try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
-            // No local-state row: the identity hydration's required join
-            // fails, modelling a partially synced origin.
-            try seedConversation(db, id: originId, name: nil, isAgentDm: false, members: [viewer, agent], withLocalState: false)
+            // Three members so the member-count check passes; no local-state
+            // row, so the identity hydration's required join fails -- the block
+            // must come from an underivable identity, not from the shape.
+            try seedConversation(db, id: originId, name: nil, isAgentDm: false, members: [viewer, agent, "other-member"], withLocalState: false)
             try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: originId, in: db)
         }
         let resolution = await resolve(fixture, conversationId: dmId)
@@ -266,16 +269,29 @@ struct CapabilityGrantScopeResolutionTests {
     func originBeingPlainDmBlocks() async throws {
         let fixture = makeFixture()
         try await fixture.dbWriter.write { [self] db in
-            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
-            // An ordinary .dm the viewer and asking agent share: it has
-            // member rows and no agent-DM flag, so only the positive
-            // group-kind check can stop a marker steered at it.
-            try seedConversation(db, id: "plain-dm", name: nil, isAgentDm: false, members: [viewer, agent], kind: .dm)
+            try seedConversation(db, id: dmId, name: "Sidekick chat", isAgentDm: true, members: [viewer, agent])
+            // A DM the viewer and asking agent share, in its real production
+            // shape: exactly two members, kind `.group` (the only kind
+            // production writes), and no agent-DM flag (it dodged
+            // classification -- unmarked, or an unverified-agent chat). Every
+            // membership guard passes; only the member-count check stops it.
+            try seedConversation(db, id: "plain-dm", name: "Sidekick chat", isAgentDm: false, members: [viewer, agent])
             try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: "plain-dm", in: db)
         }
         let resolution = await resolve(fixture, conversationId: dmId)
         #expect(resolution.scope == .unresolvableOrigin(.originNotAGroup))
         #expect(resolution.scope.grantScopeConversationId == nil)
+    }
+
+    @Test("a whitespace-only origin name blocks — a blank sheet is not named consent")
+    func whitespaceOnlyOriginNameBlocks() async throws {
+        let fixture = makeFixture()
+        // Three members so the member-count check passes; the block must come
+        // from the name being blank after trimming, not from the shape.
+        try seedDmAndOrigin(fixture, originName: "   ")
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originUnidentifiable))
+        #expect(resolution.scopeDisplayName == nil)
     }
 
     @Test("an origin that is itself an agent DM blocks")

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
@@ -208,13 +208,50 @@ struct CapabilityGrantScopeResolutionTests {
         #expect(CapabilityGrantScopeBlockReason.agentNotInOrigin.userFacingMessage.contains("still syncing"))
     }
 
-    @Test("a resolved scope is always named — a nameless origin gets the fallback noun")
-    func resolvedScopeAlwaysNamed() async throws {
+    @Test("a nameless origin blocks — consent cannot name a group that has no name")
+    func namelessOriginBlocks() async throws {
         let fixture = makeFixture()
         try seedDmAndOrigin(fixture, originName: nil)
         let resolution = await resolve(fixture, conversationId: dmId)
-        #expect(resolution.scope == .originGroup(originId))
-        #expect(resolution.scopeDisplayName == "your group chat")
+        #expect(resolution.scope == .unresolvableOrigin(.originUnnamed))
+        #expect(resolution.scopeDisplayName == nil)
+    }
+
+    @Test("an origin marker naming the DM itself blocks — member-writable input must not steer the scope")
+    func originNamingDmItselfBlocks() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: dmId, in: db)
+        }
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originNotAGroup))
+        #expect(resolution.scope.grantScopeConversationId == nil)
+    }
+
+    @Test("an origin that is itself an agent DM blocks")
+    func originBeingAnotherAgentDmBlocks() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
+            // A second agent DM the viewer and agent share: every membership
+            // check passes, so only the not-a-group guard can stop it.
+            try seedConversation(db, id: "other-agent-dm", name: "Sneaky", isAgentDm: true, members: [viewer, agent])
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: "other-agent-dm", in: db)
+        }
+        let resolution = await resolve(fixture, conversationId: dmId)
+        #expect(resolution.scope == .unresolvableOrigin(.originNotAGroup))
+    }
+
+    @Test("a nameless plain group keeps a nil name for the view model's own-conversation fallback")
+    func namelessPlainGroupKeepsNilName() async throws {
+        let fixture = makeFixture()
+        try await fixture.dbWriter.write { [self] db in
+            try seedConversation(db, id: "group-unnamed", name: nil, isAgentDm: false, members: [viewer, agent])
+        }
+        let resolution = await resolve(fixture, conversationId: "group-unnamed", isAgentDm: false)
+        #expect(resolution.scope == .conversation("group-unnamed"))
+        #expect(resolution.scopeDisplayName == nil)
     }
 
     @Test("the repository seam resolves the same DM fixture the view model hands it")
@@ -264,7 +301,7 @@ struct CapabilityRequestUnreadTests {
             senderInboxId: "agent",
             currentInboxId: "me",
             conversationId: "dm-1",
-            activeConversationId: nil
+            activeConversationIds: []
         ))
     }
 
@@ -280,14 +317,37 @@ struct CapabilityRequestUnreadTests {
             senderInboxId: "me",
             currentInboxId: "me",
             conversationId: "dm-1",
-            activeConversationId: nil
+            activeConversationIds: []
         ) == false)
         #expect(marksConversationUnread(
             contentType: .capabilityRequest,
             senderInboxId: "agent",
             currentInboxId: "me",
             conversationId: "dm-1",
-            activeConversationId: "dm-1"
+            activeConversationIds: ["dm-1"]
         ) == false)
+    }
+
+    @Test("the open agent DM is exempt alongside its parent group")
+    func activeDmExemptWithParentGroup() {
+        // The conversation screen registers both surfaces: the group (its
+        // tab bar) and the folded DM (the Agent tab). A request arriving in
+        // the DM the user is reading must not mark it unread; a different
+        // DM's request still does.
+        let active: Set<String> = ["group-1", "dm-1"]
+        #expect(marksConversationUnread(
+            contentType: .capabilityRequest,
+            senderInboxId: "agent",
+            currentInboxId: "me",
+            conversationId: "dm-1",
+            activeConversationIds: active
+        ) == false)
+        #expect(marksConversationUnread(
+            contentType: .capabilityRequest,
+            senderInboxId: "agent",
+            currentInboxId: "me",
+            conversationId: "dm-2",
+            activeConversationIds: active
+        ))
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CapabilityGrantScopeResolutionTests.swift
@@ -242,9 +242,8 @@ struct CapabilityGrantScopeResolutionTests {
         let fixture = makeFixture()
         try await fixture.dbWriter.write { [self] db in
             try seedConversation(db, id: dmId, name: nil, isAgentDm: true, members: [viewer, agent])
-            // Three members so the member-count check passes; no local-state
-            // row, so the identity hydration's required join fails -- the block
-            // must come from an underivable identity, not from the shape.
+            // No local-state row, so the identity hydration's required join
+            // fails -- the block must come from an underivable identity.
             try seedConversation(db, id: originId, name: nil, isAgentDm: false, members: [viewer, agent, "other-member"], withLocalState: false)
             try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: originId, in: db)
         }
@@ -265,29 +264,28 @@ struct CapabilityGrantScopeResolutionTests {
         #expect(resolution.scope.grantScopeConversationId == nil)
     }
 
-    @Test("an origin that is a plain DM blocks — a grant must scope to a group")
-    func originBeingPlainDmBlocks() async throws {
+    @Test("a group that shrank to the viewer and agent still resolves — membership is mutable, not a DM signal")
+    func shrunkTwoMemberGroupResolves() async throws {
         let fixture = makeFixture()
         try await fixture.dbWriter.write { [self] db in
             try seedConversation(db, id: dmId, name: "Sidekick chat", isAgentDm: true, members: [viewer, agent])
-            // A DM the viewer and asking agent share, in its real production
-            // shape: exactly two members, kind `.group` (the only kind
-            // production writes), and no agent-DM flag (it dodged
-            // classification -- unmarked, or an unverified-agent chat). Every
-            // membership guard passes; only the member-count check stops it.
-            try seedConversation(db, id: "plain-dm", name: "Sidekick chat", isAgentDm: false, members: [viewer, agent])
-            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: "plain-dm", in: db)
+            // A legitimate group whose other members left: only the viewer and
+            // the asking agent remain (2 members), kind `.group`, no agent-DM
+            // flag. It is indistinguishable in persisted state from an unmarked
+            // 2-member DM, so it must resolve -- blocking it (as the reverted
+            // member-count gate did) is the availability regression.
+            try seedConversation(db, id: originId, name: "Weekend Plans", isAgentDm: false, members: [viewer, agent])
+            try DBAgentDmOrigin.record(conversationId: dmId, originConversationId: originId, in: db)
         }
         let resolution = await resolve(fixture, conversationId: dmId)
-        #expect(resolution.scope == .unresolvableOrigin(.originNotAGroup))
-        #expect(resolution.scope.grantScopeConversationId == nil)
+        #expect(resolution.scope == .originGroup(originId))
+        #expect(resolution.scopeDisplayName == "Weekend Plans")
     }
 
     @Test("a whitespace-only origin name blocks — a blank sheet is not named consent")
     func whitespaceOnlyOriginNameBlocks() async throws {
         let fixture = makeFixture()
-        // Three members so the member-count check passes; the block must come
-        // from the name being blank after trimming, not from the shape.
+        // The block must come from the name being blank after trimming.
         try seedDmAndOrigin(fixture, originName: "   ")
         let resolution = await resolve(fixture, conversationId: dmId)
         #expect(resolution.scope == .unresolvableOrigin(.originUnidentifiable))

--- a/ConvosCore/Tests/ConvosCoreTests/CaughtUpMessageRoutingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CaughtUpMessageRoutingTests.swift
@@ -15,7 +15,7 @@ struct CaughtUpMessageRoutingTests {
             senderInboxId: other,
             currentInboxId: me,
             conversationId: conversationId,
-            activeConversationId: nil
+            activeConversationIds: []
         ))
     }
 
@@ -26,7 +26,7 @@ struct CaughtUpMessageRoutingTests {
             senderInboxId: me,
             currentInboxId: me,
             conversationId: conversationId,
-            activeConversationId: nil
+            activeConversationIds: []
         ))
     }
 
@@ -37,7 +37,7 @@ struct CaughtUpMessageRoutingTests {
             senderInboxId: other,
             currentInboxId: me,
             conversationId: conversationId,
-            activeConversationId: conversationId
+            activeConversationIds: [conversationId]
         ))
     }
 
@@ -48,7 +48,7 @@ struct CaughtUpMessageRoutingTests {
             senderInboxId: other,
             currentInboxId: me,
             conversationId: conversationId,
-            activeConversationId: "some-other-conversation"
+            activeConversationIds: ["some-other-conversation"]
         ))
     }
 
@@ -64,7 +64,7 @@ struct CaughtUpMessageRoutingTests {
                 senderInboxId: other,
                 currentInboxId: me,
                 conversationId: conversationId,
-                activeConversationId: nil
+                activeConversationIds: []
             ), "\(contentType) should not mark unread")
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/CaughtUpMessageRoutingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/CaughtUpMessageRoutingTests.swift
@@ -54,9 +54,11 @@ struct CaughtUpMessageRoutingTests {
 
     @Test("Does not mark unread for content types that never mark unread")
     func skipsNonUnreadContentTypes() {
-        // `.update` (group membership) and the connection/capability silent
-        // types never mark a conversation unread, even from another sender.
-        for contentType: MessageContentType in [.update, .connectionEvent, .capabilityRequest, .connectionInvocation] {
+        // `.update` (group membership) and the connection silent types never
+        // mark a conversation unread, even from another sender.
+        // `.capabilityRequest` deliberately left this list: a connect request
+        // in the member's agent DM is discovered through the unread dot.
+        for contentType: MessageContentType in [.update, .connectionEvent, .capabilityRequestResult, .connectionInvocation] {
             #expect(!marksConversationUnread(
                 contentType: contentType,
                 senderInboxId: other,

--- a/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
+++ b/ConvosTests/ConversationViewModelCapabilityConnectTests.swift
@@ -1,3 +1,4 @@
+import Combine
 @testable import Convos
 import ConvosConnections
 import ConvosCore
@@ -121,7 +122,7 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
 
     // MARK: - Connect-before-grant (pre-connect approvals)
 
-    func testApproveLinkedProviderResolvesImmediately() {
+    func testApproveLinkedProviderResolvesAfterScopeCheck() async {
         let viewModel = makeViewModel()
         viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-1")
 
@@ -130,8 +131,70 @@ final class ConversationViewModelCapabilityConnectTests: XCTestCase {
             bundleSelection: ["googlecalendar": ["calendar.events"]]
         )
 
+        // The approve pipeline runs after the async grant-scope consistency
+        // check; no connect step is needed, so the layout then clears.
+        await waitUntil { viewModel.pendingCapabilityPickerLayout == nil }
         XCTAssertNil(viewModel.pendingCapabilityPickerLayout,
-                     "No connect step needed — the approval resolves synchronously")
+                     "No connect step needed — the approval resolves after the scope check")
+    }
+
+    func testLateTapResolutionCannotRepaintAfterApproveDivergence() async throws {
+        let stub = StubScopeRepository(initial: CapabilityGrantScopeResolution(
+            scope: .originGroup("origin-a"),
+            scopeDisplayName: "Group A"
+        ))
+        let session = MockInboxesService()
+        session.capabilityRequestRepositoryOverride = stub
+        let viewModel = ConversationViewModel(
+            conversation: .mock(id: "test-convo"),
+            session: session,
+            messagingService: MockMessagingService(),
+            applyGlobalDefaultsForNewConversation: false
+        )
+        // Let the view model's init-time mock emissions (conversation update,
+        // capability-request observation reset) settle before arranging state
+        // by hand -- they clear the capability fields asynchronously.
+        try await Task.sleep(for: .milliseconds(200))
+        viewModel.pendingCapabilityPickerLayout = makeLayout(requestId: "req-1")
+
+        // First tap discloses scope A on the sheet.
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .pending))
+        await waitUntil { stub.callCount >= 1 }
+        XCTAssertGreaterThanOrEqual(stub.callCount, 1, "The tap must reach the injected scope resolver")
+        await waitUntil { viewModel.capabilityGrantScopeResolution?.scopeDisplayName == "Group A" }
+        XCTAssertEqual(viewModel.capabilityGrantScopeResolution?.scopeDisplayName, "Group A",
+                       "The first tap must disclose scope A before the race is arranged")
+
+        // Second tap parks inside the resolver while it still reads scope A.
+        stub.setGated(true)
+        viewModel.onTapCapabilityConnectPrompt(makePrompt(requestId: "req-1", status: .pending))
+        await waitUntil { stub.waiterCount == 1 }
+        XCTAssertEqual(stub.waiterCount, 1, "The second tap's resolution must park in the gate")
+
+        // The origin moves: new resolutions now return scope B; the approve
+        // tap re-resolves, sees B against the disclosed A, and refuses.
+        stub.setGated(false)
+        stub.setResult(CapabilityGrantScopeResolution(
+            scope: .originGroup("origin-b"),
+            scopeDisplayName: "Group B"
+        ))
+        viewModel.onCapabilityApprove(
+            providerIds: [ProviderID(rawValue: "composio.googlecalendar")],
+            bundleSelection: ["googlecalendar": ["calendar.events"]]
+        )
+        await waitUntil { viewModel.capabilityApprovalErrorMessage != nil }
+        XCTAssertEqual(viewModel.capabilityGrantScopeResolution?.scopeDisplayName, "Group B")
+        XCTAssertNotNil(viewModel.pendingCapabilityPickerLayout,
+                        "A diverged approval must not consume the request")
+
+        // The parked tap resolution lands last carrying stale scope A. The
+        // generation guard must drop it -- otherwise the sheet silently
+        // reverts to A and the user's retry diverges forever.
+        stub.releaseAll()
+        await waitUntil { stub.waiterCount == 0 }
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(viewModel.capabilityGrantScopeResolution?.scopeDisplayName, "Group B",
+                       "The divergence re-present must win over the stale tap resolution")
     }
 
     func testApproveUnlinkedProviderConnectsBeforeSendingResult() async {
@@ -279,6 +342,88 @@ private struct CancelledCloudConnectionManager: CloudConnectionManagerProtocol {
     func connect(serviceId: String) async throws -> CloudConnection { throw OAuthError.cancelled }
     func disconnect(connectionId: String) async throws {}
     func refreshConnections() async throws -> [CloudConnection] { [] }
+}
+
+/// Scope resolver with test-controlled results and timing: `setGated(true)`
+/// parks subsequent resolutions (each captures the result at call time, so a
+/// released call returns what the world looked like when it started);
+/// `releaseAll()` resumes them.
+private final class StubScopeRepository: CapabilityRequestRepositoryProtocol, @unchecked Sendable {
+    // Never emits: an emission (even nil) would asynchronously clear the
+    // layout and scope state the test arranged by hand.
+    let pendingRequestPublisher: AnyPublisher<CapabilityRequest?, Never> =
+        Empty(completeImmediately: false).eraseToAnyPublisher()
+
+    private let lock = NSLock()
+    private var result: CapabilityGrantScopeResolution
+    private var gated = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var calls = 0
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    init(initial: CapabilityGrantScopeResolution) {
+        self.result = initial
+    }
+
+    var waiterCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return waiters.count
+    }
+
+    func setResult(_ new: CapabilityGrantScopeResolution) {
+        lock.lock()
+        defer { lock.unlock() }
+        result = new
+    }
+
+    func setGated(_ value: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        gated = value
+    }
+
+    func releaseAll() {
+        lock.lock()
+        let toRelease = waiters
+        waiters.removeAll()
+        lock.unlock()
+        for waiter in toRelease {
+            waiter.resume()
+        }
+    }
+
+    private func snapshotResultAndGate() -> (CapabilityGrantScopeResolution, Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        calls += 1
+        return (result, gated)
+    }
+
+    private func park(_ continuation: CheckedContinuation<Void, Never>) {
+        lock.lock()
+        defer { lock.unlock() }
+        waiters.append(continuation)
+    }
+
+    func resolveGrantScope(
+        isAgentDm: Bool,
+        askerInboxId: String,
+        liveMarkerOrigin: @escaping @Sendable () async -> String?
+    ) async -> CapabilityGrantScopeResolution {
+        let (snapshot, shouldWait) = snapshotResultAndGate()
+        if shouldWait {
+            await withCheckedContinuation { continuation in
+                park(continuation)
+            }
+        }
+        return snapshot
+    }
 }
 
 private struct FailingCloudConnectionManager: CloudConnectionManagerProtocol {


### PR DESCRIPTION
## What & why

PR A of the personal-connections feature ("the connect pill moves to the
member's 1:1 agent conversation"), built from the personal-connections spec
(rev 3) in the session workdir; the spec's section numbers below refer to that
document. This is the iOS half that must ship first: it fixes the latent
"pill in a DM is inert" bug and the latent "DM approval would mis-scope the
grant" trap, both reachable today via the DM-ask behavior traced in CON-803.

## Ordering rule (spec section 8 — hard requirement)

The runtime PR that starts targeting pills at DM lanes deploys only after the
release containing this PR is confirmed available to the fleet
(TestFlight/App Store build visible). On older builds a DM pill renders but is
inert; on a build with the tap wiring but without the origin scoping, a DM
approval would mint grants that authorize nothing (the backend's entitlement
check keys on the agent's primary group). That is why the tap wiring and the
scoping ship together in this one PR.

## Changes

**Pill wiring in the agent DM (spec 4.1).** `AgentDmPageView` passes
`onTapCapabilityConnect` (read-only guarded) and presents the same
`CapabilityApprovalSheetView` the group path uses, including the
`isApproving:` / `approvalErrorMessage:` wiring restored by #1327.

**Origin-scoped approval (spec 4.2).** A new `CapabilityGrantScope` is derived
before any write: identity for a plain group; for an agent DM the origin group,
resolved from the `agent_dm_origin` mirror row first, then the DM's own XMTP
appData marker (the authoritative source the row mirrors). Threading:

| Use | Target |
|---|---|
| backend grant POST, ProfileUpdate ledger | origin group |
| granted / revoke transcript lines | origin group (the group update) |
| resolver bookkeeping + picker grant reads | origin group |
| device-capability enablement | origin group |
| `capability_request_result` | the pill's conversation (the DM) |

An unresolvable origin is an explicit blocked case, never a fallthrough to the
DM id: unknown origin, an origin the device has not synced, a group the user
left (its own copy, per spec 2.6), or one the asking agent has left (rebind
staleness). The approval-time consistency check verifies origin liveness, the
user's membership (no recorded departure), and the asking agent's membership.
Blocked approvals surface the spec's copy through the sheet's error path,
grant and send nothing, keep the pill pending, and emit a
`capability_approval_blocked` telemetry counter with the reason.

**Named consent.** The sheet always names the conversation the grant will
scope to ("For use in <group>") and renders its approve control only from a
resolved, named scope; blocked state replaces the control with its copy.

**Unread dot (spec 4.4).** Verification verdict: `capability_request` did
*not* mark conversations unread (`MessageContentType.marksConversationAsUnread`
excluded it), so the Agent tab's dot — the pill's only discoverability
surface — would never light. Fixed here: the type now marks unread on all
ingest paths (stream, catch-up, batch); results and connection events stay
silent. One existing routing test pinned the old behavior and was updated.

In a plain group the scope resolves to the conversation itself, keeping every
path byte-identical to today's behavior — old group pills keep rendering and
approving unchanged (spec 4.3, 7).

## Tests (15 new, 1 updated)

- `CapabilityGrantScopeResolutionTests` (11): plain-group identity + name;
  origin-row scoping; marker fallback; marker not consulted when the row
  exists; blocked cases — no row/marker, unsynced origin, departed origin
  (both member-row-absent and recorded-departure forms), agent-not-in-origin,
  origin-naming-the-DM-itself, origin-that-is-an-agent-DM, nameless origin;
  the repository seam the view model calls.
- `CapabilityRequestUnreadTests` (3): request marks unread; result does not;
  own-sender and active-conversation exemptions hold.
- Transcript harness DM fixture (1): per-viewer pending/connected derivation
  is unchanged by the agent-DM classification.
- `CaughtUpMessageRoutingTests` updated to the new unread intent.

## Gates

- `swiftlint --strict` on changed files: clean. `swiftformat --lint`: clean.
- Build `Convos (Dev)` -configuration Dev, iPhone 17 simulator: BUILD SUCCEEDED.
- `swift test --package-path ConvosCore`: 1909 tests / 256 suites, 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789744316&installation_model_id=20076&pr_number=1351&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1351&signature=573ce9f614d85521ca7bcceeffc90f2160d312db72a2dd850b2f4446202d8072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope capability approval grants to the origin group for agent DMs
> - Wires the capability connect pill into the Agent DM page view so tapping it opens an approval sheet, mirroring the existing group conversation flow.
> - Introduces `CapabilityGrantScopeResolution` to determine whether a capability approval should write grants to the current conversation or its origin group, returning a display name or a typed block reason for UI and telemetry.
> - The approval sheet now gates the approve button behind a resolved scope name (shown as "For use in <name>") and can display a blocked message in place of the button when the origin is unresolvable.
> - Approval flow in `ConversationViewModel` re-resolves scope at tap-time, binds consent to the named scope, and refuses approval if the scope diverges between sheet presentation and the tap.
> - `marksConversationUnread` is broadened from a single `activeConversationId` to an `activeConversationIds: Set<String>` so both the group and its folded agent DM can suppress unread marking simultaneously; `capabilityRequest` messages now mark conversations unread while `capabilityRequestResult` does not.
> - Risk: scope re-resolution is async, so an approval tap can be blocked or refused with an error if the origin group state changes between opening the sheet and tapping approve.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e90ae0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


## Review fixes (second commit)

Adversarial-review hardening: the origin validator rejects any DM as origin
(member-writable marker treated as untrusted input); the approve tap binds the
grant to the scope the sheet disclosed and re-presents on divergence instead of
writing; an unnamed origin derives its consent name from the member list --
the same title the rest of the app shows for it -- and only an origin whose
identity cannot be derived at all blocks, with honest copy (a nameless plain
group uses the conversation's own display name); a blocked
approval re-resolves on every pill tap so the transient block self-heals after
sync; a synchronous tap latch closes the double-tap window; and the unread
exemption now covers the open agent DM (the shared predicate takes the set of
active conversations). Guard tests are mutation-checked.



## Final round (third commit)

The origin's display name now derives exactly as the rest of the app derives
it (explicit name verbatim, else the member-based title), so ordinary unnamed
groups approve normally; the genuinely unidentifiable case blocks with honest
copy. A scope-resolution generation counter orders concurrent resolution
writers so an approve-time divergence re-present can never be repainted by a
stale in-flight pill-tap resolution. Both behaviors are pinned by
mutation-checked tests (a resolver test and a deterministic view-model race
test driven through an injectable scope repository).
