### PR TITLE
Split the Connections browser into Connected and Discover

### DIFF
--- a/Convos/Abilities/AbilitiesAccountEpoch.swift
+++ b/Convos/Abilities/AbilitiesAccountEpoch.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Observation
+
+/// Monotonic generation of the account (and scope) the abilities surfaces
+/// are rendering. `AbilitiesServices.handleAccountDataWiped` clears the
+/// disk cache and the service actor but notifies no view model, and both
+/// abilities view models retain their last snapshot when a refresh fails -
+/// so a screen open across a wipe would otherwise keep rendering the
+/// previous account's connections and accept a toggle against them.
+///
+/// View models capture the value before every await, refuse to publish a
+/// result captured under an earlier one, and drop what they already
+/// published the moment it moves. Reading `value` from a view-evaluated
+/// computed property registers the observation, so the invalidation lands
+/// on the next render rather than waiting for another fetch.
+@MainActor
+@Observable
+final class AbilitiesAccountEpoch {
+    static let shared: AbilitiesAccountEpoch = AbilitiesAccountEpoch()
+
+    private(set) var value: UInt64 = 0
+
+    func advance() {
+        value &+= 1
+    }
+}

--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -13,12 +13,18 @@ import SwiftUI
 /// replacement).
 struct AbilitiesListScreen: View {
     @State private var viewModel: AbilitiesListViewModel
+    /// The per-chat half of `.composerModal`: opt-in state and the toggle
+    /// writer for the launching DM. Nil in `.appSettings`, which has no
+    /// conversation to scope to and must fire no conversation-abilities
+    /// request at all.
+    @State private var conversationViewModel: ConversationAbilitiesViewModel?
     /// Kept so entitled rows can hand the whole latched pair down to the
     /// ability detail push (see `AbilitiesSelection`).
     private let selection: AbilitiesSelection
-    /// Which entry point raised the screen; drives only the wrapper chrome
-    /// (see `ConnectionsBrowserMode`). Both modes render the same list from
-    /// the same view model.
+    /// Which entry point raised the screen; drives the wrapper chrome, the
+    /// section headers and the Connected row's accessory (see
+    /// `ConnectionsBrowserMode`). Membership predicates are the same in
+    /// both modes.
     private let mode: ConnectionsBrowserMode
     @Environment(\.dismiss) private var dismiss: DismissAction
 
@@ -28,7 +34,49 @@ struct AbilitiesListScreen: View {
     init(selection: AbilitiesSelection, mode: ConnectionsBrowserMode) {
         self.selection = selection
         self.mode = mode
-        _viewModel = State(initialValue: AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer))
+        let listViewModel = AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer)
+        let conversationViewModel = Self.makeConversationViewModel(listViewModel, selection: selection, mode: mode)
+        if let conversationViewModel {
+            listViewModel.onCatalogCommitted = { [weak conversationViewModel] catalog in
+                conversationViewModel?.adoptCatalog(catalog)
+            }
+            listViewModel.onEntitlementActivated = { [weak conversationViewModel] abilityId in
+                conversationViewModel?.enableAfterConnect(abilityId: abilityId)
+            }
+        }
+        _viewModel = State(initialValue: listViewModel)
+        _conversationViewModel = State(initialValue: conversationViewModel)
+    }
+
+    /// Builds the per-chat view model for `.composerModal` and cross-wires
+    /// it with the list view model: the list publishes every catalog
+    /// revision it commits (so the lifecycle behind a toggle always comes
+    /// from the snapshot that sectioned the row) and every entitlement it
+    /// activates (so a connect from Discover enables the ability here).
+    /// Both directions capture weakly; `@State` owns the strong halves.
+    private static func makeConversationViewModel(
+        _ listViewModel: AbilitiesListViewModel,
+        selection: AbilitiesSelection,
+        mode: ConnectionsBrowserMode
+    ) -> ConversationAbilitiesViewModel? {
+        guard let conversationId = mode.conversationId,
+              let agentInboxId = mode.agentInboxId else {
+            return nil
+        }
+        let agent = ConversationAgentDescriptor(
+            inboxId: agentInboxId,
+            displayName: mode.agentDisplayName ?? ""
+        )
+        let conversationViewModel = ConversationAbilitiesViewModel(
+            conversationId: conversationId,
+            agents: [agent],
+            selection: selection,
+            catalogSource: .hosted
+        )
+        conversationViewModel.entitlementRecoveryRoute = .host { [weak listViewModel] ability in
+            listViewModel?.connect(ability)
+        }
+        return conversationViewModel
     }
 
     var body: some View {
@@ -42,8 +90,17 @@ struct AbilitiesListScreen: View {
         }
     }
 
+    /// The sheets modifier rides the list, never the section: attached
+    /// lower down it resolves the wrong presentation context and the
+    /// bundle picker dismisses this modal instead of presenting.
     private var listView: some View {
-        AbilitiesListView(viewModel: viewModel, selection: selection)
+        AbilitiesListView(
+            viewModel: viewModel,
+            selection: selection,
+            mode: mode,
+            conversationViewModel: conversationViewModel
+        )
+        .modifier(ConversationAbilitiesSheetsModifier(viewModel: conversationViewModel))
     }
 
     private var doneToolbarItem: some ToolbarContent {
@@ -55,34 +112,48 @@ struct AbilitiesListScreen: View {
     }
 }
 
-/// The V2 abilities catalog list (account level): searchable, split into
-/// entitled and available sections, with status badges and
-/// connect/disconnect actions stubbed through `AbilitiesServiceProtocol`.
+/// The V2 abilities catalog list: searchable, split into three sections by
+/// entitlement state, with status badges and connect actions through
+/// `AbilitiesServiceProtocol`.
 ///
 /// Entry points (all flag-gated behind Abilities V2, all via
-/// `AbilitiesListScreen`, which owns the view model and takes the
+/// `AbilitiesListScreen`, which owns the view models and takes the
 /// `ConnectionsBrowserMode` naming the caller):
 /// - App Settings connections row (`AppSettingsView.connectionsDestination`)
 ///   pushes it in place of the V1 `ConnectionsListView`, in mode
-///   `.appSettings`; the row is titled "Abilities" under the flag.
-/// - The agent composer's powerplug (quick icon or `+` menu row) presents it
-///   full-screen from `ConversationView.connectionsBrowserPresentation`, in
-///   mode `.composerModal`; the screen then supplies its own
-///   `NavigationStack` and a Done control.
+///   `.appSettings`; the row is titled "Abilities" under the flag. Account
+///   level throughout: "Connected" / "All connections" / "Status unknown",
+///   the `ellipsis` menu with Disconnect, and the detail push.
+/// - The agent composer's `+` menu presents it full-screen from
+///   `ConversationView.connectionsBrowserPresentation`, in mode
+///   `.composerModal`; the screen then supplies its own `NavigationStack`
+///   and a Done control. Here the list is where connections are turned on
+///   *for the launching chat*: "Connected" / "Discover" / "Status
+///   unknown", each Connected row carrying the same per-chat toggle the
+///   conversation info section shows, and no Disconnect anywhere (that
+///   stays app-wide, in App Settings).
+///
+/// Section membership is identical in both modes and comes from the
+/// catalog alone; the mode drives the second header string and the
+/// Connected row's accessory.
 ///
 /// A conversation toggle that needs an entitlement no longer deep-links
 /// here: it presents the scoped `AbilityConnectSheet` instead, which reuses
 /// this screen's view model for the connect machinery.
 ///
-/// Entitled rows push `AbilityDetailScreen` (delegations list) inside
-/// whichever stack the mode put the screen in - the App Settings stack when
-/// pushed, the screen's own stack when presented as the modal. Available and
-/// state-unknown rows stay non-navigable: delegations only exist against an
-/// entitlement.
+/// Entitled rows push `AbilityDetailScreen` (delegations list) in
+/// `.appSettings` only. Available, state-unknown, and `.composerModal`
+/// Connected rows stay non-navigable - the last because a `Toggle` inside
+/// a `NavigationLink` fights the row's tap target.
 struct AbilitiesListView: View {
     @Bindable var viewModel: AbilitiesListViewModel
     /// Latched pair handed down to ability detail pushes.
     let selection: AbilitiesSelection
+    /// Drives the second section's header and the Connected accessory.
+    var mode: ConnectionsBrowserMode = .appSettings
+    /// The per-chat toggle state for `.composerModal`; nil renders the
+    /// account-level accessory instead.
+    var conversationViewModel: ConversationAbilitiesViewModel?
 
     var body: some View {
         catalogList
@@ -251,8 +322,17 @@ struct AbilitiesListView: View {
                     availableRow(ability)
                 }
             } header: {
-                sectionHeader("All connections")
+                sectionHeader(availableSectionTitle)
             }
+        }
+    }
+
+    /// The account-level list enumerates what exists; the chat-scoped one
+    /// frames the same rows as things to add to this convo.
+    private var availableSectionTitle: String {
+        switch mode {
+        case .appSettings: "All connections"
+        case .composerModal: "Discover"
         }
     }
 
@@ -279,13 +359,36 @@ struct AbilitiesListView: View {
 
     // MARK: - Rows
 
+    @ViewBuilder
     private func entitledRow(_ ability: AbilitiesAPI.Ability) -> some View {
+        if let conversationViewModel {
+            scopedEntitledRow(ability, conversationViewModel: conversationViewModel)
+        } else {
+            navigableEntitledRow(ability)
+        }
+    }
+
+    private func navigableEntitledRow(_ ability: AbilitiesAPI.Ability) -> some View {
         NavigationLink {
             AbilityDetailScreen(ability: ability, selection: selection)
         } label: {
             abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
                 entitledAccessory(ability)
             }
+        }
+    }
+
+    /// Chat-scoped Connected row: status badge plus the shared per-chat
+    /// toggle, and nothing else. No `ellipsis` menu (Disconnect is
+    /// app-wide, and this surface only extends and withdraws grants) and
+    /// no detail push - the toggle needs the row's tap target, and the
+    /// push is where a disconnect would sneak back in.
+    private func scopedEntitledRow(
+        _ ability: AbilitiesAPI.Ability,
+        conversationViewModel: ConversationAbilitiesViewModel
+    ) -> some View {
+        abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
+            scopedEntitledAccessory(ability, conversationViewModel: conversationViewModel)
         }
     }
 
@@ -345,6 +448,45 @@ struct AbilitiesListView: View {
                 AbilityStatusBadge(status: entitlement.status)
                 entitledMenu(ability, status: entitlement.status)
             }
+        }
+    }
+
+    /// The badge still reports the app-wide entitlement status; the toggle
+    /// beside it reports this chat. Two different facts, so both render.
+    @ViewBuilder
+    private func scopedEntitledAccessory(
+        _ ability: AbilitiesAPI.Ability,
+        conversationViewModel: ConversationAbilitiesViewModel
+    ) -> some View {
+        if viewModel.isBusy(ability) {
+            ProgressView()
+        } else {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                if let entitlement = ability.entitlement {
+                    AbilityStatusBadge(status: entitlement.status)
+                }
+                scopedToggle(ability, conversationViewModel: conversationViewModel)
+            }
+        }
+    }
+
+    /// A Connected row the conversation view model has no row for yet is
+    /// the catalog arriving ahead of the opt-in read: loading, never a
+    /// settled OFF.
+    @ViewBuilder
+    private func scopedToggle(
+        _ ability: AbilitiesAPI.Ability,
+        conversationViewModel: ConversationAbilitiesViewModel
+    ) -> some View {
+        if let row = conversationViewModel.row(forAbilityId: ability.id) {
+            let repairAction = { viewModel.connect(ability) }
+            ConversationAbilityToggleControl(
+                row: row,
+                viewModel: conversationViewModel,
+                onNeedsAttention: repairAction
+            )
+        } else {
+            ConversationAbilityToggleLoadingControl()
         }
     }
 
@@ -419,7 +561,7 @@ struct AbilitiesListView: View {
 #Preview("Composer modal") {
     AbilitiesListScreen(
         selection: AbilitiesSelection(service: MockAbilitiesService()),
-        mode: .composerModal(conversationId: "dm-1", agentInboxId: "agent-1")
+        mode: .composerModal(conversationId: "mock-conversation-1", agentInboxId: "mock-agent-inbox-1", agentDisplayName: "Caley")
     )
 }
 

--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -37,15 +37,33 @@ struct AbilitiesListScreen: View {
         let listViewModel = AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer)
         let conversationViewModel = Self.makeConversationViewModel(listViewModel, selection: selection, mode: mode)
         if let conversationViewModel {
-            listViewModel.onCatalogCommitted = { [weak conversationViewModel] catalog in
-                conversationViewModel?.adoptCatalog(catalog)
-            }
-            listViewModel.onEntitlementActivated = { [weak conversationViewModel] abilityId in
-                conversationViewModel?.enableAfterConnect(abilityId: abilityId)
-            }
+            Self.wireActivation(list: listViewModel, conversation: conversationViewModel)
         }
         _viewModel = State(initialValue: listViewModel)
         _conversationViewModel = State(initialValue: conversationViewModel)
+    }
+
+    /// Points the list view model's catalog and activation callbacks at
+    /// the per-chat view model.
+    ///
+    /// The captures are **strong on purpose**. `@State` releases the
+    /// per-chat view model the moment the modal is dismissed, but a
+    /// connect already in flight still has to write its grant: dismissing
+    /// before `beginEntitlement` returns would otherwise connect the
+    /// ability app-wide and silently write no per-chat opt-in. The list
+    /// view model outlives the dismissal through its own mutation task,
+    /// so it carries the pipeline. No cycle results: the recovery route
+    /// in the other direction captures the list view model weakly.
+    static func wireActivation(
+        list: AbilitiesListViewModel,
+        conversation: ConversationAbilitiesViewModel
+    ) {
+        list.onCatalogCommitted = { catalog in
+            conversation.adoptCatalog(catalog)
+        }
+        list.onEntitlementActivated = { abilityId in
+            conversation.enableAfterConnect(abilityId: abilityId)
+        }
     }
 
     /// Builds the per-chat view model for `.composerModal` and cross-wires

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -25,23 +25,62 @@ final class AbilitiesListViewModel {
     /// Set when the sheet's approve action takes over the lifecycle, so
     /// the dismissal callback does not also run the cancel path.
     private var isCompletingAuthorization: Bool = false
+    /// Server-confirmed activations waiting for the authorization sheet to
+    /// finish dismissing. `pendingAuthorization == nil` is not proof of
+    /// dismissal -- `completeAuthorization` nils it before awaiting
+    /// completion, and the real dismissal arrives separately through the
+    /// sheet's `onDismiss`. Released exactly once, by
+    /// `handleAuthorizationDismissed`.
+    private var parkedActivations: [String] = []
+
+    /// Fires once per ability whose entitlement just became active through
+    /// this screen. `.composerModal` uses it to enable the ability for the
+    /// launching chat; `.appSettings` leaves it nil.
+    ///
+    /// Carries the ability **id**, never an `Ability` value: none of the
+    /// completion sites holds a refreshed one, and the pre-connect copy
+    /// they do hold still reads not-entitled.
+    var onEntitlementActivated: ((String) -> Void)?
+    /// Fires with every catalog revision this view model commits, so a
+    /// host owning a second view model can keep it on the same snapshot
+    /// that sectioned the rows.
+    var onCatalogCommitted: ((AbilitiesCatalog) -> Void)?
 
     private let service: any AbilitiesServiceProtocol
     /// Browser-session authorizer for the live transport. Nil (mock mode)
     /// keeps the stub authorization sheet as the approval step.
     private let authorizer: (any AbilityAuthorizing)?
+    private let accountEpoch: AbilitiesAccountEpoch
+    /// The account generation the published catalog belongs to. A wipe
+    /// notifies no view model, so without this a screen open across one
+    /// keeps rendering the previous account's connections.
+    private var snapshotEpoch: UInt64
 
-    init(service: any AbilitiesServiceProtocol, authorizer: (any AbilityAuthorizing)? = nil) {
+    init(
+        service: any AbilitiesServiceProtocol,
+        authorizer: (any AbilityAuthorizing)? = nil,
+        accountEpoch: AbilitiesAccountEpoch = .shared
+    ) {
         self.service = service
         self.authorizer = authorizer
+        self.accountEpoch = accountEpoch
+        self.snapshotEpoch = accountEpoch.value
     }
 
     var entitlementsUnavailable: Bool {
-        catalog?.entitlementsUnavailable ?? false
+        currentCatalog?.entitlementsUnavailable ?? false
     }
 
     var hasLoadedOnce: Bool {
-        catalog != nil
+        currentCatalog != nil
+    }
+
+    /// The published catalog, or nil once the account generation behind it
+    /// has been superseded. Reading the epoch here is what makes a wipe
+    /// land on the next render rather than the next fetch.
+    private var currentCatalog: AbilitiesCatalog? {
+        guard snapshotEpoch == accountEpoch.value else { return nil }
+        return catalog
     }
 
     var isSearching: Bool {
@@ -91,16 +130,43 @@ final class AbilitiesListViewModel {
     }
 
     func refresh() async {
+        invalidateSnapshotIfEpochChanged()
         if catalog == nil {
             isLoading = true
         }
+        let epoch: UInt64 = accountEpoch.value
         do {
-            catalog = try await service.fetchCatalog()
+            let fetched: AbilitiesCatalog = try await service.fetchCatalog()
+            guard epoch == accountEpoch.value else { return }
+            commitCatalog(fetched)
             errorMessage = nil
         } catch {
+            guard epoch == accountEpoch.value else { return }
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    /// The one place `catalog` is published, so every host holding a
+    /// second view model sees every revision this screen commits - not
+    /// just the first.
+    private func commitCatalog(_ fetched: AbilitiesCatalog) {
+        catalog = fetched
+        snapshotEpoch = accountEpoch.value
+        onCatalogCommitted?(fetched)
+    }
+
+    /// Drops a catalog published under a superseded account generation, so
+    /// a screen open across a wipe cannot keep rendering it.
+    private func invalidateSnapshotIfEpochChanged() {
+        let current: UInt64 = accountEpoch.value
+        guard current != snapshotEpoch else { return }
+        snapshotEpoch = current
+        catalog = nil
+        busyAbilityIds = []
+        pendingAuthorization = nil
+        parkedActivations = []
+        errorMessage = nil
     }
 
     /// Starts (or restarts, for expired/needs-reauth/revoked states) the
@@ -110,7 +176,7 @@ final class AbilitiesListViewModel {
     /// completion only ever runs after the user approved it, mirroring the
     /// browser-callback boundary.
     func connect(_ ability: AbilitiesAPI.Ability) {
-        guard !isBusy(ability) else { return }
+        guard !isBusy(ability), snapshotEpoch == accountEpoch.value else { return }
         busyAbilityIds.insert(ability.id)
         errorMessage = nil
         Task {
@@ -128,6 +194,11 @@ final class AbilitiesListViewModel {
                     } else {
                         pendingAuthorization = AbilityAuthorizationContext(ability: ability, redirectUrl: redirectUrl)
                     }
+                } else {
+                    // Auth-less abilities go active on begin alone, with no
+                    // authorization step to complete: this branch is the only
+                    // activation report they ever produce.
+                    reportEntitlementActivated(abilityId: ability.id)
                 }
             } catch {
                 errorMessage = error.localizedDescription
@@ -141,7 +212,32 @@ final class AbilitiesListViewModel {
     /// otherwise (the flow's own completion refresh retries).
     private func refreshCatalogQuietly() async {
         guard let fetched = try? await service.fetchCatalog() else { return }
-        catalog = fetched
+        guard snapshotEpoch == accountEpoch.value else { return }
+        commitCatalog(fetched)
+    }
+
+    /// The single funnel every activation report goes through. Fires on
+    /// the server-confirmed completion, never on the row having visibly
+    /// moved: `refreshCatalogQuietly` is allowed to fail silently, and
+    /// gating on the move would drop the report whenever it hiccups.
+    ///
+    /// While the stub authorization sheet is still dismissing the report
+    /// is parked instead, so a follow-on sheet (the bundle picker) can
+    /// never race that dismissal.
+    private func reportEntitlementActivated(abilityId: String) {
+        guard isCompletingAuthorization else {
+            onEntitlementActivated?(abilityId)
+            return
+        }
+        parkedActivations.append(abilityId)
+    }
+
+    private func releaseParkedActivations() {
+        let released: [String] = parkedActivations
+        parkedActivations = []
+        for abilityId in released {
+            onEntitlementActivated?(abilityId)
+        }
     }
 
     /// Live-transport authorization: `ASWebAuthenticationSession` replaces
@@ -178,6 +274,7 @@ final class AbilitiesListViewModel {
             return
         }
         await refreshCatalogQuietly()
+        reportEntitlementActivated(abilityId: ability.id)
     }
 
     /// Bounded same-attempt completion retry. `auth_incomplete` means the
@@ -217,6 +314,7 @@ final class AbilitiesListViewModel {
             do {
                 try await service.completeEntitlement(abilityId: context.ability.id)
                 await refreshCatalogQuietly()
+                reportEntitlementActivated(abilityId: context.ability.id)
             } catch {
                 await refresh()
                 errorMessage = error.localizedDescription
@@ -238,11 +336,15 @@ final class AbilitiesListViewModel {
     /// server-side, so refresh: the row then offers Continue (re-runs
     /// `connect`, begin is idempotent) and Disconnect (revokes the pending
     /// entitlement) instead of a stale Connect.
+    ///
+    /// This is also the second half of the activation latch: an activation
+    /// confirmed while the sheet was still on screen is released here, so
+    /// downstream work never presents a sheet into a dismissing one.
     func handleAuthorizationDismissed() {
-        guard !isCompletingAuthorization else {
-            isCompletingAuthorization = false
-            return
-        }
+        let wasCompleting: Bool = isCompletingAuthorization
+        isCompletingAuthorization = false
+        releaseParkedActivations()
+        guard !wasCompleting else { return }
         Task {
             await refresh()
         }
@@ -269,7 +371,7 @@ final class AbilitiesListViewModel {
     }
 
     private var filteredAbilities: [AbilitiesAPI.Ability] {
-        guard let catalog else { return [] }
+        guard let catalog = currentCatalog else { return [] }
         let sorted: [AbilitiesAPI.Ability] = catalog.abilities.sorted { (lhs: AbilitiesAPI.Ability, rhs: AbilitiesAPI.Ability) -> Bool in
             lhs.displayName.resolved().localizedCaseInsensitiveCompare(rhs.displayName.resolved()) == .orderedAscending
         }

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -137,11 +137,11 @@ final class AbilitiesListViewModel {
         let epoch: UInt64 = accountEpoch.value
         do {
             let fetched: AbilitiesCatalog = try await service.fetchCatalog()
-            guard epoch == accountEpoch.value else { return }
+            guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return }
             commitCatalog(fetched)
             errorMessage = nil
         } catch {
-            guard epoch == accountEpoch.value else { return }
+            guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return }
             errorMessage = error.localizedDescription
         }
         isLoading = false
@@ -188,7 +188,16 @@ final class AbilitiesListViewModel {
                 // opened a backend OAuth round, and failing here would
                 // strand it behind an error message.
                 await refreshCatalogQuietly()
-                if initiation.status == .pendingAuth, let redirectUrl = initiation.redirectUrl {
+                if initiation.status == .pendingAuth {
+                    // A pending entitlement with no redirect URL is a
+                    // malformed response, not an auth-less ability: the
+                    // server just said authorization is outstanding, so
+                    // reporting activation here would assert the opposite.
+                    guard let redirectUrl = initiation.redirectUrl else {
+                        errorMessage = LiveAbilitiesServiceError.missingConnectionRequest(abilityId: ability.id).localizedDescription
+                        busyAbilityIds.remove(ability.id)
+                        return
+                    }
                     if let authorizer {
                         await runBrowserAuthorization(for: ability, redirectUrl: redirectUrl, using: authorizer)
                     } else {
@@ -211,8 +220,14 @@ final class AbilitiesListViewModel {
     /// lifecycle: updates on success, quietly keeps the stale catalog
     /// otherwise (the flow's own completion refresh retries).
     private func refreshCatalogQuietly() async {
+        // Captured before the await, not read after it: the question is
+        // whether this result belongs to the account it is about to be
+        // committed to, and a wipe followed by a fresh refresh can leave
+        // `snapshotEpoch == accountEpoch.value` true again for a result
+        // fetched under the previous account.
+        let epoch: UInt64 = accountEpoch.value
         guard let fetched = try? await service.fetchCatalog() else { return }
-        guard snapshotEpoch == accountEpoch.value else { return }
+        guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return }
         commitCatalog(fetched)
     }
 

--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -115,8 +115,13 @@ enum AbilitiesServices {
     /// invalidates the service's in-flight fetches and re-clears, so a
     /// catalog refresh that was already on the network can neither commit
     /// nor recreate the wiped files when it resumes.
+    ///
+    /// Advancing `AbilitiesAccountEpoch` is the view-model half of the same
+    /// fence: clearing the actor and the disk says nothing to a screen that
+    /// is already holding a snapshot (see `AbilitiesAccountEpoch`).
     static func handleAccountDataWiped() {
         catalogCache?.clearAll()
+        Task { @MainActor in AbilitiesAccountEpoch.shared.advance() }
         guard let liveService else { return }
         Task { await liveService.handleAccountDataWiped() }
     }

--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -121,9 +121,21 @@ enum AbilitiesServices {
     /// is already holding a snapshot (see `AbilitiesAccountEpoch`).
     static func handleAccountDataWiped() {
         catalogCache?.clearAll()
-        Task { @MainActor in AbilitiesAccountEpoch.shared.advance() }
+        advanceAccountEpoch()
         guard let liveService else { return }
         Task { await liveService.handleAccountDataWiped() }
+    }
+
+    /// Synchronous whenever the caller is already on the main actor, which
+    /// every wipe site is. Deferring the bump to a queued task would leave
+    /// a window in which a fetch started under the wiped account can still
+    /// commit, because the view models would not yet know the epoch moved.
+    private static func advanceAccountEpoch() {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated { AbilitiesAccountEpoch.shared.advance() }
+        } else {
+            Task { @MainActor in AbilitiesAccountEpoch.shared.advance() }
+        }
     }
 
     /// Debug sub-toggle under the Abilities V2 flag: live backend versus

--- a/Convos/Abilities/ConnectionsBrowserMode.swift
+++ b/Convos/Abilities/ConnectionsBrowserMode.swift
@@ -11,18 +11,19 @@ import Foundation
 ///   (`AppSettingsView.connectionsDestination`) pushes the screen inside
 ///   the settings `NavigationStack`. No chrome of its own - the stack
 ///   supplies the back button.
-/// - **`.composerModal(...)`**: the agent composer's powerplug (quick icon
-///   or `+` menu row) presents the screen full-screen from
+/// - **`.composerModal(...)`**: the agent composer's `+` menu powerplug
+///   row presents the screen full-screen from
 ///   `ConversationView`. The screen wraps itself in its own
 ///   `NavigationStack` with a Done dismiss control; ability detail pushes
-///   run inside that stack. Carries the launching DM's context for future
-///   scoped affordances; the content itself stays account-level.
+///   run inside that stack. Carries the launching DM's context: the
+///   Connected section scopes its per-chat toggles to that conversation
+///   and agent.
 ///
 /// Both modes render the same sections from the same view model; only the
 /// wrapper differs.
 enum ConnectionsBrowserMode: Hashable, Identifiable {
     case appSettings
-    case composerModal(conversationId: String, agentInboxId: String)
+    case composerModal(conversationId: String, agentInboxId: String, agentDisplayName: String)
 
     /// The modal presentation wraps the list in its own `NavigationStack`
     /// and shows the Done dismiss control; the settings push rides the
@@ -34,21 +35,32 @@ enum ConnectionsBrowserMode: Hashable, Identifiable {
 
     /// The agent DM the modal was launched from; nil for the settings push.
     var conversationId: String? {
-        if case .composerModal(let conversationId, _) = self { return conversationId }
+        if case .composerModal(let conversationId, _, _) = self { return conversationId }
         return nil
     }
 
     /// The agent whose composer launched the modal; nil for the settings push.
     var agentInboxId: String? {
-        if case .composerModal(_, let agentInboxId) = self { return agentInboxId }
+        if case .composerModal(_, let agentInboxId, _) = self { return agentInboxId }
         return nil
     }
 
+    /// The agent whose composer launched the modal, for the toggle rows
+    /// that scope to it; nil for the settings push.
+    var agentDisplayName: String? {
+        if case .composerModal(_, _, let agentDisplayName) = self { return agentDisplayName }
+        return nil
+    }
+
+    /// Deliberately excludes `agentDisplayName`: the modal is presented
+    /// with `fullScreenCover(item:)`, so folding a renameable value into
+    /// identity would tear the modal down and re-present it the moment the
+    /// agent renames mid-session.
     var id: String {
         switch self {
         case .appSettings:
             "appSettings"
-        case let .composerModal(conversationId, agentInboxId):
+        case let .composerModal(conversationId, agentInboxId, _):
             "composerModal-\(conversationId)-\(agentInboxId)"
         }
     }

--- a/Convos/Abilities/ConversationAbilitiesSection.swift
+++ b/Convos/Abilities/ConversationAbilitiesSection.swift
@@ -46,53 +46,40 @@ struct ConversationAbilitiesSection: View {
     @ViewBuilder
     private func abilityRow(_ row: ConversationAbilitiesViewModel.Row) -> some View {
         switch row.lifecycle {
-        case .needsAttention(let status):
-            needsAttentionRow(row, status: status)
+        case .needsAttention:
+            needsAttentionRow(row)
         case .ready, .needsEntitlement, .unknown:
             toggleRow(row)
         }
     }
 
     private func toggleRow(_ row: ConversationAbilitiesViewModel.Row) -> some View {
-        let binding: Binding<Bool> = Binding(
-            get: { row.isOn },
-            set: { _ in viewModel.toggle(row) }
-        )
-        let isDisabled: Bool = viewModel.isBusy || row.lifecycle == .unknown
-        return featureRow(row) {
-            Toggle("", isOn: binding)
-                .labelsHidden()
-                .disabled(isDisabled)
+        featureRow(row) {
+            toggleControl(row)
         }
     }
 
     /// An opt-in whose entitlement is no longer active: no usable toggle,
     /// a badge, and the whole row opens the inline connect sheet to
-    /// reconnect.
-    private func needsAttentionRow(
-        _ row: ConversationAbilitiesViewModel.Row,
-        status: AbilitiesAPI.EntitlementStatus?
-    ) -> some View {
+    /// reconnect. The badge itself carries the same action (the shared
+    /// control owns it, so the browser's badge is tappable too).
+    private func needsAttentionRow(_ row: ConversationAbilitiesViewModel.Row) -> some View {
         let reconnectAction = { viewModel.presentConnect(for: row) }
         return Button(action: reconnectAction) {
             featureRow(row) {
-                attentionBadge(status: status)
+                toggleControl(row)
             }
         }
         .buttonStyle(.plain)
     }
 
-    /// A server-owned status renders its badge; an opt-in with no
-    /// entitlement at all (authoritative null) gets a neutral "Not
-    /// connected" badge -- the server never said "revoked", so the UI
-    /// must not either.
-    @ViewBuilder
-    private func attentionBadge(status: AbilitiesAPI.EntitlementStatus?) -> some View {
-        if let status {
-            AbilityStatusBadge(status: status)
-        } else {
-            AbilityNeutralBadge(label: "Not connected")
-        }
+    private func toggleControl(_ row: ConversationAbilitiesViewModel.Row) -> ConversationAbilityToggleControl {
+        let reconnectAction = { viewModel.presentConnect(for: row) }
+        return ConversationAbilityToggleControl(
+            row: row,
+            viewModel: viewModel,
+            onNeedsAttention: reconnectAction
+        )
     }
 
     private func featureRow(
@@ -170,7 +157,7 @@ private struct ConversationAbilitiesActiveSheetsModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .sheet(item: $viewModel.bundleSelection) { context in
+            .sheet(item: $viewModel.bundleSelection, onDismiss: handleBundleSelectionDismissed) { context in
                 bundleSelectionSheet(context)
             }
             .selfSizingSheet(item: $viewModel.connectContext, onDismiss: handleConnectSheetDismissed) { context in
@@ -180,8 +167,15 @@ private struct ConversationAbilitiesActiveSheetsModifier: ViewModifier {
 
     private func bundleSelectionSheet(_ context: AbilityBundleSelectionContext) -> some View {
         AbilityBundleSelectionSheet(context: context) { bundleIds in
-            viewModel.extend(ability: context.ability, agent: context.agent, bundleIds: bundleIds)
+            viewModel.confirmBundleSelection(context, bundleIds: bundleIds)
         }
+    }
+
+    /// Fires for every dismissal of the picker -- confirm, Cancel tap and
+    /// swipe-away alike -- so a cancelled auto-enable settles its row off
+    /// instead of hanging on a spinner.
+    private func handleBundleSelectionDismissed() {
+        viewModel.handleBundleSelectionDismissed()
     }
 
     /// The no-entitlement path: an inline connect flow for the tapped

--- a/Convos/Abilities/ConversationAbilitiesViewModel.swift
+++ b/Convos/Abilities/ConversationAbilitiesViewModel.swift
@@ -169,6 +169,9 @@ final class ConversationAbilitiesViewModel {
     /// The refresh chain, so every refresh runs after the one before it
     /// (see `refresh(adoptingCatalog:)`).
     private var refreshTask: Task<Void, Never>?
+    /// The mutation in flight, so an auto-enable can wait for it instead
+    /// of being dropped on `extend`'s busy guard.
+    private var mutationTask: Task<Void, Never>?
     /// Monotonic refresh stamp: a result whose stamp is not the latest is
     /// dropped. Belt-and-braces behind the serialization above, and the
     /// gate that also refuses a commit from a superseded account.
@@ -291,26 +294,46 @@ final class ConversationAbilitiesViewModel {
     /// older opt-in response land after a newer one - and a caller's
     /// `await` would not reflect the state the screen ends up with.
     func refresh(adoptingCatalog adopted: AbilitiesCatalog?) async {
+        if let adopted {
+            applyAdoptedCatalog(adopted)
+        }
+        await refreshOptIns(selfFetchesCatalog: adopted == nil)
+    }
+
+    /// Publishes the host's catalog on the spot, before any queued work.
+    /// Deferring this behind an in-flight opt-in refresh would leave the
+    /// rows sectioned by a catalog this view model has not adopted yet -
+    /// long enough for a toggle to stay enabled against an outage the
+    /// screen has already declared.
+    private func applyAdoptedCatalog(_ adopted: AbilitiesCatalog) {
+        invalidateSnapshotIfEpochChanged()
+        catalog = adopted
+        rebuildRows()
+    }
+
+    /// The opt-in half, which is the only part that queues. Runs one at a
+    /// time and in order: the service actor's sequence guard protects its
+    /// own cache commit, not each caller's returned value, so overlapping
+    /// refreshes could otherwise let an older response land after a newer
+    /// one - and a caller's `await` would not reflect the state the
+    /// screen ends up with.
+    private func refreshOptIns(selfFetchesCatalog: Bool) async {
         let previous: Task<Void, Never>? = refreshTask
         let task: Task<Void, Never> = Task { [weak self] in
             _ = await previous?.value
-            await self?.performRefresh(adoptingCatalog: adopted)
+            await self?.performRefresh(selfFetchesCatalog: selfFetchesCatalog)
         }
         refreshTask = task
         await task.value
     }
 
-    private func performRefresh(adoptingCatalog adopted: AbilitiesCatalog?) async {
+    private func performRefresh(selfFetchesCatalog: Bool) async {
         invalidateSnapshotIfEpochChanged()
         refreshGeneration &+= 1
         let generation: UInt64 = refreshGeneration
         let epoch: UInt64 = accountEpoch.value
-        if let adopted {
-            catalog = adopted
-            rebuildRows()
-        }
         do {
-            let fetchedCatalog: AbilitiesCatalog? = try await resolveCatalog(adopting: adopted)
+            let fetchedCatalog: AbilitiesCatalog? = try await resolveCatalog(selfFetches: selfFetchesCatalog)
             let fetchedOptIns: [ConversationAbility] = try await service.conversationAbilities(conversationId: conversationId)
             guard isCurrent(generation: generation, epoch: epoch) else { return }
             if let fetchedCatalog {
@@ -335,9 +358,8 @@ final class ConversationAbilitiesViewModel {
     /// publishes the snapshot that sectioned the rows, and a second fetch
     /// off the same actor at another moment can disagree with it. `nil`
     /// leaves whatever the host last published in place.
-    private func resolveCatalog(adopting adopted: AbilitiesCatalog?) async throws -> AbilitiesCatalog? {
-        if let adopted { return adopted }
-        guard catalogSource == .selfFetching else { return nil }
+    private func resolveCatalog(selfFetches: Bool) async throws -> AbilitiesCatalog? {
+        guard selfFetches, catalogSource == .selfFetching else { return nil }
         return try await service.fetchCatalog()
     }
 
@@ -347,7 +369,8 @@ final class ConversationAbilitiesViewModel {
     /// throughout the session.
     func adoptCatalog(_ adopted: AbilitiesCatalog) {
         guard catalogSource == .hosted else { return }
-        Task { await refresh(adoptingCatalog: adopted) }
+        applyAdoptedCatalog(adopted)
+        Task { await refreshOptIns(selfFetchesCatalog: false) }
     }
 
     private func isCurrent(generation: UInt64, epoch: UInt64) -> Bool {
@@ -491,8 +514,10 @@ final class ConversationAbilitiesViewModel {
         guard snapshotEpoch == accountEpoch.value else { return }
         guard let agent = agents.first else { return }
         let key = ConversationAbilityKey(abilityId: abilityId, agentInboxId: agent.inboxId)
-        let alreadyOptedIn: Bool = optIns.authoritativeValues?.contains { $0.key == key } ?? false
-        guard !alreadyOptedIn, !pendingEnablement.contains(key) else { return }
+        guard !pendingEnablement.contains(key) else { return }
+        // Only a settled read can say "no opt-in here". An unsettled one
+        // is unknown, and `extendAfterConnect` settles it before writing.
+        if optIns.isSettled, isOptedIn(key) { return }
         pendingEnablement.insert(key)
         errorMessage = nil
         rebuildRows()
@@ -500,10 +525,28 @@ final class ConversationAbilitiesViewModel {
     }
 
     private func extendAfterConnect(abilityId: String, agent: ConversationAgentDescriptor, key: ConversationAbilityKey) async {
+        // Never extend over a selection that has not been read. The
+        // three-state opt-in model is a write rule as much as a render
+        // rule: treating a failed or in-flight read as "not opted in"
+        // would PUT manifest defaults over the member's saved bundles.
+        if !optIns.isSettled {
+            await refreshOptIns(selfFetchesCatalog: false)
+        }
+        guard optIns.isSettled else {
+            clearPendingEnablement(key)
+            errorMessage = String(localized: "Couldn't check this convo's connections. Try again.")
+            return
+        }
+        guard !isOptedIn(key) else {
+            clearPendingEnablement(key)
+            return
+        }
+        // An in-flight mutation must not swallow the enablement on
+        // `extend`'s busy guard: wait for it instead of dropping it.
+        _ = await mutationTask?.value
         guard let ability = await entitledAbility(id: abilityId) else {
             clearPendingEnablement(key)
             errorMessage = AbilitiesServiceError.needsEntitlement(abilityId: abilityId).localizedDescription
-            rebuildRows()
             return
         }
         guard !ability.bundles.isEmpty else {
@@ -512,7 +555,6 @@ final class ConversationAbilitiesViewModel {
             // it spins forever.
             clearPendingEnablement(key)
             errorMessage = LiveAbilitiesServiceError.noBundlesSelected(abilityId: abilityId).localizedDescription
-            rebuildRows()
             return
         }
         if ability.bundles.count > 1 {
@@ -529,7 +571,12 @@ final class ConversationAbilitiesViewModel {
         if let published = activeAbility(id: abilityId, in: catalog) {
             return published
         }
+        // Captured before the await: the question is whether this result
+        // belongs to the account it is about to be used under, not
+        // whether some account is current by the time it returns.
+        let epoch: UInt64 = accountEpoch.value
         guard let refetched = try? await service.fetchCatalog() else { return nil }
+        guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return nil }
         return activeAbility(id: abilityId, in: refetched)
     }
 
@@ -538,8 +585,17 @@ final class ConversationAbilitiesViewModel {
         return match.entitlement?.status == .active ? match : nil
     }
 
+    /// Rebuilds on the spot: `Row` is a value type, so a confirmed write
+    /// that only mutates the set would leave the rendered row on-and-busy
+    /// until the trailing refetch returns - the exact spinner the
+    /// settle-on-the-write rule exists to avoid.
     private func clearPendingEnablement(_ key: ConversationAbilityKey) {
-        pendingEnablement.remove(key)
+        guard pendingEnablement.remove(key) != nil else { return }
+        rebuildRows()
+    }
+
+    private func isOptedIn(_ key: ConversationAbilityKey) -> Bool {
+        optIns.authoritativeValues?.contains { $0.key == key } ?? false
     }
 
     // MARK: - Bundle picker
@@ -567,7 +623,6 @@ final class ConversationAbilitiesViewModel {
         isConfirmingBundleSelection = false
         guard !wasConfirming, let key else { return }
         clearPendingEnablement(key)
-        rebuildRows()
     }
 
     // MARK: - Mutations
@@ -581,13 +636,19 @@ final class ConversationAbilitiesViewModel {
             return
         }
         guard !isBusy else {
+            // Auto-enable awaits `mutationTask` before reaching here, so
+            // this is a last resort - but it must still say so rather
+            // than settle the row off with no explanation.
+            let wasPending: Bool = pendingEnablement.contains(key)
             clearPendingEnablement(key)
-            rebuildRows()
+            if wasPending {
+                errorMessage = String(localized: "Another change was still saving. Try turning this on again.")
+            }
             return
         }
         isBusy = true
         errorMessage = nil
-        Task {
+        let task = Task {
             var mutationError: String?
             do {
                 try await service.extendAbility(
@@ -624,6 +685,7 @@ final class ConversationAbilitiesViewModel {
                 errorMessage = mutationError
             }
         }
+        mutationTask = task
     }
 
     /// The selection driving this conversation's rows. The connect sheet
@@ -654,7 +716,7 @@ final class ConversationAbilitiesViewModel {
     private func withdraw(ability: AbilitiesAPI.Ability, agent: ConversationAgentDescriptor) {
         isBusy = true
         errorMessage = nil
-        Task {
+        let task = Task {
             var mutationError: String?
             do {
                 try await service.withdrawAbility(
@@ -671,6 +733,7 @@ final class ConversationAbilitiesViewModel {
                 errorMessage = mutationError
             }
         }
+        mutationTask = task
     }
 
     /// The bundles a plain toggle-on grants: the manifest's

--- a/Convos/Abilities/ConversationAbilitiesViewModel.swift
+++ b/Convos/Abilities/ConversationAbilitiesViewModel.swift
@@ -12,6 +12,54 @@ struct ConversationAgentDescriptor: Identifiable, Hashable {
     var id: String { inboxId }
 }
 
+/// Where the catalog behind the rows comes from.
+///
+/// The conversation info view owns no catalog, so it fetches its own. The
+/// Connections browser already fetched one to place each row in its
+/// section, and a second fetch off the same actor at a different moment
+/// can disagree with it - a row sitting in Connected while this view model
+/// derives `.needsEntitlement` for it, and a dead toggle on a live
+/// connection. Hosted mode therefore suppresses every self-fetch and takes
+/// the host's snapshot instead.
+enum ConversationAbilitiesCatalogSource {
+    case selfFetching
+    case hosted
+}
+
+/// Where a row without a usable entitlement sends the member to repair it.
+///
+/// The conversation info view presents its own scoped connect sheet. The
+/// browser already has a connect flow on screen with its own sheet, so
+/// arming a second one there would stack two connect surfaces on one
+/// screen; it forwards the repair to the flow already present instead.
+enum EntitlementRecoveryRoute {
+    case inlineSheet
+    case host((AbilitiesAPI.Ability) -> Void)
+}
+
+/// The three states of the per-conversation opt-in read, which is an
+/// uncached network call with a different staleness profile from the
+/// catalog. The third state is why this is not a `Bool`: reading a failed
+/// or not-yet-landed fetch as "not enabled here" would render a settled
+/// OFF over a selection the member already made, and the next tap would
+/// extend with manifest defaults on top of it.
+enum ConversationAbilityOptIns {
+    case loading
+    case authoritative([ConversationAbility])
+    case unavailable
+
+    /// The last authoritative set, which survives a failed refresh and is
+    /// replaced only by a successful one.
+    var authoritativeValues: [ConversationAbility]? {
+        guard case .authoritative(let values) = self else { return nil }
+        return values
+    }
+
+    var isSettled: Bool {
+        authoritativeValues != nil
+    }
+}
+
 /// Sheet context for choosing bundles before extending an ability to an
 /// agent (only used when the ability has more than one bundle).
 struct AbilityBundleSelectionContext: Identifiable, Hashable {
@@ -75,20 +123,29 @@ final class ConversationAbilitiesViewModel {
         let agent: ConversationAgentDescriptor
         let isOn: Bool
         let lifecycle: Lifecycle
+        /// False while the opt-in read has produced no authoritative
+        /// answer for this conversation yet: the control renders disabled
+        /// rather than a settled OFF.
+        let hasSettledOptIn: Bool
+        /// True while an auto-enable started by a connect has not reached
+        /// a terminal state: the control reads on and busy, so the member
+        /// never sees the thing they just connected land as OFF.
+        let isPendingEnablement: Bool
 
         var id: ConversationAbilityKey {
             ConversationAbilityKey(abilityId: ability.id, agentInboxId: agent.inboxId)
         }
     }
 
-    private(set) var rows: [Row] = []
+    private var builtRows: [Row] = []
     private(set) var isBusy: Bool = false
     private(set) var errorMessage: String?
     /// Non-nil presents the bundle picker sheet.
     var bundleSelection: AbilityBundleSelectionContext?
     /// Non-nil presents the inline connect sheet: the tapped ability has no
     /// active entitlement, so the user connects (or reconnects) it right
-    /// here instead of detouring through App Settings.
+    /// here instead of detouring through App Settings. Never assigned under
+    /// a `.host` recovery route.
     var connectContext: ConversationAbilityConnectContext?
     /// Parked continuation for a connect that succeeded: the connect sheet
     /// finishes dismissing first, then `handleConnectSheetDismissed` flows
@@ -96,29 +153,116 @@ final class ConversationAbilitiesViewModel {
     private var pendingExtensionAfterConnect: ConversationAbilityConnectContext?
 
     private var catalog: AbilitiesCatalog?
-    private var optIns: [ConversationAbility] = []
+    private var optIns: ConversationAbilityOptIns = .loading
+    /// Keys whose enablement was started by a connect and has not settled.
+    /// Every exit is named in `clearPendingEnablement` callers; a key left
+    /// here would hang its row on a spinner forever.
+    private var pendingEnablement: Set<ConversationAbilityKey> = []
+    /// The key of the bundle picker currently on screen, so its dismissal
+    /// can clear the right pending enablement (`sheet(item:onDismiss:)`
+    /// hands the closure nothing).
+    private var presentedBundleSelectionKey: ConversationAbilityKey?
+    /// Set by the picker's confirm so the dismissal that follows is not
+    /// read as a cancellation -- `onDismiss` fires for both.
+    private var isConfirmingBundleSelection: Bool = false
+
+    /// The refresh chain, so every refresh runs after the one before it
+    /// (see `refresh(adoptingCatalog:)`).
+    private var refreshTask: Task<Void, Never>?
+    /// Monotonic refresh stamp: a result whose stamp is not the latest is
+    /// dropped. Belt-and-braces behind the serialization above, and the
+    /// gate that also refuses a commit from a superseded account.
+    private var refreshGeneration: UInt64 = 0
+    /// The account generation the published snapshot belongs to.
+    private var snapshotEpoch: UInt64
 
     private let conversationId: String
     private let agents: [ConversationAgentDescriptor]
     /// The (service, authorizer) pair latched at construction; both halves
     /// travel together so the needs-entitlement sheet can never mix modes.
     private let selection: AbilitiesSelection
+    private let catalogSource: ConversationAbilitiesCatalogSource
+    private let accountEpoch: AbilitiesAccountEpoch
+
+    /// Where a row without a usable entitlement routes its repair. Set by
+    /// the host after construction when the host owns the connect flow.
+    var entitlementRecoveryRoute: EntitlementRecoveryRoute = .inlineSheet
 
     private var service: any AbilitiesServiceProtocol { selection.service }
 
     init(
         conversationId: String,
         agents: [ConversationAgentDescriptor],
-        selection: AbilitiesSelection
+        selection: AbilitiesSelection,
+        catalogSource: ConversationAbilitiesCatalogSource = .selfFetching,
+        accountEpoch: AbilitiesAccountEpoch = .shared
     ) {
         self.conversationId = conversationId
         self.agents = agents
         self.selection = selection
-        refreshSoon()
+        self.catalogSource = catalogSource
+        self.accountEpoch = accountEpoch
+        self.snapshotEpoch = accountEpoch.value
+        // A hosted view model never fetches a catalog of its own; the host
+        // publishes the one that sectioned the rows.
+        if catalogSource == .selfFetching {
+            refreshSoon()
+        }
+    }
+
+    /// Empty while the published snapshot belongs to a superseded account:
+    /// reading the epoch here is what makes the invalidation land on the
+    /// next render instead of the next fetch.
+    var rows: [Row] {
+        guard snapshotEpoch == accountEpoch.value else { return [] }
+        return builtRows
     }
 
     var isSingleAgent: Bool {
         agents.count == 1
+    }
+
+    /// True when the catalog behind these rows was served without
+    /// authoritative entitlement state.
+    var entitlementsUnavailable: Bool {
+        catalog?.entitlementsUnavailable ?? false
+    }
+
+    /// Whether an outage withholds the per-chat control.
+    ///
+    /// Only where the browser sections rows by carried-forward state: there
+    /// a row can sit under Connected on an entitlement revoked elsewhere
+    /// since, and writing a grant against one the app admits it cannot
+    /// verify is the mutation the outage machinery exists to stop. The
+    /// conversation info view sections nothing and keeps its shipped
+    /// behavior, which this addendum does not change.
+    private var outageWithholdsToggle: Bool {
+        catalogSource == .hosted && entitlementsUnavailable
+    }
+
+    /// The one disabled rule behind every per-chat control, on both
+    /// surfaces. It closes on any state where a tap could write a grant
+    /// the app cannot stand behind:
+    /// - a mutation already in flight, so no toggle is left tappable for
+    ///   `toggle` to silently drop on its `isBusy` guard;
+    /// - an entitlement state the backend could not report;
+    /// - an opt-in read that has not settled, which must never render as
+    ///   a settled OFF over a selection the member already made;
+    /// - an auto-enable still landing;
+    /// - a browser row sectioned from a catalog served without
+    ///   authoritative entitlement state.
+    func isToggleDisabled(for row: Row) -> Bool {
+        if isBusy || outageWithholdsToggle { return true }
+        if row.lifecycle == .unknown { return true }
+        return !row.hasSettledOptIn || row.isPendingEnablement
+    }
+
+    /// The row for one ability, for hosts that render their own sections
+    /// and cross them with these toggles. Nil means this view model has
+    /// not caught up with the host's catalog yet - which the host renders
+    /// as loading, never as off.
+    func row(forAbilityId abilityId: String) -> Row? {
+        rows.first { $0.ability.id == abilityId }
     }
 
     func refreshSoon() {
@@ -126,24 +270,111 @@ final class ConversationAbilitiesViewModel {
     }
 
     func refresh() async {
-        // Fetch both halves before committing either: publishing a fresh
-        // catalog with stale or empty opt-ins would render opted-in rows
-        // as off, and toggling one on would then overwrite the agent's
-        // real bundle selection with defaults.
+        await refresh(adoptingCatalog: nil)
+    }
+
+    /// Refreshes opt-ins against a catalog the host already owns, instead
+    /// of fetching a second copy that can disagree with the one that
+    /// placed the row in its section. `nil` keeps the self-fetching
+    /// behavior of the conversation info view, which owns no catalog.
+    ///
+    /// Both halves still commit together: publishing a fresh catalog with
+    /// stale or empty opt-ins would render opted-in rows as off, and
+    /// toggling one on would then overwrite the agent's real bundle
+    /// selection with defaults. An adopted catalog is published up front
+    /// against the *retained* authoritative opt-ins, which is the same
+    /// guarantee - rows with no authoritative opt-in yet render unsettled.
+    ///
+    /// Refreshes run one at a time and in order. The service actor's
+    /// sequence guard protects its own cache commit, not each caller's
+    /// returned value, so overlapping refreshes could otherwise let an
+    /// older opt-in response land after a newer one - and a caller's
+    /// `await` would not reflect the state the screen ends up with.
+    func refresh(adoptingCatalog adopted: AbilitiesCatalog?) async {
+        let previous: Task<Void, Never>? = refreshTask
+        let task: Task<Void, Never> = Task { [weak self] in
+            _ = await previous?.value
+            await self?.performRefresh(adoptingCatalog: adopted)
+        }
+        refreshTask = task
+        await task.value
+    }
+
+    private func performRefresh(adoptingCatalog adopted: AbilitiesCatalog?) async {
+        invalidateSnapshotIfEpochChanged()
+        refreshGeneration &+= 1
+        let generation: UInt64 = refreshGeneration
+        let epoch: UInt64 = accountEpoch.value
+        if let adopted {
+            catalog = adopted
+            rebuildRows()
+        }
         do {
-            let fetchedCatalog = try await service.fetchCatalog()
-            let fetchedOptIns = try await service.conversationAbilities(conversationId: conversationId)
-            catalog = fetchedCatalog
-            optIns = fetchedOptIns
+            let fetchedCatalog: AbilitiesCatalog? = try await resolveCatalog(adopting: adopted)
+            let fetchedOptIns: [ConversationAbility] = try await service.conversationAbilities(conversationId: conversationId)
+            guard isCurrent(generation: generation, epoch: epoch) else { return }
+            if let fetchedCatalog {
+                catalog = fetchedCatalog
+            }
+            optIns = .authoritative(fetchedOptIns)
             errorMessage = nil
         } catch {
+            guard isCurrent(generation: generation, epoch: epoch) else { return }
+            // A failed read never demotes a set the member already saw; it
+            // only names the never-loaded case, which renders disabled.
+            if !optIns.isSettled {
+                optIns = .unavailable
+            }
             errorMessage = error.localizedDescription
         }
         rebuildRows()
     }
 
+    /// The catalog half of a refresh. A hosted view model never fetches
+    /// one - not from its initializer and not after a mutation: the host
+    /// publishes the snapshot that sectioned the rows, and a second fetch
+    /// off the same actor at another moment can disagree with it. `nil`
+    /// leaves whatever the host last published in place.
+    private func resolveCatalog(adopting adopted: AbilitiesCatalog?) async throws -> AbilitiesCatalog? {
+        if let adopted { return adopted }
+        guard catalogSource == .selfFetching else { return nil }
+        return try await service.fetchCatalog()
+    }
+
+    /// Publishes a catalog revision the host committed. Called for every
+    /// revision, not just the first: the browser refreshes from its
+    /// `.task`, its pull-to-refresh, and its mid-connect quiet refreshes
+    /// throughout the session.
+    func adoptCatalog(_ adopted: AbilitiesCatalog) {
+        guard catalogSource == .hosted else { return }
+        Task { await refresh(adoptingCatalog: adopted) }
+    }
+
+    private func isCurrent(generation: UInt64, epoch: UInt64) -> Bool {
+        generation == refreshGeneration && epoch == accountEpoch.value && epoch == snapshotEpoch
+    }
+
+    /// Drops everything published under an earlier account generation, so
+    /// a wipe can neither survive in the rows nor be crossed with the next
+    /// account's catalog.
+    private func invalidateSnapshotIfEpochChanged() {
+        let current: UInt64 = accountEpoch.value
+        guard current != snapshotEpoch else { return }
+        snapshotEpoch = current
+        catalog = nil
+        optIns = .loading
+        pendingEnablement = []
+        presentedBundleSelectionKey = nil
+        bundleSelection = nil
+        connectContext = nil
+        pendingExtensionAfterConnect = nil
+        errorMessage = nil
+        builtRows = []
+    }
+
     func toggle(_ row: Row) {
-        guard !isBusy else { return }
+        guard !isBusy, snapshotEpoch == accountEpoch.value else { return }
+        guard !outageWithholdsToggle else { return }
         switch row.lifecycle {
         case .ready:
             if row.isOn {
@@ -158,18 +389,38 @@ final class ConversationAbilitiesViewModel {
         }
     }
 
-    /// Presents the inline connect sheet for a row without a usable
-    /// entitlement. Rows not yet opted in continue into the extension after
-    /// a successful connect; already-opted-in rows (needs-attention) only
-    /// repair the entitlement, since their opt-in and bundle selection
-    /// already stand.
+    /// Routes a row without a usable entitlement to its repair flow. Rows
+    /// not yet opted in continue into the extension after a successful
+    /// connect; already-opted-in rows (needs-attention) only repair the
+    /// entitlement, since their opt-in and bundle selection already stand.
     func presentConnect(for row: Row) {
-        connectContext = ConversationAbilityConnectContext(
+        routeEntitlementRecovery(
             ability: row.ability,
             agent: row.agent,
             continuesToExtension: !row.isOn,
             preselectedBundleIds: nil
         )
+    }
+
+    /// The one place `connectContext` is assigned, so a host that owns its
+    /// own connect flow can guarantee no second sheet is ever armed.
+    private func routeEntitlementRecovery(
+        ability: AbilitiesAPI.Ability,
+        agent: ConversationAgentDescriptor,
+        continuesToExtension: Bool,
+        preselectedBundleIds: [String]?
+    ) {
+        switch entitlementRecoveryRoute {
+        case .inlineSheet:
+            connectContext = ConversationAbilityConnectContext(
+                ability: ability,
+                agent: agent,
+                continuesToExtension: continuesToExtension,
+                preselectedBundleIds: preselectedBundleIds
+            )
+        case .host(let route):
+            route(ability)
+        }
     }
 
     /// The connect sheet reports the entitlement went active. Park the
@@ -221,16 +472,119 @@ final class ConversationAbilitiesViewModel {
             // Refresh beneath the picker so the rows already show the
             // now-active entitlement while the user chooses bundles.
             refreshSoon()
-            bundleSelection = AbilityBundleSelectionContext(ability: ability, agent: context.agent)
+            presentBundleSelection(ability: ability, agent: context.agent)
         } else {
             extend(ability: ability, agent: context.agent, bundleIds: defaultBundleIds(for: ability))
         }
     }
 
+    // MARK: - Auto-enable after a connect
+
+    /// Enables the just-connected ability for this conversation. Keyed by
+    /// id on purpose: activation is the caller's server-confirmed fact,
+    /// and every connect completion site still holds the *pre-connect*
+    /// ability, whose embedded entitlement reads not-entitled - handing
+    /// that object to the extension path would bounce it straight back to
+    /// Connect. The bundles are resolved from the freshest catalog
+    /// instead. No-op when an opt-in already exists.
+    func enableAfterConnect(abilityId: String) {
+        guard snapshotEpoch == accountEpoch.value else { return }
+        guard let agent = agents.first else { return }
+        let key = ConversationAbilityKey(abilityId: abilityId, agentInboxId: agent.inboxId)
+        let alreadyOptedIn: Bool = optIns.authoritativeValues?.contains { $0.key == key } ?? false
+        guard !alreadyOptedIn, !pendingEnablement.contains(key) else { return }
+        pendingEnablement.insert(key)
+        errorMessage = nil
+        rebuildRows()
+        Task { await extendAfterConnect(abilityId: abilityId, agent: agent, key: key) }
+    }
+
+    private func extendAfterConnect(abilityId: String, agent: ConversationAgentDescriptor, key: ConversationAbilityKey) async {
+        guard let ability = await entitledAbility(id: abilityId) else {
+            clearPendingEnablement(key)
+            errorMessage = AbilitiesServiceError.needsEntitlement(abilityId: abilityId).localizedDescription
+            rebuildRows()
+            return
+        }
+        guard !ability.bundles.isEmpty else {
+            // The extension PUT requires a non-empty bundle selection, so
+            // this can never reach `extend`: clear the pending row here or
+            // it spins forever.
+            clearPendingEnablement(key)
+            errorMessage = LiveAbilitiesServiceError.noBundlesSelected(abilityId: abilityId).localizedDescription
+            rebuildRows()
+            return
+        }
+        if ability.bundles.count > 1 {
+            presentBundleSelection(ability: ability, agent: agent)
+        } else {
+            extend(ability: ability, agent: agent, bundleIds: defaultBundleIds(for: ability))
+        }
+    }
+
+    /// The freshest active-entitlement copy of `abilityId`: the published
+    /// catalog when it already carries one, else a targeted refetch. Never
+    /// re-derives activation from a pre-connect object.
+    private func entitledAbility(id abilityId: String) async -> AbilitiesAPI.Ability? {
+        if let published = activeAbility(id: abilityId, in: catalog) {
+            return published
+        }
+        guard let refetched = try? await service.fetchCatalog() else { return nil }
+        return activeAbility(id: abilityId, in: refetched)
+    }
+
+    private func activeAbility(id abilityId: String, in catalog: AbilitiesCatalog?) -> AbilitiesAPI.Ability? {
+        guard let match = catalog?.abilities.first(where: { $0.id == abilityId }) else { return nil }
+        return match.entitlement?.status == .active ? match : nil
+    }
+
+    private func clearPendingEnablement(_ key: ConversationAbilityKey) {
+        pendingEnablement.remove(key)
+    }
+
+    // MARK: - Bundle picker
+
+    private func presentBundleSelection(ability: AbilitiesAPI.Ability, agent: ConversationAgentDescriptor) {
+        let context = AbilityBundleSelectionContext(ability: ability, agent: agent)
+        presentedBundleSelectionKey = context.id
+        bundleSelection = context
+    }
+
+    /// The picker's confirm. Marks the dismissal that follows as a
+    /// confirmation, so it is not read as the cancel exit.
+    func confirmBundleSelection(_ context: AbilityBundleSelectionContext, bundleIds: [String]) {
+        isConfirmingBundleSelection = true
+        extend(ability: context.ability, agent: context.agent, bundleIds: bundleIds)
+    }
+
+    /// Runs on every dismissal of the picker. A cancel (or swipe-away)
+    /// with an auto-enable behind it must settle the row off rather than
+    /// leave it spinning.
+    func handleBundleSelectionDismissed() {
+        let key: ConversationAbilityKey? = presentedBundleSelectionKey
+        presentedBundleSelectionKey = nil
+        let wasConfirming: Bool = isConfirmingBundleSelection
+        isConfirmingBundleSelection = false
+        guard !wasConfirming, let key else { return }
+        clearPendingEnablement(key)
+        rebuildRows()
+    }
+
+    // MARK: - Mutations
+
     /// Extends `ability` to `agent` with an explicit bundle selection
     /// (called by the bundle picker sheet's confirm).
     func extend(ability: AbilitiesAPI.Ability, agent: ConversationAgentDescriptor, bundleIds: [String]) {
-        guard !isBusy else { return }
+        let key = ConversationAbilityKey(abilityId: ability.id, agentInboxId: agent.inboxId)
+        guard snapshotEpoch == accountEpoch.value else {
+            clearPendingEnablement(key)
+            return
+        }
+        guard !isBusy else {
+            clearPendingEnablement(key)
+            rebuildRows()
+            return
+        }
         isBusy = true
         errorMessage = nil
         Task {
@@ -242,17 +596,24 @@ final class ConversationAbilitiesViewModel {
                     agentInboxId: agent.inboxId,
                     bundleIds: bundleIds
                 )
+                // Settle on the confirmed write, not on the refetch below:
+                // the read can fail while the write succeeded, and gating
+                // the visual settle on it would strand a real enablement
+                // on a spinner.
+                clearPendingEnablement(key)
             } catch AbilitiesServiceError.needsEntitlement {
                 // The server says the entitlement is gone mid-extend: run
-                // the connect inline and retry with the bundles the user
+                // the repair flow and retry with the bundles the user
                 // already chose, instead of re-opening the picker.
-                connectContext = ConversationAbilityConnectContext(
+                clearPendingEnablement(key)
+                routeEntitlementRecovery(
                     ability: ability,
                     agent: agent,
                     continuesToExtension: true,
                     preselectedBundleIds: bundleIds
                 )
             } catch {
+                clearPendingEnablement(key)
                 mutationError = error.localizedDescription
             }
             isBusy = false
@@ -284,7 +645,7 @@ final class ConversationAbilitiesViewModel {
             return
         }
         if ability.bundles.count > 1 {
-            bundleSelection = AbilityBundleSelectionContext(ability: ability, agent: row.agent)
+            presentBundleSelection(ability: ability, agent: row.agent)
         } else {
             extend(ability: ability, agent: row.agent, bundleIds: defaultBundleIds(for: ability))
         }
@@ -323,23 +684,33 @@ final class ConversationAbilitiesViewModel {
 
     private func rebuildRows() {
         guard let catalog else {
-            rows = []
+            builtRows = []
             return
         }
         let sortedAbilities: [AbilitiesAPI.Ability] = catalog.abilities.sorted { (lhs: AbilitiesAPI.Ability, rhs: AbilitiesAPI.Ability) -> Bool in
             lhs.displayName.resolved().localizedCaseInsensitiveCompare(rhs.displayName.resolved()) == .orderedAscending
         }
-        let optedIn: Set<ConversationAbilityKey> = Set(optIns.map(\.key))
+        let authoritative: [ConversationAbility]? = optIns.authoritativeValues
+        let optedIn: Set<ConversationAbilityKey> = Set((authoritative ?? []).map(\.key))
+        let hasSettledOptIn: Bool = authoritative != nil
         var built: [Row] = []
         for ability in sortedAbilities {
             for agent in agents {
                 let key = ConversationAbilityKey(abilityId: ability.id, agentInboxId: agent.inboxId)
-                let isOn = optedIn.contains(key)
+                let isPending: Bool = pendingEnablement.contains(key)
+                let isOn: Bool = optedIn.contains(key) || isPending
                 let rowLifecycle: Row.Lifecycle = lifecycle(for: ability, isOptedIn: isOn)
-                built.append(Row(ability: ability, agent: agent, isOn: isOn, lifecycle: rowLifecycle))
+                built.append(Row(
+                    ability: ability,
+                    agent: agent,
+                    isOn: isOn,
+                    lifecycle: rowLifecycle,
+                    hasSettledOptIn: hasSettledOptIn,
+                    isPendingEnablement: isPending
+                ))
             }
         }
-        rows = built
+        builtRows = built
     }
 
     /// Derives row usability from both the opt-in and the entitlement

--- a/Convos/Abilities/ConversationAbilityToggleControl.swift
+++ b/Convos/Abilities/ConversationAbilityToggleControl.swift
@@ -1,0 +1,86 @@
+import ConvosCore
+import SwiftUI
+
+/// The per-conversation enablement control for one (ability, agent) pair.
+///
+/// The single implementation behind both surfaces that offer it: the
+/// conversation info section (`ConversationAbilitiesSection`) and the
+/// Connections browser's Connected section in `.composerModal`
+/// (`AbilitiesListView`). State, writer, and the disabled rule live in the
+/// view model and have exactly one implementation here; row *chrome*
+/// stays per-surface. Only the repair route differs, which is why it is a
+/// parameter and not a branch.
+struct ConversationAbilityToggleControl: View {
+    let row: ConversationAbilitiesViewModel.Row
+    let viewModel: ConversationAbilitiesViewModel
+    /// Runs when the row's entitlement needs repair (`.needsAttention`,
+    /// `.needsEntitlement`). The info view presents its own scoped connect
+    /// sheet; the browser forwards to the connect flow already on screen,
+    /// which would otherwise be a second connect sheet on one screen.
+    let onNeedsAttention: () -> Void
+
+    var body: some View {
+        switch row.lifecycle {
+        case .needsAttention(let status):
+            attentionControl(status)
+        case .ready, .needsEntitlement, .unknown:
+            toggleControl
+        }
+    }
+
+    /// The toggle reads on while an auto-enable is still landing, with a
+    /// spinner beside it: the member must never see the thing they just
+    /// connected settle as OFF. Its on state is the same green the
+    /// entitlement's "Active" badge and the capability approval toggle
+    /// use, so "on" reads the same everywhere it appears.
+    private var toggleControl: some View {
+        let binding: Binding<Bool> = Binding(
+            get: { row.isOn },
+            set: { _ in viewModel.toggle(row) }
+        )
+        let showsProgress: Bool = row.isPendingEnablement
+        let isDisabled: Bool = viewModel.isToggleDisabled(for: row)
+        return HStack(spacing: DesignConstants.Spacing.stepX) {
+            if showsProgress {
+                ProgressView()
+            }
+            Toggle("", isOn: binding)
+                .labelsHidden()
+                .tint(.colorGreen)
+                .disabled(isDisabled)
+        }
+    }
+
+    private func attentionControl(_ status: AbilitiesAPI.EntitlementStatus?) -> some View {
+        Button(action: onNeedsAttention) {
+            attentionBadge(status)
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.entitlementsUnavailable)
+    }
+
+    /// A server-owned status renders its badge; an opt-in with no
+    /// entitlement at all (authoritative null) gets a neutral "Not
+    /// connected" badge -- the server never said "revoked", so the UI
+    /// must not either.
+    @ViewBuilder
+    private func attentionBadge(_ status: AbilitiesAPI.EntitlementStatus?) -> some View {
+        if let status {
+            AbilityStatusBadge(status: status)
+        } else {
+            AbilityNeutralBadge(label: "Not connected")
+        }
+    }
+}
+
+/// Stands in for the control on a Connected row the conversation view
+/// model has not produced a row for yet (the catalog that sectioned the
+/// row landed first). Loading, never a settled OFF: reading the gap as
+/// "not enabled here" would invite a tap that extends with manifest
+/// defaults over a selection the member already made.
+struct ConversationAbilityToggleLoadingControl: View {
+    var body: some View {
+        ProgressView()
+            .accessibilityLabel("Loading connection state")
+    }
+}

--- a/Convos/Abilities/ConversationAbilityToggleControl.swift
+++ b/Convos/Abilities/ConversationAbilityToggleControl.swift
@@ -52,11 +52,15 @@ struct ConversationAbilityToggleControl: View {
     }
 
     private func attentionControl(_ status: AbilitiesAPI.EntitlementStatus?) -> some View {
+        // Deliberately never disabled, on either surface: connect and
+        // repair stay available during an outage (they are idempotent
+        // server-side, and the banner already says the state is stale).
+        // Disabling here would also freeze a path the conversation info
+        // view has always offered.
         Button(action: onNeedsAttention) {
             attentionBadge(status)
         }
         .buttonStyle(.plain)
-        .disabled(viewModel.entitlementsUnavailable)
     }
 
     /// A server-owned status renders its badge; an opt-in with no

--- a/Convos/Conversation Detail/Conversation Sheet/AgentComposerBar.swift
+++ b/Convos/Conversation Detail/Conversation Sheet/AgentComposerBar.swift
@@ -12,9 +12,8 @@ struct AgentComposerBar: View {
     @FocusState.Binding var focusState: MessagesViewInputFocus?
     let focusCoordinator: FocusCoordinator
     let isReadOnly: Bool
-    /// Host-passed capability gating the composer's `.connections` entries
-    /// (quick icon and `+` menu row alike); read from the feature flag at
-    /// the `ConversationView` seam only.
+    /// Host-passed capability gating the composer's `+` menu `.connections`
+    /// row; read from the feature flag at the `ConversationView` seam only.
     let connectionsEnabled: Bool
     /// Presents the Connections browser modal; the host owns the
     /// presentation, the composer only emits the tap.
@@ -44,10 +43,9 @@ struct AgentComposerBar: View {
 
     /// Disabled composer for the not-yet-created DM. The field and send
     /// button stay disabled until the session binds the real conversation
-    /// (normally within a second or two of the agent joining). The `+` and
-    /// the quick-action row stay visible (inert, dimmed) so the composer
-    /// keeps the agent bar's default-state shape rather than dropping the
-    /// affordances.
+    /// (normally within a second or two of the agent joining). The `+` stays
+    /// visible (inert, dimmed) so the composer keeps the agent bar's shape
+    /// rather than dropping the affordance.
     private var draftComposer: some View {
         MessagesInputView(
             displayName: .constant(""),
@@ -63,7 +61,6 @@ struct AgentComposerBar: View {
             onClearInvite: {},
             fileAttachmentPreview: { _ in EmptyView() },
             agentShareChip: { EmptyView() },
-            quickActionsAccessory: { draftQuickRow },
             attachmentsButton: { draftPlusGlyph }
         )
         .fixedSize(horizontal: false, vertical: true)
@@ -84,22 +81,6 @@ struct AgentComposerBar: View {
             .foregroundStyle(Color.colorTextPrimary)
             .frame(width: 32, height: 32)
             .opacity(0.4)
-    }
-
-    /// The quick-action row in the pre-creation composer, same curation as
-    /// the live bar's default state (`ComposerAttachmentAction.agentQuickRow`),
-    /// inert and dimmed to read as disabled alongside the field.
-    private var draftQuickRow: some View {
-        let actions: [ComposerAttachmentAction] = ComposerAttachmentAction.agentQuickRow(connectionsEnabled: connectionsEnabled)
-        return HStack(spacing: 0) {
-            ForEach(actions) { action in
-                Image(systemName: action.filledIconSystemName)
-                    .font(.system(size: 18.0, weight: .medium))
-                    .foregroundStyle(Color.colorTextPrimary)
-                    .frame(width: 32, height: 32)
-            }
-        }
-        .opacity(0.4)
     }
 
     private enum Constant {

--- a/Convos/Conversation Detail/Conversation Sheet/ConversationComposerBar.swift
+++ b/Convos/Conversation Detail/Conversation Sheet/ConversationComposerBar.swift
@@ -24,9 +24,9 @@ struct ConversationComposerBar<ExtraBarContent: View>: View {
     /// Scrolls the paired transcript to the bottom; invoked on send.
     var scrollToBottom: (() -> Void)?
     var onDebugAttachmentTap: (() -> Void)?
-    /// Agent-style composer: the group `+` menu plus the trailing curated
-    /// quick-action row, and a voice-memo entry in the empty composer's send
-    /// slot (see MessagesBottomBar).
+    /// Agent-style composer: the group `+` menu plus `.connections`, and a
+    /// voice-memo entry in the empty composer's send slot (see
+    /// MessagesBottomBar).
     var usesAgentComposerLayout: Bool = false
     /// Host-passed capability gating the `.connections` option; the bar
     /// never reads feature flags itself (see MessagesBottomBar).

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1641,15 +1641,16 @@ private extension ConversationView {
     }
 
     /// The single host seam for the composer's connections capability: the
-    /// quick icon, the `+` menu row, and the browser modal all feed from
-    /// this one read. No composer surface consults the flag directly.
+    /// `+` menu row and the browser modal both feed from this one read. No
+    /// composer surface consults the flag directly.
     var composerConnectionsEnabled: Bool {
         FeatureFlags.shared.isAbilitiesV2Enabled
     }
 
-    /// Powerplug tap, from the quick row or the `+` menu row alike: presents
-    /// the Connections browser full-screen, carrying the launching DM's
-    /// context. Guarded by the same capability that offered the entries.
+    /// Powerplug tap from the `+` menu row: presents the Connections
+    /// browser full-screen, carrying the launching DM's conversation,
+    /// agent inbox id and agent name so its Connected section can scope
+    /// its toggles. Guarded by the same capability that offered the row.
     func handleComposerConnectionsTap() {
         guard composerConnectionsEnabled,
               let agentDmSession,
@@ -1659,7 +1660,8 @@ private extension ConversationView {
         }
         connectionsBrowserContext = .composerModal(
             conversationId: dmConversationId,
-            agentInboxId: agentInboxId
+            agentInboxId: agentInboxId,
+            agentDisplayName: agentDmSession.agentName
         )
     }
 

--- a/ConvosCore/Sources/ConvosComposer/ComposerAttachmentAction.swift
+++ b/ConvosCore/Sources/ConvosComposer/ComposerAttachmentAction.swift
@@ -1,12 +1,9 @@
-/// One thing a member can attach or open from the composer, as it appears in
-/// the attachments menu the composer's `+` presents and, for a curated
-/// subset, in the agent composer's trailing quick-action row.
+/// One thing a member can attach or open from the composer, as it appears
+/// in the attachments menu the composer's `+` presents.
 ///
 /// This enum is the single declaration of what an option is: identity
-/// (stable `rawValue` id), title, icons, and dispatch routing. The lists
-/// below declare which options each surface offers; the quick row is always
-/// a curation of the `+` menu, never a second implementation
-/// (see `agentQuickRow(connectionsEnabled:)`).
+/// (stable `rawValue` id), title, icon, and dispatch routing. The lists
+/// below declare which options each surface offers.
 ///
 /// Deliberately platform-neutral (no UIKit) so the curation and routing
 /// rules stay testable from the package's macOS test run.
@@ -30,26 +27,17 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
     /// nothing a build without the debug flag should ever see.
     public static let standard: [ComposerAttachmentAction] = [.photos, .camera, .files, .voiceNote]
 
-    /// The agent composer's `+` menu. Camera lives here rather than in the
-    /// quick row; `.connections` joins only when the host enables it.
+    /// The agent composer's `+` menu, and the only surface offering
+    /// `.connections` - which joins only when the host enables it.
     public static func agentMenu(connectionsEnabled: Bool) -> [ComposerAttachmentAction] {
         agentMenuBase.filter { included($0, connectionsEnabled: connectionsEnabled) }
     }
 
-    /// The agent composer's trailing quick-action row: an ordered curation of
-    /// `agentMenu`. Changing what the row shows is a one-line edit to
-    /// `agentQuickRowBase`; the shared `included` predicate guarantees the
-    /// row can never surface an option the menu withholds.
-    public static func agentQuickRow(connectionsEnabled: Bool) -> [ComposerAttachmentAction] {
-        agentQuickRowBase.filter { included($0, connectionsEnabled: connectionsEnabled) }
-    }
-
     private static let agentMenuBase: [ComposerAttachmentAction] = [.photos, .camera, .files, .voiceNote, .connections]
-    private static let agentQuickRowBase: [ComposerAttachmentAction] = [.photos, .files, .connections]
 
-    /// The one gate both agent lists share. No list carries `.connections`
-    /// unconditionally and no surface consults the flag independently, so a
-    /// side door would require bypassing this predicate.
+    /// The one gate on `.connections`. No list carries it unconditionally
+    /// and no surface consults the flag independently, so a side door would
+    /// require bypassing this predicate.
     private static func included(_ action: ComposerAttachmentAction, connectionsEnabled: Bool) -> Bool {
         action != .connections || connectionsEnabled
     }
@@ -81,20 +69,6 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
         }
     }
 
-    /// Filled marks for the quick row, per the agent composer design. Icon
-    /// variant is a property of the option, not of the row - still one
-    /// declaration per option; menu rows keep the outline set above.
-    public var filledIconSystemName: String {
-        switch self {
-        case .photos: "photo.fill"
-        case .camera: "camera.fill"
-        case .files: "document.fill"
-        case .voiceNote: "waveform"
-        case .connections: "powerplug.fill"
-        case .debugInjector: "testtube.2"
-        }
-    }
-
     /// Where a picked option routes. Every case resolves to one of the
     /// composer's own controls except `.hostConnections`, which the composer
     /// hands to the host through its `onConnectionsTap` callback - the
@@ -117,14 +91,5 @@ public enum ComposerAttachmentAction: String, CaseIterable, Identifiable, Sendab
         case .connections: .hostConnections
         case .debugInjector: .debugInjector
         }
-    }
-}
-
-/// Layout rule for the agent composer's trailing quick-action row: the row
-/// shows only in the composer's default state and collapses the moment the
-/// member starts writing, leaving `+` and the voice button.
-public enum AgentComposerQuickRow {
-    public static func isVisible(isMessageFieldFocused: Bool, messageText: String) -> Bool {
-        !isMessageFieldFocused && messageText.isEmpty
     }
 }

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -105,14 +105,12 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
     /// App-provided chip for a staged agent-share link, forwarded to
     /// `MessagesInputView`.
     @ViewBuilder let agentShareChip: () -> AgentChip
-    /// Agent-style composer: the same `+` menu as the group composer plus a
-    /// trailing curated quick-action row (default state only), and an empty
+    /// Agent-style composer: the `+` menu gains `.connections`, and an empty
     /// composer's send slot becomes the voice-memo entry.
     var usesAgentComposerLayout: Bool = false
-    /// Host gate for the `.connections` option, quick icon and menu row
-    /// alike. The composer package cannot read the app's feature flags, so
-    /// the host passes the capability - both offered lists feed from it
-    /// through one predicate (see `ComposerAttachmentAction`).
+    /// Host gate for the `+` menu's `.connections` row. The composer package
+    /// cannot read the app's feature flags, so the host passes the
+    /// capability (see `ComposerAttachmentAction`).
     var connectionsEnabled: Bool = false
     /// Presents the host's Connections browser. The browser lives outside
     /// this package, so the composer only emits the tap.
@@ -590,9 +588,9 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         .equatable()
     }
 
-    /// Runs the picked row, from the `+` menu or the quick row alike. The
-    /// menu has already dismissed by the time the action fires, so a picker
-    /// can present right away.
+    /// Runs the row picked from the `+` menu. The menu has already
+    /// dismissed by the time the action fires, so a picker can present
+    /// right away.
     private func handleAttachmentSelected(_ action: ComposerAttachmentAction) {
         switch action.dispatch {
         case .photoPicker: isPhotoPickerPresented = true
@@ -602,79 +600,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
         case .hostConnections: onConnectionsTap?()
         case .debugInjector: onDebugAttachmentTap?()
         }
-    }
-
-    /// The agent composer's trailing quick-action row: the curated subset of
-    /// the `+` menu as always-visible filled buttons between the text and the
-    /// voice button. Shares the menu's availability rules
-    /// (`disabledAttachmentActions`) and dispatch (`handleAttachmentSelected`).
-    private var agentQuickRow: some View {
-        let actions: [ComposerAttachmentAction] = ComposerAttachmentAction.agentQuickRow(connectionsEnabled: connectionsEnabled)
-        return HStack(spacing: 0) {
-            ForEach(actions) { action in
-                inlineMediaButton(
-                    symbol: action.filledIconSystemName,
-                    action: action,
-                    label: action.title,
-                    identifier: quickRowIdentifier(for: action)
-                )
-            }
-        }
-    }
-
-    /// Stable accessibility ids: the media pair keeps the ids the old leading
-    /// strip carried (QA flows reference them); new options derive from the
-    /// action's own id.
-    private func quickRowIdentifier(for action: ComposerAttachmentAction) -> String {
-        switch action {
-        case .photos: "photo-picker-button"
-        case .files: "file-picker-button"
-        default: "quick-\(action.rawValue)-button"
-        }
-    }
-
-    /// The quick row shows in the default state only: it collapses while the
-    /// member writes, leaving `+` and the voice button.
-    private var isAgentQuickRowVisible: Bool {
-        usesAgentComposerLayout && AgentComposerQuickRow.isVisible(
-            isMessageFieldFocused: focusState == .message,
-            messageText: messageText
-        )
-    }
-
-    /// The input field's trailing accessory slot: the quick row while the
-    /// agent composer rests in its default state, nothing otherwise (the
-    /// group composer never fills the slot).
-    @ViewBuilder
-    private var quickActionsAccessory: some View {
-        if isAgentQuickRowVisible {
-            agentQuickRow
-                .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .trailing)))
-        }
-    }
-
-    private func inlineMediaButton(
-        symbol: String,
-        action: ComposerAttachmentAction,
-        label: String,
-        identifier: String
-    ) -> some View {
-        let isDisabled: Bool = disabledAttachmentActions.contains(action)
-        return Button {
-            handleAttachmentSelected(action)
-        } label: {
-            Image(systemName: symbol)
-                .font(.system(size: 18.0, weight: .medium))
-                .foregroundStyle(Color.colorTextPrimary.opacity(isDisabled ? 0.3 : 1.0))
-                .frame(width: 32, height: 32)
-                .contentShape(.circle)
-        }
-        .buttonStyle(.plain)
-        .disabled(isDisabled)
-        .hoverEffect(.lift)
-        .hoverEffectDisabled(isDisabled)
-        .accessibilityLabel(label)
-        .accessibilityIdentifier(identifier)
     }
 
     /// The voice-memo entry the agent layout puts in an empty composer's
@@ -727,7 +652,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             onClearMediaAttachment: onClearMediaAttachment,
             fileAttachmentPreview: fileAttachmentPreview,
             agentShareChip: agentShareChip,
-            quickActionsAccessory: { quickActionsAccessory },
             attachmentsButton: { attachmentsGlyph }
         )
     }
@@ -751,7 +675,6 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
             participationBubble
 
             glassStyledInputCapsule
-                .animation(.easeOut(duration: 0.2), value: isAgentQuickRowVisible)
                 .overlay(alignment: .bottomLeading) { attachmentsControlOverlay }
         }
         .disabled(!messagesTextFieldEnabled)

--- a/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesInputView.swift
@@ -4,7 +4,7 @@ import PhotosUI
 import SwiftUI
 import UIKit
 
-public struct MessagesInputView<FilePreview: View, AgentChip: View, QuickActions: View, AttachmentsButton: View>: View {
+public struct MessagesInputView<FilePreview: View, AgentChip: View, AttachmentsButton: View>: View {
     @Binding var displayName: String
     let emptyDisplayNamePlaceholder: String
     let messagePlaceholder: String
@@ -40,10 +40,6 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, QuickActions
     /// App-provided chip for a staged agent-share link. Rendered when
     /// `isShowingAgentShareChip` is true.
     @ViewBuilder let agentShareChip: () -> AgentChip
-    /// Trailing accessory between the text and the send/voice button: the
-    /// agent composer's curated quick-action row. The host supplies it (with
-    /// its own visibility rule); the group composer passes an `EmptyView`.
-    @ViewBuilder let quickActionsAccessory: () -> QuickActions
     /// The attachments control, rendered as a leading accessory inside the field
     /// just before the placeholder - see `attachmentsAccessory`. Supplied by the
     /// host because the menu it opens belongs to the composer's own state.
@@ -79,7 +75,6 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, QuickActions
         onClearMediaAttachment: ((UUID) -> Void)? = nil,
         @ViewBuilder fileAttachmentPreview: @escaping (PendingFileAttachment) -> FilePreview,
         @ViewBuilder agentShareChip: @escaping () -> AgentChip,
-        @ViewBuilder quickActionsAccessory: @escaping () -> QuickActions,
         @ViewBuilder attachmentsButton: @escaping () -> AttachmentsButton
     ) {
         _displayName = displayName
@@ -107,7 +102,6 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, QuickActions
         self.onClearMediaAttachment = onClearMediaAttachment
         self.fileAttachmentPreview = fileAttachmentPreview
         self.agentShareChip = agentShareChip
-        self.quickActionsAccessory = quickActionsAccessory
         self.attachmentsButton = attachmentsButton
     }
 
@@ -211,8 +205,6 @@ public struct MessagesInputView<FilePreview: View, AgentChip: View, QuickActions
             HStack(alignment: .bottom, spacing: 0) {
                 attachmentsAccessory
                 messageTextField
-                quickActionsAccessory()
-                    .frame(height: Self.defaultHeight)
                 trailingButton
             }
         }

--- a/ConvosCore/Tests/ConvosCoreTests/ComposerAttachmentCurationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ComposerAttachmentCurationTests.swift
@@ -4,31 +4,17 @@ import Testing
 
 @Suite("Agent composer curation")
 struct ComposerAttachmentCurationTests {
-    @Test("quick row is a subset of the menu in both flag states")
-    func quickRowIsCurationOfMenu() {
-        for connectionsEnabled in [true, false] {
-            let menu = ComposerAttachmentAction.agentMenu(connectionsEnabled: connectionsEnabled)
-            let quickRow = ComposerAttachmentAction.agentQuickRow(connectionsEnabled: connectionsEnabled)
-            for action in quickRow {
-                #expect(menu.contains(action), "quick row offers \(action) the menu withholds (connectionsEnabled: \(connectionsEnabled))")
-            }
-        }
-    }
-
-    @Test("connections appears in both lists when enabled and in neither when disabled")
+    @Test("connections appears in the agent menu when enabled and nowhere when disabled")
     func connectionsFollowsTheSingleGate() {
         #expect(ComposerAttachmentAction.agentMenu(connectionsEnabled: true).contains(.connections))
-        #expect(ComposerAttachmentAction.agentQuickRow(connectionsEnabled: true).contains(.connections))
         #expect(!ComposerAttachmentAction.agentMenu(connectionsEnabled: false).contains(.connections))
-        #expect(!ComposerAttachmentAction.agentQuickRow(connectionsEnabled: false).contains(.connections))
+        #expect(!ComposerAttachmentAction.standard.contains(.connections))
     }
 
-    @Test("agent lists keep their curated order")
+    @Test("agent menu keeps its curated order")
     func agentListOrdering() {
         #expect(ComposerAttachmentAction.agentMenu(connectionsEnabled: true) == [.photos, .camera, .files, .voiceNote, .connections])
         #expect(ComposerAttachmentAction.agentMenu(connectionsEnabled: false) == [.photos, .camera, .files, .voiceNote])
-        #expect(ComposerAttachmentAction.agentQuickRow(connectionsEnabled: true) == [.photos, .files, .connections])
-        #expect(ComposerAttachmentAction.agentQuickRow(connectionsEnabled: false) == [.photos, .files])
     }
 
     @Test("the group composer's standard menu is untouched")
@@ -61,37 +47,10 @@ struct ComposerAttachmentDispatchTests {
         #expect(ComposerAttachmentAction.debugInjector.dispatch == .debugInjector)
     }
 
-    @Test("filled icon mapping covers every quick-row case")
-    func filledIconsCoverQuickRow() {
-        for action in ComposerAttachmentAction.agentQuickRow(connectionsEnabled: true) {
-            #expect(!action.filledIconSystemName.isEmpty)
-        }
-        #expect(ComposerAttachmentAction.photos.filledIconSystemName == "photo.fill")
-        #expect(ComposerAttachmentAction.files.filledIconSystemName == "document.fill")
-        #expect(ComposerAttachmentAction.connections.filledIconSystemName == "powerplug.fill")
-    }
-
     @Test("menu rows keep the outline set")
     func outlineIconsPinned() {
         #expect(ComposerAttachmentAction.connections.iconSystemName == "powerplug")
-    }
-}
-
-@Suite("Agent quick row visibility")
-struct AgentComposerQuickRowVisibilityTests {
-    @Test("visible only in the default state")
-    func defaultStateShowsRow() {
-        #expect(AgentComposerQuickRow.isVisible(isMessageFieldFocused: false, messageText: ""))
-    }
-
-    @Test("hidden while the field is focused")
-    func focusHidesRow() {
-        #expect(!AgentComposerQuickRow.isVisible(isMessageFieldFocused: true, messageText: ""))
-    }
-
-    @Test("hidden while text is drafted")
-    func draftedTextHidesRow() {
-        #expect(!AgentComposerQuickRow.isVisible(isMessageFieldFocused: false, messageText: "hello"))
-        #expect(!AgentComposerQuickRow.isVisible(isMessageFieldFocused: true, messageText: "hello"))
+        #expect(ComposerAttachmentAction.photos.iconSystemName == "photo")
+        #expect(ComposerAttachmentAction.files.iconSystemName == "document")
     }
 }

--- a/ConvosTests/AbilitiesBrowserSectioningTests.swift
+++ b/ConvosTests/AbilitiesBrowserSectioningTests.swift
@@ -1,0 +1,158 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// The Connections browser's two-section split in `.composerModal`:
+/// Connected holds every entitlement the account has in any lifecycle
+/// state, Discover holds only authoritative not-entitled, and the outage
+/// section holds the rest.
+@MainActor
+final class AbilitiesBrowserSectioningTests: XCTestCase {
+    func testEntitledButNotActiveAbilitiesStayUnderConnected() async throws {
+        let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .standard, artificialDelay: .zero))
+        await viewModel.refresh()
+
+        // The standard fixture: an active Google Calendar, a pendingAuth
+        // Spotify and an expired Coinbase, all entitled.
+        let connectedIds: [String] = viewModel.entitledAbilities.map(\.id)
+        XCTAssertTrue(connectedIds.contains("googlecalendar"))
+        XCTAssertTrue(connectedIds.contains("spotify"), "pendingAuth is still an entitlement the account holds")
+        XCTAssertTrue(connectedIds.contains("coinbase"), "expired is still an entitlement the account holds")
+
+        let discoverIds: [String] = viewModel.availableAbilities.map(\.id)
+        XCTAssertFalse(discoverIds.contains("spotify"))
+        XCTAssertFalse(discoverIds.contains("coinbase"))
+        XCTAssertTrue(discoverIds.contains("youtube"))
+    }
+
+    func testNeedsReauthAbilityIsConnectedNotDiscoverable() async throws {
+        let service = NeedsReauthAbilitiesService()
+        let viewModel = AbilitiesListViewModel(service: service)
+        await viewModel.refresh()
+
+        XCTAssertEqual(viewModel.entitledAbilities.map(\.id), ["gmail"])
+        XCTAssertTrue(viewModel.availableAbilities.isEmpty)
+        XCTAssertTrue(viewModel.unknownStateAbilities.isEmpty)
+    }
+
+    /// Fail-open is the direction the catalog type exists to prevent: an
+    /// ability whose entitlement state the backend could not report must
+    /// not read as connectable, and must not read as connected either.
+    func testUnknownStateAbilitiesAreInNeitherSection() async throws {
+        let viewModel = AbilitiesListViewModel(
+            service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart, artificialDelay: .zero)
+        )
+        await viewModel.refresh()
+
+        XCTAssertTrue(viewModel.entitlementsUnavailable)
+        XCTAssertTrue(viewModel.entitledAbilities.isEmpty)
+        XCTAssertTrue(viewModel.availableAbilities.isEmpty)
+        XCTAssertFalse(viewModel.unknownStateAbilities.isEmpty)
+    }
+
+    /// One search field, both sections: the filter narrows every section
+    /// from one query, and a section filtered to empty hides itself.
+    func testSearchNarrowsBothSectionsFromOneQuery() async throws {
+        let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .standard, artificialDelay: .zero))
+        await viewModel.refresh()
+
+        viewModel.searchText = "youtube"
+        XCTAssertEqual(viewModel.availableAbilities.map(\.id), ["youtube"])
+        XCTAssertTrue(viewModel.entitledAbilities.isEmpty, "a section filtered to nothing hides its header")
+        XCTAssertTrue(viewModel.hasVisibleAbilities)
+
+        viewModel.searchText = "calend"
+        XCTAssertEqual(viewModel.entitledAbilities.map(\.id), ["googlecalendar"])
+        XCTAssertTrue(viewModel.availableAbilities.isEmpty)
+
+        viewModel.searchText = "zzzz"
+        XCTAssertFalse(viewModel.hasVisibleAbilities, "a no-match query hands the list to the search empty state")
+        XCTAssertTrue(viewModel.isSearching)
+    }
+
+    /// Everything-connected collapses Discover on its own; nothing-connected
+    /// puts the hero above a full Discover. Both already shipped - pinned
+    /// here so the two-section split cannot quietly regress them.
+    func testEmptyStatesNeedNoSectionOfTheirOwn() async throws {
+        let allConnected = AbilitiesListViewModel(service: EverythingConnectedAbilitiesService())
+        await allConnected.refresh()
+        XCTAssertFalse(allConnected.entitledAbilities.isEmpty)
+        XCTAssertTrue(allConnected.availableAbilities.isEmpty, "Discover self-collapses")
+        XCTAssertFalse(allConnected.showsNothingConnectedHero)
+
+        let nothingConnected = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .deviceOnly, artificialDelay: .zero))
+        await nothingConnected.refresh()
+        XCTAssertTrue(nothingConnected.entitledAbilities.isEmpty)
+        XCTAssertFalse(nothingConnected.availableAbilities.isEmpty)
+        XCTAssertTrue(nothingConnected.showsNothingConnectedHero)
+    }
+}
+
+/// A single ability whose entitlement the provider says needs
+/// reauthorization - the state `MockAbilitiesService` never produces.
+private struct NeedsReauthAbilitiesService: AbilitiesServiceProtocol {
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        let gmail = try XCTUnwrap(MockAbilitiesService.standardCatalog().first { $0.id == "gmail" })
+        let entitlement = try AbilitiesAPI.Entitlement(status: .needsReauth, expiresAt: nil, extensionCount: 1)
+        return AbilitiesCatalog(catalogVersion: 1, abilities: [gmail.withEntitlementState(.entitled(entitlement))])
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func completeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func revokeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        []
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+}
+
+/// Every catalog ability entitled and active: the "everything connected"
+/// empty state, which no `MockAbilitiesService` scenario produces.
+private struct EverythingConnectedAbilitiesService: AbilitiesServiceProtocol {
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        let entitlement = try AbilitiesAPI.Entitlement(status: .active, expiresAt: nil, extensionCount: 0)
+        let abilities: [AbilitiesAPI.Ability] = MockAbilitiesService.standardCatalog()
+            .map { $0.withEntitlementState(.entitled(entitlement)) }
+        return AbilitiesCatalog(catalogVersion: 1, abilities: abilities)
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func completeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func revokeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        []
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+}

--- a/ConvosTests/ConnectionsBrowserModeTests.swift
+++ b/ConvosTests/ConnectionsBrowserModeTests.swift
@@ -8,20 +8,52 @@ final class ConnectionsBrowserModeTests: XCTestCase {
         XCTAssertFalse(mode.showsDismissChrome)
         XCTAssertNil(mode.conversationId)
         XCTAssertNil(mode.agentInboxId)
+        XCTAssertNil(mode.agentDisplayName)
     }
 
     func testComposerModalModeRendersWithDismissChrome() {
-        let mode: ConnectionsBrowserMode = .composerModal(conversationId: "dm-1", agentInboxId: "agent-1")
+        let mode: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-1",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley"
+        )
         XCTAssertTrue(mode.showsDismissChrome)
         XCTAssertEqual(mode.conversationId, "dm-1")
         XCTAssertEqual(mode.agentInboxId, "agent-1")
+        XCTAssertEqual(mode.agentDisplayName, "Caley")
     }
 
     func testModeIdentitiesAreDistinct() {
         let settings: ConnectionsBrowserMode = .appSettings
-        let modal: ConnectionsBrowserMode = .composerModal(conversationId: "dm-1", agentInboxId: "agent-1")
-        let otherModal: ConnectionsBrowserMode = .composerModal(conversationId: "dm-2", agentInboxId: "agent-1")
+        let modal: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-1",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley"
+        )
+        let otherModal: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-2",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley"
+        )
         XCTAssertNotEqual(settings.id, modal.id)
         XCTAssertNotEqual(modal.id, otherModal.id)
+    }
+
+    /// The modal presents via `fullScreenCover(item:)`, so identity change
+    /// tears it down and re-presents it. An agent renaming mid-session must
+    /// not do that.
+    func testRenamingTheAgentLeavesTheModalIdentityUnchanged() {
+        let before: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-1",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley"
+        )
+        let after: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-1",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley the Second"
+        )
+        XCTAssertEqual(before.id, after.id)
+        XCTAssertNotEqual(before, after, "the value still carries the new name")
     }
 }

--- a/ConvosTests/ConversationAbilitiesBrowserModeTests.swift
+++ b/ConvosTests/ConversationAbilitiesBrowserModeTests.swift
@@ -1,0 +1,682 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// The per-chat half of the Connections browser: a conversation view model
+/// hosted by the list screen, which owns no catalog of its own, never
+/// settles a toggle OFF on an unread state, and auto-enables what the
+/// member just connected.
+@MainActor
+final class ConversationAbilitiesBrowserModeTests: XCTestCase {
+    private enum TestError: Error {
+        case rowNotFound(String)
+    }
+
+    private let agent: ConversationAgentDescriptor = ConversationAgentDescriptor(
+        inboxId: "mock-agent-inbox-1",
+        displayName: "Caley"
+    )
+    private let conversationId: String = "browser-conversation"
+
+    private func makeHostedViewModel(
+        service: ScriptedAbilitiesService,
+        epoch: AbilitiesAccountEpoch = AbilitiesAccountEpoch()
+    ) -> ConversationAbilitiesViewModel {
+        ConversationAbilitiesViewModel(
+            conversationId: conversationId,
+            agents: [agent],
+            selection: AbilitiesSelection(service: service),
+            catalogSource: .hosted,
+            accountEpoch: epoch
+        )
+    }
+
+    private func row(_ abilityId: String, in viewModel: ConversationAbilitiesViewModel) throws -> ConversationAbilitiesViewModel.Row {
+        guard let row = viewModel.rows.first(where: { $0.ability.id == abilityId }) else {
+            throw TestError.rowNotFound(abilityId)
+        }
+        return row
+    }
+
+    // MARK: - Hosted catalog ownership
+
+    /// A hosted view model must never fetch a catalog: a second fetch off
+    /// the same actor at another moment can disagree with the one that
+    /// sectioned the rows, and the toggle would then read a lifecycle from
+    /// a snapshot the row was never placed by.
+    func testHostedViewModelNeverFetchesItsOwnCatalog() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+
+        await viewModel.refresh()
+        let observedCatalogFetchCount = await service.catalogFetchCount
+        XCTAssertEqual(observedCatalogFetchCount, 0)
+        XCTAssertTrue(viewModel.rows.isEmpty, "no catalog, no rows")
+
+        let catalog = await service.currentCatalog()
+        await viewModel.refresh(adoptingCatalog: catalog)
+        let observedCatalogFetchCount2 = await service.catalogFetchCount
+        XCTAssertEqual(observedCatalogFetchCount2, 0, "the adopted catalog replaces the fetch entirely")
+        XCTAssertFalse(viewModel.rows.isEmpty)
+    }
+
+    /// The invariant: a row entitled in the adopted catalog never renders a
+    /// lifecycle derived from a different snapshot - so never
+    /// `.needsEntitlement` or `.unknown`.
+    func testAdoptedCatalogBacksEveryRowLifecycle() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        let catalog = await service.currentCatalog()
+
+        // The service moves on underneath: a self-fetching view model would
+        // pick this newer state up and disagree with the host's sections.
+        await service.setEntitlement(abilityId: "googlecalendar", state: .notEntitled)
+        await viewModel.refresh(adoptingCatalog: catalog)
+
+        let entitledIds: [String] = catalog.abilities
+            .filter { $0.entitlement?.status == .active }
+            .map(\.id)
+        XCTAssertFalse(entitledIds.isEmpty)
+        for abilityId in entitledIds {
+            let row = try row(abilityId, in: viewModel)
+            XCTAssertEqual(row.lifecycle, .ready, "\(abilityId) is active in the sectioning catalog")
+        }
+    }
+
+    /// Mutations must not pull in a catalog revision the host has not
+    /// sectioned its rows from either.
+    func testHostedMutationRefreshDoesNotFetchACatalog() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        viewModel.extend(ability: try activeAbility("googlecalendar", in: viewModel), agent: agent, bundleIds: ["calendar.events"])
+        try await settle { !viewModel.isBusy && viewModel.rows.contains { $0.ability.id == "googlecalendar" && $0.isOn } }
+
+        let observedCatalogFetchCount3 = await service.catalogFetchCount
+        XCTAssertEqual(observedCatalogFetchCount3, 0)
+    }
+
+    // MARK: - Opt-in read failure
+
+    /// Loading and unavailable both render disabled, never a settled OFF:
+    /// reading a failed fetch as "not enabled here" would invite a tap that
+    /// extends with manifest defaults over a real selection.
+    func testFailedOptInReadRendersDisabledRatherThanOff() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setConversationAbilitiesFailure(true)
+        let viewModel = makeHostedViewModel(service: service)
+
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        let row = try row("googlecalendar", in: viewModel)
+        XCTAssertFalse(row.hasSettledOptIn)
+        XCTAssertTrue(viewModel.isToggleDisabled(for: row), "an unsettled opt-in read is never a settled OFF")
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func testAuthoritativeOptInsSurviveAFailedRefresh() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "googlecalendar", agentInboxId: agent.inboxId, bundleIds: ["calendar.events"])])
+        let viewModel = makeHostedViewModel(service: service)
+        let catalog = await service.currentCatalog()
+        await viewModel.refresh(adoptingCatalog: catalog)
+
+        XCTAssertTrue(try row("googlecalendar", in: viewModel).isOn)
+
+        await service.setConversationAbilitiesFailure(true)
+        await viewModel.refresh(adoptingCatalog: catalog)
+
+        let row = try row("googlecalendar", in: viewModel)
+        XCTAssertTrue(row.isOn, "the last authoritative set is replaced only by a successful one")
+        XCTAssertTrue(row.hasSettledOptIn)
+    }
+
+    // MARK: - Outage
+
+    /// While the catalog admits it cannot verify entitlement state, every
+    /// per-chat control in the browser's Connected section is disabled and
+    /// no tap writes a grant: a row can be sitting there on an entitlement
+    /// revoked elsewhere since.
+    func testOutageDisablesEveryToggleAndBlocksWrites() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        let live = await service.currentCatalog()
+        let stale = AbilitiesCatalog(
+            catalogVersion: live.catalogVersion,
+            entitlementsUnavailable: true,
+            abilities: live.abilities
+        )
+        await viewModel.refresh(adoptingCatalog: stale)
+
+        XCTAssertTrue(viewModel.entitlementsUnavailable)
+        XCTAssertFalse(viewModel.rows.isEmpty)
+        for row in viewModel.rows {
+            XCTAssertTrue(viewModel.isToggleDisabled(for: row), "\(row.ability.id) is toggleable during an outage")
+        }
+
+        viewModel.toggle(try row("googlecalendar", in: viewModel))
+        try await Task.sleep(for: .milliseconds(50))
+        let observedExtendCount = await service.extendCount
+        XCTAssertEqual(observedExtendCount, 0)
+        XCTAssertNil(viewModel.bundleSelection)
+    }
+
+    // MARK: - Auto-enable
+
+    func testAutoEnableNeverShowsASettledOffFrame() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        // youtube is catalog-only until the connect lands. One bundle, so
+        // the auto-enable extends straight through without the picker.
+        try await service.keepFirstBundleOnly(abilityId: "youtube")
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        viewModel.enableAfterConnect(abilityId: "youtube")
+
+        // Immediately, before the write lands: on and busy, never off.
+        let pending = try row("youtube", in: viewModel)
+        XCTAssertTrue(pending.isOn)
+        XCTAssertTrue(pending.isPendingEnablement)
+        XCTAssertTrue(viewModel.isToggleDisabled(for: pending))
+
+        try await settle { await service.extendCount == 1 }
+        try await settle { !viewModel.rows.contains { $0.ability.id == "youtube" && $0.isPendingEnablement } }
+        XCTAssertTrue(try row("youtube", in: viewModel).isOn, "the row settles on")
+    }
+
+    /// The activation callback carries an id, and the bundles are resolved
+    /// from the freshest catalog: handing the pre-connect ability over
+    /// would bounce straight back to Connect, since it still reads
+    /// not-entitled.
+    func testAutoEnableResolvesTheFreshAbilityRatherThanThePreConnectCopy() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        let preConnect = await service.currentCatalog()
+        await viewModel.refresh(adoptingCatalog: preConnect)
+
+        let staleRow = try row("youtube", in: viewModel)
+        XCTAssertEqual(staleRow.lifecycle, .needsEntitlement, "the published copy still reads not-entitled")
+
+        try await service.keepFirstBundleOnly(abilityId: "youtube")
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        viewModel.enableAfterConnect(abilityId: "youtube")
+
+        try await settle { await service.extendCount == 1 }
+        let observedLastExtend = await service.lastExtend
+        let extended = try XCTUnwrap(observedLastExtend)
+        XCTAssertEqual(extended.abilityId, "youtube")
+        XCTAssertEqual(extended.bundleIds, ["youtube.search"], "manifest defaults off the refetched ability")
+    }
+
+    func testAutoEnableIsANoOpWhenAnOptInAlreadyExists() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "googlecalendar", agentInboxId: agent.inboxId, bundleIds: ["calendar.availability"])])
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        viewModel.enableAfterConnect(abilityId: "googlecalendar")
+        try await Task.sleep(for: .milliseconds(50))
+
+        let observedExtendCount2 = await service.extendCount
+        XCTAssertEqual(observedExtendCount2, 0, "an existing opt-in keeps its bundle selection")
+    }
+
+    // MARK: - Pending-enablement exits
+
+    func testPendingEnablementClearsWhenTheExtendFails() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setExtendFailure(.transport)
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+        try await service.keepFirstBundleOnly(abilityId: "youtube")
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { !viewModel.rows.contains { $0.ability.id == "youtube" && $0.isPendingEnablement } }
+
+        let row = try row("youtube", in: viewModel)
+        XCTAssertFalse(row.isOn, "a failed extend settles the row off")
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    func testPendingEnablementClearsWhenTheExtendBouncesNeedsEntitlement() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setExtendFailure(.needsEntitlement)
+        var repaired: [String] = []
+        let viewModel = makeHostedViewModel(service: service)
+        viewModel.entitlementRecoveryRoute = .host { ability in repaired.append(ability.id) }
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+        try await service.keepFirstBundleOnly(abilityId: "youtube")
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { !repaired.isEmpty }
+        try await settle { !viewModel.rows.contains { $0.ability.id == "youtube" && $0.isPendingEnablement } }
+
+        XCTAssertEqual(repaired, ["youtube"], "repair goes to the host's connect flow, not a second sheet")
+        XCTAssertNil(viewModel.connectContext, "a hosted view model never arms its own connect sheet")
+        XCTAssertFalse(try row("youtube", in: viewModel).isOn)
+    }
+
+    /// The exit with no shipped `onDismiss` before this change: a picker
+    /// swiped away reports nothing, so the row would spin forever.
+    func testPendingEnablementClearsWhenTheBundlePickerIsCancelled() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+        // The fixture ships youtube with two bundles, so the auto-enable
+        // routes through the picker.
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { viewModel.bundleSelection != nil }
+        XCTAssertTrue(try row("youtube", in: viewModel).isPendingEnablement)
+
+        // Swipe-away: SwiftUI nils the item, then calls onDismiss.
+        viewModel.bundleSelection = nil
+        viewModel.handleBundleSelectionDismissed()
+
+        let row = try row("youtube", in: viewModel)
+        XCTAssertFalse(row.isPendingEnablement, "a cancelled picker settles the row off")
+        XCTAssertFalse(row.isOn)
+        let observedExtendCount3 = await service.extendCount
+        XCTAssertEqual(observedExtendCount3, 0)
+    }
+
+    func testConfirmingTheBundlePickerIsNotReadAsACancel() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { viewModel.bundleSelection != nil }
+        let context = try XCTUnwrap(viewModel.bundleSelection)
+
+        viewModel.confirmBundleSelection(context, bundleIds: ["youtube.library"])
+        viewModel.bundleSelection = nil
+        viewModel.handleBundleSelectionDismissed()
+
+        // The dismissal that follows a confirm is not the cancel exit: the
+        // row must stay on and busy until the write lands.
+        XCTAssertTrue(try row("youtube", in: viewModel).isPendingEnablement)
+
+        try await settle { await service.extendCount == 1 }
+        let observedLastExtend2 = await service.lastExtend
+        let extended = try XCTUnwrap(observedLastExtend2)
+        XCTAssertEqual(extended.bundleIds, ["youtube.library"])
+        try await settle { viewModel.rows.contains { $0.ability.id == "youtube" && $0.isOn && !$0.isPendingEnablement } }
+    }
+
+    /// A zero-bundle ability returns before the extend ever runs, so the
+    /// pending row has to be cleared on that path too.
+    func testPendingEnablementClearsForAZeroBundleAbility() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        try await service.stripBundles(abilityId: "youtube")
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { viewModel.errorMessage != nil }
+
+        let row = try row("youtube", in: viewModel)
+        XCTAssertFalse(row.isPendingEnablement)
+        XCTAssertFalse(row.isOn)
+        let observedExtendCount4 = await service.extendCount
+        XCTAssertEqual(observedExtendCount4, 0)
+    }
+
+    /// The conversation info view sections nothing by carried-forward
+    /// state, so it keeps its shipped behavior: this addendum governs the
+    /// browser, and silently freezing the info view's toggles would be a
+    /// regression dressed as caution.
+    func testOutageDoesNotWithholdTheInfoViewToggle() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "googlecalendar", agentInboxId: agent.inboxId, bundleIds: ["calendar.events"])])
+        let viewModel = ConversationAbilitiesViewModel(
+            conversationId: conversationId,
+            agents: [agent],
+            selection: AbilitiesSelection(service: service),
+            accountEpoch: AbilitiesAccountEpoch()
+        )
+        let live = await service.currentCatalog()
+        await service.serveEntitlementsUnavailable(true)
+        await viewModel.refresh()
+
+        XCTAssertTrue(viewModel.entitlementsUnavailable)
+        let row = try row("googlecalendar", in: viewModel)
+        XCTAssertEqual(row.lifecycle, .ready, "last-known state carries the entitlement forward")
+        XCTAssertFalse(viewModel.isToggleDisabled(for: row), "the info view toggle is not frozen by the browser's rule")
+        XCTAssertFalse(live.entitlementsUnavailable)
+    }
+
+    // MARK: - Withdraw is per-chat only
+
+    func testTogglingOffWithdrawsTheOptInAndLeavesTheEntitlementAlone() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "googlecalendar", agentInboxId: agent.inboxId, bundleIds: ["calendar.events"])])
+        let viewModel = makeHostedViewModel(service: service)
+        let catalog = await service.currentCatalog()
+        await viewModel.refresh(adoptingCatalog: catalog)
+
+        viewModel.toggle(try row("googlecalendar", in: viewModel))
+        try await settle { await service.withdrawCount == 1 }
+
+        let observedRevokeCount = await service.revokeCount
+        XCTAssertEqual(observedRevokeCount, 0, "toggling off is never an app-wide disconnect")
+        let refreshed = await service.currentCatalog()
+        let ability = try XCTUnwrap(refreshed.abilities.first { $0.id == "googlecalendar" })
+        XCTAssertEqual(ability.entitlement?.status, .active, "the account still holds the entitlement")
+    }
+
+    /// The off-write is the shared control's single writer, so one broken
+    /// path breaks both surfaces. Pinned from the info view's own
+    /// (self-fetching) configuration as well as the browser's above.
+    func testInfoViewTogglesAnActiveConnectionOff() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "googlecalendar", agentInboxId: agent.inboxId, bundleIds: ["calendar.events"])])
+        let viewModel = ConversationAbilitiesViewModel(
+            conversationId: conversationId,
+            agents: [agent],
+            selection: AbilitiesSelection(service: service),
+            accountEpoch: AbilitiesAccountEpoch()
+        )
+        await viewModel.refresh()
+
+        let onRow = try row("googlecalendar", in: viewModel)
+        XCTAssertTrue(onRow.isOn)
+        XCTAssertEqual(onRow.lifecycle, .ready)
+        XCTAssertFalse(viewModel.isToggleDisabled(for: onRow), "a settled ON row is tappable")
+
+        viewModel.toggle(onRow)
+        try await settle { await service.withdrawCount == 1 }
+        try await settle { !viewModel.rows.contains { $0.ability.id == "googlecalendar" && $0.isOn } }
+
+        let observedExtendCountOff = await service.extendCount
+        XCTAssertEqual(observedExtendCountOff, 0, "toggling off never re-extends")
+        let observedRevokeCountOff = await service.revokeCount
+        XCTAssertEqual(observedRevokeCountOff, 0, "and never disconnects app-wide")
+    }
+
+    // MARK: - Account epoch
+
+    /// A wipe notifies no view model, so a modal open across one would keep
+    /// rendering the previous account's connections and accept a toggle
+    /// against them.
+    func testAccountWipeDropsTheSnapshotAndBlocksWrites() async throws {
+        let epoch = AbilitiesAccountEpoch()
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "googlecalendar", agentInboxId: agent.inboxId, bundleIds: ["calendar.events"])])
+        let viewModel = makeHostedViewModel(service: service, epoch: epoch)
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        let staleRow = try row("googlecalendar", in: viewModel)
+        XCTAssertTrue(staleRow.isOn)
+
+        epoch.advance()
+
+        XCTAssertTrue(viewModel.rows.isEmpty, "the previous account's connections stop rendering")
+        viewModel.toggle(staleRow)
+        try await Task.sleep(for: .milliseconds(50))
+        let observedWithdrawCount = await service.withdrawCount
+        XCTAssertEqual(observedWithdrawCount, 0, "a toggle tap must not write against them")
+        let observedExtendCount5 = await service.extendCount
+        XCTAssertEqual(observedExtendCount5, 0)
+    }
+
+    func testAccountWipeAlsoEmptiesTheListViewModel() async throws {
+        let epoch = AbilitiesAccountEpoch()
+        let viewModel = AbilitiesListViewModel(
+            service: MockAbilitiesService(scenario: .standard, artificialDelay: .zero),
+            accountEpoch: epoch
+        )
+        await viewModel.refresh()
+        XCTAssertFalse(viewModel.entitledAbilities.isEmpty)
+
+        epoch.advance()
+
+        XCTAssertTrue(viewModel.entitledAbilities.isEmpty)
+        XCTAssertTrue(viewModel.availableAbilities.isEmpty)
+        XCTAssertFalse(viewModel.hasLoadedOnce)
+    }
+
+    // MARK: - Activation reporting
+
+    /// All three connect completion sites report the activation, and the
+    /// stub-sheet path waits for the sheet's own dismissal - nilling
+    /// `pendingAuthorization` is not proof of it.
+    func testAuthLessConnectReportsItsActivation() async throws {
+        var activated: [String] = []
+        let viewModel = AbilitiesListViewModel(service: AuthLessAbilitiesService())
+        viewModel.onEntitlementActivated = { activated.append($0) }
+        await viewModel.refresh()
+
+        let ability = try XCTUnwrap(viewModel.availableAbilities.first)
+        viewModel.connect(ability)
+        try await settle { !activated.isEmpty }
+
+        XCTAssertEqual(activated, [ability.id], "an auth-less ability goes active on begin alone")
+    }
+
+    func testStubSheetActivationWaitsForTheSheetDismissal() async throws {
+        var activated: [String] = []
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let viewModel = AbilitiesListViewModel(service: service)
+        viewModel.onEntitlementActivated = { activated.append($0) }
+        await viewModel.refresh()
+
+        let youtube = try XCTUnwrap(viewModel.availableAbilities.first { $0.id == "youtube" })
+        viewModel.connect(youtube)
+        try await settle { viewModel.pendingAuthorization != nil }
+
+        let context = try XCTUnwrap(viewModel.pendingAuthorization)
+        viewModel.completeAuthorization(context)
+        try await settle { !viewModel.isBusy(youtube) }
+        XCTAssertTrue(activated.isEmpty, "pendingAuthorization == nil is not proof the sheet dismissed")
+
+        viewModel.handleAuthorizationDismissed()
+        XCTAssertEqual(activated, ["youtube"])
+
+        viewModel.handleAuthorizationDismissed()
+        XCTAssertEqual(activated, ["youtube"], "released exactly once")
+    }
+
+    // MARK: - Helpers
+
+    private func activeEntitlement() throws -> AbilitiesAPI.Entitlement {
+        try AbilitiesAPI.Entitlement(status: .active, expiresAt: nil, extensionCount: 0)
+    }
+
+    private func activeAbility(_ abilityId: String, in viewModel: ConversationAbilitiesViewModel) throws -> AbilitiesAPI.Ability {
+        try row(abilityId, in: viewModel).ability
+    }
+
+    /// Polls `condition` on the main actor until it holds, so a
+    /// fire-and-forget view-model task can land without a fixed sleep.
+    private func settle(
+        timeout: Duration = .seconds(3),
+        _ condition: @MainActor () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTFail("condition never settled")
+    }
+}
+
+/// A catalog-and-opt-ins service the tests drive directly: it counts every
+/// call, so "the hosted view model never fetches a catalog" is a fact the
+/// test can assert rather than infer.
+private actor ScriptedAbilitiesService: AbilitiesServiceProtocol {
+    enum ExtendFailure {
+        case transport
+        case needsEntitlement
+    }
+
+    struct ExtendRecord {
+        let abilityId: String
+        let agentInboxId: String
+        let bundleIds: [String]
+    }
+
+    private(set) var catalogFetchCount: Int = 0
+    private(set) var extendCount: Int = 0
+    private(set) var withdrawCount: Int = 0
+    private(set) var revokeCount: Int = 0
+    private(set) var lastExtend: ExtendRecord?
+
+    private var abilities: [AbilitiesAPI.Ability] = MockAbilitiesService.standardCatalog()
+    private var optIns: [ConversationAbility] = []
+    private var conversationAbilitiesFails: Bool = false
+    private var extendFailure: ExtendFailure?
+    private var servesEntitlementsUnavailable: Bool = false
+
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        catalogFetchCount += 1
+        return AbilitiesCatalog(
+            catalogVersion: 1,
+            entitlementsUnavailable: servesEntitlementsUnavailable,
+            abilities: abilities
+        )
+    }
+
+    /// The catalog without counting it as a view-model fetch: the tests use
+    /// this to stand in for what the host already owns.
+    func currentCatalog() -> AbilitiesCatalog {
+        AbilitiesCatalog(catalogVersion: 1, abilities: abilities)
+    }
+
+    func setEntitlement(abilityId: String, state: AbilitiesAPI.EntitlementState) {
+        abilities = abilities.map { $0.id == abilityId ? $0.withEntitlementState(state) : $0 }
+    }
+
+    func setOptIns(_ values: [ConversationAbility]) {
+        optIns = values
+    }
+
+    func setConversationAbilitiesFailure(_ fails: Bool) {
+        conversationAbilitiesFails = fails
+    }
+
+    func serveEntitlementsUnavailable(_ unavailable: Bool) {
+        servesEntitlementsUnavailable = unavailable
+    }
+
+    func setExtendFailure(_ failure: ExtendFailure?) {
+        extendFailure = failure
+    }
+
+    /// The fixture ships two bundles per ability, which routes a toggle-on
+    /// through the picker; a single-bundle ability extends straight through.
+    func keepFirstBundleOnly(abilityId: String) throws {
+        try replaceBundles(abilityId: abilityId) { Array($0.prefix(1)) }
+    }
+
+    func stripBundles(abilityId: String) throws {
+        try replaceBundles(abilityId: abilityId) { _ in [] }
+    }
+
+    private func replaceBundles(
+        abilityId: String,
+        _ transform: ([AbilitiesAPI.AbilityBundle]) -> [AbilitiesAPI.AbilityBundle]
+    ) throws {
+        abilities = try abilities.map { (ability: AbilitiesAPI.Ability) -> AbilitiesAPI.Ability in
+            guard ability.id == abilityId else { return ability }
+            return try AbilitiesAPI.Ability(
+                id: ability.id,
+                version: ability.version,
+                displayName: ability.displayName,
+                subtitle: ability.subtitle,
+                icon: ability.icon,
+                auth: ability.auth,
+                bundles: transform(ability.bundles),
+                entitlementState: ability.entitlementState
+            )
+        }
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func completeEntitlement(abilityId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func revokeEntitlement(abilityId: String) async throws {
+        revokeCount += 1
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        if conversationAbilitiesFails {
+            throw AbilitiesServiceError.accountRequired
+        }
+        return optIns
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        switch extendFailure {
+        case .transport:
+            throw AbilitiesServiceError.accountRequired
+        case .needsEntitlement:
+            throw AbilitiesServiceError.needsEntitlement(abilityId: abilityId)
+        case .none:
+            break
+        }
+        extendCount += 1
+        lastExtend = ExtendRecord(abilityId: abilityId, agentInboxId: agentInboxId, bundleIds: bundleIds)
+        optIns.removeAll { $0.abilityId == abilityId && $0.agentInboxId == agentInboxId }
+        optIns.append(ConversationAbility(abilityId: abilityId, agentInboxId: agentInboxId, bundleIds: bundleIds))
+    }
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
+        withdrawCount += 1
+        optIns.removeAll { $0.abilityId == abilityId && $0.agentInboxId == agentInboxId }
+    }
+}
+
+/// One ability whose manifest needs no authorization: `beginEntitlement`
+/// returns active, and the `pendingAuth` branch never runs for it.
+private actor AuthLessAbilitiesService: AbilitiesServiceProtocol {
+    private var isEntitled: Bool = false
+
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        let entitlementState: AbilitiesAPI.EntitlementState = isEntitled
+            ? .entitled(try AbilitiesAPI.Entitlement(status: .active, expiresAt: nil, extensionCount: 0))
+            : .notEntitled
+        let ability = try AbilitiesAPI.Ability(
+            id: "weather",
+            version: 1,
+            displayName: AbilitiesAPI.LocalizedText(en: "Weather"),
+            subtitle: AbilitiesAPI.LocalizedText(en: "Forecasts"),
+            auth: AbilitiesAPI.AbilityAuth(type: .none),
+            bundles: [],
+            entitlementState: entitlementState
+        )
+        return AbilitiesCatalog(catalogVersion: 1, abilities: [ability])
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        isEntitled = true
+        return AbilityEntitlementInitiation(status: .active)
+    }
+
+    func completeEntitlement(abilityId: String) async throws {}
+
+    func revokeEntitlement(abilityId: String) async throws {
+        isEntitled = false
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        []
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {}
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {}
+}

--- a/ConvosTests/ConversationAbilitiesBrowserModeTests.swift
+++ b/ConvosTests/ConversationAbilitiesBrowserModeTests.swift
@@ -484,6 +484,239 @@ final class ConversationAbilitiesBrowserModeTests: XCTestCase {
         XCTAssertEqual(activated, ["youtube"], "released exactly once")
     }
 
+    // MARK: - Codex review regressions
+
+    /// B1. The three-state opt-in model is a write rule as much as a
+    /// render rule: an unsettled read must read as "unknown", never as
+    /// "no opt-in here". Reading it as absent PUTs manifest defaults over
+    /// a bundle selection the member already made.
+    func testAutoEnableNeverOverwritesABundleSelectionItHasNotRead() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "youtube", agentInboxId: agent.inboxId, bundleIds: ["youtube.library"])])
+        await service.setConversationAbilitiesFailure(true)
+        let viewModel = makeHostedViewModel(service: service)
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        let unsettled = try row("youtube", in: viewModel)
+        XCTAssertFalse(unsettled.hasSettledOptIn, "the read failed, so nothing is known about this chat")
+
+        // The read recovers, and it says the member already opted in with
+        // a custom selection.
+        await service.setConversationAbilitiesFailure(false)
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { !viewModel.rows.contains { $0.ability.id == "youtube" && $0.isPendingEnablement } }
+
+        let observedExtendB1 = await service.extendCount
+        XCTAssertEqual(observedExtendB1, 0, "an existing selection is never overwritten with manifest defaults")
+        let optIns = await service.currentOptIns()
+        XCTAssertEqual(optIns.first { $0.abilityId == "youtube" }?.bundleIds, ["youtube.library"])
+    }
+
+    /// B1, second half: a read that stays down must refuse the write and
+    /// say so, rather than guess.
+    func testAutoEnableRefusesWhenTheOptInReadStaysDown() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setConversationAbilitiesFailure(true)
+        let viewModel = makeHostedViewModel(service: service)
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle { viewModel.errorMessage != nil }
+
+        let observedExtendB1b = await service.extendCount
+        XCTAssertEqual(observedExtendB1b, 0)
+        XCTAssertFalse(try row("youtube", in: viewModel).isPendingEnablement)
+    }
+
+    /// B2. The host's catalog has to land on the spot. Queued behind an
+    /// in-flight opt-in refresh, the rows stay sectioned by a catalog the
+    /// screen has already replaced - long enough to write a grant against
+    /// an outage it has already declared.
+    func testAdoptedCatalogAppliesSynchronously() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        let live = await service.currentCatalog()
+        await viewModel.refresh(adoptingCatalog: live)
+        XCTAssertFalse(viewModel.entitlementsUnavailable)
+
+        // A slow opt-in read is in flight when the outage catalog arrives.
+        await service.setConversationAbilitiesDelay(.milliseconds(400))
+        Task { await viewModel.refresh(adoptingCatalog: live) }
+        try await Task.sleep(for: .milliseconds(20))
+
+        let stale = AbilitiesCatalog(
+            catalogVersion: live.catalogVersion,
+            entitlementsUnavailable: true,
+            abilities: live.abilities
+        )
+        viewModel.adoptCatalog(stale)
+
+        XCTAssertTrue(viewModel.entitlementsUnavailable, "the outage is visible immediately, not after the queue drains")
+        for row in viewModel.rows {
+            XCTAssertTrue(viewModel.isToggleDisabled(for: row), "\(row.ability.id) stayed writable during a declared outage")
+        }
+    }
+
+    /// B4. A connect completing while another mutation is in flight must
+    /// not be swallowed by `extend`'s busy guard: Discover's Connect
+    /// buttons stay tappable throughout, so this is reachable.
+    func testAutoEnableWaitsForAnInFlightMutationInsteadOfBeingDropped() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        try await service.keepFirstBundleOnly(abilityId: "youtube")
+        // Single-bundle on both sides, so each toggle-on extends straight
+        // through instead of routing via the picker.
+        try await service.keepFirstBundleOnly(abilityId: "googlecalendar")
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        // Toggle googlecalendar on; its PUT is still landing.
+        await service.setExtendDelay(.milliseconds(250))
+        viewModel.toggle(try row("googlecalendar", in: viewModel))
+        XCTAssertTrue(viewModel.isBusy)
+
+        viewModel.enableAfterConnect(abilityId: "youtube")
+        try await settle(timeout: .seconds(6)) { await service.extendCount == 2 }
+
+        let optIns = await service.currentOptIns()
+        XCTAssertTrue(optIns.contains { $0.abilityId == "youtube" }, "the auto-enable survived the busy window")
+        XCTAssertTrue(optIns.contains { $0.abilityId == "googlecalendar" })
+    }
+
+    /// B5. `Row` is a value type, so clearing the pending set without
+    /// rebuilding leaves the row on-and-busy until the trailing refetch
+    /// returns - the spinner the settle-on-the-write rule exists to avoid.
+    func testConfirmedWriteSettlesTheRowBeforeTheTrailingRefetchReturns() async throws {
+        let service = ScriptedAbilitiesService()
+        let viewModel = makeHostedViewModel(service: service)
+        try await service.keepFirstBundleOnly(abilityId: "youtube")
+        await service.setEntitlement(abilityId: "youtube", state: .entitled(try activeEntitlement()))
+        await viewModel.refresh(adoptingCatalog: await service.currentCatalog())
+
+        // The write confirms quickly; the opt-in refetch behind it stalls
+        // for far longer than the settle budget below, so a row that waits
+        // for the refetch cannot pass.
+        await service.setConversationAbilitiesDelay(.milliseconds(2000))
+        viewModel.enableAfterConnect(abilityId: "youtube")
+
+        try await settle(timeout: .seconds(4)) { await service.extendCount == 1 }
+        try await settle(timeout: .milliseconds(400)) {
+            !viewModel.rows.contains { $0.ability.id == "youtube" && $0.isPendingEnablement }
+        }
+    }
+
+    /// S2. A `pendingAuth` initiation with no redirect URL is a malformed
+    /// response, not an auth-less ability. Reporting activation there
+    /// asserts the opposite of what the server just said.
+    func testPendingAuthWithoutARedirectUrlReportsNoActivation() async throws {
+        var activated: [String] = []
+        let viewModel = AbilitiesListViewModel(service: MalformedPendingAuthService())
+        viewModel.onEntitlementActivated = { activated.append($0) }
+        await viewModel.refresh()
+
+        let ability = try XCTUnwrap(viewModel.availableAbilities.first)
+        viewModel.connect(ability)
+        try await settle { viewModel.errorMessage != nil }
+
+        XCTAssertTrue(activated.isEmpty, "a pending entitlement never reports activation")
+        XCTAssertNil(viewModel.pendingAuthorization, "and no authorization sheet is armed without a URL")
+    }
+
+    /// B3. The wipe has to land before the next line of the caller runs.
+    /// Bumping it on a queued task leaves a window in which a fetch
+    /// started under the wiped account can still commit.
+    func testAccountWipeAdvancesTheSharedEpochSynchronously() {
+        let before: UInt64 = AbilitiesAccountEpoch.shared.value
+        AbilitiesServices.handleAccountDataWiped()
+        XCTAssertEqual(AbilitiesAccountEpoch.shared.value, before &+ 1, "the epoch moved before this line ran")
+    }
+
+    /// B3, second half: a catalog fetched under the previous account must
+    /// not commit once the epoch has moved on - even after a newer
+    /// refresh has resynced the snapshot, which is what makes a
+    /// "current epoch" check read true again.
+    func testACatalogFetchedUnderAWipedAccountNeverCommits() async throws {
+        let epoch = AbilitiesAccountEpoch()
+        let service = GatedCatalogService()
+        let viewModel = AbilitiesListViewModel(service: service, accountEpoch: epoch)
+        await viewModel.refresh()
+        let connecting = try XCTUnwrap(viewModel.availableAbilities.first)
+        XCTAssertEqual(connecting.id, "account-a")
+
+        // Connect's mid-flow quiet refresh is the fetch that stalls: it is
+        // the one whose epoch guard used to be read after the await.
+        await service.gateNextFetch()
+        viewModel.connect(connecting)
+        try await settle { await service.fetchCount == 2 }
+
+        // The account is wiped, and a newer refresh resyncs the snapshot to
+        // the new epoch - which is exactly what makes an "is the epoch
+        // current now" check read true again for the stalled fetch.
+        epoch.advance()
+        await service.setMarker("account-b")
+        await viewModel.refresh()
+        XCTAssertEqual(viewModel.availableAbilities.first?.id, "account-b")
+
+        // Only now does the pre-wipe fetch return.
+        await service.releaseGate()
+        try await settle { await service.fetchCount >= 3 || !viewModel.isBusy(connecting) }
+        try await Task.sleep(for: .milliseconds(100))
+
+        XCTAssertEqual(
+            viewModel.availableAbilities.first?.id,
+            "account-b",
+            "a catalog fetched under the wiped account must not overwrite the current one"
+        )
+    }
+
+    /// S1. Repair stays reachable during an outage on both surfaces: the
+    /// spec explicitly refused to disable connect and repair there, and
+    /// the conversation info view has always offered the tap. (The
+    /// control's `.disabled` removal itself is a view-layer change; this
+    /// pins the writer contract behind it.)
+    func testRepairStaysAvailableDuringAnOutage() async throws {
+        let service = ScriptedAbilitiesService()
+        await service.setOptIns([ConversationAbility(abilityId: "coinbase", agentInboxId: agent.inboxId, bundleIds: ["coinbase.prices"])])
+        let viewModel = ConversationAbilitiesViewModel(
+            conversationId: conversationId,
+            agents: [agent],
+            selection: AbilitiesSelection(service: service),
+            accountEpoch: AbilitiesAccountEpoch()
+        )
+        await service.serveEntitlementsUnavailable(true)
+        await viewModel.refresh()
+
+        XCTAssertTrue(viewModel.entitlementsUnavailable)
+        let attention = try row("coinbase", in: viewModel)
+        XCTAssertEqual(attention.lifecycle, .needsAttention(.expired), "an opt-in on a non-active entitlement needs repair")
+
+        viewModel.presentConnect(for: attention)
+        XCTAssertNotNil(viewModel.connectContext, "repair is never withheld by an outage")
+    }
+
+    // MARK: - Wiring
+
+    /// B6. `@State` releases the per-chat view model the moment the modal
+    /// is dismissed, but a connect already in flight still has to write
+    /// its grant. The list view model outlives the dismissal through its
+    /// own mutation task, so the activation callback has to carry the
+    /// per-chat model with it.
+    func testActivationWiringOutlivesTheModalDismissal() async throws {
+        let service = ScriptedAbilitiesService()
+        let listViewModel = AbilitiesListViewModel(service: service)
+        weak var probe: ConversationAbilitiesViewModel?
+
+        do {
+            let conversationViewModel = makeHostedViewModel(service: service)
+            probe = conversationViewModel
+            AbilitiesListScreen.wireActivation(list: listViewModel, conversation: conversationViewModel)
+        }
+
+        XCTAssertNotNil(probe, "dismissing the modal must not strand a connect that has not written its grant")
+    }
+
     // MARK: - Helpers
 
     private func activeEntitlement() throws -> AbilitiesAPI.Entitlement {
@@ -535,6 +768,16 @@ private actor ScriptedAbilitiesService: AbilitiesServiceProtocol {
     private var conversationAbilitiesFails: Bool = false
     private var extendFailure: ExtendFailure?
     private var servesEntitlementsUnavailable: Bool = false
+    private var conversationAbilitiesDelay: Duration = .zero
+    private var extendDelay: Duration = .zero
+
+    func setConversationAbilitiesDelay(_ delay: Duration) {
+        conversationAbilitiesDelay = delay
+    }
+
+    func setExtendDelay(_ delay: Duration) {
+        extendDelay = delay
+    }
 
     func fetchCatalog() async throws -> AbilitiesCatalog {
         catalogFetchCount += 1
@@ -543,6 +786,10 @@ private actor ScriptedAbilitiesService: AbilitiesServiceProtocol {
             entitlementsUnavailable: servesEntitlementsUnavailable,
             abilities: abilities
         )
+    }
+
+    func currentOptIns() -> [ConversationAbility] {
+        optIns
     }
 
     /// The catalog without counting it as a view-model fetch: the tests use
@@ -613,6 +860,9 @@ private actor ScriptedAbilitiesService: AbilitiesServiceProtocol {
     }
 
     func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        if conversationAbilitiesDelay > .zero {
+            try? await Task.sleep(for: conversationAbilitiesDelay)
+        }
         if conversationAbilitiesFails {
             throw AbilitiesServiceError.accountRequired
         }
@@ -620,6 +870,9 @@ private actor ScriptedAbilitiesService: AbilitiesServiceProtocol {
     }
 
     func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        if extendDelay > .zero {
+            try? await Task.sleep(for: extendDelay)
+        }
         switch extendFailure {
         case .transport:
             throw AbilitiesServiceError.accountRequired
@@ -678,5 +931,87 @@ private actor AuthLessAbilitiesService: AbilitiesServiceProtocol {
 
     func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {}
 
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {}
+}
+
+/// One ability whose `beginEntitlement` answers `pendingAuth` without a
+/// redirect URL - a malformed response, and the shape that used to fall
+/// into the auth-less branch and report a false activation.
+private actor MalformedPendingAuthService: AbilitiesServiceProtocol {
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        let ability = try AbilitiesAPI.Ability(
+            id: "gmail",
+            version: 1,
+            displayName: AbilitiesAPI.LocalizedText(en: "Gmail"),
+            subtitle: AbilitiesAPI.LocalizedText(en: "Read and send email"),
+            auth: AbilitiesAPI.AbilityAuth(type: .oauth),
+            bundles: [],
+            entitlementState: .notEntitled
+        )
+        return AbilitiesCatalog(catalogVersion: 1, abilities: [ability])
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        AbilityEntitlementInitiation(status: .pendingAuth, redirectUrl: nil)
+    }
+
+    func completeEntitlement(abilityId: String) async throws {}
+    func revokeEntitlement(abilityId: String) async throws {}
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] { [] }
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {}
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {}
+}
+
+/// A catalog service whose first fetch can be held open, so a response
+/// captured under one account can be made to return after the account has
+/// been wiped and a newer refresh has already committed.
+private actor GatedCatalogService: AbilitiesServiceProtocol {
+    private(set) var fetchCount: Int = 0
+    private var marker: String = "account-a"
+    private var gatedFetchIndex: Int?
+    private var isGateReleased: Bool = false
+
+    func gateNextFetch() {
+        gatedFetchIndex = fetchCount + 1
+        isGateReleased = false
+    }
+
+    func releaseGate() {
+        isGateReleased = true
+    }
+
+    func setMarker(_ value: String) {
+        marker = value
+    }
+
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        fetchCount += 1
+        let index: Int = fetchCount
+        let servedMarker: String = marker
+        if index == gatedFetchIndex {
+            while !isGateReleased {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+        }
+        let ability = try AbilitiesAPI.Ability(
+            id: servedMarker,
+            version: 1,
+            displayName: AbilitiesAPI.LocalizedText(en: servedMarker),
+            subtitle: AbilitiesAPI.LocalizedText(en: servedMarker),
+            auth: AbilitiesAPI.AbilityAuth(type: .none),
+            bundles: [],
+            entitlementState: .notEntitled
+        )
+        return AbilitiesCatalog(catalogVersion: 1, abilities: [ability])
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        AbilityEntitlementInitiation(status: .active)
+    }
+
+    func completeEntitlement(abilityId: String) async throws {}
+    func revokeEntitlement(abilityId: String) async throws {}
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] { [] }
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {}
     func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {}
 }


### PR DESCRIPTION
## What

The 1:1 Connections browser (`.composerModal`) stops being an account-level list and becomes the place you turn connections on **for this chat**. `.appSettings` is untouched. The composer's quick-row shortcut icons are deleted; the `+` menu is the only entry.

## Sections (§2)

| Section | Membership | `.appSettings` header | `.composerModal` header | `.composerModal` accessory |
|---|---|---|---|---|
| A | `entitled(_)`, any status | Connected | Connected | status badge + per-chat toggle |
| B | `notEntitled` | All connections | Discover | Connect button (unchanged) |
| C | `unknown` | Status unknown | Status unknown | none |

Membership predicates are the existing computeds and do not change; the mode drives only the second header string and the Connected accessory. Non-active entitlements stay in Connected — demoting them would ask a member to "connect" an account they already hold. Section C is never folded into Discover.

## Shared toggle (§3)

`ConversationAbilityToggleControl` is the single implementation behind both surfaces that offer it. State, writer and the disabled rule live in the view model with exactly one implementation (`isToggleDisabled(for:)`); row chrome stays per-surface. Only the repair route differs, so it is a parameter, not a branch — the browser routes repair to the connect flow already on screen rather than arming a second sheet, via an injected `EntitlementRecoveryRoute` (`extend` assigns `connectContext` directly on a `needsEntitlement` bounce, so this had to be made true rather than assumed).

Opt-ins are a three-state model (`loading` / `authoritative` / `unavailable`). Loading and unavailable render **disabled, never a settled OFF**, and the last authoritative set survives a failed refresh.

## Data model (§4)

The modal owns two view models and exactly one catalog. In browser mode the conversation view model never fetches a catalog — not from its initializer, not after a mutation; the list publishes every revision it commits, so the lifecycle behind a toggle always comes from the snapshot that sectioned the row. Refreshes are serialized and generation-stamped, and both view models carry an account epoch (`AbilitiesAccountEpoch`) so a wipe mid-session cannot keep rendering the previous account's connections or accept a toggle against them.

`ConnectionsBrowserMode.composerModal` gains `agentDisplayName`; `id` deliberately excludes it, since the modal presents via `fullScreenCover(item:)` and folding a renameable value into identity would tear the modal down on an agent rename.

## Auto-enable (§5)

Fired from all three completion sites, keyed on the ability **id** — every completion site holds the pre-connect copy, which still reads not-entitled and which `requestExtension` would bounce straight back to Connect. The bundles are resolved from the freshest catalog. A pending enablement renders **on and busy** with every exit in the table named (extend success, extend failure, `needsEntitlement` bounce, picker cancel, zero-bundle rejection), and the report is latched until the authorization sheet's own `onDismiss` — nilling `pendingAuthorization` is not proof of dismissal.

## Quick-row removal (§8)

Deleted across 5 files, including the `.animation(..., value: isAgentQuickRowVisible)` on `glassStyledInputCapsule` (a compile error if missed) and four stale doc comments. Kept: `.connections`, `agentMenu`, the `included` predicate, the outline icon set, `Dispatch` routing, `onConnectionsTap`, `usesAgentComposerLayout`. Voice button, group composer and menu registry unchanged. No QA yaml references the removed ids.

## Also in this PR

- Toggle on-state uses `.colorGreen`, matching the entitlement's "Active" badge and the capability approval toggle.
- The §2 outage rule is scoped to the browser's Connected section, per the spec's wording. The conversation info view keeps its shipped behavior; freezing its toggles would have been a regression dressed as caution.

## Testing

- **41 abilities tests** across `ConversationAbilitiesBrowserModeTests`, `AbilitiesBrowserSectioningTests`, `ConnectionsBrowserModeTests`, `ConversationAbilitiesViewModelTests`.
- **17 mutation checks**, each applied → its target test fails → restored → suite green. Includes the picker-cancel exit (no shipped `onDismiss` before this change) and the off-write path, which breaks **both** surfaces' pins when mutated — one writer, two surfaces, both pinned.
- Full `ConvosCore` suite: 1935 tests / 260 suites passed.
- `ConvosTests`: 416 passed. One failure, `ConversationViewModelDoneRevokeTests.testApproveAllTogglesOffDismissesSheetAndKeepsRequestPending`, is **pre-existing on `origin/dev`** — verified by stashing this branch and re-running against a clean tree.
- `swiftlint --strict`: 0 violations. `swiftformat --lint`: 0 files require formatting. `Convos (Dev)` simulator build: succeeded, **0 long-type-check warnings**.

## Not in scope

The composer focus-spin fix (`FocusCoordinator`, PR #1360) is not on `dev` and is untouched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789765343&installation_model_id=20076&pr_number=1365&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1365&signature=bd17451fae35868a0767129a971375c07245ed8c953d1b79eb073fbca8b297eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split the Connections browser into Connected and Discover sections for composer modal
> - Adds a `composerModal` mode to `AbilitiesListView` that renders a "Discover" section for unconnected abilities and per-conversation toggles instead of navigation links for connected abilities; app settings mode retains the existing layout.
> - Introduces `ConversationAbilitiesViewModel` hosted mode where the view model adopts a catalog from `AbilitiesListViewModel` rather than self-fetching, keeping both in sync without redundant network calls.
> - Adds auto-enable flow (`enableAfterConnect`) so abilities connected from the browser automatically enable per-conversation, showing a spinner until settled and handling multi-bundle selection.
> - Removes the agent composer quick-action row from `MessagesBottomBar`, `MessagesInputView`, and `AgentComposerBar`; connections are now accessible only via the `+` menu.
> - Introduces `AbilitiesAccountEpoch` to invalidate view-model snapshots after account wipes, preventing stale catalogs from rendering across account switches.
> - Risk: the trailing quick-action row is permanently removed from the agent composer, which is a breaking UI change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34084e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->