### PR TITLE
Cache the ability icons so they stop flashing their symbol placeholder

### DIFF
--- a/Convos/Abilities/AbilityEscalationPromptCard.swift
+++ b/Convos/Abilities/AbilityEscalationPromptCard.swift
@@ -193,7 +193,7 @@ struct AbilityEscalationPromptSurface: View {
     }
 }
 
-/// Self-contained preview fixtures: a data: URI so `AsyncImage` has a real
+/// Self-contained preview fixtures: a data: URI so the icon loader has a real
 /// image to decode without any network dependency.
 private enum PreviewData {
     static let calendarIconDataUrl: String = """

--- a/Convos/Abilities/AbilityIconLoader.swift
+++ b/Convos/Abilities/AbilityIconLoader.swift
@@ -1,0 +1,65 @@
+import ConvosCore
+import UIKit
+
+/// Memory-and-disk caching for the backend-served ability icons, layered on
+/// the app's shared `ImageCache`.
+///
+/// The icons are versioned, immutable PNGs with an alpha channel - the
+/// backend serves `/ability-icons/<slug>-v<n>.png` with
+/// `Cache-Control: immutable, max-age=1y` - so the URL is a permanent cache
+/// key that never needs revalidating, and a bumped icon keys separately
+/// instead of serving the previous bytes.
+///
+/// They use the cache's identifier-based API rather than the object-based
+/// `ImageCacheable` path because that path persists to disk as JPEG, which
+/// would flatten each icon's transparency onto an opaque square from the
+/// first cold launch onwards.
+enum AbilityIconLoader {
+    /// The memory hit, synchronously. Non-nil means a view can draw the icon
+    /// in its first frame, which is what keeps a re-rendered row from
+    /// flashing its symbol placeholder.
+    static func cachedIcon(for url: URL) -> UIImage? {
+        ImageCache.shared.image(for: cacheKey(for: url), imageFormat: .png)
+    }
+
+    /// Memory, then disk, then the network - caching at whichever step it had
+    /// to descend to.
+    static func icon(for url: URL) async -> UIImage? {
+        let key = cacheKey(for: url)
+        if let cached = await ImageCache.shared.imageAsync(for: key, imageFormat: .png) {
+            return cached
+        }
+        guard let fetched = await fetchIcon(at: url) else { return nil }
+        ImageCache.shared.cacheImage(fetched, for: key, imageFormat: .png)
+        return fetched
+    }
+
+    /// Namespaced so an icon URL can never collide with another cache client's
+    /// identifier space.
+    static func cacheKey(for url: URL) -> String {
+        "ability-icon-\(url.absoluteString)"
+    }
+
+    private static func fetchIcon(at url: URL) async -> UIImage? {
+        // SwiftUI previews hand over a data: URI so they need no network, and
+        // URLSession does not serve that scheme.
+        if url.scheme == "data" {
+            return (try? Data(contentsOf: url)).flatMap { UIImage(data: $0) }
+        }
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                Log.error("Ability icon fetch failed for \(url): unexpected response")
+                return nil
+            }
+            guard let image = UIImage(data: data) else {
+                Log.error("Ability icon at \(url) could not be decoded")
+                return nil
+            }
+            return image
+        } catch {
+            Log.error("Ability icon fetch failed for \(url): \(error)")
+            return nil
+        }
+    }
+}

--- a/Convos/Abilities/AbilityRowComponents.swift
+++ b/Convos/Abilities/AbilityRowComponents.swift
@@ -4,29 +4,54 @@ import SwiftUI
 /// Icon for an ability row: the server-provided image when the manifest
 /// carries an icon URL, otherwise a local symbol fallback keyed by
 /// ability id (the backend omits icons until its asset story lands).
+///
+/// The server image is resolved through `AbilityIconLoader`, not `AsyncImage`.
+/// `AsyncImage` begins every instance in its empty phase and reaches the
+/// loaded phase asynchronously even when the bytes are already in `URLCache`,
+/// so each new instance - a list re-render, a sheet, a detail push - showed
+/// the symbol placeholder for at least a frame before the colored icon
+/// replaced it. Reading the memory cache during `body` instead means a
+/// previously seen icon is on screen in the first frame.
 struct AbilityIconView: View {
     let ability: AbilitiesAPI.Ability
     /// Defaults preserve every existing call site's 40pt chip.
     var iconSize: CGFloat = Constant.iconSize
     /// Defaults preserve every existing call site's filled background.
     var showsBackground: Bool = true
+    /// Set once the loader resolves the icon from disk or the network. A
+    /// memory hit never needs it: `displayImage` finds that directly.
+    @State private var loadedIcon: UIImage?
 
     var body: some View {
-        Group {
-            if let iconUrl {
-                AsyncImage(url: iconUrl) { image in
-                    image
-                        .resizable()
-                        .scaledToFit()
-                } placeholder: {
-                    symbolImage
-                }
-            } else {
-                symbolImage
-            }
+        iconContent
+            .frame(width: iconSize, height: iconSize)
+            .background(backgroundChip)
+            .task(id: iconUrl) { await loadIcon() }
+    }
+
+    @ViewBuilder
+    private var iconContent: some View {
+        if let displayImage {
+            Image(uiImage: displayImage)
+                .resizable()
+                .scaledToFit()
+        } else {
+            symbolImage
         }
-        .frame(width: iconSize, height: iconSize)
-        .background(backgroundChip)
+    }
+
+    /// The freshly loaded icon, else whatever the memory cache already holds.
+    /// The cache read is an in-memory lookup, cheap enough for `body`, and is
+    /// what removes the placeholder frame on a warm cache.
+    private var displayImage: UIImage? {
+        if let loadedIcon { return loadedIcon }
+        guard let iconUrl else { return nil }
+        return AbilityIconLoader.cachedIcon(for: iconUrl)
+    }
+
+    private func loadIcon() async {
+        guard let iconUrl else { return }
+        loadedIcon = await AbilityIconLoader.icon(for: iconUrl)
     }
 
     @ViewBuilder

--- a/ConvosTests/AbilityIconLoaderTests.swift
+++ b/ConvosTests/AbilityIconLoaderTests.swift
@@ -1,0 +1,82 @@
+@testable import Convos
+import ConvosCore
+import UIKit
+import XCTest
+
+/// The icons flickered because every fresh `AbilityIconView` had to reach the
+/// network layer asynchronously before it could draw. What removes the
+/// flicker is the synchronous memory hit, so that is what these pin - along
+/// with the version scoping that keeps a bumped icon from serving the
+/// previous one's bytes.
+final class AbilityIconLoaderTests: XCTestCase {
+    private var cachedKeys: [String] = []
+
+    override func tearDown() {
+        for key in cachedKeys {
+            ImageCache.shared.removeImage(for: key)
+        }
+        cachedKeys = []
+        super.tearDown()
+    }
+
+    func testCachedIconIsNilBeforeAnythingIsCached() throws {
+        let url = try makeIconURL(slug: uniqueSlug("googlecalendar"), version: 1)
+
+        XCTAssertNil(AbilityIconLoader.cachedIcon(for: url))
+    }
+
+    func testCachedIconReturnsTheCachedImageSynchronously() throws {
+        let url = try makeIconURL(slug: uniqueSlug("gmail"), version: 1)
+        cache(makeIcon(), for: url)
+
+        XCTAssertNotNil(AbilityIconLoader.cachedIcon(for: url))
+    }
+
+    func testIconResolvesFromTheCacheWithoutFetching() async throws {
+        let url = try makeIconURL(slug: uniqueSlug("spotify"), version: 1)
+        cache(makeIcon(), for: url)
+
+        let resolved = await AbilityIconLoader.icon(for: url)
+
+        XCTAssertNotNil(resolved)
+    }
+
+    /// The icon URL carries the version, so a bumped icon must miss rather
+    /// than resolve to the previous version's cached bytes.
+    func testABumpedIconVersionDoesNotResolveToThePreviousVersion() throws {
+        // The two URLs differ only in the version segment.
+        let slug = uniqueSlug("coinbase")
+        let firstVersion = try makeIconURL(slug: slug, version: 1)
+        let secondVersion = try makeIconURL(slug: slug, version: 2)
+        cache(makeIcon(), for: firstVersion)
+
+        XCTAssertNotNil(AbilityIconLoader.cachedIcon(for: firstVersion))
+        XCTAssertNil(AbilityIconLoader.cachedIcon(for: secondVersion))
+    }
+
+    // MARK: - Helpers
+
+    /// Unique per test so the process-wide `ImageCache` cannot carry an entry
+    /// between them.
+    private func uniqueSlug(_ name: String) -> String {
+        "\(name)-\(UUID().uuidString)"
+    }
+
+    /// The shape the backend serves: slug, version, `.png`.
+    private func makeIconURL(slug: String, version: Int) throws -> URL {
+        try XCTUnwrap(URL(string: "https://example.invalid/ability-icons/\(slug)-v\(version).png"))
+    }
+
+    private func makeIcon() -> UIImage {
+        UIGraphicsImageRenderer(size: CGSize(width: 8, height: 8)).image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
+        }
+    }
+
+    private func cache(_ image: UIImage, for url: URL) {
+        let key = AbilityIconLoader.cacheKey(for: url)
+        cachedKeys.append(key)
+        ImageCache.shared.cacheImage(image, for: key, imageFormat: .png)
+    }
+}


### PR DESCRIPTION
## The bug

The colored connection icons blink to a grey SF Symbol and back every time a view carrying one loads — the connections list, the ability detail push, the escalation card, every ability sheet.

## Cause

`Convos/Abilities/AbilityRowComponents.swift:17` rendered the server icon with a bare `AsyncImage(url:)` whose `placeholder` is the local SF Symbol fallback.

It is **not** a re-fetch. The backend already serves these correctly: `backend/src/routes/ability-icons.ts:44-45` sets `maxAge: "1y", immutable: true`, and the filenames are versioned (`googlecalendar-v1.png`), so the bytes are in `URLCache`. The blink is `AsyncImage` itself — it begins every instance in the `.empty` phase and reaches `.success` asynchronously even on a `URLCache` hit. Because `AbilityIconView` is instantiated afresh on every list re-render, sheet presentation, and detail push, and because its placeholder looks nothing like the loaded icon, the transition is visible every time.

## Fix

Icons resolve through the app's existing `ImageCache` (`ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift`) instead — the same cache `AvatarView` uses. New `Convos/Abilities/AbilityIconLoader.swift` is a thin front for it; no new cache layer.

`AbilityIconView` reads the memory cache during `body`, so an icon the app has already loaded is on screen in the **first frame** with no placeholder at all. An async `.task` fills in from disk or the network on a miss. That is the property `AsyncImage` structurally cannot provide.

### Why the identifier-based API and not `ImageCacheable`

The object-based path (`loadImage(for:)` → `fetchImageFromNetwork` → `saveImageToDisk`) hardcodes `imageFormat: .jpg`. Every ability icon is a 256x256 **RGBA** PNG, so conforming `Ability` to `ImageCacheable` would have flattened the transparency onto an opaque square from the first cold launch onward — trading the flicker for a worse, permanent artifact. Its continuity-hint store is JPEG-only too, and would have made the cold-start first frame a black-boxed icon.

The identifier-based API (`image(for:imageFormat:)` / `imageAsync(for:imageFormat:)` / `cacheImage(_:for:imageFormat:)`) takes the format, so the disk copy stays PNG. `QRCodeGenerator.swift:172` is the existing precedent for using it with `.png`.

### Cache key

The full icon URL, namespaced `ability-icon-<url>`. The URL carries the icon version, so a bumped icon keys separately instead of serving the previous version's bytes — pinned by a test.

## Verification

- `swiftlint --strict` clean; `swiftformat --lint` clean (0/1274).
- `Convos (Dev)` simulator build (`-configuration Dev`, iPhone 17 arm64, worktree-local `.derivedData`): BUILD SUCCEEDED, no type-check-budget warnings. Note this configuration is also what the scheme's ArchiveAction uses.
- `swift test --package-path ConvosCore`: 1902 tests in 255 suites passed.
- `ConvosTests/AbilityIconLoaderTests.swift`: 4 tests passed. **Mutation-checked** — collapsing `cacheKey` so it drops the version segment makes `testABumpedIconVersionDoesNotResolveToThePreviousVersion` fail (v2 resolves to v1's cached bytes), and it passes again once restored.

## Scope

Only ability icons. `Convos/Conversation Detail/AgentFilesLinksView.swift:370` also uses a bare `AsyncImage`, for file/link thumbnails — same class of issue, different surface, left alone here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789750418&installation_model_id=20076&pr_number=1355&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1355&signature=7fe42508e056138ae7d25985430e2a37797b6f7374dc482fdca1dbc812593c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache ability icons to prevent symbol placeholder flash on load
> - Adds [`AbilityIconLoader`](https://github.com/xmtplabs/convos-ios/pull/1355/files#diff-328792cb784ad3f16dacda373876604cc20c2d97f94d853b4c7b23a97ebfeef3), an enum with memory and disk caching for ability icons, supporting both `data:` URIs and network URLs with 2xx validation, storing results as PNG keyed by URL.
> - Updates [`AbilityIconView`](https://github.com/xmtplabs/convos-ios/pull/1355/files#diff-79bc8d012318dfc04bf2c5f1b10965f05d497f2b295a149e4b16025a7bcbadcf) to replace `AsyncImage` with `AbilityIconLoader`: synchronously returns a cached icon on the first frame to avoid the placeholder flash, then falls back to async fetch.
> - Behavioral Change: icons previously fetched fresh on every render are now cached in memory; a version bump in the icon URL will produce a distinct cache key and bypass the old cached bytes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dec877.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->