### PR TITLE
fix(transcript): stop an exactly sized cell fighting its own measurement

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/Messages Collection Layout/MessagesCollectionLayout.swift
+++ b/ConvosCore/Sources/ConvosComposer/Messages Collection Layout/MessagesCollectionLayout.swift
@@ -464,8 +464,20 @@ open class MessagesCollectionLayout: UICollectionViewLayout {
             return true
         }
 
+        // An exact size is the delegate's answer, and `itemSize(with:)` writes
+        // it over whatever the cell measured. Letting the cell's preferred
+        // height invalidate the layout as well pits the two against each other
+        // with no way to settle: the delegate's number is written back, the
+        // cell reports its own again, and the pass repeats until UIKit traps it
+        // as a recursive layout loop. The empty-state cell is exactly sized -
+        // its height is what a fresh conversation's sheet opens to - and its
+        // hosted content measures taller than the number the delegate fixes,
+        // so every empty conversation opened was one of these loops.
+        let isExactlySized = isExactlySized(preferredMessageAttributes.kind,
+                                            at: preferredAttributes.indexPath)
+
         let shouldInvalidateLayout = item.calculatedSize == nil
-        || (_supportSelfSizingInvalidation
+        || (_supportSelfSizingInvalidation && !isExactlySized
             ? (item.size.height - preferredMessageAttributes.size.height).rounded() != 0 : false)
         || item.alignment != preferredMessageAttributes.alignment
         || item.interItemSpacing != preferredMessageAttributes.interItemSpacing
@@ -1043,6 +1055,16 @@ extension MessagesCollectionLayout {
         case let .exact(size):
             return (estimated: size, exact: size)
         }
+    }
+
+    /// Whether the delegate fixes this item's size outright, rather than
+    /// offering an estimate for the cell to self-size away from.
+    private func isExactlySized(_ kind: ItemKind, at indexPath: IndexPath) -> Bool {
+        guard let delegate else { return false }
+        if case .exact = delegate.sizeForItem(self, of: kind, at: indexPath) {
+            return true
+        }
+        return false
     }
 
     private func itemSize(with preferredAttributes: MessagesLayoutAttributes) -> CGSize {

--- a/QAAutomationServer/QAAutomationServer.swift
+++ b/QAAutomationServer/QAAutomationServer.swift
@@ -178,7 +178,7 @@ enum ElementInfoBuilder {
 
         if depth < maxDepth {
             let childElements = element.children(matching: .any)
-            if !childElements.isEmpty && childElements.count < 50 {
+            if childElements.count > 0 && childElements.count < 50 {
                 children = (0..<childElements.count).compactMap { i in
                     let child = childElements.element(boundBy: i)
                     guard child.exists else { return nil }


### PR DESCRIPTION
Opening a conversation whose transcript is empty crashes on UIKit's "stuck in a recursive layout loop" trap. It reproduces on `dev` with no branch of mine involved: tap the only conversation in the list.

`UICollectionViewFeedbackLoopDebugger` reports the shape of it — over a hundred consecutive passes, each one invalidating item `(0-0)` for `PreferredAttributes` and each one producing **0 changes**:

```
For layout pass 84, tracked invalidation with index 0 had 0 change(s).
Reason: "PreferredAttributes"; invalidatedItems: ["(0-0)"].
```

Instrumenting `shouldInvalidateLayout` named the disagreement outright, identically on all 102 passes it logged:

```
kind=cell path=(0-0) state=beforeUpdate calcNil=false
heightDiffers=true (item=120.0 preferred=154.0)
alignDiffers=false spacingDiffers=false
```

The empty-state cell is sized `.exact` by the layout delegate — its height is what a fresh conversation's sheet opens to, so an estimate would let that wander — and `itemSize(with:)` writes an exact size over whatever the cell measured. `shouldInvalidateLayout` then compared that written 120 against the 154 the hosted cell self-sizes to. Neither side could yield: the comparison invalidated the layout, the invalidation wrote the delegate's number back, and the next pass compared the same two values again, until UIKit capped it.

So an exact size is now taken as the delegate's answer: an exactly sized item's measured height no longer drives invalidation. Alignment and inter-item spacing still do, and estimated items are untouched — they are the ones self-sizing exists for.

This is a third pass at this crash after #1350 and #1354. Those latched `shortContentTopSlack` so a layout pass could not move the inset under itself, which was a real cycle and remains fixed; this is a different one, in the item-size comparison, and it survived both because it needs no inset movement at all.

Verified against the same conversation and the same tap, driven through `QAAutomationServer` rather than by hand: before, the trap and 102 identical invalidation logs; after, no trap, the conversation opens, and the `No comments yet` cell renders.

The second commit repairs that harness, which no longer compiled (`XCUIElementQuery` has no `isEmpty`) and so could not be run at all. Happy to split it out if you would rather keep this to one file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789767787&installation_model_id=20076&pr_number=1366&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1366&signature=4b192a2c86f3ebc896bb7baf9294a58039e055ac619dba5af0e4afd215423d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop exactly-sized transcript cells from invalidating their own layout
> Cells whose delegate-provided size is `.exact` were triggering self-sizing feedback loops: the layout would invalidate in response to the cell's preferred size, which conflicted with the fixed size already provided.
>
> - Adds a private helper `isExactlySized(kind:at:)` in [MessagesCollectionLayout.swift](https://github.com/xmtplabs/convos-ios/pull/1366/files#diff-f18adf6cfb7a8c869b88c780dd709ed0ab8392753867eebcfd5c91a82abfeda9) that queries the delegate for the item's size kind.
> - `shouldInvalidateLayout(forPreferredLayoutAttributes:withOriginalAttributes:)` now skips self-sizing invalidation when the item is exactly sized, even if `supportSelfSizingInvalidation` is enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7eff54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->