### PR TITLE
Centre the Agent tab's empty states in the sheet, not in the frame it is handed

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -54,6 +54,17 @@ struct AgentDmPageView: View {
     /// opens on the Agent tab.
     var onContentHeightChanged: ((CGFloat) -> Void)?
 
+    /// How much of this page's top the sheet is clipping away.
+    ///
+    /// The sheet hands its transcripts one constant, full-height frame at
+    /// every detent, bottom-aligned, and clips whatever overflows its top
+    /// edge (see `ConversationSheetContent.transcript`). The transcript wants
+    /// that overflow - it scrolls content up through it - but the empty
+    /// states below want it padded back out: centering in the full frame puts
+    /// them in the band above the sheet, so at anything short of `full` they
+    /// are clipped away entirely and the tab reads as blank.
+    @Environment(\.transcriptClippedTopOverflow) private var clippedTopOverflow: CGFloat
+
     /// Fill of the preparing bar. Creeps while the agent is on its way; it
     /// tracks elapsed time, not real progress, since nothing reports any.
     @State private var preparingProgress: Double = Constant.progressStart
@@ -169,8 +180,8 @@ struct AgentDmPageView: View {
     }
 
     /// Offered when the conversation has no agent at all (Figma 7488:14502).
-    /// Centered in the space above the sheet rather than the full view, so it
-    /// reads as centered on screen.
+    /// Centered in the sheet's visible band rather than in the full-height
+    /// frame the sheet hands its transcripts - see `clippedTopOverflow`.
     private var addAgentState: some View {
         VStack(spacing: DesignConstants.Spacing.step3x) {
             Button(action: session.requestAgentJoin) {
@@ -188,6 +199,12 @@ struct AgentDmPageView: View {
                 .foregroundStyle(.colorLava)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Inset to the band the sheet is showing - the clipped overflow off
+        // the top, the chrome's clearance off the bottom - so this centers in
+        // what the reader can see and follows the sheet's edge as it resizes.
+        // The background sits outside both, so the dark surface still fills
+        // the clipped region.
+        .padding(.top, clippedTopOverflow)
         .padding(.bottom, extraBottomInset)
         .background(.colorBackgroundSurfaceless)
     }
@@ -204,6 +221,12 @@ struct AgentDmPageView: View {
             progressBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Inset to the band the sheet is showing - the clipped overflow off
+        // the top, the chrome's clearance off the bottom - so this centers in
+        // what the reader can see and follows the sheet's edge as it resizes.
+        // The background sits outside both, so the dark surface still fills
+        // the clipped region.
+        .padding(.top, clippedTopOverflow)
         .padding(.bottom, extraBottomInset)
         .background(.colorBackgroundSurfaceless)
         .task(id: isPreparing) {


### PR DESCRIPTION
The Agent tab's "Preparing your agent chat" state doesn't resize with the conversation sheet, and at anything short of the `full` detent the tab reads as blank.

### Cause

`ConversationSheetContent.transcript` hands its transcripts **one constant, full-height frame at every detent**, bottom-aligned, and clips whatever overflows the sheet's top edge. That's deliberate — it's what keeps a transcript's scroll position from sliding when the sheet is dragged.

But a child that centres itself with `.frame(maxHeight: .infinity)` centres in *that frame*, not in the sheet. At `full` the two coincide and it looks right; at every smaller detent the centre sits in the clipped band above the sheet's top edge, so nothing is drawn where the reader is looking.

The group transcript is unaffected — `MessagesView` already reads `\.transcriptClippedTopOverflow` and passes it down to the collection view as a top content inset. `AgentDmPageView` was the one page handed the oversized frame without accounting for it.

### Fix

Both empty states — `preparingState` and the `addAgentState` next to it, which had the identical bug — now pad by that same `\.transcriptClippedTopOverflow`, which is the measurement of exactly the band being clipped. They centre in what the reader can see, and follow the sheet's edge live as it's dragged, since the overflow arrives every frame of a drag. The background stays outside the insets, so the dark surface still fills the clipped region.

### Verification

A headless SwiftUI render harness reproducing the sheet's layout contract — an 800pt held frame shown through a 400pt sheet over 150pt of chrome, expected centre 125pt:

| | result |
|---|---|
| before | content **not visible at all** — clipped away entirely |
| after | content at y=111…141, **centre 126pt** |

`xcodebuild build -scheme "Convos (Local)" -configuration Local`: BUILD SUCCEEDED, 0 errors, 0 type-check warnings.

### Note

The doc comment on `AgentDmPageView.onContentHeightChanged` still claims it "caps how far the sheet opens on the Agent tab", but `ConversationView` stopped passing it in #1325. Stale, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789756793&installation_model_id=20076&pr_number=1357&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1357&signature=5619baa7af7a06e82423c722c824b4ca99c9d41d5927254950a1dbeac4b5cdd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centre Agent tab empty states within the sheet's visible band at partial detents
> The `addAgentState` and `preparingState` views in [AgentDmPageView.swift](https://github.com/xmtplabs/convos-ios/pull/1357/files#diff-d3c09c173a2b279a809729d0bb25db13ede2e56e7b1c18bd65422a32610eab57) were vertically centering relative to their full-height frame, causing them to appear clipped or off-centre when the sheet is at a partial detent. A top padding equal to `clippedTopOverflow` (read from the `transcriptClippedTopOverflow` environment key) is added before the existing bottom inset, so both states center within the sheet's visible band instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 702938d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->