### PR TITLE
Fix composer focus/keyboard spin that hangs the agent composer

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/FocusCoordinator.swift
+++ b/ConvosCore/Sources/ConvosComposer/FocusCoordinator.swift
@@ -51,8 +51,10 @@ public final class FocusCoordinator {
     // MARK: - Private Properties
 
     /// Tracks whether we're in the middle of a programmatic focus transition
-    /// This prevents false positives when detecting manual keyboard dismissal
-    private var isProgrammaticTransition: Bool = false
+    /// This prevents false positives when detecting manual keyboard dismissal.
+    /// Readable within the module so tests can assert the coordinator does not
+    /// begin a transition in response to a self-induced, no-op keyboard event.
+    private(set) var isProgrammaticTransition: Bool = false
 
     /// The target focus we're transitioning to (if in a programmatic transition)
     private var transitionTarget: MessagesViewInputFocus?
@@ -378,14 +380,16 @@ public final class FocusCoordinator {
             return
         }
 
-        Log.info("Updating focus for size class change: \(String(describing: horizontalSizeClass))")
-
-        // Update to the new default based on new size class
+        // Update to the new default based on new size class.
         let newDefault = defaultFocus
-        if currentFocus != newDefault {
-            beginProgrammaticTransition(to: newDefault)
-            currentFocus = newDefault
-        }
+        // Skip no-op size-class notifications: an equal-value `currentFocus`
+        // write still triggers Observation and can feed the same relayout spin
+        // as the keyboard path.
+        guard currentFocus != newDefault else { return }
+
+        Log.info("Updating focus for size class change: \(String(describing: horizontalSizeClass))")
+        beginProgrammaticTransition(to: newDefault)
+        currentFocus = newDefault
     }
 
     private func beginProgrammaticTransition(to target: MessagesViewInputFocus?) {
@@ -438,11 +442,22 @@ public final class FocusCoordinator {
         currentFocus = defaultFocus
     }
 
-    private func updateKeyboardState(frame: CGRect, isShowEvent: Bool, screen: UIScreen) {
-        // Get screen bounds to determine if keyboard is actually visible
-        // Use the screen from the notification, or fall back to main screen
-        let screenHeight = screen.bounds.height
+    private func updateKeyboardState(frame: CGRect, isShowEvent: Bool, screen: UIScreen, isFrameChange: Bool = false) {
+        updateKeyboardState(
+            screenHeight: screen.bounds.height,
+            frame: frame,
+            isShowEvent: isShowEvent,
+            isFrameChange: isFrameChange
+        )
+    }
 
+    /// Screen-free core of the keyboard-state machine. Split out so the
+    /// idempotency guards below can be exercised synchronously in tests
+    /// without a live `UIScreen`. `isFrameChange` is true for the
+    /// `keyboardWillChangeFrame`/`keyboardDidChangeFrame` callbacks, which
+    /// fire repeatedly during an input-accessory relayout and must not
+    /// downgrade a latched keyboard type back to `.unknown`.
+    func updateKeyboardState(screenHeight: CGFloat, frame: CGRect, isShowEvent: Bool, isFrameChange: Bool) {
         // Check if keyboard frame is on screen
         let keyboardBottomY = frame.origin.y + frame.size.height
         let isKeyboardOnScreen = frame.origin.y < screenHeight && keyboardBottomY > 0
@@ -466,8 +481,13 @@ public final class FocusCoordinator {
             // During hide events, we can't distinguish between:
             // 1. Software keyboard being dismissed
             // 2. External keyboard being connected
-            // So we set to unknown if we were in standard state
-            if keyboardType == .standard {
+            // So we set to unknown if we were in standard state.
+            // A frame-change event (not a genuine hide) can momentarily report
+            // the keyboard off-screen while an input-accessory relayout is in
+            // flight; that must not reset a latched type to unknown, or the type
+            // oscillates unknown <-> standard and drives the focus/relayout spin.
+            // Only a genuine hide downgrades.
+            if keyboardType == .standard && !isFrameChange {
                 newKeyboardType = .unknown
             } else {
                 // If we're already external or unknown, keep current state
@@ -492,6 +512,13 @@ public final class FocusCoordinator {
         // Don't interrupt active editing of displayName, conversationName, or sideConvoName
         guard currentFocus == nil else { return }
         let newDefault = defaultFocus
+        // A relayout-induced keyboard notification can re-fire with the type
+        // toggled but the resulting default unchanged (compact stays nil either
+        // way). Assigning `currentFocus` the value it already holds still
+        // triggers Observation, which re-renders the composer, relays out the
+        // input accessory, and fires another keyboard notification: a tight
+        // spin. Only transition when the default actually differs.
+        guard newDefault != currentFocus else { return }
 
         Log.info("Keyboard type changed: \(previousKeyboardType) → \(newKeyboardType), updating focus to: \(String(describing: newDefault))")
         beginProgrammaticTransition(to: newDefault)
@@ -541,7 +568,7 @@ extension FocusCoordinator: KeyboardListenerDelegate {
             // Use the screen from the notification, or fall back to main screen
             let screenHeight = screen.bounds.height
             let isShowingKeyboard = info.frameEnd.origin.y < screenHeight
-            updateKeyboardState(frame: info.frameEnd, isShowEvent: isShowingKeyboard, screen: screen)
+            updateKeyboardState(frame: info.frameEnd, isShowEvent: isShowingKeyboard, screen: screen, isFrameChange: true)
         }
     }
 
@@ -552,7 +579,7 @@ extension FocusCoordinator: KeyboardListenerDelegate {
             // Use the screen from the notification, or fall back to main screen
             let screenHeight = screen.bounds.height
             let isShowingKeyboard = info.frameEnd.origin.y < screenHeight
-            updateKeyboardState(frame: info.frameEnd, isShowEvent: isShowingKeyboard, screen: screen)
+            updateKeyboardState(frame: info.frameEnd, isShowEvent: isShowingKeyboard, screen: screen, isFrameChange: true)
         }
     }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/FocusCoordinatorSpinTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/FocusCoordinatorSpinTests.swift
@@ -1,0 +1,77 @@
+#if canImport(UIKit)
+@testable import ConvosComposer
+import CoreGraphics
+import SwiftUI
+import Testing
+
+/// Regression coverage for the composer focus/keyboard spin: opening the agent
+/// composer's `+` menu on an iPhone (compact) triggered an input-accessory
+/// relayout storm whose frame-change notifications re-entered
+/// `FocusCoordinator`, which kept re-deriving the keyboard type and re-beginning
+/// a no-op programmatic transition. Assigning `currentFocus` the value it
+/// already held still triggered Observation, re-rendering the composer and
+/// relaying out the accessory - a tight main-thread spin that ate the
+/// "Connections" tap. These tests drive the screen-free core of the state
+/// machine directly and assert the coordinator ignores self-induced, no-op
+/// events.
+@MainActor
+@Suite("FocusCoordinator keyboard spin")
+struct FocusCoordinatorSpinTests {
+    private let screenHeight: CGFloat = 852
+    // Software keyboard up: on-screen, substantial height.
+    private let onScreen = CGRect(x: 0, y: 512, width: 393, height: 340)
+    // Momentarily reported off-screen while the accessory view re-lays-out.
+    private let offScreen = CGRect(x: 0, y: 852, width: 393, height: 340)
+
+    @Test("compact composer does not spin on a relayout frame-change storm")
+    func doesNotSpinOnFrameChangeStorm() {
+        let coordinator = FocusCoordinator(horizontalSizeClass: .compact)
+
+        coordinator.updateKeyboardState(screenHeight: screenHeight, frame: onScreen, isShowEvent: true, isFrameChange: false)
+        #expect(coordinator.keyboardType == .standard)
+        #expect(coordinator.currentFocus == nil)
+        #expect(coordinator.isProgrammaticTransition == false)
+
+        // A single relayout frame-change reporting the keyboard "down" must not
+        // reset the latched type (fix 3) nor begin a transition (fix 1). This is
+        // the sharpest mutation detector: reverting either guard fails here.
+        coordinator.updateKeyboardState(screenHeight: screenHeight, frame: offScreen, isShowEvent: false, isFrameChange: true)
+        #expect(coordinator.keyboardType == .standard)
+        #expect(coordinator.isProgrammaticTransition == false)
+
+        // The full storm: dozens of hide/show frame-change pairs.
+        for _ in 0..<50 {
+            coordinator.updateKeyboardState(screenHeight: screenHeight, frame: offScreen, isShowEvent: false, isFrameChange: true)
+            coordinator.updateKeyboardState(screenHeight: screenHeight, frame: onScreen, isShowEvent: true, isFrameChange: true)
+        }
+        #expect(coordinator.keyboardType == .standard)
+        #expect(coordinator.currentFocus == nil)
+        #expect(coordinator.isProgrammaticTransition == false)
+    }
+
+    @Test("a genuine hide still resets the latched keyboard type")
+    func genuineHideStillResets() {
+        let coordinator = FocusCoordinator(horizontalSizeClass: .compact)
+
+        coordinator.updateKeyboardState(screenHeight: screenHeight, frame: onScreen, isShowEvent: true, isFrameChange: false)
+        #expect(coordinator.keyboardType == .standard)
+
+        // A real keyboardWillHide (not a frame change) must downgrade so the next
+        // appearance is re-detected - the frame-change latch must not swallow it.
+        coordinator.updateKeyboardState(screenHeight: screenHeight, frame: offScreen, isShowEvent: false, isFrameChange: false)
+        #expect(coordinator.keyboardType == .unknown)
+    }
+
+    @Test("an external keyboard on iPad still adopts the message default")
+    func externalKeyboardStillFocusesMessageOnRegular() {
+        let coordinator = FocusCoordinator(horizontalSizeClass: .regular)
+
+        // External keyboard reports an off-screen (or tiny) frame on a show event.
+        coordinator.updateKeyboardState(screenHeight: screenHeight, frame: offScreen, isShowEvent: true, isFrameChange: false)
+        #expect(coordinator.keyboardType == .external)
+        // Regular width + external keeps focus on the message field (default),
+        // so the idempotency guard must not suppress this real transition.
+        #expect(coordinator.currentFocus == .message)
+    }
+}
+#endif


### PR DESCRIPTION
## Problem

In the 1:1 agent chat, with the composer focused, opening the `+` menu spun the main thread and made tapping **Connections** do nothing. Logs showed a tight repeating loop:

```
Keyboard type changed: unknown -> external/standard, updating focus to: nil  (FocusCoordinator.swift:496)
Beginning programmatic transition to: nil                                    (:400)
Updating focus for size class change: Optional(...compact)                   (:381)
```

plus a recurring `_UIKBCompatInputView` / `_UIRemoteKeyboardPlaceholderView` AutoLayout conflict. It reproduces with the **software** keyboard too (`unknown -> standard`), so the external keyboard is not the cause, and the AutoLayout conflict is a downstream symptom.

## Root cause (pre-existing, not new in the composer redesign)

`FocusCoordinator` is `@Observable`, and Swift Observation fires on **every** stored-property assignment, including one equal to the current value. `updateKeyboardState` and `updateFocusForSizeClassChange` wrote `currentFocus` (and re-began a programmatic transition) even when the resolved default did not change. On a compact composer that no-op `nil` write re-rendered the composer, relaid out the input accessory, and fired another keyboard notification that re-entered the same handler — a tight main-thread spin that ate the tap.

The keyboard type also never latched: transient `keyboardWillChangeFrame`/`keyboardDidChangeFrame` events reset `.standard -> .unknown` every cycle (matching the "unknown" read each iteration). Opening the `+` menu is what first kicks the relayout that seeds the loop; the loop itself is FocusCoordinator not idempotently handling its own induced events.

## Fix (minimal, `FocusCoordinator` only)

- Only begin a transition / write `currentFocus` when the resolved default focus **actually differs** (both the keyboard-type and size-class paths).
- Only downgrade a latched keyboard type `.standard -> .unknown` on a **genuine hide**, never on a relayout frame-change (`isFrameChange` flag). The external-keyboard upgrade path and real dismissals are unaffected.
- Extracted a screen-free `updateKeyboardState(screenHeight:frame:isShowEvent:isFrameChange:)` core so the state machine is unit-testable without a live `UIScreen`.

No app-authored constraint is touched: the composer uses the system `keyboardLayoutGuide`, so the conflict is between system-internal views and clears once the spin stops.

## Verification

- `Convos (Dev)` build SUCCEEDED (iPhone 17 sim), 0 type-check warnings, 0 errors.
- swiftlint --strict and swiftformat clean.
- New iOS regression test `ConvosCore/Tests/ConvosCoreTests/FocusCoordinatorSpinTests.swift` — 3/3 pass; drives the relayout frame-change storm and asserts the coordinator neither begins a transition nor loses its latched type. **Mutation-checked**: reverting the guards makes `doesNotSpinOnFrameChangeStorm` fail.
- The test is UIKit-gated (FocusCoordinator is iOS-only), so it runs via the `ConvosCore` scheme on an iOS destination, not the macOS `swift test` sweep.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789758028&installation_model_id=20076&pr_number=1360&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1360&signature=3d13356e266d3c637ba69985e4085f8350c3b5727286278e71786850694c477d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix focus/keyboard spin that hangs the agent composer during keyboard frame changes
> - Prevents `keyboardType` from downgrading to `.unknown` during frame-change notifications (e.g. input-accessory relayouts) by threading an `isFrameChange` flag through `updateKeyboardState` in [FocusCoordinator.swift](https://github.com/xmtplabs/convos-ios/pull/1360/files#diff-92ca799264d9b4ed37a2034a54c7d6dbf301e8687221cbb4f499eeffc22c2e23); only genuine hide events trigger a downgrade.
> - Adds early-return guards in `updateFocusForSizeClassChange` and the keyboard-state core to skip focus reassignment when the computed default already equals `currentFocus`, preventing no-op `@Observable` writes that trigger re-entrant updates.
> - Adds regression tests in [FocusCoordinatorSpinTests.swift](https://github.com/xmtplabs/convos-ios/pull/1360/files#diff-dd3359bdb06187ac15b465d7457eeb64d69cb9e1f68abf005608b5c936dd0a3e) covering frame-change storms, genuine hides, and external keyboard focus defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eecfa19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->