### PR TITLE
docs: document how to add a secret / env key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,35 @@ All dependencies managed through SPM. See `ConvosCore/Package.swift` for current
 - Environments: Production, Development, Local
 - Firebase configuration per environment
 
+### Adding a secret / env key
+
+Secrets are a **generated, git-ignored `Secrets.swift`** (`Convos/Config/Secrets.swift`,
+mirrored in `ConvosAppClip/` and `ShareExtension/`), regenerated on every build from
+root `.env` by the Xcode build phase `Scripts/build-phases/copy-env-config-main-app.sh`.
+Non-secret per-environment runtime config lives in the bundled `config.{local,dev,pr,prod}.json`
+(read by `ConfigManager`); the `.xcconfig` files select which one and set bundle ids.
+There is **no Infisical here** (that's the convos-assistants stack) — this repo uses
+`.env` + 1Password + GitHub Actions secrets.
+
+To add a new key `NEW_KEY`:
+1. Add `NEW_KEY=` to root **`.env`** and document it in **`.env.example`**. Local/Dev
+   builds auto-append any extra `.env` key to `Secrets.swift`, so it's readable as
+   `Secrets.NEW_KEY` immediately.
+2. **For CI / TestFlight / Prod builds you must ALSO wire it explicitly** — a value in
+   your local `.env` does nothing in CI. Add it to `Scripts/generate-secrets-secure.sh`
+   and add the corresponding GitHub Actions repo secret/var (see the workflow headers in
+   `.github/workflows/testflight-dev.yml` / `testflight-prod.yml`). Missing this is the
+   classic "works locally, empty in the build" trap.
+3. Read it in Swift via `Secrets.NEW_KEY`. A URL/host override that should flow through
+   `ConfigManager` goes via `ConvosSecretOverrides`; other values are read directly.
+
+- **Footgun:** a fresh clone/worktree has **no `.env`** (git-ignored), so the app builds
+  with empty secrets and silently ships without an App Check token or backend override.
+  Copy `.env` from an existing checkout (or `.env.example` + `make secrets`) first.
+- App Check debug tokens are **per bundle id** and sourced from 1Password; sync/rotate via
+  the `/firebase-token` command. Code signing is fastlane `match` (repo
+  `convos-certificates`, `MATCH_PASSWORD`).
+
 ## Deep Linking
 
 ### URL Handling Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,23 +276,29 @@ All dependencies managed through SPM. See `ConvosCore/Package.swift` for current
 ### Adding a secret / env key
 
 Secrets are a **generated, git-ignored `Secrets.swift`** (`Convos/Config/Secrets.swift`,
-mirrored in `ConvosAppClip/` and `ShareExtension/`), regenerated on every build from
-root `.env` by the Xcode build phase `Scripts/build-phases/copy-env-config-main-app.sh`.
-Non-secret per-environment runtime config lives in the bundled `config.{local,dev,pr,prod}.json`
-(read by `ConfigManager`); the `.xcconfig` files select which one and set bundle ids.
-There is **no Infisical here** (that's the convos-assistants stack) — this repo uses
-`.env` + 1Password + GitHub Actions secrets.
+with separate copies for `ConvosAppClip/` and `ShareExtension/`), regenerated on every
+build from root `.env`. Each target has its own build-phase generator:
+`Scripts/build-phases/copy-env-config-main-app.sh` for the app,
+`copy-env-config-share-extension.sh` for the extension. Non-secret per-environment runtime
+config lives in the bundled `config.{local,dev,pr,prod}.json` (read by `ConfigManager`);
+the `.xcconfig` files select which one and set bundle ids. There is **no Infisical here**
+(that's the convos-assistants stack) — this repo uses `.env` + 1Password + GitHub Actions
+secrets.
 
 To add a new key `NEW_KEY`:
-1. Add `NEW_KEY=` to root **`.env`** and document it in **`.env.example`**. Local/Dev
-   builds auto-append any extra `.env` key to `Secrets.swift`, so it's readable as
-   `Secrets.NEW_KEY` immediately.
-2. **For CI / TestFlight / Prod builds you must ALSO wire it explicitly** — a value in
-   your local `.env` does nothing in CI. Add it to `Scripts/generate-secrets-secure.sh`
-   and add the corresponding GitHub Actions repo secret/var (see the workflow headers in
-   `.github/workflows/testflight-dev.yml` / `testflight-prod.yml`). Missing this is the
-   classic "works locally, empty in the build" trap.
-3. Read it in Swift via `Secrets.NEW_KEY`. A URL/host override that should flow through
+1. Add `NEW_KEY=` to root **`.env`** and document it in **`.env.example`**. **Only the
+   Local configuration auto-appends** arbitrary `.env` keys to `Secrets.swift`, so
+   `Secrets.NEW_KEY` is readable immediately in a Local build.
+2. **Every other build — Dev, CI, TestFlight, Prod — needs the key wired explicitly;** a
+   value in your local `.env` does nothing there. The Dev/CI path emits only its hard-coded
+   key list, so add `NEW_KEY` to `Scripts/generate-secrets-secure.sh` and add the matching
+   GitHub Actions repo secret/var (see the headers in `.github/workflows/testflight-dev.yml`
+   / `testflight-prod.yml`). Missing this is the classic "works in a Local build, empty
+   everywhere else" trap.
+3. If the **ShareExtension** (or App Clip) needs the key, wire it into that target's
+   generator too (`copy-env-config-share-extension.sh` currently emits only
+   `FIREBASE_APP_CHECK_DEBUG_TOKEN`) — the main-app generator does not cover it.
+4. Read it in Swift via `Secrets.NEW_KEY`. A URL/host override that should flow through
    `ConfigManager` goes via `ConvosSecretOverrides`; other values are read directly.
 
 - **Footgun:** a fresh clone/worktree has **no `.env`** (git-ignored), so the app builds


### PR DESCRIPTION
## Summary

Expands the thin **Environment Configuration** section of `CLAUDE.md` with the actual procedure for adding a secret / env key, which wasn't written down anywhere.

Covers:
- Secrets = generated git-ignored `Secrets.swift` from root `.env` (template `.env.example`), regenerated by the build phase; runtime config in `config.{local,dev,pr,prod}.json` via `ConfigManager`.
- The critical CI gap: a value in local `.env` does nothing in CI/TestFlight/Prod — it must also be wired in `Scripts/generate-secrets-secure.sh` + GitHub Actions secrets.
- Footguns: a fresh worktree has no `.env` (silently empty secrets), and App Check debug tokens are per-bundle-id (1Password, `/firebase-token`).

Part of a cross-repo effort to document secret/env-key management consistently (convos-assistants and backend are covered in that repo's `AGENTS.md`). Docs-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789757273&installation_model_id=20076&pr_number=1359&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1359&signature=9fc7d46ba10e2ed84c55d088776207817181d9e4f72f466057fe3e68fb425827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document how to add a secret or env key in CLAUDE.md
> Adds an 'Adding a secret / env key' section to [CLAUDE.md](https://github.com/xmtplabs/convos-ios/pull/1359/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) covering the full lifecycle of adding a new key to the project.
>
> - Explains how `Secrets.swift` is generated per target from `.env` via build-phase scripts (`copy-env-config-main-app.sh`, `copy-env-config-share-extension.sh`, `generate-secrets-secure.sh`)
> - Documents the difference between Local (arbitrary `.env` keys auto-appended) and Dev/CI/TestFlight/Prod environments (require explicit wiring in scripts and GitHub Actions secrets/vars)
> - Describes how to access keys in Swift via `Secrets.NEW_KEY` and `ConvosSecretOverrides` through `ConfigManager` for URL/host overrides
> - Adds operational notes: fresh clones lack `.env`, App Check debug tokens per bundle ID are in 1Password, and code signing uses fastlane match with `MATCH_PASSWORD`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90dd727.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->