### PR TITLE
Redesign the agent composer around a + menu and open Connections from it

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -60,18 +60,25 @@ struct AbilitiesListScreen: View {
 /// connect/disconnect actions stubbed through `AbilitiesServiceProtocol`.
 ///
 /// Entry points (all flag-gated behind Abilities V2, all via
-/// `AbilitiesListScreen`, which owns the view model):
+/// `AbilitiesListScreen`, which owns the view model and takes the
+/// `ConnectionsBrowserMode` naming the caller):
 /// - App Settings connections row (`AppSettingsView.connectionsDestination`)
-///   pushes it in place of the V1 `ConnectionsListView`; the row is titled
-///   "Abilities" under the flag.
+///   pushes it in place of the V1 `ConnectionsListView`, in mode
+///   `.appSettings`; the row is titled "Abilities" under the flag.
+/// - The agent composer's powerplug (quick icon or `+` menu row) presents it
+///   full-screen from `ConversationView.connectionsBrowserPresentation`, in
+///   mode `.composerModal`; the screen then supplies its own
+///   `NavigationStack` and a Done control.
 ///
 /// A conversation toggle that needs an entitlement no longer deep-links
 /// here: it presents the scoped `AbilityConnectSheet` instead, which reuses
 /// this screen's view model for the connect machinery.
 ///
-/// Entitled rows push `AbilityDetailScreen` (delegations list) inside the
-/// App Settings `NavigationStack`. Available and state-unknown rows stay
-/// non-navigable: delegations only exist against an entitlement.
+/// Entitled rows push `AbilityDetailScreen` (delegations list) inside
+/// whichever stack the mode put the screen in - the App Settings stack when
+/// pushed, the screen's own stack when presented as the modal. Available and
+/// state-unknown rows stay non-navigable: delegations only exist against an
+/// entitlement.
 struct AbilitiesListView: View {
     @Bindable var viewModel: AbilitiesListViewModel
     /// Latched pair handed down to ability detail pushes.
@@ -150,14 +157,16 @@ struct AbilitiesListView: View {
         }
     }
 
+    /// No retry here on purpose: `errorMessage` is set by connect, disconnect
+    /// and delegation failures as well as catalog fetches, and the only retry
+    /// this screen can offer is a catalog refetch - which would report success
+    /// for a failed connect and clear the message without retrying anything.
+    /// The outage banner above is where a refetch is the right action.
     private func errorBanner(_ message: String) -> some View {
         Section {
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
-                Text(message)
-                    .font(.footnote)
-                    .foregroundStyle(.colorCaution)
-                retryButton
-            }
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.colorCaution)
         }
     }
 
@@ -179,11 +188,11 @@ struct AbilitiesListView: View {
 
     /// The selling-point state for a member with nothing connected yet: a
     /// mosaic of catalog icons over one line of copy, with the available
-    /// list right below. Only when the catalog actually loaded - an outage
-    /// shows its own banner instead.
+    /// list right below. When it shows is the view model's call
+    /// (`showsNothingConnectedHero`), which withholds it during an outage.
     @ViewBuilder
     private var nothingConnectedHeroSection: some View {
-        if showsNothingConnectedHero {
+        if viewModel.showsNothingConnectedHero {
             Section {
                 VStack(alignment: .leading, spacing: DesignConstants.Spacing.step3x) {
                     heroIconMosaic
@@ -199,13 +208,6 @@ struct AbilitiesListView: View {
             .listRowSeparator(.hidden)
             .listSectionSeparator(.hidden)
         }
-    }
-
-    private var showsNothingConnectedHero: Bool {
-        viewModel.hasLoadedOnce
-            && !viewModel.isSearching
-            && viewModel.entitledAbilities.isEmpty
-            && !viewModel.availableAbilities.isEmpty
     }
 
     private var heroIconMosaic: some View {
@@ -249,7 +251,7 @@ struct AbilitiesListView: View {
                     availableRow(ability)
                 }
             } header: {
-                sectionHeader("Available")
+                sectionHeader("All connections")
             }
         }
     }
@@ -264,7 +266,7 @@ struct AbilitiesListView: View {
                     unknownStateRow(ability)
                 }
             } header: {
-                sectionHeader("Connections")
+                sectionHeader("Status unknown")
             }
         }
     }

--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -16,17 +16,42 @@ struct AbilitiesListScreen: View {
     /// Kept so entitled rows can hand the whole latched pair down to the
     /// ability detail push (see `AbilitiesSelection`).
     private let selection: AbilitiesSelection
+    /// Which entry point raised the screen; drives only the wrapper chrome
+    /// (see `ConnectionsBrowserMode`). Both modes render the same list from
+    /// the same view model.
+    private let mode: ConnectionsBrowserMode
+    @Environment(\.dismiss) private var dismiss: DismissAction
 
     /// Takes the whole selection so the service and its authorizer are
     /// latched together for the screen's lifetime -- the halves must never
     /// be resolved at different times (see `AbilitiesSelection`).
-    init(selection: AbilitiesSelection) {
+    init(selection: AbilitiesSelection, mode: ConnectionsBrowserMode) {
         self.selection = selection
+        self.mode = mode
         _viewModel = State(initialValue: AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer))
     }
 
     var body: some View {
+        if mode.showsDismissChrome {
+            NavigationStack {
+                listView
+                    .toolbar { doneToolbarItem }
+            }
+        } else {
+            listView
+        }
+    }
+
+    private var listView: some View {
         AbilitiesListView(viewModel: viewModel, selection: selection)
+    }
+
+    private var doneToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .confirmationAction) {
+            let action = { dismiss() }
+            Button("Done", action: action)
+                .accessibilityIdentifier("connections-browser-done-button")
+        }
     }
 }
 
@@ -57,6 +82,7 @@ struct AbilitiesListView: View {
             .searchable(text: $viewModel.searchText, prompt: "Search connections")
             .overlay { listOverlay }
             .task { await viewModel.refresh() }
+            .refreshable { await viewModel.refresh() }
             .selfSizingSheet(item: $viewModel.pendingAuthorization, onDismiss: handleAuthorizationDismissed) { context in
                 authorizationSheet(context)
             }
@@ -71,6 +97,7 @@ struct AbilitiesListView: View {
             if let errorMessage = viewModel.errorMessage {
                 errorBanner(errorMessage)
             }
+            nothingConnectedHeroSection
             entitledSection
             availableSection
             unknownStateSection
@@ -106,14 +133,18 @@ struct AbilitiesListView: View {
     /// Shown when the backend served the catalog without entitlement
     /// state. Rows carry last-known state; rows with no last-known state
     /// render in the state-unknown section, never as "not connected".
+    /// Carries an explicit retry alongside the list's pull-to-refresh.
     private var unavailableBanner: some View {
         Section {
-            HStack(spacing: DesignConstants.Spacing.step2x) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.colorLava)
-                Text("Can't check connection status right now. Showing the last-known state.")
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+                HStack(spacing: DesignConstants.Spacing.step2x) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.colorLava)
+                    Text("Can't check connection status right now. Showing the last-known state.")
+                        .font(.footnote)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+                retryButton
             }
             .accessibilityIdentifier("abilities-unavailable-banner")
         }
@@ -121,9 +152,68 @@ struct AbilitiesListView: View {
 
     private func errorBanner(_ message: String) -> some View {
         Section {
-            Text(message)
-                .font(.footnote)
-                .foregroundStyle(.colorCaution)
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.colorCaution)
+                retryButton
+            }
+        }
+    }
+
+    private var retryButton: some View {
+        let action: () -> Void = {
+            Task { await viewModel.refresh() }
+        }
+        return Button(action: action) {
+            Text("Retry")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.colorTextPrimary)
+                .padding(.horizontal, DesignConstants.Spacing.step3x)
+                .padding(.vertical, DesignConstants.Spacing.stepX)
+                .background(Capsule().fill(Color.colorFillMinimal))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("abilities-retry-button")
+    }
+
+    /// The selling-point state for a member with nothing connected yet: a
+    /// mosaic of catalog icons over one line of copy, with the available
+    /// list right below. Only when the catalog actually loaded - an outage
+    /// shows its own banner instead.
+    @ViewBuilder
+    private var nothingConnectedHeroSection: some View {
+        if showsNothingConnectedHero {
+            Section {
+                VStack(alignment: .leading, spacing: DesignConstants.Spacing.step3x) {
+                    heroIconMosaic
+                    // Placeholder copy pending design input.
+                    Text("Nothing connected yet. Connect the apps you use and your agent can put them to work.")
+                        .font(.subheadline)
+                        .foregroundStyle(.colorTextSecondary)
+                }
+                .padding(.vertical, DesignConstants.Spacing.step2x)
+                .listRowBackground(Color.clear)
+                .accessibilityIdentifier("abilities-nothing-connected-hero")
+            }
+            .listRowSeparator(.hidden)
+            .listSectionSeparator(.hidden)
+        }
+    }
+
+    private var showsNothingConnectedHero: Bool {
+        viewModel.hasLoadedOnce
+            && !viewModel.isSearching
+            && viewModel.entitledAbilities.isEmpty
+            && !viewModel.availableAbilities.isEmpty
+    }
+
+    private var heroIconMosaic: some View {
+        let mosaicAbilities: [AbilitiesAPI.Ability] = Array(viewModel.availableAbilities.prefix(5))
+        return HStack(spacing: DesignConstants.Spacing.step2x) {
+            ForEach(mosaicAbilities) { ability in
+                AbilityIconView(ability: ability)
+            }
         }
     }
 
@@ -320,24 +410,31 @@ struct AbilitiesListView: View {
 
 #Preview("Standard") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService()))
+        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService()), mode: .appSettings)
     }
+}
+
+#Preview("Composer modal") {
+    AbilitiesListScreen(
+        selection: AbilitiesSelection(service: MockAbilitiesService()),
+        mode: .composerModal(conversationId: "dm-1", agentInboxId: "agent-1")
+    )
 }
 
 #Preview("Entitlements unavailable") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailable)))
+        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailable)), mode: .appSettings)
     }
 }
 
 #Preview("Cold-start outage") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart)))
+        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart)), mode: .appSettings)
     }
 }
 
 #Preview("Device only") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .deviceOnly)))
+        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .deviceOnly)), mode: .appSettings)
     }
 }

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -48,6 +48,20 @@ final class AbilitiesListViewModel {
         !trimmedQuery.isEmpty
     }
 
+    /// Whether the list should sell the feature rather than enumerate it:
+    /// the catalog loaded authoritatively, the member is not searching, and
+    /// they hold nothing. Withheld under `entitlementsUnavailable`, where
+    /// every ability reads as not-entitled from last-known state and
+    /// "nothing connected yet" would assert stale state as fact directly
+    /// under a banner admitting the app cannot check.
+    var showsNothingConnectedHero: Bool {
+        hasLoadedOnce
+            && !entitlementsUnavailable
+            && !isSearching
+            && entitledAbilities.isEmpty
+            && !availableAbilities.isEmpty
+    }
+
     /// Abilities the caller holds an entitlement for, in any lifecycle
     /// state. Under `entitlementsUnavailable` this reflects last-known
     /// state, already resolved by the service.

--- a/Convos/Abilities/ConnectionsBrowserMode.swift
+++ b/Convos/Abilities/ConnectionsBrowserMode.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Drives the chrome `AbilitiesListScreen` wraps the Connections browser in,
+/// based on where the browser was opened from. Mirrors `ContactDetailMode`
+/// and `ContactsPickerMode`'s "one view, multiple entry points" pattern -
+/// see `CLAUDE.md`'s "View Modes for Multi-Entry-Point Surfaces" section
+/// for the convention.
+///
+/// Entry-point mapping:
+/// - **`.appSettings`**: the App Settings connections row
+///   (`AppSettingsView.connectionsDestination`) pushes the screen inside
+///   the settings `NavigationStack`. No chrome of its own - the stack
+///   supplies the back button.
+/// - **`.composerModal(...)`**: the agent composer's powerplug (quick icon
+///   or `+` menu row) presents the screen full-screen from
+///   `ConversationView`. The screen wraps itself in its own
+///   `NavigationStack` with a Done dismiss control; ability detail pushes
+///   run inside that stack. Carries the launching DM's context for future
+///   scoped affordances; the content itself stays account-level.
+///
+/// Both modes render the same sections from the same view model; only the
+/// wrapper differs.
+enum ConnectionsBrowserMode: Hashable, Identifiable {
+    case appSettings
+    case composerModal(conversationId: String, agentInboxId: String)
+
+    /// The modal presentation wraps the list in its own `NavigationStack`
+    /// and shows the Done dismiss control; the settings push rides the
+    /// presenting stack and shows neither.
+    var showsDismissChrome: Bool {
+        if case .composerModal = self { return true }
+        return false
+    }
+
+    /// The agent DM the modal was launched from; nil for the settings push.
+    var conversationId: String? {
+        if case .composerModal(let conversationId, _) = self { return conversationId }
+        return nil
+    }
+
+    /// The agent whose composer launched the modal; nil for the settings push.
+    var agentInboxId: String? {
+        if case .composerModal(_, let agentInboxId) = self { return agentInboxId }
+        return nil
+    }
+
+    var id: String {
+        switch self {
+        case .appSettings:
+            "appSettings"
+        case let .composerModal(conversationId, agentInboxId):
+            "composerModal-\(conversationId)-\(agentInboxId)"
+        }
+    }
+}

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -261,7 +261,7 @@ struct AppSettingsView: View {
     @ViewBuilder
     private var connectionsDestination: some View {
         if FeatureFlags.shared.isAbilitiesV2Enabled {
-            AbilitiesListScreen(selection: AbilitiesServices.selection)
+            AbilitiesListScreen(selection: AbilitiesServices.selection, mode: .appSettings)
         } else {
             ConnectionsListView(viewModel: viewModel.connectionsListViewModel)
         }

--- a/Convos/Conversation Detail/Conversation Sheet/AgentComposerBar.swift
+++ b/Convos/Conversation Detail/Conversation Sheet/AgentComposerBar.swift
@@ -12,6 +12,13 @@ struct AgentComposerBar: View {
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let focusCoordinator: FocusCoordinator
     let isReadOnly: Bool
+    /// Host-passed capability gating the composer's `.connections` entries
+    /// (quick icon and `+` menu row alike); read from the feature flag at
+    /// the `ConversationView` seam only.
+    let connectionsEnabled: Bool
+    /// Presents the Connections browser modal; the host owns the
+    /// presentation, the composer only emits the tap.
+    let onConnectionsTap: () -> Void
     /// Scrolls the DM transcript to the bottom; invoked on send.
     var scrollToBottom: (() -> Void)?
 
@@ -25,7 +32,9 @@ struct AgentComposerBar: View {
                 messagePlaceholder: "Chat with \(session.agentName)",
                 isGroupComposer: false,
                 scrollToBottom: scrollToBottom,
-                usesInlineMediaButtons: true,
+                usesAgentComposerLayout: true,
+                connectionsEnabled: connectionsEnabled,
+                onConnectionsTap: onConnectionsTap,
                 extraBarContent: { EmptyView() }
             )
         } else {
@@ -35,9 +44,10 @@ struct AgentComposerBar: View {
 
     /// Disabled composer for the not-yet-created DM. The field and send
     /// button stay disabled until the session binds the real conversation
-    /// (normally within a second or two of the agent joining). The media
-    /// buttons stay visible (inert, dimmed) so the composer keeps the
-    /// agent bar's shape rather than dropping the affordances.
+    /// (normally within a second or two of the agent joining). The `+` and
+    /// the quick-action row stay visible (inert, dimmed) so the composer
+    /// keeps the agent bar's default-state shape rather than dropping the
+    /// affordances.
     private var draftComposer: some View {
         MessagesInputView(
             displayName: .constant(""),
@@ -53,7 +63,8 @@ struct AgentComposerBar: View {
             onClearInvite: {},
             fileAttachmentPreview: { _ in EmptyView() },
             agentShareChip: { EmptyView() },
-            attachmentsButton: { draftMediaButtons }
+            quickActionsAccessory: { draftQuickRow },
+            attachmentsButton: { draftPlusGlyph }
         )
         .fixedSize(horizontal: false, vertical: true)
         .clipShape(.rect(cornerRadius: Constant.draftCornerRadius))
@@ -64,14 +75,25 @@ struct AgentComposerBar: View {
         .padding(.horizontal, DesignConstants.Spacing.step4x)
     }
 
-    /// The media buttons in the pre-creation composer: kept visible so the
-    /// bar holds the agent style's shape, but inert and dimmed (no
-    /// conversation to attach to yet) to read as disabled alongside the
-    /// field. Mirrors `MessagesBottomBar.inlineMediaButtons`.
-    private var draftMediaButtons: some View {
-        HStack(spacing: 0) {
-            ForEach(["camera.fill", "photo.fill", "document.fill"], id: \.self) { symbol in
-                Image(systemName: symbol)
+    /// The `+` in the pre-creation composer: kept visible so the bar holds
+    /// the agent layout's shape, but inert and dimmed (no conversation to
+    /// attach to yet). Mirrors `MessagesBottomBar.attachmentsGlyph`.
+    private var draftPlusGlyph: some View {
+        Image(systemName: "plus")
+            .font(.system(size: 18.0, weight: .medium))
+            .foregroundStyle(Color.colorTextPrimary)
+            .frame(width: 32, height: 32)
+            .opacity(0.4)
+    }
+
+    /// The quick-action row in the pre-creation composer, same curation as
+    /// the live bar's default state (`ComposerAttachmentAction.agentQuickRow`),
+    /// inert and dimmed to read as disabled alongside the field.
+    private var draftQuickRow: some View {
+        let actions: [ComposerAttachmentAction] = ComposerAttachmentAction.agentQuickRow(connectionsEnabled: connectionsEnabled)
+        return HStack(spacing: 0) {
+            ForEach(actions) { action in
+                Image(systemName: action.filledIconSystemName)
                     .font(.system(size: 18.0, weight: .medium))
                     .foregroundStyle(Color.colorTextPrimary)
                     .frame(width: 32, height: 32)

--- a/Convos/Conversation Detail/Conversation Sheet/ConversationComposerBar.swift
+++ b/Convos/Conversation Detail/Conversation Sheet/ConversationComposerBar.swift
@@ -24,9 +24,16 @@ struct ConversationComposerBar<ExtraBarContent: View>: View {
     /// Scrolls the paired transcript to the bottom; invoked on send.
     var scrollToBottom: (() -> Void)?
     var onDebugAttachmentTap: (() -> Void)?
-    /// Agent-style composer: inline media buttons and a voice-memo entry in
-    /// the empty composer's send slot (see MessagesBottomBar).
-    var usesInlineMediaButtons: Bool = false
+    /// Agent-style composer: the group `+` menu plus the trailing curated
+    /// quick-action row, and a voice-memo entry in the empty composer's send
+    /// slot (see MessagesBottomBar).
+    var usesAgentComposerLayout: Bool = false
+    /// Host-passed capability gating the `.connections` option; the bar
+    /// never reads feature flags itself (see MessagesBottomBar).
+    var connectionsEnabled: Bool = false
+    /// Presents the host's Connections browser from the composer's
+    /// powerplug entries.
+    var onConnectionsTap: (() -> Void)?
     /// Extra rows above the composer, e.g. the onboarding view and the
     /// capability-approved toast on the Group tab.
     @ViewBuilder let extraBarContent: () -> ExtraBarContent
@@ -77,7 +84,9 @@ struct ConversationComposerBar<ExtraBarContent: View>: View {
             voiceMemoRecorder: viewModel.voiceMemoRecorder,
             onSendVoiceMemo: { viewModel.sendVoiceMemo() },
             onDebugAttachmentTap: onDebugAttachmentTap,
-            usesInlineMediaButtons: usesInlineMediaButtons,
+            usesAgentComposerLayout: usesAgentComposerLayout,
+            connectionsEnabled: connectionsEnabled,
+            onConnectionsTap: onConnectionsTap,
             onBaseHeightChanged: { _ in
                 // The sheet measures its own full card height; the bar's base
                 // height is not needed separately.

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -709,7 +709,18 @@ private extension ConversationView {
     /// from a message in the agent transcript belongs to that lane.
     @ViewBuilder
     func conversationPresentations(_ content: some View) -> some View {
-        messagePresentations(conversationLevelPresentations(content))
+        messagePresentations(conversationLevelPresentations(connectionsBrowserPresentation(content)))
+    }
+
+    /// The Connections browser, raised full-screen by the agent composer's
+    /// powerplug. Its own function so `conversationLevelPresentations` stays
+    /// inside the type-check budget it was already split to respect.
+    @ViewBuilder
+    func connectionsBrowserPresentation(_ content: some View) -> some View {
+        content
+            .fullScreenCover(item: $connectionsBrowserContext) { mode in
+                AbilitiesListScreen(selection: AbilitiesServices.selection, mode: mode)
+            }
     }
 
     /// The sheets the conversation itself raises, as opposed to the ones a
@@ -755,9 +766,6 @@ private extension ConversationView {
             }
             .selfSizingSheet(isPresented: $viewModel.presentingExplodedInviteInfo) {
                 ExplodeInfoView()
-            }
-            .fullScreenCover(item: $connectionsBrowserContext) { mode in
-                AbilitiesListScreen(selection: AbilitiesServices.selection, mode: mode)
             }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -133,6 +133,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// when the shown conversation changes).
     @State private var escalationViewModel: ConversationEscalationViewModel?
     @State private var presentingAddFromContactsPicker: Bool = false
+    /// Non-nil presents the Connections browser modal, carrying the
+    /// launching agent DM's context (see `ConnectionsBrowserMode`).
+    @State private var connectionsBrowserContext: ConnectionsBrowserMode?
     /// Drives the system share sheet behind the top bar's invite-link button.
     @State private var presentingInviteShareSheet: Bool = false
     @State private var navState: ConversationNavigatorImpl = .init()
@@ -752,6 +755,9 @@ private extension ConversationView {
             }
             .selfSizingSheet(isPresented: $viewModel.presentingExplodedInviteInfo) {
                 ExplodeInfoView()
+            }
+            .fullScreenCover(item: $connectionsBrowserContext) { mode in
+                AbilitiesListScreen(selection: AbilitiesServices.selection, mode: mode)
             }
     }
 
@@ -1613,6 +1619,8 @@ private extension ConversationView {
                     focusState: agentFocus,
                     focusCoordinator: agentFocusCoordinator,
                     isReadOnly: effectiveReadOnly,
+                    connectionsEnabled: composerConnectionsEnabled,
+                    onConnectionsTap: handleComposerConnectionsTap,
                     scrollToBottom: { agentScrollToBottom?(true) }
                 )
                 // The participation control governs the group room; it has
@@ -1620,6 +1628,29 @@ private extension ConversationView {
                 .environment(\.agentParticipation, nil)
             }
         }
+    }
+
+    /// The single host seam for the composer's connections capability: the
+    /// quick icon, the `+` menu row, and the browser modal all feed from
+    /// this one read. No composer surface consults the flag directly.
+    var composerConnectionsEnabled: Bool {
+        FeatureFlags.shared.isAbilitiesV2Enabled
+    }
+
+    /// Powerplug tap, from the quick row or the `+` menu row alike: presents
+    /// the Connections browser full-screen, carrying the launching DM's
+    /// context. Guarded by the same capability that offered the entries.
+    func handleComposerConnectionsTap() {
+        guard composerConnectionsEnabled,
+              let agentDmSession,
+              let agentInboxId = agentDmSession.agentInboxId,
+              let dmConversationId = agentDmSession.dmViewModel?.conversation.id else {
+            return
+        }
+        connectionsBrowserContext = .composerModal(
+            conversationId: dmConversationId,
+            agentInboxId: agentInboxId
+        )
     }
 
     /// The message long-press menu for whichever transcript raised it, layered

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -123,6 +123,10 @@ let package = Package(
             dependencies: [
                 "ConvosCore",
                 "ConvosAppData",
+                // The composer's curation registry (ComposerAttachmentAction)
+                // is platform-neutral so its invariants run in the macOS test
+                // sweep; the rest of the target compiles empty off-iOS.
+                "ConvosComposer",
                 .target(name: "ConvosCoreiOS", condition: .when(platforms: [.iOS])),
                 .product(name: "XMTPiOS", package: "libxmtp"),
                 .product(name: "CSecp256k1", package: "CSecp256k1.swift"),

--- a/ConvosCore/Sources/ConvosComposer/ComposerAttachmentAction.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerAttachmentAction.swift
@@ -1,22 +1,58 @@
-#if canImport(UIKit)
-import SwiftUI
-
-/// One thing a member can attach, as it appears in the attachments menu the
-/// composer's `+` presents.
+/// One thing a member can attach or open from the composer, as it appears in
+/// the attachments menu the composer's `+` presents and, for a curated
+/// subset, in the agent composer's trailing quick-action row.
+///
+/// This enum is the single declaration of what an option is: identity
+/// (stable `rawValue` id), title, icons, and dispatch routing. The lists
+/// below declare which options each surface offers; the quick row is always
+/// a curation of the `+` menu, never a second implementation
+/// (see `agentQuickRow(connectionsEnabled:)`).
+///
+/// Deliberately platform-neutral (no UIKit) so the curation and routing
+/// rules stay testable from the package's macOS test run.
 public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendable {
     case photos
     case camera
     case files
     case voiceNote
+    /// Opens the host's Connections browser (account-level ability
+    /// entitlements). Offered only in the agent composer, and only when the
+    /// host passes `connectionsEnabled` - the composer package cannot read
+    /// feature flags itself.
+    case connections
     /// Injects a canned attachment for testing. Only ever offered behind
     /// `FeatureFlags.isDebugInjectorEnabled`, which is hard-locked off in
     /// production - so it is absent from `standard` and a host has to ask for
     /// it by name.
     case debugInjector
 
-    /// What the menu offers a member. Everything real, and nothing a build
-    /// without the debug flag should ever see.
+    /// What the group composer's menu offers a member. Everything real, and
+    /// nothing a build without the debug flag should ever see.
     public static let standard: [ComposerAttachmentAction] = [.photos, .camera, .files, .voiceNote]
+
+    /// The agent composer's `+` menu. Camera lives here rather than in the
+    /// quick row; `.connections` joins only when the host enables it.
+    public static func agentMenu(connectionsEnabled: Bool) -> [ComposerAttachmentAction] {
+        agentMenuBase.filter { included($0, connectionsEnabled: connectionsEnabled) }
+    }
+
+    /// The agent composer's trailing quick-action row: an ordered curation of
+    /// `agentMenu`. Changing what the row shows is a one-line edit to
+    /// `agentQuickRowBase`; the shared `included` predicate guarantees the
+    /// row can never surface an option the menu withholds.
+    public static func agentQuickRow(connectionsEnabled: Bool) -> [ComposerAttachmentAction] {
+        agentQuickRowBase.filter { included($0, connectionsEnabled: connectionsEnabled) }
+    }
+
+    private static let agentMenuBase: [ComposerAttachmentAction] = [.photos, .camera, .files, .voiceNote, .connections]
+    private static let agentQuickRowBase: [ComposerAttachmentAction] = [.photos, .files, .connections]
+
+    /// The one gate both agent lists share. No list carries `.connections`
+    /// unconditionally and no surface consults the flag independently, so a
+    /// side door would require bypassing this predicate.
+    private static func included(_ action: ComposerAttachmentAction, connectionsEnabled: Bool) -> Bool {
+        action != .connections || connectionsEnabled
+    }
 
     public var id: String { rawValue }
 
@@ -26,6 +62,7 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
         case .camera: "Camera"
         case .files: "Files"
         case .voiceNote: "Voice note"
+        case .connections: "Connections"
         case .debugInjector: "Test attachment"
         }
     }
@@ -39,8 +76,55 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
         case .camera: "camera"
         case .files: "document"
         case .voiceNote: "waveform"
+        case .connections: "powerplug"
         case .debugInjector: "testtube.2"
         }
     }
+
+    /// Filled marks for the quick row, per the agent composer design. Icon
+    /// variant is a property of the option, not of the row - still one
+    /// declaration per option; menu rows keep the outline set above.
+    public var filledIconSystemName: String {
+        switch self {
+        case .photos: "photo.fill"
+        case .camera: "camera.fill"
+        case .files: "document.fill"
+        case .voiceNote: "waveform"
+        case .connections: "powerplug.fill"
+        case .debugInjector: "testtube.2"
+        }
+    }
+
+    /// Where a picked option routes. Every case resolves to one of the
+    /// composer's own controls except `.hostConnections`, which the composer
+    /// hands to the host through its `onConnectionsTap` callback - the
+    /// Connections browser lives outside the composer package.
+    public enum Dispatch: Equatable, Sendable {
+        case photoPicker
+        case cameraPicker
+        case filePicker
+        case voiceMemo
+        case hostConnections
+        case debugInjector
+    }
+
+    public var dispatch: Dispatch {
+        switch self {
+        case .photos: .photoPicker
+        case .camera: .cameraPicker
+        case .files: .filePicker
+        case .voiceNote: .voiceMemo
+        case .connections: .hostConnections
+        case .debugInjector: .debugInjector
+        }
+    }
 }
-#endif
+
+/// Layout rule for the agent composer's trailing quick-action row: the row
+/// shows only in the composer's default state and collapses the moment the
+/// member starts writing, leaving `+` and the voice button.
+public enum AgentComposerQuickRow {
+    public static func isVisible(isMessageFieldFocused: Bool, messageText: String) -> Bool {
+        !isMessageFieldFocused && messageText.isEmpty
+    }
+}

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -677,53 +677,82 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         .accessibilityIdentifier(identifier)
     }
 
-    @ViewBuilder
-    private var normalInputView: some View {
-        HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
-            participationBubble
+    /// The voice-memo entry the agent layout puts in an empty composer's
+    /// send slot; the group composer leaves the slot alone. Hoisted to a
+    /// typed property so the solver never has to resolve a conditional
+    /// optional closure inside `MessagesInputView`'s argument list.
+    private var voiceMemoTapWhenEmpty: (() -> Void)? {
+        guard usesAgentComposerLayout else { return nil }
+        return { startVoiceMemoRecording() }
+    }
 
-            MessagesInputView(
-                displayName: $displayName,
-                emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
-                messagePlaceholder: messagePlaceholder,
-                messageText: $messageText,
-                pendingMediaAttachments: pendingMediaAttachments,
-                composerLinkPreview: composerLinkPreview,
-                pendingInviteURL: pendingInviteURL,
-                pendingInviteIsEditable: pendingInviteIsEditable,
-                pendingInviteEmoji: pendingInviteEmoji,
-                pendingInviteConvoName: $pendingInviteConvoName,
-                pendingInviteImage: $pendingInviteImage,
-                pendingInviteExplodeDuration: pendingInviteExplodeDuration,
-                onSetInviteExplodeDuration: onSetInviteExplodeDuration,
-                onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
-                isShowingAgentShareChip: isShowingAgentShareChip,
-                sendButtonEnabled: sendButtonEnabled,
-                focusState: $focusState,
-                messagesTextFieldEnabled: messagesTextFieldEnabled,
-                onSendMessage: onSendMessage,
-                onClearInvite: onClearInvite,
-                onVoiceMemoTapWhenEmpty: usesAgentComposerLayout ? { startVoiceMemoRecording() } : nil,
-                onClearLinkPreview: onClearLinkPreview,
-                onClearMediaAttachment: onClearMediaAttachment,
-                fileAttachmentPreview: fileAttachmentPreview,
-                agentShareChip: agentShareChip,
-                quickActionsAccessory: { quickActionsAccessory },
-                attachmentsButton: { attachmentsGlyph }
-            )
-            .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
+    private var inputCapsuleOpacity: Double {
+        messagesTextFieldEnabled ? 1.0 : 0.4
+    }
+
+    /// The `+` menu's invisible hit target, floated over the inert glyph
+    /// inside the capsule (see `attachmentsControl`).
+    private var attachmentsControlOverlay: some View {
+        attachmentsControl
+            .padding(DesignConstants.Spacing.step2x)
+    }
+
+    /// The input capsule, unstyled. Kept in a property of its own so the
+    /// type-checker never solves this argument list and a modifier chain in
+    /// the same expression.
+    private var inputCapsule: some View {
+        MessagesInputView(
+            displayName: $displayName,
+            emptyDisplayNamePlaceholder: emptyDisplayNamePlaceholder,
+            messagePlaceholder: messagePlaceholder,
+            messageText: $messageText,
+            pendingMediaAttachments: pendingMediaAttachments,
+            composerLinkPreview: composerLinkPreview,
+            pendingInviteURL: pendingInviteURL,
+            pendingInviteIsEditable: pendingInviteIsEditable,
+            pendingInviteEmoji: pendingInviteEmoji,
+            pendingInviteConvoName: $pendingInviteConvoName,
+            pendingInviteImage: $pendingInviteImage,
+            pendingInviteExplodeDuration: pendingInviteExplodeDuration,
+            onSetInviteExplodeDuration: onSetInviteExplodeDuration,
+            onInviteConvoNameEditingEnded: onInviteConvoNameEditingEnded,
+            isShowingAgentShareChip: isShowingAgentShareChip,
+            sendButtonEnabled: sendButtonEnabled,
+            focusState: $focusState,
+            messagesTextFieldEnabled: messagesTextFieldEnabled,
+            onSendMessage: onSendMessage,
+            onClearInvite: onClearInvite,
+            onVoiceMemoTapWhenEmpty: voiceMemoTapWhenEmpty,
+            onClearLinkPreview: onClearLinkPreview,
+            onClearMediaAttachment: onClearMediaAttachment,
+            fileAttachmentPreview: fileAttachmentPreview,
+            agentShareChip: agentShareChip,
+            quickActionsAccessory: { quickActionsAccessory },
+            attachmentsButton: { attachmentsGlyph }
+        )
+    }
+
+    /// The capsule's glass styling, split from both the construction above
+    /// and the animation/overlay below so no one expression carries a long
+    /// chain on top of a large call.
+    private var glassStyledInputCapsule: some View {
+        inputCapsule
+            .opacity(inputCapsuleOpacity)
             .fixedSize(horizontal: false, vertical: true)
             .clipShape(.rect(cornerRadius: 26.0))
             .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
             .glassEffectID("input", in: namespace)
             .glassEffectTransition(.matchedGeometry)
-            .animation(.easeOut(duration: 0.2), value: isAgentQuickRowVisible)
-            .overlay(alignment: .bottomLeading) {
-                // The `+` menu's invisible hit target, floated over the inert
-                // glyph inside the capsule (see `attachmentsControl`).
-                attachmentsControl
-                    .padding(DesignConstants.Spacing.step2x)
-            }
+    }
+
+    @ViewBuilder
+    private var normalInputView: some View {
+        HStack(alignment: .bottom, spacing: DesignConstants.Spacing.step2x) {
+            participationBubble
+
+            glassStyledInputCapsule
+                .animation(.easeOut(duration: 0.2), value: isAgentQuickRowVisible)
+                .overlay(alignment: .bottomLeading) { attachmentsControlOverlay }
         }
         .disabled(!messagesTextFieldEnabled)
     }

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -105,10 +105,18 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     /// App-provided chip for a staged agent-share link, forwarded to
     /// `MessagesInputView`.
     @ViewBuilder let agentShareChip: () -> AgentChip
-    /// Agent-style composer: the media buttons (camera, photos, files) sit
-    /// inline at the field's leading edge instead of behind the `+` menu,
-    /// and an empty composer's send slot becomes the voice-memo entry.
-    var usesInlineMediaButtons: Bool = false
+    /// Agent-style composer: the same `+` menu as the group composer plus a
+    /// trailing curated quick-action row (default state only), and an empty
+    /// composer's send slot becomes the voice-memo entry.
+    var usesAgentComposerLayout: Bool = false
+    /// Host gate for the `.connections` option, quick icon and menu row
+    /// alike. The composer package cannot read the app's feature flags, so
+    /// the host passes the capability - both offered lists feed from it
+    /// through one predicate (see `ComposerAttachmentAction`).
+    var connectionsEnabled: Bool = false
+    /// Presents the host's Connections browser. The browser lives outside
+    /// this package, so the composer only emits the tap.
+    var onConnectionsTap: (() -> Void)?
 
     @State private var voiceMemoKeyboardKeeperText: String = ""
     @State private var isExpanded: Bool = false
@@ -162,7 +170,9 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         voiceMemoRecorder: VoiceMemoRecorder,
         onSendVoiceMemo: @escaping () -> Void,
         onDebugAttachmentTap: (() -> Void)? = nil,
-        usesInlineMediaButtons: Bool = false,
+        usesAgentComposerLayout: Bool = false,
+        connectionsEnabled: Bool = false,
+        onConnectionsTap: (() -> Void)? = nil,
         onBaseHeightChanged: @escaping (CGFloat) -> Void,
         @ViewBuilder bottomBarContent: @escaping () -> BottomBarContent,
         @ViewBuilder quickEditView: @escaping (String, Binding<Bool>) -> QuickEdit,
@@ -204,7 +214,9 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         self.voiceMemoRecorder = voiceMemoRecorder
         self.onSendVoiceMemo = onSendVoiceMemo
         self.onDebugAttachmentTap = onDebugAttachmentTap
-        self.usesInlineMediaButtons = usesInlineMediaButtons
+        self.usesAgentComposerLayout = usesAgentComposerLayout
+        self.connectionsEnabled = connectionsEnabled
+        self.onConnectionsTap = onConnectionsTap
         self.onBaseHeightChanged = onBaseHeightChanged
         self.bottomBarContent = bottomBarContent
         self.quickEditView = quickEditView
@@ -517,12 +529,17 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         }
     }
 
-    /// The rows the menu draws. The debug injector joins them only where the
+    /// The rows the menu draws: the group composer's standard set, or the
+    /// agent composer's set (camera folded in, `.connections` behind the
+    /// host-passed gate). The debug injector joins them only where the
     /// host handed one over, which it does behind `isDebugInjectorEnabled` -
     /// hard-locked off in production, so no member ever sees the row.
     private var offeredAttachmentActions: [ComposerAttachmentAction] {
-        guard onDebugAttachmentTap != nil else { return ComposerAttachmentAction.standard }
-        return ComposerAttachmentAction.standard + [.debugInjector]
+        let base: [ComposerAttachmentAction] = usesAgentComposerLayout
+            ? ComposerAttachmentAction.agentMenu(connectionsEnabled: connectionsEnabled)
+            : ComposerAttachmentAction.standard
+        guard onDebugAttachmentTap != nil else { return base }
+        return base + [.debugInjector]
     }
 
     /// What the composer can't offer right now. The menu greys these rows rather
@@ -573,41 +590,66 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         .equatable()
     }
 
-    /// Runs the picked row. The menu has already dismissed by the time the
-    /// action fires, so a picker can present right away.
+    /// Runs the picked row, from the `+` menu or the quick row alike. The
+    /// menu has already dismissed by the time the action fires, so a picker
+    /// can present right away.
     private func handleAttachmentSelected(_ action: ComposerAttachmentAction) {
-        switch action {
-        case .photos: isPhotoPickerPresented = true
-        case .camera: isCameraPresented = true
-        case .files: isFilePickerPresented = true
-        case .voiceNote: startVoiceMemoRecording()
+        switch action.dispatch {
+        case .photoPicker: isPhotoPickerPresented = true
+        case .cameraPicker: isCameraPresented = true
+        case .filePicker: isFilePickerPresented = true
+        case .voiceMemo: startVoiceMemoRecording()
+        case .hostConnections: onConnectionsTap?()
         case .debugInjector: onDebugAttachmentTap?()
         }
     }
 
-    /// The agent-style leading accessory: the media actions as always-visible
-    /// buttons instead of rows behind the `+` menu. Shares the menu variant's
-    /// availability rules (`disabledAttachmentActions`).
-    private var inlineMediaButtons: some View {
-        HStack(spacing: 0) {
-            inlineMediaButton(
-                symbol: "camera.fill",
-                action: .camera,
-                label: "Camera",
-                identifier: "camera-button"
-            )
-            inlineMediaButton(
-                symbol: "photo.fill",
-                action: .photos,
-                label: "Photo library",
-                identifier: "photo-picker-button"
-            )
-            inlineMediaButton(
-                symbol: "document.fill",
-                action: .files,
-                label: "Attach file",
-                identifier: "file-picker-button"
-            )
+    /// The agent composer's trailing quick-action row: the curated subset of
+    /// the `+` menu as always-visible filled buttons between the text and the
+    /// voice button. Shares the menu's availability rules
+    /// (`disabledAttachmentActions`) and dispatch (`handleAttachmentSelected`).
+    private var agentQuickRow: some View {
+        let actions: [ComposerAttachmentAction] = ComposerAttachmentAction.agentQuickRow(connectionsEnabled: connectionsEnabled)
+        return HStack(spacing: 0) {
+            ForEach(actions) { action in
+                inlineMediaButton(
+                    symbol: action.filledIconSystemName,
+                    action: action,
+                    label: action.title,
+                    identifier: quickRowIdentifier(for: action)
+                )
+            }
+        }
+    }
+
+    /// Stable accessibility ids: the media pair keeps the ids the old leading
+    /// strip carried (QA flows reference them); new options derive from the
+    /// action's own id.
+    private func quickRowIdentifier(for action: ComposerAttachmentAction) -> String {
+        switch action {
+        case .photos: "photo-picker-button"
+        case .files: "file-picker-button"
+        default: "quick-\(action.rawValue)-button"
+        }
+    }
+
+    /// The quick row shows in the default state only: it collapses while the
+    /// member writes, leaving `+` and the voice button.
+    private var isAgentQuickRowVisible: Bool {
+        usesAgentComposerLayout && AgentComposerQuickRow.isVisible(
+            isMessageFieldFocused: focusState == .message,
+            messageText: messageText
+        )
+    }
+
+    /// The input field's trailing accessory slot: the quick row while the
+    /// agent composer rests in its default state, nothing otherwise (the
+    /// group composer never fills the slot).
+    @ViewBuilder
+    private var quickActionsAccessory: some View {
+        if isAgentQuickRowVisible {
+            agentQuickRow
+                .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .trailing)))
         }
     }
 
@@ -661,18 +703,13 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
                 messagesTextFieldEnabled: messagesTextFieldEnabled,
                 onSendMessage: onSendMessage,
                 onClearInvite: onClearInvite,
-                onVoiceMemoTapWhenEmpty: usesInlineMediaButtons ? { startVoiceMemoRecording() } : nil,
+                onVoiceMemoTapWhenEmpty: usesAgentComposerLayout ? { startVoiceMemoRecording() } : nil,
                 onClearLinkPreview: onClearLinkPreview,
                 onClearMediaAttachment: onClearMediaAttachment,
                 fileAttachmentPreview: fileAttachmentPreview,
                 agentShareChip: agentShareChip,
-                attachmentsButton: {
-                    if usesInlineMediaButtons {
-                        inlineMediaButtons
-                    } else {
-                        attachmentsGlyph
-                    }
-                }
+                quickActionsAccessory: { quickActionsAccessory },
+                attachmentsButton: { attachmentsGlyph }
             )
             .opacity(messagesTextFieldEnabled ? 1.0 : 0.4)
             .fixedSize(horizontal: false, vertical: true)
@@ -680,13 +717,12 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
             .glassEffectID("input", in: namespace)
             .glassEffectTransition(.matchedGeometry)
+            .animation(.easeOut(duration: 0.2), value: isAgentQuickRowVisible)
             .overlay(alignment: .bottomLeading) {
-                // The invisible `+` menu control only overlays the glyph
-                // variant; the inline buttons are real buttons.
-                if !usesInlineMediaButtons {
-                    attachmentsControl
-                        .padding(DesignConstants.Spacing.step2x)
-                }
+                // The `+` menu's invisible hit target, floated over the inert
+                // glyph inside the capsule (see `attachmentsControl`).
+                attachmentsControl
+                    .padding(DesignConstants.Spacing.step2x)
             }
         }
         .disabled(!messagesTextFieldEnabled)

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -4,7 +4,7 @@ import PhotosUI
 import SwiftUI
 import UIKit
 
-public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsButton: View>: View {
+public struct MessagesInputView<FilePreview: View, AgentChip: View, QuickActions: View, AttachmentsButton: View>: View {
     @Binding var displayName: String
     let emptyDisplayNamePlaceholder: String
     let messagePlaceholder: String
@@ -40,6 +40,10 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
     /// App-provided chip for a staged agent-share link. Rendered when
     /// `isShowingAgentShareChip` is true.
     @ViewBuilder let agentShareChip: () -> AgentChip
+    /// Trailing accessory between the text and the send/voice button: the
+    /// agent composer's curated quick-action row. The host supplies it (with
+    /// its own visibility rule); the group composer passes an `EmptyView`.
+    @ViewBuilder let quickActionsAccessory: () -> QuickActions
     /// The attachments control, rendered as a leading accessory inside the field
     /// just before the placeholder - see `attachmentsAccessory`. Supplied by the
     /// host because the menu it opens belongs to the composer's own state.
@@ -75,6 +79,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
         onClearMediaAttachment: ((UUID) -> Void)? = nil,
         @ViewBuilder fileAttachmentPreview: @escaping (PendingFileAttachment) -> FilePreview,
         @ViewBuilder agentShareChip: @escaping () -> AgentChip,
+        @ViewBuilder quickActionsAccessory: @escaping () -> QuickActions,
         @ViewBuilder attachmentsButton: @escaping () -> AttachmentsButton
     ) {
         _displayName = displayName
@@ -102,6 +107,7 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
         self.onClearMediaAttachment = onClearMediaAttachment
         self.fileAttachmentPreview = fileAttachmentPreview
         self.agentShareChip = agentShareChip
+        self.quickActionsAccessory = quickActionsAccessory
         self.attachmentsButton = attachmentsButton
     }
 
@@ -205,6 +211,8 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsB
             HStack(alignment: .bottom, spacing: 0) {
                 attachmentsAccessory
                 messageTextField
+                quickActionsAccessory()
+                    .frame(height: Self.defaultHeight)
                 trailingButton
             }
         }

--- a/ConvosCore/Tests/ConvosCoreTests/ComposerAttachmentCurationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ComposerAttachmentCurationTests.swift
@@ -1,0 +1,97 @@
+import ConvosComposer
+import Foundation
+import Testing
+
+@Suite("Agent composer curation")
+struct ComposerAttachmentCurationTests {
+    @Test("quick row is a subset of the menu in both flag states")
+    func quickRowIsCurationOfMenu() {
+        for connectionsEnabled in [true, false] {
+            let menu = ComposerAttachmentAction.agentMenu(connectionsEnabled: connectionsEnabled)
+            let quickRow = ComposerAttachmentAction.agentQuickRow(connectionsEnabled: connectionsEnabled)
+            for action in quickRow {
+                #expect(menu.contains(action), "quick row offers \(action) the menu withholds (connectionsEnabled: \(connectionsEnabled))")
+            }
+        }
+    }
+
+    @Test("connections appears in both lists when enabled and in neither when disabled")
+    func connectionsFollowsTheSingleGate() {
+        #expect(ComposerAttachmentAction.agentMenu(connectionsEnabled: true).contains(.connections))
+        #expect(ComposerAttachmentAction.agentQuickRow(connectionsEnabled: true).contains(.connections))
+        #expect(!ComposerAttachmentAction.agentMenu(connectionsEnabled: false).contains(.connections))
+        #expect(!ComposerAttachmentAction.agentQuickRow(connectionsEnabled: false).contains(.connections))
+    }
+
+    @Test("agent lists keep their curated order")
+    func agentListOrdering() {
+        #expect(ComposerAttachmentAction.agentMenu(connectionsEnabled: true) == [.photos, .camera, .files, .voiceNote, .connections])
+        #expect(ComposerAttachmentAction.agentMenu(connectionsEnabled: false) == [.photos, .camera, .files, .voiceNote])
+        #expect(ComposerAttachmentAction.agentQuickRow(connectionsEnabled: true) == [.photos, .files, .connections])
+        #expect(ComposerAttachmentAction.agentQuickRow(connectionsEnabled: false) == [.photos, .files])
+    }
+
+    @Test("the group composer's standard menu is untouched")
+    func standardMenuUnchanged() {
+        #expect(ComposerAttachmentAction.standard == [.photos, .camera, .files, .voiceNote])
+        #expect(!ComposerAttachmentAction.standard.contains(.connections))
+    }
+}
+
+@Suite("Composer attachment dispatch")
+struct ComposerAttachmentDispatchTests {
+    @Test("connections routes to the host callback, never to a picker")
+    func connectionsRoutesToHost() {
+        #expect(ComposerAttachmentAction.connections.dispatch == .hostConnections)
+    }
+
+    @Test("only connections routes to the host callback")
+    func onlyConnectionsRoutesToHost() {
+        for action in ComposerAttachmentAction.allCases where action != .connections {
+            #expect(action.dispatch != .hostConnections, "\(action) must not route to the host connections callback")
+        }
+    }
+
+    @Test("picker actions keep their picker routing")
+    func pickerRoutingPinned() {
+        #expect(ComposerAttachmentAction.photos.dispatch == .photoPicker)
+        #expect(ComposerAttachmentAction.camera.dispatch == .cameraPicker)
+        #expect(ComposerAttachmentAction.files.dispatch == .filePicker)
+        #expect(ComposerAttachmentAction.voiceNote.dispatch == .voiceMemo)
+        #expect(ComposerAttachmentAction.debugInjector.dispatch == .debugInjector)
+    }
+
+    @Test("filled icon mapping covers every quick-row case")
+    func filledIconsCoverQuickRow() {
+        for action in ComposerAttachmentAction.agentQuickRow(connectionsEnabled: true) {
+            #expect(!action.filledIconSystemName.isEmpty)
+        }
+        #expect(ComposerAttachmentAction.photos.filledIconSystemName == "photo.fill")
+        #expect(ComposerAttachmentAction.files.filledIconSystemName == "document.fill")
+        #expect(ComposerAttachmentAction.connections.filledIconSystemName == "powerplug.fill")
+    }
+
+    @Test("menu rows keep the outline set")
+    func outlineIconsPinned() {
+        #expect(ComposerAttachmentAction.connections.iconSystemName == "powerplug")
+    }
+}
+
+@Suite("Agent quick row visibility")
+struct AgentComposerQuickRowVisibilityTests {
+    @Test("visible only in the default state")
+    func defaultStateShowsRow() {
+        #expect(AgentComposerQuickRow.isVisible(isMessageFieldFocused: false, messageText: ""))
+    }
+
+    @Test("hidden while the field is focused")
+    func focusHidesRow() {
+        #expect(!AgentComposerQuickRow.isVisible(isMessageFieldFocused: true, messageText: ""))
+    }
+
+    @Test("hidden while text is drafted")
+    func draftedTextHidesRow() {
+        #expect(!AgentComposerQuickRow.isVisible(isMessageFieldFocused: false, messageText: "hello"))
+        #expect(!AgentComposerQuickRow.isVisible(isMessageFieldFocused: true, messageText: "hello"))
+    }
+}

--- a/ConvosTests/AbilitiesListHeroVisibilityTests.swift
+++ b/ConvosTests/AbilitiesListHeroVisibilityTests.swift
@@ -1,0 +1,86 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// The hero is the first thing the composer's powerplug shows, so it must
+/// never claim "nothing connected yet" on state the app knows is stale.
+@MainActor
+final class AbilitiesListHeroVisibilityTests: XCTestCase {
+    func testHeroShowsWhenNothingIsEntitledAndStateIsAuthoritative() async {
+        let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .deviceOnly, artificialDelay: .zero))
+        await viewModel.refresh()
+
+        XCTAssertFalse(viewModel.entitlementsUnavailable)
+        XCTAssertTrue(viewModel.entitledAbilities.isEmpty)
+        XCTAssertFalse(viewModel.availableAbilities.isEmpty)
+        XCTAssertTrue(viewModel.showsNothingConnectedHero)
+    }
+
+    func testHeroIsWithheldWhenEntitlementStateIsUnavailable() async {
+        let viewModel = AbilitiesListViewModel(service: StaleOutageAbilitiesService())
+        await viewModel.refresh()
+
+        // The trap this pins: an outage whose last-known state held nothing
+        // leaves the hero's other four terms all true.
+        XCTAssertTrue(viewModel.entitlementsUnavailable)
+        XCTAssertTrue(viewModel.hasLoadedOnce)
+        XCTAssertFalse(viewModel.isSearching)
+        XCTAssertTrue(viewModel.entitledAbilities.isEmpty)
+        XCTAssertFalse(viewModel.availableAbilities.isEmpty)
+
+        XCTAssertFalse(viewModel.showsNothingConnectedHero)
+    }
+
+    func testHeroIsWithheldWhileSearching() async {
+        let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .deviceOnly, artificialDelay: .zero))
+        await viewModel.refresh()
+        viewModel.searchText = "cal"
+
+        XCTAssertTrue(viewModel.isSearching)
+        XCTAssertFalse(viewModel.showsNothingConnectedHero)
+    }
+
+    func testHeroIsWithheldBeforeTheCatalogLoads() {
+        let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .deviceOnly, artificialDelay: .zero))
+
+        XCTAssertFalse(viewModel.hasLoadedOnce)
+        XCTAssertFalse(viewModel.showsNothingConnectedHero)
+    }
+}
+
+/// Entitlement lookup is down and the last-known state it carries forward
+/// held no entitlements - the one shape no `MockAbilitiesService` scenario
+/// produces, and the exact shape that makes the hero lie.
+private struct StaleOutageAbilitiesService: AbilitiesServiceProtocol {
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        AbilitiesCatalog(
+            catalogVersion: 1,
+            entitlementsUnavailable: true,
+            abilities: MockAbilitiesService.standardCatalog().map { $0.withEntitlementState(.notEntitled) }
+        )
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func completeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func revokeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        []
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+}

--- a/ConvosTests/ConnectionsBrowserModeTests.swift
+++ b/ConvosTests/ConnectionsBrowserModeTests.swift
@@ -1,0 +1,27 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+final class ConnectionsBrowserModeTests: XCTestCase {
+    func testAppSettingsModeRendersWithoutDismissChrome() {
+        let mode: ConnectionsBrowserMode = .appSettings
+        XCTAssertFalse(mode.showsDismissChrome)
+        XCTAssertNil(mode.conversationId)
+        XCTAssertNil(mode.agentInboxId)
+    }
+
+    func testComposerModalModeRendersWithDismissChrome() {
+        let mode: ConnectionsBrowserMode = .composerModal(conversationId: "dm-1", agentInboxId: "agent-1")
+        XCTAssertTrue(mode.showsDismissChrome)
+        XCTAssertEqual(mode.conversationId, "dm-1")
+        XCTAssertEqual(mode.agentInboxId, "agent-1")
+    }
+
+    func testModeIdentitiesAreDistinct() {
+        let settings: ConnectionsBrowserMode = .appSettings
+        let modal: ConnectionsBrowserMode = .composerModal(conversationId: "dm-1", agentInboxId: "agent-1")
+        let otherModal: ConnectionsBrowserMode = .composerModal(conversationId: "dm-2", agentInboxId: "agent-1")
+        XCTAssertNotEqual(settings.id, modal.id)
+        XCTAssertNotEqual(modal.id, otherModal.id)
+    }
+}


### PR DESCRIPTION
## What

The 1:1 agent-chat composer redesign and the unified Connections browser modal it opens.

**Composer.** The Agent tab used a leading strip of always-visible media buttons and no attachments menu, so camera/photo/files were the only things it could ever offer. It now renders the group composer's `+` menu plus a *trailing* curated quick-action row -- photo, document, powerplug in the default state, collapsing to `+` and voice as soon as the field takes focus or the member starts typing. Camera moves into the `+` menu.

**Browser.** The powerplug (quick icon and `+` menu row alike) opens the account-level Connections browser full-screen. The screen is not new: `AbilitiesListScreen` now takes a `ConnectionsBrowserMode` so the App Settings push and the composer modal render the same list from the same view model, differing only in wrapper chrome (`.composerModal` supplies its own `NavigationStack` + Done).

## One curation, one gate

`ComposerAttachmentAction` stays the single declaration of what an option is. It gains `.connections`, a `filledIconSystemName` for the quick row (menu rows keep the outline set), and a `Dispatch` enum so `.connections` routes to a host callback rather than a picker.

```swift
static func agentMenu(connectionsEnabled: Bool) -> [ComposerAttachmentAction]
static func agentQuickRow(connectionsEnabled: Bool) -> [ComposerAttachmentAction]
```

Both are base lists run through one `included(_:connectionsEnabled:)` predicate. The row can never surface an option the menu withholds, and neither list carries `.connections` unconditionally -- a side door would require bypassing the predicate, which the tests pin in both flag states.

`ConvosComposer` cannot read the app's `FeatureFlags`, so the V2 gate arrives as a host-passed `connectionsEnabled` capability threaded `AgentComposerBar` -> `ConversationComposerBar` -> `MessagesBottomBar`, read from `FeatureFlags.shared.isAbilitiesV2Enabled` at exactly one seam (`ConversationView`), which also guards the modal presentation. Flag off: no powerplug anywhere, row is `[.photos, .files]`, and the rest of the redesign still ships.

## Also in here

- `usesInlineMediaButtons` renamed `usesAgentComposerLayout` so the old "leading strip instead of `+`" semantic cannot be reached for.
- The catalog-outage banner had no retry control; the browser adds an explicit Retry plus pull-to-refresh, in both modes.
- A hero state for a member with nothing connected yet (copy is placeholder pending design input).
- The pre-creation draft composer mirrors the new default-state layout, dimmed.

## Not in here

The group composer is untouched -- its offered actions still come from `standard`, which never contains `.connections`. Per-conversation enablement (`ConversationAbilitiesSection`) is untouched too: "connected to the app" and "enabled here" stay distinct surfaces.

## Verification

- `swiftlint --strict` clean, `swiftformat --lint` clean (0/1270 files require formatting).
- `Convos (Dev)` simulator build (`-configuration Dev`, iPhone 17 arm64, worktree-local `.derivedData`): BUILD SUCCEEDED with the changed files forced to recompile -- no type-check-budget warnings.
- `swift test --package-path ConvosCore`: 1906 tests in 257 suites passed, including the three new suites in `ConvosCore/Tests/ConvosCoreTests/ComposerAttachmentCurationTests.swift` (curation invariant in both flag states, dispatch routing, quick-row visibility).
- `ConvosTests/ConnectionsBrowserModeTests.swift` pins the mode wrapper (chrome, carried context, distinct identities).
- Screenshots captured off mock data: composer default state matches Figma node 7865-42114 (`+`, placeholder, photo/document/powerplug, circular voice button); the modal renders Connected + Available with search and Done.

No backend E2E in this PR -- that runs once for the whole stack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789747099&installation_model_id=20076&pr_number=1352&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1352&signature=bfdf5bde34f1d9371e86b149472a0957412e07d6cfcf60f7141f5d6c5c731d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign the agent composer with a + menu and open the Connections browser from it
> - Adds a `+` menu and curated quick-actions row to the agent composer bar via `ComposerAttachmentAction`, with a new `connections` case gated by the Abilities V2 feature flag.
> - Introduces `ConnectionsBrowserMode` to distinguish `appSettings` vs `composerModal` presentation, carrying conversation and agent inbox context for the latter.
> - `ConversationView` presents `AbilitiesListScreen` in a full-screen cover when the user taps the connections entry, scoped to the current agent DM.
> - `AbilitiesListScreen` wraps in its own `NavigationStack` with a Done button when shown as a composer modal; in app settings mode it renders without extra chrome.
> - Adds a 'nothing connected' hero section to `AbilitiesListView` with pull-to-refresh and a Retry button on the outage banner.
> - Behavioral Change: the agent composer's inline media buttons are replaced by the new `+` menu and quick-actions row; pre-creation state renders these dimmed and inert.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e1f9cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->