### PR TITLE
Show the variant badge in an agent DM

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -262,7 +262,11 @@ struct AgentDmPageView: View {
                 return item
             }
         }
-        items.insert(.agentDmInfo(agentName: agentName), at: 0)
+        // The stamp lives on the agent member's profile, written by the
+        // assistants worker at join. nil for a default agent, and nil off dev,
+        // where the header renders exactly as before.
+        let variant = dmVm.conversation.members.first(where: { $0.isAgent })?.profile.variant
+        items.insert(.agentDmInfo(agentName: agentName, variant: variant), at: 0)
         return items
     }
 

--- a/ConvosCore/Sources/ConvosComposer/AgentDmInfoCellView.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentDmInfoCellView.swift
@@ -9,15 +9,33 @@ import SwiftUI
 ///
 /// Figma 7686:39662. The three lines step down the iOS type scale -
 /// .body medium, .subheadline, .footnote - with the disclosure in secondary.
+///
+/// Dev-only: when the agent was built on a variant, the shared variant ribbon
+/// sits above the title as a badge. Everywhere else the ribbon rides the agent
+/// contact card, which a DM deliberately drops - so this header is the only
+/// place a DM can answer "which runtime am I talking to?". Without it a
+/// varianted agent is indistinguishable from a default one until its behavior
+/// disagrees, which is the whole failure mode the variant work exists to close.
 public struct AgentDmInfoCellView: View {
     let agentName: String
+    let variant: AgentVariantStamp?
 
-    public init(agentName: String) {
+    public init(agentName: String, variant: AgentVariantStamp? = nil) {
         self.agentName = agentName
+        self.variant = variant
     }
 
     public var body: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
+            if !ConfigManager.shared.currentEnvironment.isProduction, let variant {
+                // Sized to its content and centered, rather than the full-bleed
+                // bar the contact-card overlay uses: this header is a centered
+                // column, and a full-width left-aligned bar would read as a
+                // banner across the screen instead of a badge on the agent.
+                AgentVariantRibbon(variant: variant)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .clipShape(Capsule())
+            }
             Text("1-on-1 with \(agentName)")
                 .font(.body.weight(.medium))
                 .foregroundStyle(.colorTextPrimary)

--- a/ConvosCore/Sources/ConvosComposer/AgentDmInfoCellView.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentDmInfoCellView.swift
@@ -27,7 +27,13 @@ public struct AgentDmInfoCellView: View {
 
     public var body: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
-            if !ConfigManager.shared.currentEnvironment.isProduction, let variant {
+            // The empty-label guard is not defensive noise: the worker forwards
+            // `metadata.variant` verbatim for the cosmetic banner, so a stamp
+            // that parseVariantDescriptor would reject still decodes here. Its
+            // ribbon would be a bare emoji on a yellow pill - a placeholder that
+            // says less than showing nothing.
+            if !ConfigManager.shared.currentEnvironment.isProduction,
+               let variant, !variant.label.isEmpty {
                 // Sized to its content and centered, rather than the full-bleed
                 // bar the contact-card overlay uses: this header is a centered
                 // column, and a full-width left-aligned bar would read as a

--- a/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages View Controller/View Controller/Cells/MessagesListItemTypeCell.swift
@@ -155,8 +155,8 @@ class MessagesListItemTypeCell: UICollectionViewCell {
                         .padding(.vertical, DesignConstants.Spacing.step4x)
                         .padding(.horizontal, DesignConstants.Spacing.step4x)
 
-                case let .agentDmInfo(agentName):
-                    AgentDmInfoCellView(agentName: agentName)
+                case let .agentDmInfo(agentName, variant):
+                    AgentDmInfoCellView(agentName: agentName, variant: variant)
 
                 case .typingIndicator:
                     EmptyView()

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessagesListItemType.swift
@@ -59,8 +59,11 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
     case agentBuilderSummary(AgentBuilderCardContent)
     case agentActivating(AgentActivatingCardContent)
     /// The agent-DM disclosure header: always the first cell of an agent-DM
-    /// transcript (and its empty state). See docs/plans/agent-dms.md.
-    case agentDmInfo(agentName: String)
+    /// transcript (and its empty state). See docs/plans/agent-dms.md. Carries
+    /// the agent's variant stamp so the DM can say which runtime it is talking
+    /// to -- the in-chat ribbon rides the agent contact card, which a DM
+    /// deliberately drops, so without this a varianted DM looks like any other.
+    case agentDmInfo(agentName: String, variant: AgentVariantStamp?)
     case typingIndicator(typers: [ConversationMember])
 
     public var id: String {
@@ -89,8 +92,10 @@ public enum MessagesListItemType: Identifiable, Equatable, Hashable, Sendable {
             return "agent-builder-summary-\(content.id)"
         case .agentActivating(let content):
             return "agent-activating-\(content.id)"
-        case .agentDmInfo:
-            return "agent-dm-info"
+        case .agentDmInfo(_, let variant):
+            // The slug rides the identity so a stamp that arrives after first
+            // render (profile sync) re-renders the cell instead of sticking.
+            return "agent-dm-info-\(variant?.slug ?? "none")"
         case .typingIndicator:
             return "typing-indicator"
         }

--- a/ConvosCore/Tests/ConvosCoreTests/MessagesListItemTypeIdentityTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessagesListItemTypeIdentityTests.swift
@@ -1,0 +1,45 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+// MARK: - Agent DM Header Identity
+
+/// The agent-DM header's identity carries the variant slug so a stamp that
+/// lands after first render - the profile sync that fills in the agent
+/// member - changes the item's id and forces the diffable data source to
+/// rebuild the cell. Were the id constant, the header would keep rendering
+/// its pre-sync self and the variant badge would never appear.
+struct MessagesListItemTypeAgentDmInfoIdentityTests {
+    private static let stamp: AgentVariantStamp = .init(
+        slug: "pr-3454",
+        label: "G Maps",
+        whatToTest: "Places lookups run through the Maps ability.",
+        prUrl: "https://github.com/xmtplabs/convos-assistants/pull/3454"
+    )
+
+    @Test("A default agent's header identity names no variant")
+    func identityWithoutVariant() {
+        let item: MessagesListItemType = .agentDmInfo(agentName: "Agent", variant: nil)
+        #expect(item.id == "agent-dm-info-none")
+    }
+
+    @Test("A varianted agent's header identity carries the slug")
+    func identityWithVariant() {
+        let item: MessagesListItemType = .agentDmInfo(agentName: "Agent", variant: Self.stamp)
+        #expect(item.id == "agent-dm-info-pr-3454")
+    }
+
+    @Test("A stamp arriving after first render changes the header's identity")
+    func identityChangesWhenStampArrives() {
+        let before: MessagesListItemType = .agentDmInfo(agentName: "Agent", variant: nil)
+        let after: MessagesListItemType = .agentDmInfo(agentName: "Agent", variant: Self.stamp)
+        #expect(before.id != after.id)
+        #expect(before != after)
+    }
+
+    @Test("The header still explains an empty transcript with a variant attached")
+    func explainsEmptyTranscriptWithVariant() {
+        let item: MessagesListItemType = .agentDmInfo(agentName: "Agent", variant: Self.stamp)
+        #expect(item.explainsAnEmptyTranscript)
+    }
+}


### PR DESCRIPTION
A 1-on-1 with a varianted agent shows no variant marker at all.

The dev variant ribbon rides the agent contact card. A DM deliberately drops that card — `dmItems` nils `group.agentContactCard` and leads with the disclosure header instead — so the ribbon has nothing to attach to. You can pick a variant, open the DM, and have nothing on screen distinguish it from a default agent until its behavior disagrees. That is precisely the failure the variant tooling exists to close, and it's the one surface where it still bites.

### The change

`AgentDmInfoCellView` now takes the agent's `AgentVariantStamp` and renders the shared `AgentVariantRibbon` above the title, so the DM answers "which runtime am I talking to?" the same way the group transcript does, with the same 🧪 label and PR link.

Sized to content and clipped to a capsule rather than the full-bleed bar the contact-card overlay uses — the header is a centered column, where a full-width left-aligned bar would read as a banner across the screen instead of a badge on the agent.

Plumbing: the stamp rides `MessagesListItemType.agentDmInfo` so the cell has it at render time, and the slug is part of the item's `id` so a stamp that lands after first paint (profile sync) re-renders the cell instead of sticking. `AgentDmPageView` reads it off the agent member's profile, where the assistants worker writes it at join.

Dev-only and nil-guarded on both counts: off dev, or for a default agent, the header renders exactly as it does today. The new `init` parameter defaults to nil, so the call site in the share extension is untouched.

### Verification — please read

**I could not build or test this.** I'm running on Linux with no Swift toolchain, so nothing here has been compiled and SwiftLint has not run. That is why it's a draft — CI should be the first thing that compiles it.

Checked by hand instead: every other `agentDmInfo` pattern match is non-binding (`case .agentDmInfo:` in three switches, `if case .agentDmInfo = self`), so adding an associated value leaves them compiling; only the two binding sites are updated. `AgentVariantStamp` is already `Equatable, Hashable, Sendable`, so the enum's synthesized conformances hold. `AgentVariantRibbon` and `ConfigManager` are both already used inside ConvosComposer.

### Related

Backend side landed in convos-assistants#3460 (the join response now reports the applied variant, and the agent row records it); the cache fix that made a fresh variant selectable at all is #1346.

Follow-up worth considering, not in here: the backend now also returns `variantDropped` — the slug you asked for and did not get. Surfacing *that* would catch the case where the pick never bound, which this badge cannot show because there is no stamp to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQyDQjA1jrkdwPNoG25krY

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQyDQjA1jrkdwPNoG25krY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789753045&installation_model_id=20076&pr_number=1356&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1356&signature=4651172e6a9fd94eac30200eee45bf456e457f984c0f2f07dcd53c62b77aa8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show the agent variant badge in the agent DM info header
> - Adds an optional `variant: AgentVariantStamp?` to the `MessagesListItemType.agentDmInfo` enum case and threads it through to `AgentDmInfoCellView`.
> - In non-production builds, `AgentDmInfoCellView` renders an `AgentVariantRibbon` above the agent name when a non-empty variant stamp is present.
> - The `agentDmInfo` item's computed `id` now includes the variant slug (e.g. `agent-dm-info-none` vs `agent-dm-info-<slug>`), so diffable data sources rebuild the cell when the variant changes.
> - Behavioral Change: all call sites constructing `.agentDmInfo` must now supply the variant argument; the item's identity value has changed from the constant `agent-dm-info`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0509a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->