### PR TITLE
Mpr/web native plugins

### DIFF
--- a/Convos.xcodeproj/project.pbxproj
+++ b/Convos.xcodeproj/project.pbxproj
@@ -3028,11 +3028,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		713D94073026882A00E53855 /* BezelKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 713D94063026882A00E53855 /* XCRemoteSwiftPackageReference "BezelKit" */;
-			productName = BezelKit;
-		};
 		1AEE475B3FE0066D11742B75 /* ConvosComposer */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ConvosComposer;
@@ -3044,6 +3039,11 @@
 		6295E0ABD82D9105D8ECF82F /* ConvosCoreiOS */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ConvosCoreiOS;
+		};
+		713D94073026882A00E53855 /* BezelKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 713D94063026882A00E53855 /* XCRemoteSwiftPackageReference "BezelKit" */;
+			productName = BezelKit;
 		};
 		7A15D61B2EEBB0CF00627BC5 /* ConvosCoreiOS */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -43,7 +43,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "mpr/web-plugins",
-        "revision" : "6403c372e8778e07bec2feebd9b6cbbbd9527227"
+        "revision" : "3638574b2020ab52e73ac18c1af2acb62595d926"
       }
     },
     {

--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "839f86aab75322b73f2d74ee4c2f3408b5cb0c32691ca85a2fee2c71bde9b5ff",
+  "originHash" : "e48dce065f2fbaa058b5c66e388240cc8b2184047ee2355a1d710237363402f8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "da310944a7c7ec3aa40369a22951e114749e5474"
+        "branch" : "mpr/web-plugins",
+        "revision" : "6403c372e8778e07bec2feebd9b6cbbbd9527227"
       }
     },
     {

--- a/Convos/Config/FeatureFlags.swift
+++ b/Convos/Config/FeatureFlags.swift
@@ -163,6 +163,24 @@ final class FeatureFlags {
         }
     }
 
+    /// Off by default -- gates `WKWebView.isInspectable` on the home/space and
+    /// browser sub-page web views so Safari Web Inspector can attach to the
+    /// `window.convos` bridge. Deliberately reachable in every environment so
+    /// the bridge can be inspected on a production build; production users opt
+    /// in from the curated prod debug menu. Default-off keeps the web views
+    /// closed to the inspector for everyone else.
+    var isWebInspectorEnabled: Bool {
+        get {
+            access(keyPath: \.isWebInspectorEnabled)
+            return UserDefaults.standard.bool(forKey: Constant.webInspectorEnabledKey)
+        }
+        set {
+            withMutation(keyPath: \.isWebInspectorEnabled) {
+                UserDefaults.standard.set(newValue, forKey: Constant.webInspectorEnabledKey)
+            }
+        }
+    }
+
     /// Mock credits/subscription state used by the in-app paywall preview surface
     /// in the Debug menu. Non-production only; defaults to `.plusAmple`.
     var mockCreditsPreset: CreditsStatePreset {
@@ -234,5 +252,6 @@ final class FeatureFlags {
         static let xmtpBidiStreamsEnabledKey: String = "featureFlags.xmtpBidiStreamsEnabled"
         static let abilitiesV2EnabledKey: String = "featureFlags.abilitiesV2Enabled"
         static let spaceShareEnabledKey: String = "featureFlags.spaceShareEnabled"
+        static let webInspectorEnabledKey: String = "featureFlags.webInspectorEnabled"
     }
 }

--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -736,6 +736,16 @@ extension ConversationInfoView {
         } label: {
             Text("Hidden messages")
         }
+        NavigationLink {
+            SpaceURLDebugView(
+                currentURLString: { viewModel.conversation.spaceURL?.absoluteString },
+                updateSpaceURL: { urlString in
+                    try await viewModel.debugOverrideSpaceURL(urlString)
+                }
+            )
+        } label: {
+            Text("Space URL")
+        }
         Button {
             showingRestoreInviteTagAlert = true
         } label: {

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1477,9 +1477,32 @@ private extension ConversationView {
                 webURL: viewModel.conversation.spaceURL,
                 onNavigationRequest: { url in
                     pushHomeBrowserPage(for: url)
-                }
+                },
+                bridgeNavigation: homeBridgeNavigation
             )
         }
+    }
+
+    /// Native destinations for the home page's `window.convos` invite/chat
+    /// calls, mirroring Android's `DesktopBridgeNavigation` wiring in
+    /// `ConversationScreen`. Each closure reads live state when invoked: the
+    /// bridge holds one instance per web view, refreshed on every update pass.
+    private var homeBridgeNavigation: HomeBridgeNavigation {
+        HomeBridgeNavigation(
+            showShareSheet: {
+                // Same routing as the composer's "Invite friends": a full
+                // conversation can't mint invites and explains itself instead.
+                if viewModel.isFull {
+                    showingFullInfo = true
+                } else {
+                    presentingInviteShareSheet = true
+                }
+            },
+            showScan: { onScanInviteCode() },
+            showInviteCode: { viewModel.showInviteCode() },
+            showInvitePicker: { presentingAddFromContactsPicker = true },
+            showMembersList: { viewModel.presentingConversationSettings = true }
+        )
     }
 
     /// The single host seam for the composer's connections capability: the

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1491,6 +1491,12 @@ private extension ConversationView {
     private var homeBridgeNavigation: HomeBridgeNavigation {
         HomeBridgeNavigation(
             showShareSheet: {
+                // Same gate as the native invite controls: a stale/removed
+                // device or pending-invite conversation can't mint or share.
+                guard inviteActionsEnabled else {
+                    Log.warning("HomeBridgeNavigation showShareSheet ignored; invite actions disabled")
+                    return
+                }
                 // Same routing as the composer's "Invite friends": a full
                 // conversation can't mint invites and explains itself instead.
                 if viewModel.isFull {
@@ -1501,10 +1507,20 @@ private extension ConversationView {
             },
             showScan: { onScanInviteCode() },
             showInviteCode: {
+                guard inviteActionsEnabled else {
+                    Log.warning("HomeBridgeNavigation showInviteCode ignored; invite actions disabled")
+                    return
+                }
                 Log.info("HomeBridgeNavigation wired showInviteCode closure invoked; forwarding to viewModel")
                 viewModel.showInviteCode()
             },
-            showInvitePicker: { presentingAddFromContactsPicker = true },
+            showInvitePicker: {
+                guard inviteActionsEnabled else {
+                    Log.warning("HomeBridgeNavigation showInvitePicker ignored; invite actions disabled")
+                    return
+                }
+                presentingAddFromContactsPicker = true
+            },
             showMembersList: { viewModel.presentingConversationSettings = true }
         )
     }
@@ -1778,6 +1794,15 @@ extension ConversationView {
     /// view it (e.g. it was open when the removal landed).
     private var effectiveReadOnly: Bool {
         isReadOnly || viewModel.conversation.wasRemoved
+    }
+
+    /// Whether the invite/share affordances may fire. Mirrors the exact gate
+    /// the native `inviteButton` uses (`.disabled(!messagesTopBarTrailingItemEnabled
+    /// || effectiveReadOnly)`), so a stale/removed device or a pending-invite
+    /// conversation can't mint or share invites. The Home web bridge routes its
+    /// invite closures through this same read rather than re-deriving the rule.
+    private var inviteActionsEnabled: Bool {
+        messagesTopBarTrailingItemEnabled && !effectiveReadOnly
     }
 
     /// Read-only surfaces suppress every leading affordance. The inline

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1446,7 +1446,8 @@ private extension ConversationView {
             entry: entry,
             onNavigationRequest: { url in
                 pushHomeBrowserPage(for: url)
-            }
+            },
+            bridgeNavigation: homeBridgeNavigation
         )
     }
 
@@ -1499,7 +1500,10 @@ private extension ConversationView {
                 }
             },
             showScan: { onScanInviteCode() },
-            showInviteCode: { viewModel.showInviteCode() },
+            showInviteCode: {
+                Log.info("HomeBridgeNavigation wired showInviteCode closure invoked; forwarding to viewModel")
+                viewModel.showInviteCode()
+            },
             showInvitePicker: { presentingAddFromContactsPicker = true },
             showMembersList: { viewModel.presentingConversationSettings = true }
         )

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4240,6 +4240,16 @@ extension ConversationViewModel {
         UIPasteboard.general.string = urlString
     }
 
+    /// Presents the invite-code sheet (`InviteCodeSheet`) via
+    /// `ConversationPresenter`. Used by the home page's
+    /// `window.convos.showInviteCode()` bridge call.
+    func showInviteCode() {
+        // A full conversation can't mint new invite links, so even if the
+        // sheet is reached, the invite code can't be shown.
+        guard !isFull else { return }
+        presentingInviteCode = true
+    }
+
     /// Adds the given inboxIds as members of this conversation via the
     /// existing `addMembers` flow. Used by the "Add from Contacts" entry on
     /// the chat plus-menu.

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4240,6 +4240,14 @@ extension ConversationViewModel {
         UIPasteboard.general.string = urlString
     }
 
+    /// Debug override for the Space web URL: writes the given value into the
+    /// group's appData (or clears it when nil), replacing whatever the
+    /// Assistant Worker published. Backs the "Space URL" row in conversation
+    /// info's debug section.
+    func debugOverrideSpaceURL(_ urlString: String?) async throws {
+        try await metadataWriter.updateSpaceURL(urlString, for: conversation.id)
+    }
+
     /// Presents the invite-code sheet (`InviteCodeSheet`) via
     /// `ConversationPresenter`. Used by the home page's
     /// `window.convos.showInviteCode()` bridge call.

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4252,9 +4252,13 @@ extension ConversationViewModel {
     /// `ConversationPresenter`. Used by the home page's
     /// `window.convos.showInviteCode()` bridge call.
     func showInviteCode() {
+        Log.info("ConversationViewModel.showInviteCode called (conversationId=\(conversation.id), isFull=\(isFull))")
         // A full conversation can't mint new invite links, so even if the
         // sheet is reached, the invite code can't be shown.
-        guard !isFull else { return }
+        guard !isFull else {
+            Log.warning("ConversationViewModel.showInviteCode: conversation is full; not presenting invite code sheet")
+            return
+        }
         presentingInviteCode = true
     }
 

--- a/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
+++ b/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
@@ -1,0 +1,176 @@
+import ConvosBridge
+import Foundation
+
+/// Native destinations for the home page's `window.convos` invite/chat calls.
+/// Mirrors Android's `DesktopBridgeNavigation`: defaults are no-ops so
+/// bridge-backed surfaces that aren't conversation-scoped (the browser
+/// popups) can leave them unset. Each closure should read live conversation
+/// state when invoked, since the owning bridge is created once per web view
+/// and refreshed on every update pass.
+struct HomeBridgeNavigation {
+    var showShareSheet: @MainActor @Sendable () -> Void = {}
+    var showScan: @MainActor @Sendable () -> Void = {}
+    var showInviteCode: @MainActor @Sendable () -> Void = {}
+    var showInvitePicker: @MainActor @Sendable () -> Void = {}
+    var showMembersList: @MainActor @Sendable () -> Void = {}
+}
+
+/// Main-actor state shared between the hosting web view (which refreshes the
+/// navigation closures as SwiftUI re-renders) and the plugin implementations
+/// (which hop here from the bridge dispatcher's arbitrary tasks).
+///
+/// Agent status is a local placeholder matching the Android stubs: real
+/// wiring to the conversation view model is a follow-up.
+@MainActor
+final class HomeBridgeHost {
+    var navigation: HomeBridgeNavigation = HomeBridgeNavigation()
+    var onMarkReady: () -> Void = {}
+
+    private(set) var agentStatus: AgentStatus = AgentStatus(state: .NONE, progress: nil)
+    private var agentStatusContinuations: [UUID: AsyncStream<AgentStatus>.Continuation] = [:]
+
+    func updateAgentStatus(_ status: AgentStatus) {
+        agentStatus = status
+        for continuation in agentStatusContinuations.values {
+            continuation.yield(status)
+        }
+    }
+
+    /// Registers a stream observer, immediately yielding the current status so
+    /// subscribers start with a value (matching Android's state flow).
+    func addAgentStatusObserver(id: UUID, continuation: AsyncStream<AgentStatus>.Continuation) {
+        agentStatusContinuations[id] = continuation
+        continuation.yield(agentStatus)
+    }
+
+    func removeAgentStatusObserver(id: UUID) {
+        agentStatusContinuations.removeValue(forKey: id)
+    }
+}
+
+/// Builds the plugin dispatcher list wired into a home surface's
+/// `ConvosWebBridge`, one implementation per shared `@BridgePlugin` interface
+/// (mirroring Android's `desktopBridgeHandlers`).
+enum HomeBridgePlugins {
+    @MainActor
+    static func dispatchers(host: HomeBridgeHost) -> [BridgePluginDispatcher] {
+        [
+            EventsPluginDispatcher(HomeEventsPlugin()),
+            AppPluginDispatcher(HomeAppPlugin(host: host)),
+            InvitePluginDispatcher(HomeInvitePlugin(host: host)),
+            ChatPluginDispatcher(HomeChatPlugin(host: host)),
+            ThingsPluginDispatcher(HomeThingsPlugin()),
+            DesktopPluginDispatcher(HomeDesktopPlugin()),
+        ]
+    }
+}
+
+// The bridge dispatcher invokes plugin methods off the main actor, so each
+// implementation is a non-isolated Sendable class that hops to the main actor
+// before touching the host.
+
+private final class HomeEventsPlugin: EventsPlugin, Sendable {
+    func trackEvent(name: String) {
+        Log.debug("bridge trackEvent: \(name)")
+    }
+}
+
+private final class HomeAppPlugin: AppPlugin, Sendable {
+    private let host: HomeBridgeHost
+
+    init(host: HomeBridgeHost) {
+        self.host = host
+    }
+
+    func markReady() {
+        let host = host
+        Task { @MainActor in host.onMarkReady() }
+    }
+}
+
+private final class HomeInvitePlugin: InvitePlugin, Sendable {
+    private let host: HomeBridgeHost
+
+    init(host: HomeBridgeHost) {
+        self.host = host
+    }
+
+    func showShareSheet() {
+        let host = host
+        Task { @MainActor in host.navigation.showShareSheet() }
+    }
+
+    func showScan() {
+        let host = host
+        Task { @MainActor in host.navigation.showScan() }
+    }
+
+    func showInviteCode() {
+        let host = host
+        Task { @MainActor in host.navigation.showInviteCode() }
+    }
+
+    func showInvitePicker() {
+        let host = host
+        Task { @MainActor in host.navigation.showInvitePicker() }
+    }
+}
+
+private final class HomeChatPlugin: ChatPlugin, Sendable {
+    private let host: HomeBridgeHost
+
+    init(host: HomeBridgeHost) {
+        self.host = host
+    }
+
+    func showMembersList() {
+        let host = host
+        Task { @MainActor in host.navigation.showMembersList() }
+    }
+
+    func getAgentStatus() async throws -> AgentStatus {
+        await MainActor.run { [host] in host.agentStatus }
+    }
+
+    func requestAgentJoin() {
+        let host = host
+        Task { @MainActor in
+            host.updateAgentStatus(AgentStatus(state: .JOINING, progress: 0))
+        }
+    }
+
+    func onAgentStatusChanged() -> AsyncStream<AgentStatus> {
+        let host = host
+        return AsyncStream { continuation in
+            let id = UUID()
+            Task { @MainActor in
+                host.addAgentStatusObserver(id: id, continuation: continuation)
+            }
+            continuation.onTermination = { _ in
+                Task { @MainActor in host.removeAgentStatusObserver(id: id) }
+            }
+        }
+    }
+}
+
+private final class HomeThingsPlugin: ThingsPlugin, Sendable {
+    // Future wiring point: the "Things" surface in ConversationInfoView
+    // (AgentFilesLinksView); stubbed for parity with Android.
+    func showThingsList() {
+        Log.debug("bridge showThingsList (stub)")
+    }
+
+    func getThingsList() async throws -> [ThingInfo] {
+        []
+    }
+}
+
+private final class HomeDesktopPlugin: DesktopPlugin, Sendable {
+    func replyToWidget(id: String, widget: WidgetRef) {
+        Log.debug("bridge replyToWidget(\(id), \(widget.title))")
+    }
+
+    func popupWidget(id: String, url: String, bounds: PopupBounds) {
+        Log.debug("bridge popupWidget(\(id), \(url))")
+    }
+}

--- a/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
+++ b/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
@@ -10,7 +10,9 @@ import Foundation
 struct HomeBridgeNavigation {
     var showShareSheet: @MainActor @Sendable () -> Void = {}
     var showScan: @MainActor @Sendable () -> Void = {}
-    var showInviteCode: @MainActor @Sendable () -> Void = {}
+    var showInviteCode: @MainActor @Sendable () -> Void = {
+        Log.warning("HomeBridgeNavigation.showInviteCode invoked on the default (unwired) navigation - the web view showing this page was not given a conversation-scoped bridgeNavigation")
+    }
     var showInvitePicker: @MainActor @Sendable () -> Void = {}
     var showMembersList: @MainActor @Sendable () -> Void = {}
 }
@@ -71,7 +73,7 @@ enum HomeBridgePlugins {
 
 private final class HomeEventsPlugin: EventsPlugin, Sendable {
     func trackEvent(name: String) {
-        Log.debug("bridge trackEvent: \(name)")
+        Log.info("bridge trackEvent: \(name)")
     }
 }
 
@@ -84,6 +86,7 @@ private final class HomeAppPlugin: AppPlugin, Sendable {
 
     func markReady() {
         let host = host
+        Log.info("bridge app.markReady received")
         Task { @MainActor in host.onMarkReady() }
     }
 }
@@ -107,6 +110,7 @@ private final class HomeInvitePlugin: InvitePlugin, Sendable {
 
     func showInviteCode() {
         let host = host
+        Log.info("bridge invite.showInviteCode received; hopping to main actor to invoke navigation")
         Task { @MainActor in host.navigation.showInviteCode() }
     }
 

--- a/Convos/Conversation Detail/Home/HomeBrowserPageView.swift
+++ b/Convos/Conversation Detail/Home/HomeBrowserPageView.swift
@@ -20,6 +20,11 @@ struct HomeBrowserPageView: View {
     /// Fired when this page requests navigation away from its own URL; the
     /// host pushes another page for it.
     var onNavigationRequest: @MainActor (URL) -> Void = { _ in }
+    /// Native destinations for this page's `window.convos` calls. Threaded
+    /// through from the conversation so a sub-page (e.g. `/members`) can
+    /// present the invite code, members list, etc. - without it these calls
+    /// would hit the no-op default `HomeBridgeNavigation`.
+    var bridgeNavigation: HomeBridgeNavigation = HomeBridgeNavigation()
 
     var body: some View {
         GeometryReader { proxy in
@@ -28,7 +33,8 @@ struct HomeBrowserPageView: View {
                 url: entry.url,
                 topContentInset: topInset,
                 bottomContentInset: proxy.safeAreaInsets.bottom,
-                onNavigationRequest: onNavigationRequest
+                onNavigationRequest: onNavigationRequest,
+                bridgeNavigation: bridgeNavigation
             )
             .ignoresSafeArea(edges: .vertical)
         }

--- a/Convos/Conversation Detail/Home/HomeLayoutView.swift
+++ b/Convos/Conversation Detail/Home/HomeLayoutView.swift
@@ -13,6 +13,9 @@ struct HomeLayoutView: View {
     /// Fired when the page requests navigation away from the space URL; the
     /// host presents it in the home browser popup.
     var onNavigationRequest: @MainActor (URL) -> Void = { _ in }
+    /// Native destinations for the page's `window.convos` calls; forwarded
+    /// down to the web surface.
+    var bridgeNavigation: HomeBridgeNavigation = HomeBridgeNavigation()
 
     var body: some View {
         // The placeholder page (no URL) skips the insets - it fits the viewport
@@ -28,7 +31,8 @@ struct HomeLayoutView: View {
                 url: webURL,
                 topContentInset: hasPage ? topInset : 0,
                 bottomContentInset: hasPage ? proxy.safeAreaInsets.bottom : 0,
-                onNavigationRequest: onNavigationRequest
+                onNavigationRequest: onNavigationRequest,
+                bridgeNavigation: bridgeNavigation
             )
             .ignoresSafeArea(edges: .vertical)
         }

--- a/Convos/Conversation Detail/Home/HomeWebSurface.swift
+++ b/Convos/Conversation Detail/Home/HomeWebSurface.swift
@@ -19,6 +19,9 @@ struct HomeWebSurface: View {
     /// Forwarded to `HomeWebView`; fired when the page requests navigation
     /// away from the space URL.
     var onNavigationRequest: @MainActor (URL) -> Void = { _ in }
+    /// Forwarded to `HomeWebView`: native destinations for the page's
+    /// `window.convos` calls.
+    var bridgeNavigation: HomeBridgeNavigation = HomeBridgeNavigation()
 
     /// Whether the page is showing rather than the cover.
     ///
@@ -33,13 +36,15 @@ struct HomeWebSurface: View {
         isScrollEnabled: Bool = true,
         topContentInset: CGFloat = 0,
         bottomContentInset: CGFloat = 0,
-        onNavigationRequest: @escaping @MainActor (URL) -> Void = { _ in }
+        onNavigationRequest: @escaping @MainActor (URL) -> Void = { _ in },
+        bridgeNavigation: HomeBridgeNavigation = HomeBridgeNavigation()
     ) {
         self.url = url
         self.isScrollEnabled = isScrollEnabled
         self.topContentInset = topContentInset
         self.bottomContentInset = bottomContentInset
         self.onNavigationRequest = onNavigationRequest
+        self.bridgeNavigation = bridgeNavigation
         _isLoaded = State(initialValue: HomeWebViewPool.shared.adoption(for: url) == .painted)
     }
 
@@ -50,18 +55,7 @@ struct HomeWebSurface: View {
                 isScrollEnabled: isScrollEnabled,
                 topContentInset: topContentInset,
                 bottomContentInset: bottomContentInset,
-                onLoaded: {
-                    // Without a URL the web view loads its inline placeholder,
-                    // which finishes immediately. That is not the space
-                    // arriving, and revealing it would replace the preparing
-                    // state with a bare "Home".
-                    guard url != nil else { return }
-                    // The fallback: a page that reports no paint at all still
-                    // has to be revealed, and a beat past didFinish is the old
-                    // guess at when it has drawn. `onFirstPaint` normally gets
-                    // there first and makes this a no-op.
-                    reveal(after: Constant.revealDelay)
-                },
+                onLoaded: handleLoaded,
                 onFirstPaint: {
                     guard url != nil else { return }
                     // The page says it has drawn, so there is nothing left to
@@ -75,7 +69,9 @@ struct HomeWebSurface: View {
                     // progress bar.
                     isLoaded = true
                 },
-                onNavigationRequest: onNavigationRequest
+                onNavigationRequest: onNavigationRequest,
+                bridgeNavigation: bridgeNavigation,
+                onMarkReady: handleMarkReady
             )
             HomeCoverView(hasSpaceURL: url != nil)
                 .opacity(isLoaded ? 0 : 1)
@@ -97,6 +93,33 @@ struct HomeWebSurface: View {
     private func reveal(after delay: Double) {
         guard !isLoaded else { return }
         withAnimation(.easeInOut(duration: Constant.coverFadeDuration).delay(delay)) {
+            isLoaded = true
+        }
+    }
+
+    /// The didFinish fallback reveal, for pages that never call markReady.
+    private func handleLoaded() {
+        // Without a URL the web view loads its inline placeholder,
+        // which finishes immediately. That is not the space
+        // arriving, and revealing it would replace the preparing
+        // state with a bare "Home".
+        guard url != nil else { return }
+        // The reveal waits a beat past didFinish - a JS page
+        // hasn't painted yet at that moment - and only the
+        // fade animates: the cover must never fade IN, or the
+        // cleared layer shows through.
+        withAnimation(.easeInOut(duration: Constant.coverFadeDuration).delay(Constant.revealDelay)) {
+            isLoaded = true
+        }
+    }
+
+    /// The page declared itself painted through `window.convos.markReady()`,
+    /// so the cover can drop immediately - no didFinish heuristic delay. When
+    /// both paths fire, the first to set `isLoaded` wins and the other is a
+    /// no-op.
+    private func handleMarkReady() {
+        guard url != nil else { return }
+        withAnimation(.easeInOut(duration: Constant.coverFadeDuration)) {
             isLoaded = true
         }
     }

--- a/Convos/Conversation Detail/Home/HomeWebView.swift
+++ b/Convos/Conversation Detail/Home/HomeWebView.swift
@@ -84,9 +84,12 @@ struct HomeWebView: UIViewRepresentable {
         // second before it can even start a navigation. See `HomeWebViewPool`.
         let adoption = HomeWebViewPool.shared.adoption(for: url)
         let webView = HomeWebViewPool.shared.acquire()
-        // Temporary: allow Safari Web Inspector to attach to the home/space and
-        // browser sub-page web views while debugging the window.convos bridge.
-        webView.isInspectable = true
+        // Allow Safari Web Inspector to attach to the home/space and browser
+        // sub-page web views while debugging the window.convos bridge. Gated on
+        // a feature flag (off by default) that is reachable in every
+        // environment via the debug menus, so the bridge can be inspected on a
+        // production build without shipping the web views open by default.
+        webView.isInspectable = FeatureFlags.shared.isWebInspectorEnabled
         let coordinator = context.coordinator
         HomeWebViewPool.shared.paintReporter(of: webView)?.onPaint = { source in
             MainActor.assumeIsolated { coordinator.reportPaint(source) }

--- a/Convos/Conversation Detail/Home/HomeWebView.swift
+++ b/Convos/Conversation Detail/Home/HomeWebView.swift
@@ -56,8 +56,15 @@ struct HomeWebView: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
-        coordinator.bridge?.detach(from: webView)
-        coordinator.bridge = nil
+        // The bridge stays installed for the pooled view's next surface; only
+        // its host is repointed, so it is not detached here. Reset the host to
+        // defaults so a page still loaded in the released view cannot call back
+        // into this torn-down surface.
+        if let binding = HomeWebViewPool.shared.bridgeBinding(of: webView) {
+            binding.host.navigation = HomeBridgeNavigation()
+            binding.host.onMarkReady = {}
+            binding.bridge.onReady = nil
+        }
         coordinator.bridgeHost = nil
         // Back to the pool with what it is showing, so a page that is still
         // drawn can be handed straight back on re-entry.
@@ -107,20 +114,20 @@ struct HomeWebView: UIViewRepresentable {
         // stack onto the manual indicator insets.
         webView.scrollView.contentInsetAdjustmentBehavior = .never
         webView.scrollView.automaticallyAdjustsScrollIndicatorInsets = false
-        // Expose window.convos before any load: updateUIView performs the
-        // first load only after makeUIView returns, so the document-start
-        // script injection precedes both the placeholder and the space URL.
-        // The bridge registers through a weak proxy, so the coordinator
-        // retains it for the web view's lifetime.
-        let host = HomeBridgeHost()
-        host.navigation = bridgeNavigation
-        host.onMarkReady = onMarkReady
-        let bridge = ConvosWebBridge(plugins: HomeBridgePlugins.dispatchers(host: host))
-        bridge.onReady = { Log.info("HomeWebView: convos.js reported ready (url=\(url?.absoluteString ?? "placeholder"))") }
-        Log.info("HomeWebView.makeUIView attaching bridge (url=\(url?.absoluteString ?? "placeholder"))")
-        bridge.attach(to: webView)
-        context.coordinator.bridge = bridge
-        context.coordinator.bridgeHost = host
+        // The convos bridge is installed on the pooled view, not here: the pool
+        // loads the space URL speculatively before this surface exists, and a
+        // bridge attached on adoption would miss that load - its document-start
+        // `convos.js` runs on the next navigation, and the adopted page is not
+        // reloaded. See `HomeWebViewPool.makeWebView`. Point the host at this
+        // surface so the page's `window.convos` calls reach this conversation.
+        if let binding = HomeWebViewPool.shared.bridgeBinding(of: webView) {
+            binding.host.navigation = bridgeNavigation
+            binding.host.onMarkReady = onMarkReady
+            binding.bridge.onReady = {
+                Log.info("HomeWebView: convos.js reported ready (url=\(url?.absoluteString ?? "placeholder"))")
+            }
+            context.coordinator.bridgeHost = binding.host
+        }
         return webView
     }
 
@@ -200,12 +207,10 @@ struct HomeWebView: UIViewRepresentable {
         /// stale (e.g. the placeholder finishing after the real Space URL
         /// superseded it) and must not flip the interception state.
         var activeNavigation: WKNavigation?
-        /// The window.convos bridge for this web view. Registered through a
-        /// weak proxy, so the coordinator holds the strong reference; detached
-        /// in dismantleUIView.
-        var bridge: ConvosWebBridge?
-        /// Mutable state behind the bridge's plugin implementations; its
-        /// closures are refreshed on every updateUIView pass.
+        /// The pooled view's bridge host, its closures repointed at this surface
+        /// while it holds the view and refreshed on every updateUIView pass. The
+        /// bridge itself is owned by the pool, not the coordinator, so it can
+        /// outlive this surface and keep `window.convos` across a hand-back.
         var bridgeHost: HomeBridgeHost?
 
         init(

--- a/Convos/Conversation Detail/Home/HomeWebView.swift
+++ b/Convos/Conversation Detail/Home/HomeWebView.swift
@@ -1,3 +1,4 @@
+import ConvosBridge
 import SwiftUI
 import UIKit
 import WebKit
@@ -39,6 +40,12 @@ struct HomeWebView: UIViewRepresentable {
     /// navigation is cancelled in place; the host presents it in the home
     /// browser popup instead.
     var onNavigationRequest: @MainActor (URL) -> Void = { _ in }
+    /// Native destinations for the page's `window.convos` calls; the default
+    /// no-op set is what the browser popups use.
+    var bridgeNavigation: HomeBridgeNavigation = HomeBridgeNavigation()
+    /// Fired on the main actor when the page calls `window.convos.markReady()`,
+    /// i.e. it has painted and any loading cover may be dismissed.
+    var onMarkReady: @MainActor () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -49,6 +56,9 @@ struct HomeWebView: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.bridge?.detach(from: webView)
+        coordinator.bridge = nil
+        coordinator.bridgeHost = nil
         // Back to the pool with what it is showing, so a page that is still
         // drawn can be handed straight back on re-entry.
         // The URL asked for, not the one that committed: a page that redirects
@@ -94,6 +104,19 @@ struct HomeWebView: UIViewRepresentable {
         // stack onto the manual indicator insets.
         webView.scrollView.contentInsetAdjustmentBehavior = .never
         webView.scrollView.automaticallyAdjustsScrollIndicatorInsets = false
+        // Expose window.convos before any load: updateUIView performs the
+        // first load only after makeUIView returns, so the document-start
+        // script injection precedes both the placeholder and the space URL.
+        // The bridge registers through a weak proxy, so the coordinator
+        // retains it for the web view's lifetime.
+        let host = HomeBridgeHost()
+        host.navigation = bridgeNavigation
+        host.onMarkReady = onMarkReady
+        let bridge = ConvosWebBridge(plugins: HomeBridgePlugins.dispatchers(host: host))
+        bridge.onReady = { Log.debug("HomeWebView: convos.js reported ready") }
+        bridge.attach(to: webView)
+        context.coordinator.bridge = bridge
+        context.coordinator.bridgeHost = host
         return webView
     }
 
@@ -101,6 +124,10 @@ struct HomeWebView: UIViewRepresentable {
         context.coordinator.onLoaded = onLoaded
         context.coordinator.onFirstPaint = onFirstPaint
         context.coordinator.onNavigationRequest = onNavigationRequest
+        // Refresh the bridge's closures so they capture live host state, the
+        // same way the delegate closures above are reassigned every pass.
+        context.coordinator.bridgeHost?.navigation = bridgeNavigation
+        context.coordinator.bridgeHost?.onMarkReady = onMarkReady
         webView.scrollView.isScrollEnabled = isScrollEnabled
         let scrollView = webView.scrollView
         if scrollView.contentInset.top != topContentInset || scrollView.contentInset.bottom != bottomContentInset {
@@ -169,6 +196,13 @@ struct HomeWebView: UIViewRepresentable {
         /// stale (e.g. the placeholder finishing after the real Space URL
         /// superseded it) and must not flip the interception state.
         var activeNavigation: WKNavigation?
+        /// The window.convos bridge for this web view. Registered through a
+        /// weak proxy, so the coordinator holds the strong reference; detached
+        /// in dismantleUIView.
+        var bridge: ConvosWebBridge?
+        /// Mutable state behind the bridge's plugin implementations; its
+        /// closures are refreshed on every updateUIView pass.
+        var bridgeHost: HomeBridgeHost?
 
         init(
             onLoaded: @escaping @MainActor () -> Void,

--- a/Convos/Conversation Detail/Home/HomeWebView.swift
+++ b/Convos/Conversation Detail/Home/HomeWebView.swift
@@ -77,6 +77,9 @@ struct HomeWebView: UIViewRepresentable {
         // second before it can even start a navigation. See `HomeWebViewPool`.
         let adoption = HomeWebViewPool.shared.adoption(for: url)
         let webView = HomeWebViewPool.shared.acquire()
+        // Temporary: allow Safari Web Inspector to attach to the home/space and
+        // browser sub-page web views while debugging the window.convos bridge.
+        webView.isInspectable = true
         let coordinator = context.coordinator
         HomeWebViewPool.shared.paintReporter(of: webView)?.onPaint = { source in
             MainActor.assumeIsolated { coordinator.reportPaint(source) }
@@ -113,7 +116,8 @@ struct HomeWebView: UIViewRepresentable {
         host.navigation = bridgeNavigation
         host.onMarkReady = onMarkReady
         let bridge = ConvosWebBridge(plugins: HomeBridgePlugins.dispatchers(host: host))
-        bridge.onReady = { Log.debug("HomeWebView: convos.js reported ready") }
+        bridge.onReady = { Log.info("HomeWebView: convos.js reported ready (url=\(url?.absoluteString ?? "placeholder"))") }
+        Log.info("HomeWebView.makeUIView attaching bridge (url=\(url?.absoluteString ?? "placeholder"))")
         bridge.attach(to: webView)
         context.coordinator.bridge = bridge
         context.coordinator.bridgeHost = host

--- a/Convos/Conversation Detail/Home/HomeWebViewPool.swift
+++ b/Convos/Conversation Detail/Home/HomeWebViewPool.swift
@@ -1,3 +1,4 @@
+import ConvosBridge
 import ConvosCore
 import UIKit
 import WebKit
@@ -181,6 +182,12 @@ final class HomeWebViewPool {
         webView.configuration.userContentController.paintReporter
     }
 
+    /// The convos bridge and host installed on a pooled view, for the surface
+    /// to point the host's navigation at itself while it holds the view.
+    func bridgeBinding(of webView: WKWebView) -> HomeBridgeBinding? {
+        HomeBridgeBindingRegistry.shared.binding(for: webView.configuration.userContentController)
+    }
+
     private func makeWebView() -> WKWebView {
         let configuration = WKWebViewConfiguration()
         // The paint script is not installed here: it carries the token of the
@@ -199,7 +206,23 @@ final class HomeWebViewPool {
             reporter,
             for: configuration.userContentController
         )
-        return WKWebView(frame: .zero, configuration: configuration)
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        // The convos bridge is installed with the view, not by the surface that
+        // adopts it. The pool's `prepare` loads the space URL before any surface
+        // exists, and a bridge attached only on adoption would miss that load:
+        // its document-start `convos.js` runs on the next navigation, and an
+        // adopted page is not reloaded, so `window.convos` would never appear.
+        // The message handler outlives every surface; the host it dispatches to
+        // is repointed at whichever surface currently holds the view, and reset
+        // when the view returns to the pool. See `HomeWebView.makeUIView`.
+        let host = HomeBridgeHost()
+        let bridge = ConvosWebBridge(plugins: HomeBridgePlugins.dispatchers(host: host))
+        bridge.attach(to: webView)
+        HomeBridgeBindingRegistry.shared.register(
+            HomeBridgeBinding(bridge: bridge, host: host),
+            for: configuration.userContentController
+        )
+        return webView
     }
 
     /// Arms the paint reporter for a load about to be issued on this view.
@@ -215,6 +238,15 @@ final class HomeWebViewPool {
         let token = UUID().uuidString
         let controller = webView.configuration.userContentController
         controller.removeAllUserScripts()
+        // `removeAllUserScripts` clears every document-start script, the convos
+        // bridge's `window.convos` bootstrap among them. Reinstall it before the
+        // paint script so the page it is about to load still gets the bridge;
+        // without this the button-gating `window.convos` is defined only on the
+        // warm `about:blank` and never on the space URL. The message handler is
+        // not a user script, so it survives the clear untouched.
+        if let bootstrap = ConvosWebBridge.bootstrapUserScript {
+            controller.addUserScript(bootstrap)
+        }
         controller.addUserScript(
             WKUserScript(
                 source: HomeWebViewPaintReporter.script(token: token),
@@ -405,6 +437,48 @@ final class HomeWebViewPaintReporterRegistry {
     }
 
     func reporter(for controller: WKUserContentController) -> HomeWebViewPaintReporter? {
+        table.object(forKey: controller)
+    }
+}
+
+/// The convos bridge installed on a pooled view, together with the mutable host
+/// its plugins dispatch to.
+///
+/// The bridge is registered through a weak proxy, so it needs a strong owner:
+/// the pool holds it here for the life of the view rather than the surface, so
+/// `window.convos` survives a surface being torn down and the view returning to
+/// the pool. The host's closures are repointed at each adopting surface and
+/// reset when the view is released. See `HomeWebViewPool.makeWebView`.
+@MainActor
+final class HomeBridgeBinding {
+    let bridge: ConvosWebBridge
+    let host: HomeBridgeHost
+
+    init(bridge: ConvosWebBridge, host: HomeBridgeHost) {
+        self.bridge = bridge
+        self.host = host
+    }
+}
+
+/// Maps a content controller to the convos bridge binding installed on it.
+///
+/// The same reason as `HomeWebViewPaintReporterRegistry`: WebKit will not hand
+/// a message handler back, so the pool keeps its own map to reach the bridge it
+/// installed. Keys are weak so an evicted web view takes its entry with it.
+@MainActor
+final class HomeBridgeBindingRegistry {
+    static let shared: HomeBridgeBindingRegistry = HomeBridgeBindingRegistry()
+
+    private let table: NSMapTable<WKUserContentController, HomeBridgeBinding> =
+        .weakToStrongObjects()
+
+    private init() {}
+
+    func register(_ binding: HomeBridgeBinding, for controller: WKUserContentController) {
+        table.setObject(binding, forKey: controller)
+    }
+
+    func binding(for controller: WKUserContentController) -> HomeBridgeBinding? {
         table.object(forKey: controller)
     }
 }

--- a/Convos/Conversation Detail/SpaceURLDebugView.swift
+++ b/Convos/Conversation Detail/SpaceURLDebugView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+/// Debug surface for the conversation's Space web URL. The Assistant Worker
+/// is the value's normal authority; this screen lets an engineer overwrite it
+/// (e.g. with a local or ngrok page while testing the window.convos bridge)
+/// or clear it back to the waiting state. The worker may replace the override
+/// on its next publish.
+struct SpaceURLDebugView: View {
+    private let currentURLString: () -> String?
+    private let updateSpaceURL: (_ urlString: String?) async throws -> Void
+
+    @State private var urlInput: String = ""
+    @State private var currentValue: String?
+    @State private var actionStatus: String?
+    @State private var isUpdating: Bool = false
+
+    init(
+        currentURLString: @escaping () -> String?,
+        updateSpaceURL: @escaping (_ urlString: String?) async throws -> Void
+    ) {
+        self.currentURLString = currentURLString
+        self.updateSpaceURL = updateSpaceURL
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16.0) {
+                currentValueSection
+                Divider()
+                controls
+            }
+            .padding()
+        }
+        .navigationTitle("Space URL")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            currentValue = currentURLString()
+            urlInput = currentValue ?? ""
+        }
+    }
+
+    @ViewBuilder
+    private var currentValueSection: some View {
+        VStack(alignment: .leading, spacing: 8.0) {
+            Text("Current value")
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.colorTextSecondary)
+            Text(currentValue ?? "none published")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.colorTextPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+    }
+
+    @ViewBuilder
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 8.0) {
+            Text("Override")
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.colorTextSecondary)
+            TextField("https://…", text: $urlInput)
+                .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .keyboardType(.URL)
+            HStack(spacing: 12.0) {
+                Button {
+                    update(clearing: false)
+                } label: {
+                    Text("Update")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isUpdating || !isInputValid)
+                Button {
+                    update(clearing: true)
+                } label: {
+                    Text("Clear")
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .disabled(isUpdating)
+            }
+            if let actionStatus {
+                Text(actionStatus)
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    /// A non-empty input must at least parse as an http(s) URL before the
+    /// override can be written; the home surface refuses other schemes anyway.
+    private var isInputValid: Bool {
+        let trimmed = urlInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
+    }
+
+    @MainActor
+    private func update(clearing: Bool) {
+        let trimmed = urlInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let newValue: String? = clearing ? nil : trimmed
+        Task {
+            isUpdating = true
+            actionStatus = clearing ? "Clearing…" : "Updating…"
+            do {
+                try await updateSpaceURL(newValue)
+                currentValue = currentURLString()
+                actionStatus = clearing ? "Cleared." : "Updated."
+                if clearing {
+                    urlInput = ""
+                }
+            } catch {
+                actionStatus = "Failed: \(error.localizedDescription)"
+            }
+            isUpdating = false
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SpaceURLDebugView(
+            currentURLString: { "https://spaces.convos.org/preview" },
+            updateSpaceURL: { _ in }
+        )
+    }
+}

--- a/Convos/Debug View/DebugView.swift
+++ b/Convos/Debug View/DebugView.swift
@@ -82,6 +82,7 @@ struct DebugViewSection: View {
             Toggle("Listen (agent participation)", isOn: Bindable(FeatureFlags.shared).isListenParticipationEnabled)
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
             Toggle("Share Space (copy import link)", isOn: Bindable(FeatureFlags.shared).isSpaceShareEnabled)
+            Toggle("Web inspector (space/browser web views)", isOn: Bindable(FeatureFlags.shared).isWebInspectorEnabled)
             abilitiesFeatureToggles
 
             let showInfoAction = { showingAgentsInfoSheet = true }

--- a/Convos/Debug View/ProdDebugMenuView.swift
+++ b/Convos/Debug View/ProdDebugMenuView.swift
@@ -20,7 +20,7 @@ import UserNotifications
 //
 // Hard rules enforced here:
 // - No mutating controls (no "Request Now", no "Register Device Again", no
-//   purchase / change-plan CTAs, no mock-credit toggles). Three deliberate
+//   purchase / change-plan CTAs, no mock-credit toggles). Four deliberate
 //   exceptions, each flipping only a local default so a tester can opt this
 //   install into a feature we are dogfooding in production:
 //   - the XMTP bidi streaming opt-in, which selects the stream transport at
@@ -32,6 +32,9 @@ import UserNotifications
 //     per-conversation section from the V1 connections UI to the V2 one and
 //     points them at the live abilities backend. Off by default; nothing
 //     mutates until a tester connects an ability from that surface.
+//   - the Web inspector opt-in, which only decides whether the space/browser
+//     web views set `isInspectable`. Off by default; it mutates nothing and
+//     merely lets Safari Web Inspector attach to debug the window.convos bridge.
 // - The live `BackendAuthProbe` (JWT minter) is never imported or instantiated
 //   here. The identity readout uses `DeviceIdentitySnapshot`, which is
 //   network-free and carries no JWT.
@@ -185,6 +188,7 @@ struct ProdDebugMenuView: View {
             Toggle("XMTP bidi streaming (applies next launch)", isOn: Bindable(FeatureFlags.shared).isXMTPBidiStreamsEnabled)
             Toggle("Abilities v2", isOn: Bindable(FeatureFlags.shared).isAbilitiesV2Enabled)
             Toggle("Share Space (copy import link)", isOn: Bindable(FeatureFlags.shared).isSpaceShareEnabled)
+            Toggle("Web inspector (space/browser web views)", isOn: Bindable(FeatureFlags.shared).isWebInspectorEnabled)
         }
     }
 

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f69f6a73a70ced5aee5850da0a38d9e5b06551d660cce8026403e4cc36795af8",
+  "originHash" : "28dfd1ca67a57621dbd11fe70e5e00d3317acd3a9c2d5c0220582f5b8dfa43f9",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "da310944a7c7ec3aa40369a22951e114749e5474"
+        "branch" : "mpr/web-plugins",
+        "revision" : "6403c372e8778e07bec2feebd9b6cbbbd9527227"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -34,7 +34,7 @@
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
         "branch" : "mpr/web-plugins",
-        "revision" : "6403c372e8778e07bec2feebd9b6cbbbd9527227"
+        "revision" : "3638574b2020ab52e73ac18c1af2acb62595d926"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -39,7 +39,8 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        // TODO: revert to branch: "main" once the web-plugins bridge PR merges in convos-shared
+        // Temporary pin: the ConvosBridge product only exists on the web-plugins
+        // branch so far; revert to branch: "main" once that PR merges in convos-shared.
         .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "mpr/web-plugins"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -39,7 +39,8 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "main"),
+        // TODO: revert to branch: "main" once the web-plugins bridge PR merges in convos-shared
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "mpr/web-plugins"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),
@@ -62,6 +63,7 @@ let package = Package(
                 .product(name: "ConvosAppData", package: "ConvosAppData"),
                 .product(name: "ConvosConnections", package: "ConvosConnections"),
                 .product(name: "ConvosMetrics", package: "convos-shared"),
+                .product(name: "ConvosBridge", package: "convos-shared"),
                 .target(name: "ConvosConnectionsXMTP"),
             ],
             swiftSettings: [

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -142,6 +142,26 @@ extension XMTPiOS.Group {
         }
     }
 
+    /// Overwrites the Space web URL in appData, or clears it when nil. The
+    /// Assistant Worker is the value's authority (see `spaceURL`); this setter
+    /// exists only for the debug override in conversation info, and the worker
+    /// may replace whatever it writes on its next publish.
+    public func updateSpaceURL(_ urlString: String?) async throws {
+        try await atomicUpdateMetadata(operation: "updateSpaceURL") { metadata in
+            if let urlString {
+                metadata.spaceURL = urlString
+            } else {
+                metadata.clearSpaceURL()
+            }
+        } verify: { metadata in
+            if let urlString {
+                return metadata.spaceURL == urlString
+            } else {
+                return !metadata.hasSpaceURL
+            }
+        }
+    }
+
     /// Stamps this conversation as a private DM with an agent. Called once by
     /// the device that creates the DM conversation, before adding the agent.
     public func markAsAgentDm(originConversationId: Data? = nil) async throws {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
@@ -14,6 +14,7 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
     public var updatedImages: [(image: ImageType, conversation: Conversation)] = []
     public var updatedExpiresAt: [(expiresAt: Date, conversationId: String)] = []
     public var updatedParticipationModes: [(mode: ConversationParticipationMode, conversationId: String)] = []
+    public var updatedSpaceURLs: [(urlString: String?, conversationId: String)] = []
     public var updatedIncludeInfoInPublicPreview: [(enabled: Bool, conversationId: String)] = []
     public var lockedConversations: [String] = []
     public var unlockedConversations: [String] = []
@@ -69,6 +70,10 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
 
     public func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws {
         updatedParticipationModes.append((mode: mode, conversationId: conversationId))
+    }
+
+    public func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {
+        updatedSpaceURLs.append((urlString: urlString, conversationId: conversationId))
     }
 
     public func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -879,6 +879,37 @@ extension DBConversation {
         )
     }
 
+    func with(spaceURLString: String?) -> Self {
+        .init(
+            id: id,
+            clientConversationId: clientConversationId,
+            inviteTag: inviteTag,
+            creatorId: creatorId,
+            kind: kind,
+            consent: consent,
+            createdAt: createdAt,
+            name: name,
+            description: description,
+            imageURLString: imageURLString,
+            publicImageURLString: publicImageURLString,
+            includeInfoInPublicPreview: includeInfoInPublicPreview,
+            expiresAt: expiresAt,
+            debugInfo: debugInfo,
+            isLocked: isLocked,
+            imageSalt: imageSalt,
+            imageNonce: imageNonce,
+            imageEncryptionKey: imageEncryptionKey,
+            conversationEmoji: conversationEmoji,
+            imageLastRenewed: imageLastRenewed,
+            isUnused: isUnused,
+            hasHadVerifiedAgent: hasHadVerifiedAgent,
+            isAgentDm: isAgentDm,
+            participationMode: participationMode,
+            spaceURLString: spaceURLString,
+            adder: adder
+        )
+    }
+
     func with(isAgentDm: Bool) -> Self {
         .init(
             id: id,

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -20,6 +20,7 @@ public protocol ConversationMetadataWriterProtocol: Sendable {
     func updateImage(_ image: ImageType, for conversation: Conversation) async throws
     func updateExpiresAt(_ expiresAt: Date, for conversationId: String) async throws
     func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws
+    func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws
     func lockConversation(for conversationId: String) async throws
     func unlockConversation(for conversationId: String) async throws
@@ -160,6 +161,31 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
 
         Log.info("Updated conversation participation mode for \(conversationId): \(mode.rawValue)")
         QAEvent.emit(.conversation, "participation_mode_updated", ["id": conversationId, "mode": mode.rawValue])
+    }
+
+    /// Debug override for the Space web URL. The Assistant Worker is the
+    /// value's normal authority (see `XMTPGroup.spaceURL`); this writes the
+    /// override into the group's appData so it survives resyncs and reaches
+    /// other members, and mirrors it into the local row so the home surface
+    /// reloads without waiting a round trip. Pass nil to clear.
+    func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+
+        guard let conversation = try await inboxReady.client.conversation(with: conversationId),
+              case .group(let group) = conversation else {
+            throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
+        }
+
+        try await group.updateSpaceURL(urlString)
+
+        try await databaseWriter.write { db in
+            guard let localConversation = try DBConversation.fetchOne(db, key: conversationId) else {
+                throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
+            }
+            try localConversation.with(spaceURLString: urlString).save(db)
+        }
+
+        Log.info("Updated conversation space URL for \(conversationId): \(urlString ?? "nil")")
     }
 
     func updateDescription(_ description: String, for conversationId: String) async throws {

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
@@ -345,6 +345,7 @@ private final class RecordingMetadataWriter: ConversationMetadataWriterProtocol,
     }
 
     func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws {}
+    func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {}
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws {}
     func lockConversation(for conversationId: String) async throws {}
     func unlockConversation(for conversationId: String) async throws {}


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789761468&installation_model_id=20076&pr_number=1362&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1362&signature=2300e3972bb792574e2e8da94ee46ad8a1c734fa986021beae782b5894fa81dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native bridge plugins for `window.convos` APIs in home web views
> - Introduces `HomeBridgePlugins` and `HomeBridgeHost` in [HomeBridgePlugins.swift](https://github.com/xmtplabs/convos-ios/pull/1362/files#diff-23c56a8d659763767660397b377be515ad42a474bd58e26ee6a7c5ec7a01ccfa), implementing `EventsPlugin`, `AppPlugin`, `InvitePlugin`, `ChatPlugin`, `ThingsPlugin`, and `DesktopPlugin` so `window.convos` calls from the web layer route to native navigation closures.
> - Pooled `WKWebView` instances now install a persistent `ConvosWebBridge` via `HomeWebViewPool` and `HomeBridgeBindingRegistry`, restoring the bootstrap script after user-script clears so the bridge survives page reloads.
> - `ConversationView.homeBridgeNavigation` wires invite, share, scan, and members-list actions to native affordances with state-aware gating via the new `inviteActionsEnabled` property.
> - Adds a debug `SpaceURLDebugView` and `ConversationMetadataWriter.updateSpaceURL` to override or clear the Space URL in both XMTP appData and the local DB.
> - Adds `FeatureFlags.isWebInspectorEnabled` (UserDefaults-backed) and exposes it in debug menus; when enabled, `WKWebView.isInspectable` is set.
> - Risk: `ConversationMetadataWriterProtocol` gains a new `updateSpaceURL` requirement; out-of-tree conformers must implement it. The bridge `showInviteCode` is a no-op when the conversation is full.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abccf81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->