### PR TITLE
Keep the launch path off the reader pool's critical section

### DIFF
--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -296,7 +296,7 @@ struct AppSettingsView: View {
     }
 
     @State private var presentingPaywall: Bool = false
-    @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
+    @State private var creditBalance: CreditBalance?
     @State private var currentSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
     @State private var subscriptionSyncState: SubscriptionSyncState = SubscriptionServices.shared.currentSyncState
 

--- a/Convos/Conversations List/ConversationsView.swift
+++ b/Convos/Conversations List/ConversationsView.swift
@@ -39,7 +39,7 @@ struct ConversationsView: View {
     @Environment(\.scenePhase) private var scenePhase: ScenePhase
     @State private var conversationPendingExplosion: Conversation?
     @State private var preferredColumn: NavigationSplitViewColumn = .sidebar
-    @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
+    @State private var creditBalance: CreditBalance?
     @State private var currentSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
     @State private var staleDeviceSheetDismissed: Bool = false
 

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -50,7 +50,7 @@ struct ProdDebugMenuView: View {
     @State private var identity: DeviceIdentitySnapshot?
     @State private var installations: InstallationsSnapshot?
     @State private var debugModeEnabled: Bool = DebugMenuFlagStore.isEnabled()
-    @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
+    @State private var creditBalance: CreditBalance?
     @State private var currentSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
 
     var body: some View {

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -57,9 +57,15 @@ struct MainTabView: View {
     /// Live subscription drives the app-indicator subtitle (plan name,
     /// or "Basic" when not subscribed). Seeded from the service's current
     /// value so the first render doesn't flicker, then kept in sync via
-    /// `.onReceive` on the publisher.
+    /// `.onReceive` on the publisher. Seeding is safe here because the
+    /// subscription's current value is held in memory.
     @State private var userSubscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
-    @State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
+    /// Not seeded, unlike the subscription above: the balance's current value
+    /// comes from a synchronous database read, and a `@State` default is
+    /// evaluated on every init of this view - so seeding it blocks the main
+    /// thread on the reader pool during body evaluation. See
+    /// `CreditsServiceProtocol.currentBalance`. The publisher fills it in.
+    @State private var creditBalance: CreditBalance?
     /// Shared namespace for the app-settings pill -> sheet zoom transition.
     /// The pill applies
     /// `.matchedTransitionSource(id: ..., in: namespace)` and the

--- a/Convos/Subscription/SubscriptionSettingsView.swift
+++ b/Convos/Subscription/SubscriptionSettingsView.swift
@@ -9,7 +9,7 @@ struct SubscriptionSettingsView: View {
     // Seed @State synchronously from whatever the services have cached so the
     // first render shows real data instead of nil for one runloop tick.
     // `.onReceive` still drives updates on subsequent fetches.
-    @State private var balance: CreditBalance? = CreditsServices.shared.currentBalance
+    @State private var balance: CreditBalance?
     @State private var subscription: UserSubscription? = SubscriptionServices.shared.currentSubscription
     @State private var syncState: SubscriptionSyncState = SubscriptionServices.shared.currentSyncState
     @State private var presentingPaywall: Bool = false

--- a/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServiceProtocol.swift
+++ b/ConvosCore/Sources/ConvosCore/Services/Credits/CreditsServiceProtocol.swift
@@ -3,6 +3,17 @@ import Foundation
 
 public protocol CreditsServiceProtocol: AnyObject, Sendable {
     var balancePublisher: AnyPublisher<CreditBalance?, Never> { get }
+
+    /// The cached balance, read synchronously.
+    ///
+    /// The backend implementation reads the database to answer this, so it
+    /// blocks for as long as it takes to get a connection out of the reader
+    /// pool - which at launch, with the list observations running, has been
+    /// seconds. Never call it on the main thread, and in particular never as
+    /// the default value of a SwiftUI `@State`: those are evaluated on every
+    /// init of the view, so it lands inside body evaluation and takes the
+    /// whole scene down with a watchdog kill. Observe `balancePublisher`
+    /// instead - it schedules asynchronously for this same reason.
     var currentBalance: CreditBalance? { get }
 
     /// Pull a fresh balance from the backend. The default `force: false` is

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/ConversationsRepository.swift
@@ -263,9 +263,12 @@ extension Database {
         resortByActivity: Bool
     ) throws -> [Conversation] {
         let summaries = try agentDmSummaries(forGroupIds: conversations.map(\.id), consent: consent)
-        let folded = try conversations.map { (conversation: Conversation) -> Conversation in
-            guard let summary = try summaries[conversation.id]
-                ?? agentDmSummaryFromGroupMembers(of: conversation, consent: consent) else {
+        let legacySummaries = try legacyAgentDmSummaries(
+            forGroupsWithoutLinks: conversations.filter { summaries[$0.id] == nil },
+            consent: consent
+        )
+        let folded = conversations.map { (conversation: Conversation) -> Conversation in
+            guard let summary = summaries[conversation.id] ?? legacySummaries[conversation.id] else {
                 return conversation
             }
             var row = conversation
@@ -352,30 +355,98 @@ extension Database {
         return summaries
     }
 
-    /// Legacy path for a DM saved before `agent_dm_origin` existed, which has no
-    /// link row until its next save. Finds the DM from the group's verified-agent
-    /// member instead, which is what every row used to do.
-    func agentDmSummaryFromGroupMembers(
-        of conversation: Conversation,
+    /// Legacy path for DMs saved before `agent_dm_origin` existed, which have no
+    /// link row until their next save. Finds each DM from its group's
+    /// verified-agent member instead, which is what every row used to do.
+    ///
+    /// Resolved for the whole batch in one query, for the same reason
+    /// `agentDmSummaries` is: the per-group form compiled and ran a fresh 1:1
+    /// lookup for every group that had no link row, and before the link table
+    /// is populated that is every row in the list. Inside the list observation
+    /// that is N statement compilations, on every connection in the reader pool
+    /// at once - which starved the pool at launch and blocked whatever else
+    /// needed a reader, up to and including the main thread.
+    func legacyAgentDmSummaries(
+        forGroupsWithoutLinks conversations: [Conversation],
         consent: [Consent]
-    ) throws -> Conversation.AgentDmSummary? {
-        guard let agentMember = conversation.members.first(where: { $0.isVerifiedAgent }) else {
-            return nil
+    ) throws -> [String: Conversation.AgentDmSummary] {
+        var agentByGroupId: [String: (inboxId: String, displayName: String)] = [:]
+        for conversation in conversations {
+            guard let agentMember = conversation.members.first(where: { $0.isVerifiedAgent }) else {
+                continue
+            }
+            agentByGroupId[conversation.id] = (agentMember.profile.inboxId, agentMember.displayName)
         }
-        guard let dm = try composeOneToOne(
-            with: agentMember.profile.inboxId,
-            excluding: nil,
-            consent: consent,
-            onlyAgentDms: true
-        ) else {
-            return nil
+        guard !agentByGroupId.isEmpty else { return [:] }
+
+        let agentInboxIds: [String] = Array(Set(agentByGroupId.values.map(\.inboxId)))
+        // The same 1:1 shape `composeOneToOne` matches - the agent is a member,
+        // the current user is a member, and those two are the whole membership -
+        // widened from one inbox to the batch's.
+        let batchedOneToOnePredicate: SQL = """
+            EXISTS (
+                SELECT 1 FROM conversation_members AS cm_other
+                WHERE cm_other.conversationId = conversation.id
+                AND cm_other.inboxId IN \(agentInboxIds)
+            )
+            AND EXISTS (
+                SELECT 1 FROM conversation_members AS cm_self
+                WHERE cm_self.conversationId = conversation.id
+                AND cm_self.inboxId IN (SELECT inboxId FROM inbox)
+            )
+            AND (
+                SELECT COUNT(*) FROM conversation_members AS cm_count
+                WHERE cm_count.conversationId = conversation.id
+            ) = 2
+            """
+        let dmDetails = try DBConversation
+            .filter(
+                !DBConversation.Columns.id.like("draft-%")
+                || (DBConversation.Columns.inviteTag != nil
+                    && length(DBConversation.Columns.inviteTag) > 0)
+            )
+            .filter(DBConversation.Columns.isAgentDm == true)
+            .filter(consent.contains(DBConversation.Columns.consent))
+            .filter(DBConversation.Columns.expiresAt == nil || DBConversation.Columns.expiresAt > Date())
+            .filter(DBConversation.Columns.isUnused == false)
+            .joining(required: DBConversation.localState.filter(ConversationLocalState.Columns.wasRemoved == false))
+            .filter(literal: batchedOneToOnePredicate)
+            .detailedConversationQuery()
+            .fetchAll(self)
+        guard !dmDetails.isEmpty else { return [:] }
+
+        let currentInboxId = try DBInbox.currentInboxId(self) ?? ""
+        let contactNameResolver = try ContactsRepository.contactNameResolverInTransaction(db: self)
+        // Keyed by the agent's inbox id, keeping the most recently active DM -
+        // `composeOneToOne` fetched one row from a query ordered by activity
+        // descending, so the same match wins here.
+        var dmByAgentInboxId: [String: Conversation] = [:]
+        for details in dmDetails {
+            let dm = details.hydrateConversation(
+                currentInboxId: currentInboxId,
+                contactNameResolver: contactNameResolver
+            )
+            guard let agentInboxId = dm.members.first(where: { !$0.isCurrentUser })?.profile.inboxId else {
+                continue
+            }
+            if let existing = dmByAgentInboxId[agentInboxId],
+               existing.lastActivityDate >= dm.lastActivityDate {
+                continue
+            }
+            dmByAgentInboxId[agentInboxId] = dm
         }
-        return Conversation.AgentDmSummary(
-            inboxId: agentMember.profile.inboxId,
-            displayName: agentMember.displayName,
-            lastMessage: dm.lastMessage,
-            isUnread: dm.isUnread
-        )
+
+        var summaries: [String: Conversation.AgentDmSummary] = [:]
+        for (groupId, agent) in agentByGroupId {
+            guard let dm = dmByAgentInboxId[agent.inboxId] else { continue }
+            summaries[groupId] = Conversation.AgentDmSummary(
+                inboxId: agent.inboxId,
+                displayName: agent.displayName,
+                lastMessage: dm.lastMessage,
+                isUnread: dm.isUnread
+            )
+        }
+        return summaries
     }
 
     /// A single conversation by id under the same eligibility filters as


### PR DESCRIPTION
Fixes the cold-launch `0x8BADF00D` scene-create watchdog kill (~19.7s, `EXC_CRASH`/`SIGKILL`).

Found while pulling device crash logs for an unrelated bug — three of them on `org.convos.ios-preview`
(builds 1235 and 1266) are this, not the sheet crash.

## What the crash reports show

Every one of the five GRDB reader connections busy inside the conversations-list observation:

```
ConvosDB-MainApp.reader.1..5   ValueReducers.Fetch -> ConversationsRepository observation
                               -> Database.composeAllConversations(consent:)
                               -> Database.foldAgentDms(...)
                               -> Database.composeOneToOne(...onlyAgentDms:)
                               -> Statement.init / sqlite3 yy_reduce, flattenSubquery, analyzeAggregate
```

…and two more callers queued on `GRDB.Pool.barrier` in `Pool.get()`, one of them the main thread:

```
22  BackendCreditsService.currentBalance.getter
23  ConversationsView.init(...)
24  MainTabView.tabView.getter -> TabView -> Tab -> NavigationStack
39  MainTabView.body.getter
```

Both halves are needed. A saturated pool on its own is slow; the main thread waiting on it is what
makes the watchdog fire.

## Cause 1 — a synchronous database read inside SwiftUI body evaluation

`CreditsServiceProtocol.currentBalance` is a blocking `databaseReader.read`. It was the default value
of a `@State` in five views:

```swift
@State private var creditBalance: CreditBalance? = CreditsServices.shared.currentBalance
```

A `@State` default is evaluated on **every** init of the view, not just the first, so this ran a
blocking pool read on the main thread during body evaluation — every time `MainTabView`'s body was
re-evaluated.

`balancePublisher` already avoids this deliberately; its comment says `.immediate` was rejected
because it *"performs a synchronous database read that can stall for seconds when the reader pool is
busy (app-hang CONVOS-IOS-3Y). Consumers only assign state, so a deferred initial value is fine."*
The publisher was fixed; the seed kept doing the forbidden thing.

All five views already `.onReceive(CreditsServices.shared.balancePublisher)`, so the seed only ever
bought one frame. Removed, and the hazard is now documented on the protocol requirement so the next
person who reaches for `currentBalance` in a view sees why not.

The sibling `SubscriptionServices.shared.currentSubscription` seed is left alone — that one is
`subscriptionSubject.value`, in memory, no I/O.

## Cause 2 — an N+1 in the legacy agent-DM fold

`foldAgentDms` resolves linked DMs for the whole batch in two queries, but fell back to
`agentDmSummaryFromGroupMembers` per group when `agent_dm_origin` had no link row — and until that
table is populated, that is every row in the list. Each fallback compiled and ran a fresh
`composeOneToOne` 1:1 lookup, which is why the readers are all sitting in SQLite's parser/planner
rather than executing.

Replaced with `legacyAgentDmSummaries(forGroupsWithoutLinks:consent:)`: one query for the batch,
matching the same 1:1 shape (`composeOneToOne`'s predicate widened from one inbox to the batch's),
indexed by the agent's inbox id keeping the most recently active DM — the same row the
activity-ordered `fetchOne` would have returned.

## Provenance

- The N+1 arrived with #1236 (CON-761: Agent DMs, Aug 2, count 1211). Crash build 1235 is after it
  and before the perf work.
- #1320 (startup perf, Aug 14, count 1258) batched the linked path and is **not** a cause — two of the
  three crashes predate it. It left this fallback behind, which is why crash build 1266 still hit it.
- The `@State` seed dates to #880 (May 28) and was harmless until the pool got busy enough.

The Aug 4 startup investigation (`docs/investigations/2026-08-04-startup-performance.md`) already
called out "an N+1 per-agent-conversation subquery" in the list query; this closes the remaining one.

## Verification

`swift test --package-path ConvosCore` — 1947 passed, 0 failures. The agent-DM fold suite covers this
path directly and passes unchanged, including:

- "A DM with no recorded origin folds through the group's agent member" (the rewritten fallback)
- "A group with no link and no agent member folds nothing"
- "A page of rows folds without a per-row DM lookup"

Not yet verified against a heavy account on device — the watchdog kill is load-dependent, so a cold
launch on an account with several hundred conversations is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789759983&installation_model_id=20076&pr_number=1361&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1361&signature=0b7f41d63af5553126ddc87dc0e7e3c13714933646217630d7c5f22e56a52749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move legacy agent DM resolution off the reader pool's critical section with a batched query
> - Replaces per-conversation `agentDmSummaryFromGroupMembers` fallback calls in `ConversationsRepository` with a single batched `legacyAgentDmSummaries` query that resolves all missing agent DM summaries at once.
> - The new batched path collects verified-agent members for all affected groups, fetches matching DMs in one statement, hydrates conversations, and picks the most recently active DM per agent inbox.
> - Removes synchronous `CreditsServices.shared.currentBalance` seeding from SwiftUI `@State` defaults across `MainTabView`, `ConversationsView`, `AppSettingsView`, `SubscriptionSettingsView`, and `ProdDebugMenuView`; `creditBalance` now starts as `nil` and is populated via `balancePublisher`.
> - Documents `currentBalance` in `CreditsServiceProtocol` as unsafe to call on the main thread or use as a `@State` default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a406624.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->