### PR TITLE
fix(onboarding): make the first-launch nametag sheet a required step

### DIFF
--- a/Convos/Profile/ProfileSetupSheet.swift
+++ b/Convos/Profile/ProfileSetupSheet.swift
@@ -99,6 +99,17 @@ struct ProfileSetupSheet: View {
             && !isSaving
     }
 
+    /// First launch is a required step: the sheet can only be completed
+    /// with the CTA, never swiped away or tapped out of. In edit mode it
+    /// stays swipe-away-able, but only once the save gate (a non-empty
+    /// name) is satisfied.
+    private var isInteractiveDismissDisabled: Bool {
+        switch mode {
+        case .firstLaunch: true
+        case .edit: !canSave
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0.0) {
             header
@@ -139,9 +150,7 @@ struct ProfileSetupSheet: View {
         }
         .presentationDetents([.height(contentHeight)])
         .presentationDragIndicator(.hidden)
-        // Until the save gate is satisfied (name entered, terms accepted on
-        // first launch) the sheet can only be completed, not swiped away.
-        .interactiveDismissDisabled(!canSave)
+        .interactiveDismissDisabled(isInteractiveDismissDisabled)
         .presentationBackground(.colorBackgroundRaisedSecondary)
         // Expose the sheet as an accessibility container so its identifier
         // stays on the container node instead of propagating down and

--- a/qa/tests/01-onboarding.md
+++ b/qa/tests/01-onboarding.md
@@ -13,7 +13,7 @@ Verify that a first-time user is offered the first-launch "Hello / My name is" p
 ### Launch into first-launch profile setup
 
 1. Launch the app. It lands on the home shell (Chats tab, compose button visible).
-2. The "Hello / My name is" profile setup sheet self-presents over the Chats tab. Poll for `profile-setup-name-field` with `sim_wait_for_element` (timeout: 20s — the sheet waits for the inbox and global profile load on a cold fresh install). It presents on every launch while the user has no name or photo set — including users who completed onboarding before this sheet existed — and cannot be swiped away while "Come in" is disabled. On a true fresh install it presents immediately; after a reinstall it waits for the restored profile to load.
+2. The "Hello / My name is" profile setup sheet self-presents over the Chats tab. Poll for `profile-setup-name-field` with `sim_wait_for_element` (timeout: 20s — the sheet waits for the inbox and global profile load on a cold fresh install). It presents on every launch while the user has no name or photo set — including users who completed onboarding before this sheet existed — and can never be swiped away: "Come in" is the only way out. On a true fresh install it presents immediately; after a reinstall it waits for the restored profile to load.
 3. Verify the sheet's empty state:
    - A name field (`profile-setup-name-field`) with placeholder "Name", an avatar on the left (`profile-setup-avatar`) showing the `person.crop.circle.fill` icon, and photo/camera buttons on the right (`profile-setup-photo-button`, `profile-setup-camera-button`).
    - The "I agree to Convos Privacy & Terms" row with a toggle (`profile-setup-terms-toggle`), ON by default.
@@ -47,12 +47,13 @@ Verify that a first-time user is offered the first-launch "Hello / My name is" p
 
 ## Dismissal gating (01b)
 
-The sheet cannot be swiped away while "Come in" is disabled, and it re-presents on every launch until a profile is set:
+The first-launch sheet is a required step — it can never be swiped away or
+tapped out of, only completed with "Come in":
 
-1. On a fresh install with the name field empty, try to swipe the sheet down — it must bounce back (interactive dismissal is disabled while the save gate is unsatisfied).
-2. Type a name (terms toggle already on) so "Come in" enables, then swipe the sheet down without saving. Dismissal now succeeds.
-3. Create a conversation. No profile prompt appears in the conversation (the inline "Add your name and pic" flow was removed; the Nametag sheet is the only profile-setup surface) — the user simply chats as "Somebody".
-4. Relaunch the app without ever saving a profile — the sheet self-presents again (it gates on the profile being unset, not on having been shown before). Once a name or photo is saved, it stops appearing.
+1. On a fresh install with the name field empty, try to swipe the sheet down — it must bounce back, and tapping the dimmed area above it must do nothing.
+2. Type a name (terms toggle already on) so "Come in" enables, then try to swipe the sheet down again — it must still bounce back. Only tapping "Come in" dismisses it.
+3. Tap "Come in", then create a conversation. No profile prompt appears in the conversation (the inline "Add your name and pic" flow was removed; the Nametag sheet is the only profile-setup surface).
+4. The edit-mode sheet (Settings > My info) is unchanged: it stays swipe-away-able once a name is present.
 
 ## Pass/Fail Criteria
 
@@ -60,7 +61,8 @@ The sheet cannot be swiped away while "Come in" is disabled, and it re-presents 
 - [ ] First-launch "Hello / My name is" sheet self-presents with name field, terms toggle, and "Come in" button
 - [ ] "Come in" is disabled until a name is entered and the terms toggle is on
 - [ ] Profile can be set via the sheet; the avatar shows a live monogram while typing
-- [ ] Conversation can be created after dismissal
+- [ ] The first-launch sheet cannot be swiped away or tapped out of, at any point
+- [ ] Conversation can be created after completing the sheet
 - [ ] The in-conversation profile prompt does not appear after completing the sheet
 - [ ] Notification permission step is shown in the first conversation
 - [ ] Onboarding completes and the conversation is usable

--- a/qa/tests/structured/01-onboarding.yaml
+++ b/qa/tests/structured/01-onboarding.yaml
@@ -58,8 +58,9 @@ steps:
       iCloud-synced keychain backup; an erased simulator satisfies that. If
       the found-device pairing sheet appears instead, the simulator was not
       fully erased. The CTA reads "Come in" and is disabled until a name is
-      entered (the terms toggle defaults on). While the CTA is disabled the
-      sheet cannot be swiped away (interactive dismissal is blocked).
+      entered (the terms toggle defaults on). The sheet is a required step: it
+      can never be swiped away or tapped out of, whether or not the CTA is
+      enabled — "Come in" is the only exit.
 
   - id: first_launch_profile_setup
     name: "Set name via the first-launch sheet"
@@ -104,8 +105,8 @@ steps:
     note: >
       The in-conversation "Add your name and pic" prompt was removed
       entirely — the Nametag sheet is the only profile-setup surface. An
-      unnamed user (CTA enabled then swiped away without saving) simply
-      chats as "Somebody" and the sheet re-presents on the next launch.
+      user who reached the conversation has necessarily completed the
+      first-launch sheet, since that sheet cannot be dismissed any other way.
 
   - id: notification_permission
     name: "Notification permission step shown"


### PR DESCRIPTION
## Problem

The first-launch "Hello / My name is" sheet gated interactive dismissal on the save gate:

```swift
.interactiveDismissDisabled(!canSave)
```

The terms toggle defaults on, so typing a single character flips `canSave` to `true` and the sheet immediately becomes swipe-away-able. A new user could type a name, swipe the sheet down without ever tapping **Come in**, and land in the app with no profile saved — chatting as "Somebody" until the next launch re-presented the sheet.

## Fix

Onboarding is meant to be a step every user completes, so first launch is now unconditionally non-dismissible — **Come in** is the only way out:

```swift
private var isInteractiveDismissDisabled: Bool {
    switch mode {
    case .firstLaunch: true
    case .edit: !canSave
    }
}
```

Edit mode (Settings > My info, own profile in a conversation) is unchanged and still swipes away once a name is present.

`interactiveDismissDisabled` sets `isModalInPresentation`, which blocks the swipe-down *and* the tap-outside while leaving programmatic dismissal alone — so the CTA's save-then-dismiss path is unaffected.

## Verification

Ran on a purpose-cloned, erased simulator via `idb` (fresh install, sheet self-presenting):

| Step | Result |
|---|---|
| Name typed so CTA is enabled, swipe down ×2 | sheet still present, same frame |
| Tap the dimmed area above the sheet | sheet still present |
| Tap **Come in** | sheet dismisses, profile saves |

**Control run** — temporarily restored the old `!canSave` condition, rebuilt, fresh install, ran the *same* swipe: sheet dismissed. That confirms the gesture genuinely dismisses sheets and the new modifier is what blocks it, rather than the swipe being a no-op.

Builds clean on `dev` (`Convos (Dev)` / `-configuration Dev`), swiftlint clean.

## QA docs

`qa/tests/01-onboarding.md` and `qa/tests/structured/01-onboarding.yaml` encoded the old contract — 01b step 2 read *"Type a name … then swipe the sheet down without saving. Dismissal now succeeds."* Both are updated to describe the required-step behavior, plus a new pass/fail checkbox for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789756990&installation_model_id=20076&pr_number=1358&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1358&signature=7b718edfcdca26631c6f83a401d6bdcc7a293ae3ca46295a4ffcadd422192101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make first-launch nametag sheet non-dismissible until saved
> Adds `isInteractiveDismissDisabled` to `ProfileSetupSheet` in [ProfileSetupSheet.swift](https://github.com/xmtplabs/convos-ios/pull/1358/files#diff-c33a881ce64e49858c5109b26bfa4ca9c278483c650338b9c92d38279c40cbf5) to separate dismissal gating by mode. In first-launch mode the sheet is always non-dismissible — only tapping "Come in" (save) closes it. Edit mode retains the prior behavior where dismissal is blocked only while the save gate is unsatisfied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93a6fb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->