### PR TITLE
Send an unfinished OAuth back to Discover, on a fresh link

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -71,7 +71,13 @@ struct AbilitiesListScreen: View {
     /// revision it commits (so the lifecycle behind a toggle always comes
     /// from the snapshot that sectioned the row) and every entitlement it
     /// activates (so a connect from Discover enables the ability here).
-    /// Both directions capture weakly; `@State` owns the strong halves.
+    ///
+    /// The two edges capture with deliberately different strengths. The
+    /// forward edge (`wireActivation`) holds the per-chat view model
+    /// **strongly**, so a connect already in flight still writes its grant
+    /// after the modal is dismissed. The reverse edge wired here - the
+    /// recovery route back into the list view model - captures **weakly**,
+    /// which is what stops the pair from retaining each other.
     private static func makeConversationViewModel(
         _ listViewModel: AbilitiesListViewModel,
         selection: AbilitiesSelection,
@@ -152,8 +158,9 @@ struct AbilitiesListScreen: View {
 ///   stays app-wide, in App Settings).
 ///
 /// Section membership is identical in both modes and comes from the
-/// catalog alone; the mode drives the second header string and the
-/// Connected row's accessory.
+/// catalog alone (`AbilitiesListViewModel.section(for:)`, which is where
+/// the status-to-section mapping is spelled out); the mode drives the
+/// second header string and the Connected row's accessory.
 ///
 /// A conversation toggle that needs an entitlement no longer deep-links
 /// here: it presents the scoped `AbilityConnectSheet` instead, which reuses
@@ -513,11 +520,12 @@ struct AbilitiesListView: View {
         let disconnectAction = { viewModel.disconnect(ability) }
         return Menu {
             switch status {
-            case .pendingAuth:
-                Button("Continue connecting", action: continueAction)
             case .expired, .needsReauth, .revoked:
                 Button("Reconnect", action: continueAction)
-            case .active:
+            case .active, .pendingAuth:
+                // `pendingAuth` never reaches this menu: an unfinished
+                // authorization is a Discover row with a Connect button,
+                // not a Connected row with a repair entry.
                 EmptyView()
             }
             Button("Disconnect", role: .destructive, action: disconnectAction)

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -221,10 +221,14 @@ final class AbilitiesListViewModel {
     /// Starts the entitlement, or restarts it for every state that can
     /// reach this method with one already on file (`pendingAuth` from a
     /// Discover row, `expired` / `needsReauth` / `revoked` from a Connected
-    /// row's Reconnect). Restarting is not a resume: the service mints a
-    /// fresh provider link session each time, because the one a previous
-    /// attempt handed out has its own expiry and re-serving it is what
-    /// walks the member into "this link has expired".
+    /// row's Reconnect).
+    ///
+    /// A restart never re-serves the previous consent URL -- that link
+    /// session has its own expiry, and re-opening it is what walks the
+    /// member into "this link has expired". The service does try to finish
+    /// the outstanding round first, silently, which is why a connect tap on
+    /// a row whose authorization already went through upstream comes straight
+    /// back as active with no sign-in at all.
     ///
     /// A `pendingAuth` initiation with a redirect URL opens the
     /// authorization step: the injected browser authorizer when one is
@@ -314,10 +318,10 @@ final class AbilitiesListViewModel {
     /// the stub sheet, then the same complete/cancel lifecycle runs. On any
     /// failure the entitlement stays `pendingAuth` server-side, so a
     /// refresh returns the row to Discover offering Connect; only non-cancel
-    /// failures surface a message. That Connect opens a new round against a
-    /// new link session -- the abandoned one is not resumable, and initiate
-    /// answers `active` outright if the round it restarts turned out to
-    /// have completed upstream.
+    /// failures surface a message. That Connect first re-submits the round
+    /// already outstanding -- which resolves it outright if the provider
+    /// finished in the meantime -- and only otherwise opens a new one
+    /// against a new link session.
     private func runBrowserAuthorization(
         for ability: AbilitiesAPI.Ability,
         redirectUrl: String,
@@ -353,8 +357,10 @@ final class AbilitiesListViewModel {
     /// connection-request id, which the service keeps across
     /// `auth_incomplete` failures. If it still isn't active after the
     /// budget, the final error surfaces its retry copy and the row returns
-    /// to Discover -- where Connect re-runs initiate, which reports the
-    /// connection active by then and needs no second sign-in.
+    /// to Discover -- where Connect re-submits this same id before minting
+    /// anything, so a connection that finished INITIALIZING in the meantime
+    /// lands with no second sign-in. Nothing else would ever complete it:
+    /// the provider sends no webhook.
     private func completeRetryingAuthIncomplete(abilityId: String) async throws {
         let retryDelays: [Duration] = [.seconds(1), .seconds(2)]
         for delay in retryDelays {

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -101,24 +101,73 @@ final class AbilitiesListViewModel {
             && !availableAbilities.isEmpty
     }
 
-    /// Abilities the caller holds an entitlement for, in any lifecycle
-    /// state. Under `entitlementsUnavailable` this reflects last-known
-    /// state, already resolved by the service.
+    /// Abilities the caller holds a usable account connection for: the
+    /// OAuth round finished and left an entitlement the agent can act on,
+    /// however that entitlement has aged since. Under
+    /// `entitlementsUnavailable` this reflects last-known state, already
+    /// resolved by the service.
     var entitledAbilities: [AbilitiesAPI.Ability] {
-        filteredAbilities.filter { $0.entitlement != nil }
+        filteredAbilities.filter { Self.section(for: $0) == .connected }
     }
 
-    /// Abilities the caller is authoritatively not entitled to and can
-    /// connect. Unknown states are deliberately excluded: an outage with
-    /// no last-known state must never render as "Available".
+    /// Abilities the caller can connect: no entitlement at all, or one
+    /// still waiting on an authorization that never completed. Unknown
+    /// states are deliberately excluded - an outage with no last-known
+    /// state must never render as connectable.
     var availableAbilities: [AbilitiesAPI.Ability] {
-        filteredAbilities.filter { $0.entitlementState == .notEntitled }
+        filteredAbilities.filter { Self.section(for: $0) == .discover }
     }
 
     /// Abilities whose entitlement state could not be determined (outage
     /// with no last-known state). Rendered without connect controls.
     var unknownStateAbilities: [AbilitiesAPI.Ability] {
-        filteredAbilities.filter { $0.entitlementState == .unknown }
+        filteredAbilities.filter { Self.section(for: $0) == .statusUnknown }
+    }
+
+    /// Which of the browser's three sections an ability belongs in. Both
+    /// modes share the mapping; only headers and row accessories differ.
+    enum BrowserSection: Hashable {
+        /// "Connected" in both modes.
+        case connected
+        /// "All connections" in app settings, "Discover" in the chat-scoped
+        /// browser. Carries the Connect affordance in both.
+        case discover
+        /// "Status unknown": browsable, no controls.
+        case statusUnknown
+    }
+
+    /// Section membership as one total function of entitlement state, so a
+    /// status added to the wire contract has to be classified here rather
+    /// than inheriting a default.
+    ///
+    /// `pendingAuth` is the entry that does not read the way its wire shape
+    /// suggests. The backend writes it when authorization is *initiated*,
+    /// not when it is being processed, so an OAuth the member abandoned at
+    /// the provider's sign-in page leaves exactly the same record as one
+    /// still on screen. Filing it under Connected therefore advertised
+    /// accounts that were never linked, with a repair route that could only
+    /// re-offer the dead consent link. It belongs in Discover, where
+    /// Connect opens a fresh round - the only action that can actually
+    /// finish the job.
+    ///
+    /// Everything else that is entitled stays Connected: `expired`,
+    /// `needsReauth` and `revoked` all describe a connection that did exist
+    /// and can be repaired in place, and the badge beside them is what
+    /// tells the member what to fix.
+    static func section(for ability: AbilitiesAPI.Ability) -> BrowserSection {
+        switch ability.entitlementState {
+        case .notEntitled:
+            return .discover
+        case .unknown:
+            return .statusUnknown
+        case .entitled(let entitlement):
+            switch entitlement.status {
+            case .pendingAuth:
+                return .discover
+            case .active, .expired, .needsReauth, .revoked:
+                return .connected
+            }
+        }
     }
 
     var hasVisibleAbilities: Bool {
@@ -169,9 +218,16 @@ final class AbilitiesListViewModel {
         errorMessage = nil
     }
 
-    /// Starts (or restarts, for expired/needs-reauth/revoked states) the
-    /// entitlement. A `pendingAuth` initiation with a redirect URL opens
-    /// the authorization step: the injected browser authorizer when one is
+    /// Starts the entitlement, or restarts it for every state that can
+    /// reach this method with one already on file (`pendingAuth` from a
+    /// Discover row, `expired` / `needsReauth` / `revoked` from a Connected
+    /// row's Reconnect). Restarting is not a resume: the service mints a
+    /// fresh provider link session each time, because the one a previous
+    /// attempt handed out has its own expiry and re-serving it is what
+    /// walks the member into "this link has expired".
+    ///
+    /// A `pendingAuth` initiation with a redirect URL opens the
+    /// authorization step: the injected browser authorizer when one is
     /// present (live transport), the stub sheet otherwise. Either way,
     /// completion only ever runs after the user approved it, mirroring the
     /// browser-callback boundary.
@@ -182,11 +238,10 @@ final class AbilitiesListViewModel {
         Task {
             do {
                 let initiation = try await service.beginEntitlement(abilityId: ability.id)
-                // Cosmetic mid-flow refresh (the row shows Continue and
-                // Disconnect behind the authorization surface). It must
-                // never gate the authorization step: begin has already
-                // opened a backend OAuth round, and failing here would
-                // strand it behind an error message.
+                // Cosmetic mid-flow refresh, behind the authorization
+                // surface. It must never gate the authorization step: begin
+                // has already opened a backend OAuth round, and failing here
+                // would strand it behind an error message.
                 await refreshCatalogQuietly()
                 if initiation.status == .pendingAuth {
                     // A pending entitlement with no redirect URL is a
@@ -258,11 +313,11 @@ final class AbilitiesListViewModel {
     /// Live-transport authorization: `ASWebAuthenticationSession` replaces
     /// the stub sheet, then the same complete/cancel lifecycle runs. On any
     /// failure the entitlement stays `pendingAuth` server-side, so a
-    /// refresh leaves the row offering Continue and Disconnect; only
-    /// non-cancel failures surface a message. Continue then resumes the
-    /// same attempt: the service re-serves the retained consent URL and
-    /// completion echoes the retained connection-request id -- it never
-    /// mints a new backend connection request.
+    /// refresh returns the row to Discover offering Connect; only non-cancel
+    /// failures surface a message. That Connect opens a new round against a
+    /// new link session -- the abandoned one is not resumable, and initiate
+    /// answers `active` outright if the round it restarts turned out to
+    /// have completed upstream.
     private func runBrowserAuthorization(
         for ability: AbilitiesAPI.Ability,
         redirectUrl: String,
@@ -297,8 +352,9 @@ final class AbilitiesListViewModel {
     /// (still INITIALIZING); each retry re-submits the same retained
     /// connection-request id, which the service keeps across
     /// `auth_incomplete` failures. If it still isn't active after the
-    /// budget, the final error surfaces its retry copy and the pending row
-    /// offers Continue -- which resumes this same attempt.
+    /// budget, the final error surfaces its retry copy and the row returns
+    /// to Discover -- where Connect re-runs initiate, which reports the
+    /// connection active by then and needs no second sign-in.
     private func completeRetryingAuthIncomplete(abilityId: String) async throws {
         let retryDelays: [Duration] = [.seconds(1), .seconds(2)]
         for delay in retryDelays {
@@ -348,9 +404,9 @@ final class AbilitiesListViewModel {
 
     /// Runs on every dismissal of the authorization sheet. Unless
     /// approval already took over, the entitlement stays `pendingAuth`
-    /// server-side, so refresh: the row then offers Continue (re-runs
-    /// `connect`, begin is idempotent) and Disconnect (revokes the pending
-    /// entitlement) instead of a stale Connect.
+    /// server-side, so refresh: the row settles back into Discover with a
+    /// live Connect (begin is idempotent) rather than sitting under
+    /// Connected claiming an account the member never finished linking.
     ///
     /// This is also the second half of the activation latch: an activation
     /// confirmed while the sheet was still on screen is released here, so

--- a/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesEndpointsAPI.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/AbilitiesEndpointsAPI.swift
@@ -78,13 +78,20 @@ extension AbilitiesAPI {
 
     /// `POST /v2/abilities/{abilityId}/entitlement` response. OAuth
     /// abilities answer `pending_auth` with the provider consent URL and the
-    /// connection-request id to echo back to complete; auth-less abilities
-    /// answer `active` with both auth fields null.
+    /// connection-request id to echo back to complete.
     ///
-    /// Strict per the schema: `status` accepts only the two values the
-    /// contract allows, and both auth fields are required-nullable -- the
-    /// key must be present, its value may be null. Encoding reproduces the
-    /// explicit nulls.
+    /// `active` comes back in two shapes, and both are legal. An auth-less
+    /// ability short-circuits with both auth fields null. An OAuth ability
+    /// whose entitlement row is already active answers `active` while still
+    /// carrying the auth fields of the request the endpoint minted on the
+    /// way through -- it links unconditionally before consulting the row.
+    /// Those fields describe a round the caller has no reason to run, so
+    /// they are decoded and ignored rather than rejected: refusing them
+    /// makes the client throw on a connection that genuinely works.
+    ///
+    /// `status` still accepts only the two values the contract allows, and
+    /// both auth fields stay required-nullable -- the key must be present,
+    /// its value may be null. Encoding reproduces the explicit nulls.
     public struct EntitlementInitiationResponse: Codable, Sendable, Hashable {
         public let status: EntitlementStatus
         public let redirectUrl: String?
@@ -115,10 +122,11 @@ extension AbilitiesAPI {
             self.connectionRequestId = connectionRequestId
         }
 
-        /// Shared by decoding and programmatic construction so the type is
-        /// strict in both directions: `pending_auth` carries both auth
-        /// fields, `active` carries neither, and no other status exists in
-        /// the initiation contract.
+        /// Shared by decoding and programmatic construction, and strict only
+        /// where the contract is: `pending_auth` is unusable without both
+        /// auth fields, so it still requires them, and no status outside the
+        /// initiation contract is accepted. `active` is deliberately not
+        /// constrained -- see the type's note on its two legal shapes.
         private static func validate(status: EntitlementStatus, redirectUrl: String?, connectionRequestId: String?) throws {
             switch status {
             case .pendingAuth:
@@ -126,9 +134,7 @@ extension AbilitiesAPI {
                     throw WireValidationError.incoherentEntitlementState
                 }
             case .active:
-                guard redirectUrl == nil, connectionRequestId == nil else {
-                    throw WireValidationError.incoherentEntitlementState
-                }
+                break
             default:
                 throw WireValidationError.incoherentEntitlementState
             }

--- a/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
@@ -42,18 +42,20 @@ extension LiveAbilitiesServiceError: LocalizedError {
 ///   disk cache is bypassed entirely -- an accountless catalog is never
 ///   persisted over an account-scoped one.
 /// - the per-ability OAuth attempt from `beginEntitlement`: the connection
-///   request id `completeEntitlement` must echo. Kept on `auth_incomplete`
-///   so the bounded completion retry re-submits the same id, dropped on any
-///   other completion failure. It is process-local by design: not a bearer
-///   credential, and a restart mid-auth recovers by re-running begin.
+///   request id `completeEntitlement` must echo. Kept across
+///   `auth_incomplete` and dropped on any other completion failure, so the
+///   next connect tap can re-submit it before minting anything -- the only
+///   way a round that went ACTIVE after the retry budget expired ever
+///   reaches the entitlement row, since no provider webhook exists. It is
+///   process-local by design: not a bearer credential, and a restart
+///   mid-auth recovers by re-running begin.
 ///
-/// The consent URL a begin returns is deliberately **not** retained. It
-/// belongs to one provider link session, which expires on its own clock;
-/// re-serving a stored one on a later connect tap is how a member reaches
-/// a provider page reading "link session has expired" with no way forward.
-/// Every begin therefore mints a fresh session against the idempotent
-/// initiate endpoint, which answers `active` outright when the round it is
-/// restarting already completed upstream.
+/// The consent URL that comes back with it is deliberately **not** retained.
+/// It belongs to one provider link session, which expires on its own clock;
+/// re-serving a stored one on a later connect tap is how a member reaches a
+/// provider page reading "link session has expired" with no way forward. The
+/// id and the URL age differently, so they get separate policies: re-submit
+/// the id, re-mint the URL.
 ///
 /// Begins and completes are deduplicated per ability with in-flight task
 /// maps: actor reentrancy would otherwise let overlapping begins overwrite
@@ -180,17 +182,26 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         }
     }
 
-    /// Opens an OAuth round for an ability, always against a freshly minted
-    /// provider link session.
+    /// Finishes the outstanding round for an ability if there is one, and
+    /// otherwise opens a new one against a freshly minted link session.
     ///
     /// Every entry point that can reach a `pendingAuth` ability funnels
     /// here -- the browser's Connect button, the conversation toggle's
-    /// repair route, the inline connect sheet -- and each of them is a tap
-    /// that may land minutes or hours after the round it is retrying. A
-    /// consent URL does not survive that wait, so none is carried over:
-    /// initiate is idempotent per (account, ability), so restarting costs
-    /// one request and answers `active` outright when the previous round
-    /// completed upstream in the meantime.
+    /// repair route, the inline connect sheet -- and each is a tap that may
+    /// land minutes or hours after the round it is retrying. The two pieces
+    /// of that round age very differently, which is why they get opposite
+    /// policies:
+    ///
+    /// - The **consent URL** is dead. It belongs to one provider link
+    ///   session with its own expiry, so it is never stored and never
+    ///   re-served; a restart always mints a new one.
+    /// - The **connection-request id** may well have gone ACTIVE upstream
+    ///   in the meantime. Nothing else in the system would notice: there is
+    ///   no provider webhook, and the entitlement row flips only on a
+    ///   complete this client submits. So the id is retained and re-submitted
+    ///   first. When it lands, the round finishes with no sign-in at all.
+    ///
+    /// Only when that fails (or there is no id) does a fresh round start.
     ///
     /// Concurrent begins for the same ability still share one request --
     /// that is tap-storm deduplication within a single round, not a
@@ -202,15 +213,20 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         // account's attempts before a new one can be minted under them.
         let scope = await myInboxIdProvider?()
         prepareLastKnownCatalog(for: scope)
+        // Finish before restarting. A round whose completion ran out of
+        // retry budget is very often ACTIVE upstream by now, and nothing
+        // else will ever notice: there is no provider webhook, and the
+        // entitlement row only flips on a complete this client submits.
+        // Re-submitting the retained id is cheap, silent, and the only path
+        // that finishes such a round without a second sign-in.
+        if pendingAttempts[abilityId] != nil, let resumed = await completeRetainedAttempt(abilityId: abilityId) {
+            return resumed
+        }
         let epoch = scopeEpoch
         let inFlightKey = attemptKey(abilityId: abilityId, epoch: epoch)
         if let inFlight = inFlightBegins[inFlightKey] {
             return try await inFlight.value
         }
-        // The round being restarted is over as far as this client is
-        // concerned: drop its id now, so a begin that fails on the network
-        // cannot leave a completion able to echo a superseded request.
-        pendingAttempts[abilityId] = nil
         let task = Task { () throws -> AbilityEntitlementInitiation in
             do {
                 let response = try await apiClient.createAbilityEntitlement(abilityId: abilityId, redirectUri: redirectUri)
@@ -219,8 +235,19 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
                 // anywhere after entry (including during the identity
                 // resolution above), the attempt belongs to the previous
                 // identity and must not be retained.
-                if let connectionRequestId = response.connectionRequestId, scopeEpoch == epoch, wipeCount == wipeMark {
+                // Only `pending_auth` leaves a round outstanding. An OAuth
+                // ability whose row is already active answers `active` while
+                // still carrying the request this call minted on the way
+                // through; retaining that id would schedule a completion for
+                // a round nobody is going to authorize.
+                if response.status == .pendingAuth, let connectionRequestId = response.connectionRequestId,
+                   scopeEpoch == epoch, wipeCount == wipeMark {
                     pendingAttempts[abilityId] = PendingAttempt(connectionRequestId: connectionRequestId)
+                }
+                guard response.status == .pendingAuth else {
+                    // Same reason the id is dropped: there is nothing here
+                    // for the caller to authorize, so no URL is handed up.
+                    return AbilityEntitlementInitiation(status: response.status)
                 }
                 return AbilityEntitlementInitiation(status: response.status, redirectUrl: response.redirectUrl)
             } catch {
@@ -230,6 +257,25 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         inFlightBegins[inFlightKey] = task
         defer { inFlightBegins[inFlightKey] = nil }
         return try await task.value
+    }
+
+    /// Tries to finish the retained round before a restart mints a new one.
+    /// Returns the activation when the round completed, nil when the caller
+    /// should go on and mint.
+    ///
+    /// It routes through `completeEntitlement` rather than the client
+    /// directly so the retained id keeps exactly one lifecycle: duplicate
+    /// completes join the in-flight one, `auth_incomplete` keeps the id for
+    /// the next attempt, and any other failure drops it. That is also why
+    /// nothing is cleared here on the way out -- an id that survives a
+    /// failure is the recovery path, not debris.
+    private func completeRetainedAttempt(abilityId: String) async -> AbilityEntitlementInitiation? {
+        do {
+            try await completeEntitlement(abilityId: abilityId)
+            return AbilityEntitlementInitiation(status: .active)
+        } catch {
+            return nil
+        }
     }
 
     public func completeEntitlement(abilityId: String) async throws {
@@ -249,7 +295,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
                     abilityId: abilityId,
                     connectionRequestId: attempt.connectionRequestId
                 )
-                removeAttempt(abilityId: abilityId, epoch: epoch)
+                removeAttempt(abilityId: abilityId, epoch: epoch, connectionRequestId: attempt.connectionRequestId)
             } catch let error as AbilitiesAPI.EndpointError where error.isAuthIncomplete {
                 // Retained on purpose: auth_incomplete is retryable against
                 // the same connection request (ownership is verified by id
@@ -263,7 +309,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
                 // fault after which the request state is unknown): retrying
                 // the same id cannot be trusted to converge, so the next
                 // connect re-begins. Begin is idempotent server-side.
-                removeAttempt(abilityId: abilityId, epoch: epoch)
+                removeAttempt(abilityId: abilityId, epoch: epoch, connectionRequestId: attempt.connectionRequestId)
                 throw mapServiceError(error, abilityId: abilityId)
             }
         }
@@ -279,7 +325,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         } catch {
             throw mapServiceError(error, abilityId: abilityId)
         }
-        removeAttempt(abilityId: abilityId, epoch: epoch)
+        discardAttempt(abilityId: abilityId, epoch: epoch)
     }
 
     public func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
@@ -401,11 +447,27 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         "\(epoch):\(abilityId)"
     }
 
-    /// Drops a retained attempt only if it still belongs to the epoch that
-    /// created it; after a scope change the same ability id may already
-    /// carry the new account's attempt.
-    private func removeAttempt(abilityId: String, epoch: UInt64) {
+    /// Drops whatever round is retained for the ability, whichever one it
+    /// is. Only for revoke, which invalidates every outstanding round for
+    /// the entitlement rather than concluding a particular one.
+    private func discardAttempt(abilityId: String, epoch: UInt64) {
         guard scopeEpoch == epoch else { return }
+        pendingAttempts.removeValue(forKey: abilityId)
+    }
+
+    /// Drops a retained attempt only if it is still the one the caller was
+    /// working on: same epoch, same connection-request id.
+    ///
+    /// `pendingAttempts` is keyed by ability id alone, so a completion that
+    /// outlives the surface that started it (the composer modal's connect
+    /// deliberately survives dismissal) would otherwise delete an attempt a
+    /// later begin had already stored in its place. The next completion then
+    /// throws `missingConnectionRequest` -- "sign-in session expired" right
+    /// after a successful sign-in. The epoch alone cannot catch it: both
+    /// rounds belong to the same account.
+    private func removeAttempt(abilityId: String, epoch: UInt64, connectionRequestId: String) {
+        guard scopeEpoch == epoch else { return }
+        guard pendingAttempts[abilityId]?.connectionRequestId == connectionRequestId else { return }
         pendingAttempts.removeValue(forKey: abilityId)
     }
 

--- a/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
@@ -41,15 +41,19 @@ extension LiveAbilitiesServiceError: LocalizedError {
 ///   With no resolvable scope (device-only caller, or no provider) the
 ///   disk cache is bypassed entirely -- an accountless catalog is never
 ///   persisted over an account-scoped one.
-/// - the per-ability OAuth attempt from `beginEntitlement` (connection
-///   request id + consent URL). While an attempt is retained, begin
-///   short-circuits to it instead of minting a new backend connection
-///   request, so "Continue connecting" resumes the same attempt;
-///   `completeEntitlement` echoes the retained id, keeps it on
-///   `auth_incomplete` (same-id retry), and drops it on any other
-///   completion failure so the next connect re-begins. It is
-///   process-local by design: not a bearer credential, and a restart
-///   mid-auth recovers by re-running begin.
+/// - the per-ability OAuth attempt from `beginEntitlement`: the connection
+///   request id `completeEntitlement` must echo. Kept on `auth_incomplete`
+///   so the bounded completion retry re-submits the same id, dropped on any
+///   other completion failure. It is process-local by design: not a bearer
+///   credential, and a restart mid-auth recovers by re-running begin.
+///
+/// The consent URL a begin returns is deliberately **not** retained. It
+/// belongs to one provider link session, which expires on its own clock;
+/// re-serving a stored one on a later connect tap is how a member reaches
+/// a provider page reading "link session has expired" with no way forward.
+/// Every begin therefore mints a fresh session against the idempotent
+/// initiate endpoint, which answers `active` outright when the round it is
+/// restarting already completed upstream.
 ///
 /// Begins and completes are deduplicated per ability with in-flight task
 /// maps: actor reentrancy would otherwise let overlapping begins overwrite
@@ -77,11 +81,11 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
     private let isShimEnabled: @Sendable () -> Bool
 
     /// One OAuth round in flight for an ability: the Composio connection
-    /// request id `completeEntitlement` must echo, plus the consent URL a
-    /// resumed begin re-serves.
+    /// request id `completeEntitlement` must echo. The round's consent URL
+    /// is not a field here on purpose -- a URL that is never stored is a
+    /// URL that cannot be replayed after its link session expired.
     private struct PendingAttempt {
         let connectionRequestId: String
-        let redirectUrl: String?
     }
 
     private var lastKnownCatalog: AbilitiesCatalog?
@@ -176,25 +180,37 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
         }
     }
 
+    /// Opens an OAuth round for an ability, always against a freshly minted
+    /// provider link session.
+    ///
+    /// Every entry point that can reach a `pendingAuth` ability funnels
+    /// here -- the browser's Connect button, the conversation toggle's
+    /// repair route, the inline connect sheet -- and each of them is a tap
+    /// that may land minutes or hours after the round it is retrying. A
+    /// consent URL does not survive that wait, so none is carried over:
+    /// initiate is idempotent per (account, ability), so restarting costs
+    /// one request and answers `active` outright when the previous round
+    /// completed upstream in the meantime.
+    ///
+    /// Concurrent begins for the same ability still share one request --
+    /// that is tap-storm deduplication within a single round, not a
+    /// resumption across rounds.
     public func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
         let wipeMark = wipeCount
         // Resolve the scope first so an account switch is detected here
         // too, not only on catalog fetches: the switch clears the previous
-        // account's attempts before the resume check below can serve one.
+        // account's attempts before a new one can be minted under them.
         let scope = await myInboxIdProvider?()
         prepareLastKnownCatalog(for: scope)
-        // Resume before re-begin: a retained attempt means an OAuth round
-        // is already open for this ability, and re-serving its consent URL
-        // keeps "Continue connecting" on the same backend connection
-        // request instead of minting a new one.
-        if let attempt = pendingAttempts[abilityId] {
-            return AbilityEntitlementInitiation(status: .pendingAuth, redirectUrl: attempt.redirectUrl)
-        }
         let epoch = scopeEpoch
         let inFlightKey = attemptKey(abilityId: abilityId, epoch: epoch)
         if let inFlight = inFlightBegins[inFlightKey] {
             return try await inFlight.value
         }
+        // The round being restarted is over as far as this client is
+        // concerned: drop its id now, so a begin that fails on the network
+        // cannot leave a completion able to echo a superseded request.
+        pendingAttempts[abilityId] = nil
         let task = Task { () throws -> AbilityEntitlementInitiation in
             do {
                 let response = try await apiClient.createAbilityEntitlement(abilityId: abilityId, redirectUri: redirectUri)
@@ -204,10 +220,7 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
                 // resolution above), the attempt belongs to the previous
                 // identity and must not be retained.
                 if let connectionRequestId = response.connectionRequestId, scopeEpoch == epoch, wipeCount == wipeMark {
-                    pendingAttempts[abilityId] = PendingAttempt(
-                        connectionRequestId: connectionRequestId,
-                        redirectUrl: response.redirectUrl
-                    )
+                    pendingAttempts[abilityId] = PendingAttempt(connectionRequestId: connectionRequestId)
                 }
                 return AbilityEntitlementInitiation(status: response.status, redirectUrl: response.redirectUrl)
             } catch {
@@ -240,8 +253,9 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
             } catch let error as AbilitiesAPI.EndpointError where error.isAuthIncomplete {
                 // Retained on purpose: auth_incomplete is retryable against
                 // the same connection request (ownership is verified by id
-                // server-side), so both an immediate retry and a later
-                // "Continue connecting" resume this attempt.
+                // server-side), which is what the bounded completion retry
+                // re-submits. A later connect tap is a different matter --
+                // it mints its own round and its own id.
                 throw error
             } catch {
                 // Any other completion failure invalidates the attempt

--- a/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
+++ b/ConvosCore/Sources/ConvosCore/Abilities/LiveAbilitiesService.swift
@@ -458,13 +458,18 @@ public actor LiveAbilitiesService: AbilitiesServiceProtocol {
     /// Drops a retained attempt only if it is still the one the caller was
     /// working on: same epoch, same connection-request id.
     ///
-    /// `pendingAttempts` is keyed by ability id alone, so a completion that
-    /// outlives the surface that started it (the composer modal's connect
-    /// deliberately survives dismissal) would otherwise delete an attempt a
-    /// later begin had already stored in its place. The next completion then
-    /// throws `missingConnectionRequest` -- "sign-in session expired" right
-    /// after a successful sign-in. The epoch alone cannot catch it: both
-    /// rounds belong to the same account.
+    /// The id comparison is load-bearing, not belt-and-braces. `pendingAttempts`
+    /// is keyed by ability id alone, and `beginEntitlement`'s resume-first pass
+    /// closes only the *begin after a complete* ordering. The reverse ordering
+    /// stays open: a begin gets past its resume pass while round A is still
+    /// retained, and is on the network minting round B when A's authorization
+    /// finally returns. That completion captured A before B was stored, so it
+    /// joins nothing and sees nothing -- and on success calls in here to
+    /// conclude A while B is what `pendingAttempts` now holds. Without the id
+    /// check it deletes B, and the second authorization dies on
+    /// `missingConnectionRequest`: "sign-in session expired" right after a
+    /// successful sign-in. The epoch cannot catch it -- both rounds belong to
+    /// the same account.
     private func removeAttempt(abilityId: String, epoch: UInt64, connectionRequestId: String) {
         guard scopeEpoch == epoch else { return }
         guard pendingAttempts[abilityId]?.connectionRequestId == connectionRequestId else { return }

--- a/ConvosCore/Tests/ConvosCoreTests/AbilitiesEndpointsContractTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/AbilitiesEndpointsContractTests.swift
@@ -68,16 +68,11 @@ struct AbilitiesEndpointsContractTests {
         }
     }
 
-    @Test("Initiation rejects incoherent status/auth-field combinations")
+    @Test("Initiation rejects a pending_auth with nothing to authorize")
     func initiationRejectsIncoherentShapes() {
         #expect(throws: (any Error).self) {
             _ = try decode(AbilitiesAPI.EntitlementInitiationResponse.self, """
             { "status": "pending_auth", "redirectUrl": null, "connectionRequestId": null }
-            """)
-        }
-        #expect(throws: (any Error).self) {
-            _ = try decode(AbilitiesAPI.EntitlementInitiationResponse.self, """
-            { "status": "active", "redirectUrl": "https://x.example", "connectionRequestId": "creq_1" }
             """)
         }
         #expect(throws: AbilitiesAPI.WireValidationError.incoherentEntitlementState) {
@@ -86,6 +81,26 @@ struct AbilitiesEndpointsContractTests {
         #expect(throws: AbilitiesAPI.WireValidationError.incoherentEntitlementState) {
             _ = try AbilitiesAPI.EntitlementInitiationResponse(status: .pendingAuth)
         }
+    }
+
+    /// `active` has two legal shapes, both from the same endpoint: the
+    /// auth-less short-circuit carries null auth fields, and an OAuth
+    /// ability whose row is already active carries the fields of the request
+    /// the endpoint minted before it consulted the row. Rejecting the second
+    /// makes the client throw on a connection that works.
+    @Test("Initiation accepts an active carrying the auth fields of an unused request")
+    func initiationAcceptsActiveWithAuthFields() throws {
+        let decoded = try decode(AbilitiesAPI.EntitlementInitiationResponse.self, """
+        { "status": "active", "redirectUrl": "https://x.example", "connectionRequestId": "creq_1" }
+        """)
+        #expect(decoded.status == .active)
+        #expect(decoded.redirectUrl == "https://x.example")
+        #expect(decoded.connectionRequestId == "creq_1")
+
+        let authLess = try decode(AbilitiesAPI.EntitlementInitiationResponse.self, """
+        { "status": "active", "redirectUrl": null, "connectionRequestId": null }
+        """)
+        #expect(authLess.redirectUrl == nil)
     }
 
     @Test("Complete response rejects every non-active status (const)")

--- a/ConvosCore/Tests/ConvosCoreTests/LiveAbilitiesServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LiveAbilitiesServiceTests.swift
@@ -64,6 +64,29 @@ private final class AbilitiesStubAPIClient: TestStubAPIClient, @unchecked Sendab
 
 /// Mutable identity for tests that switch accounts mid-run. Reads and
 /// writes are sequenced by the test body itself.
+/// A one-shot gate a stubbed endpoint can park on, so a test can hold one
+/// request open while it drives another.
+private actor TestGate {
+    private var isOpen: Bool = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let resumed = waiters
+        waiters = []
+        for continuation in resumed {
+            continuation.resume()
+        }
+    }
+}
+
 private final class ScopeBox: @unchecked Sendable {
     var inboxId: String?
 
@@ -246,12 +269,14 @@ struct LiveAbilitiesServiceTests {
     }
 
     /// The reported dead end: an OAuth the member walked away from leaves a
-    /// `pendingAuth` entitlement whose consent URL expires on the
-    /// provider's clock. Re-serving that URL on the next connect tap lands
-    /// them on "link session has expired" with nothing to do about it, so
-    /// begin mints a new link session every time and completion echoes the
-    /// new round's id.
-    @Test("A later connect tap mints a fresh link session, never the stale one")
+    /// `pendingAuth` entitlement whose consent URL expires on the provider's
+    /// clock. Re-serving that URL on the next connect tap lands them on
+    /// "link session has expired" with nothing to do about it, so a restart
+    /// always mints a new link session.
+    ///
+    /// Here the retained round is genuinely dead (completion is rejected
+    /// outright), which is the branch that has to fall through to a mint.
+    @Test("A later connect tap on a dead round mints a fresh link session")
     func laterConnectMintsAFreshSession() async throws {
         let client = AbilitiesStubAPIClient()
         client.onCreateEntitlement = { _, _ in
@@ -261,13 +286,14 @@ struct LiveAbilitiesServiceTests {
                 connectionRequestId: "creq-stale"
             )
         }
+        client.onCompleteEntitlement = { _, _ in throw AbilitiesAPI.EndpointError.abilityMismatch }
         let service = makeService(client: client)
 
         let first = try await service.beginEntitlement(abilityId: "spotify")
         #expect(first.redirectUrl == "https://consent.example/stale")
 
         // The member abandoned that round; by the time they tap again the
-        // link session behind it is dead.
+        // link session behind it is dead, and so is the request.
         client.onCreateEntitlement = { _, _ in
             try AbilitiesAPI.EntitlementInitiationResponse(
                 status: .pendingAuth,
@@ -283,13 +309,50 @@ struct LiveAbilitiesServiceTests {
 
         client.onCompleteEntitlement = { _, _ in AbilitiesAPI.EntitlementCompleteResponse() }
         try await service.completeEntitlement(abilityId: "spotify")
-        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-fresh"], "completion echoes the round it belongs to")
+        #expect(client.completeCalls.map(\.connectionRequestId).last == "creq-fresh", "completion echoes the round it belongs to")
     }
 
-    /// `auth_incomplete` keeps the id for the bounded completion retry
-    /// inside one round -- but a connect tap after that retry gave up is a
-    /// new round, and gets a new session and a new id.
-    @Test("authIncomplete retries the same id, while a later connect starts over")
+    /// The other branch, and the one the bug report never got to see: the
+    /// member did finish consent, the completion retries ran out while
+    /// Composio was still INITIALIZING, and the connection went ACTIVE
+    /// afterwards. No webhook exists, so the entitlement row is still
+    /// `pending_auth` and only a complete this client sends can move it.
+    /// The next tap must therefore re-submit the retained id before minting
+    /// anything -- otherwise the member signs in a second time for a
+    /// connection that already works.
+    @Test("A later connect tap finishes the outstanding round instead of re-authorizing")
+    func laterConnectFinishesTheOutstandingRound() async throws {
+        let client = AbilitiesStubAPIClient()
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/x",
+                connectionRequestId: "creq-slow"
+            )
+        }
+        client.onCompleteEntitlement = { _, _ in
+            throw AbilitiesAPI.EndpointError.authIncomplete(connectionStatus: "INITIALIZING")
+        }
+        let service = makeService(client: client)
+        _ = try await service.beginEntitlement(abilityId: "spotify")
+        await #expect(throws: AbilitiesAPI.EndpointError.authIncomplete(connectionStatus: "INITIALIZING")) {
+            try await service.completeEntitlement(abilityId: "spotify")
+        }
+
+        // Composio finishes; nothing tells the backend.
+        client.onCompleteEntitlement = { _, _ in AbilitiesAPI.EntitlementCompleteResponse() }
+        let resumed = try await service.beginEntitlement(abilityId: "spotify")
+
+        #expect(resumed.status == .active, "the round completed, so there is nothing to authorize")
+        #expect(resumed.redirectUrl == nil)
+        #expect(client.createCalls.count == 1, "no new link session is minted for a round that just finished")
+        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-slow", "creq-slow"])
+    }
+
+    /// `auth_incomplete` keeps the id: the bounded completion retry
+    /// re-submits it inside the round, and a later connect tap re-submits it
+    /// once more before falling through to a fresh session.
+    @Test("authIncomplete retries the same id, then the next tap re-tries it before minting")
     func authIncompleteRetriesTheSameIdThenStartsOver() async throws {
         let client = AbilitiesStubAPIClient()
         client.onCreateEntitlement = { _, _ in
@@ -323,81 +386,78 @@ struct LiveAbilitiesServiceTests {
         let restarted = try await service.beginEntitlement(abilityId: "spotify")
         #expect(restarted.redirectUrl == "https://consent.example/y")
         #expect(client.createCalls.count == 2)
+        #expect(client.completeCalls.count == 3, "the tap tried the outstanding round once more first")
     }
 
-    /// Restarting is cheap because initiate is idempotent per (account,
-    /// ability): if the abandoned round turned out to have completed
-    /// upstream, the restart answers `active` outright and no second
-    /// sign-in is asked for.
-    @Test("A restart whose round completed upstream answers active with no consent step")
-    func restartAnswersActiveWhenTheRoundAlreadyCompleted() async throws {
+    /// The backend links unconditionally before consulting the entitlement
+    /// row, so an OAuth ability whose row is already active answers `active`
+    /// while still carrying the auth fields of the request it just minted.
+    /// Rejecting that shape makes the client throw on a connection that
+    /// genuinely works; both shapes have to decode, and neither leaves the
+    /// caller anything to authorize.
+    @Test("Both shapes of an active initiation decode and carry no authorization step")
+    func activeInitiationDecodesInBothShapes() async throws {
+        let authLess = #"{"status":"active","redirectUrl":null,"connectionRequestId":null}"#
+        let oauth = #"{"status":"active","redirectUrl":"https://consent.example/unused","connectionRequestId":"creq-unused"}"#
+
+        for wire in [authLess, oauth] {
+            let decoded = try JSONDecoder().decode(AbilitiesAPI.EntitlementInitiationResponse.self, from: Data(wire.utf8))
+            #expect(decoded.status == .active)
+
+            let client = AbilitiesStubAPIClient()
+            client.onCreateEntitlement = { _, _ in decoded }
+            let service = makeService(client: client)
+
+            let initiation = try await service.beginEntitlement(abilityId: "spotify")
+            #expect(initiation.status == .active)
+            #expect(initiation.redirectUrl == nil, "an active entitlement has nothing to authorize")
+
+            // The minted-but-unused request is not a round to complete later.
+            await #expect(throws: LiveAbilitiesServiceError.missingConnectionRequest(abilityId: "spotify")) {
+                try await service.completeEntitlement(abilityId: "spotify")
+            }
+        }
+    }
+
+    /// A completion can outlive the surface that started it -- the composer
+    /// modal's connect deliberately survives dismissal -- so a connect tap
+    /// elsewhere can land while one is still in flight. It must not open a
+    /// competing round against the same ability: it joins the completion
+    /// already running, and only mints if that one did not finish the job.
+    /// This is what keeps a concluding round from ever concluding *over* a
+    /// newer one's retained id.
+    @Test("A connect tap during an in-flight completion joins it instead of racing it")
+    func connectDuringCompletionJoinsIt() async throws {
         let client = AbilitiesStubAPIClient()
         client.onCreateEntitlement = { _, _ in
             try AbilitiesAPI.EntitlementInitiationResponse(
                 status: .pendingAuth,
-                redirectUrl: "https://consent.example/x",
-                connectionRequestId: "creq-1"
+                redirectUrl: "https://consent.example/first",
+                connectionRequestId: "creq-first"
             )
         }
-        let service = makeService(client: client)
-        _ = try await service.beginEntitlement(abilityId: "spotify")
-
-        client.onCreateEntitlement = { _, _ in
-            try AbilitiesAPI.EntitlementInitiationResponse(status: .active)
-        }
-        let restarted = try await service.beginEntitlement(abilityId: "spotify")
-
-        #expect(restarted.status == .active)
-        #expect(restarted.redirectUrl == nil)
-    }
-
-    /// A begin that fails on the network must not leave the superseded
-    /// round's id behind: completion would then echo an id the client has
-    /// already walked away from.
-    @Test("A failed restart drops the superseded connection-request id")
-    func failedRestartDropsTheSupersededId() async throws {
-        let client = AbilitiesStubAPIClient()
-        client.onCreateEntitlement = { _, _ in
-            try AbilitiesAPI.EntitlementInitiationResponse(
-                status: .pendingAuth,
-                redirectUrl: "https://consent.example/x",
-                connectionRequestId: "creq-old"
-            )
-        }
-        let service = makeService(client: client)
-        _ = try await service.beginEntitlement(abilityId: "spotify")
-
-        client.onCreateEntitlement = { _, _ in throw URLError(.timedOut) }
-        _ = try? await service.beginEntitlement(abilityId: "spotify")
-
-        await #expect(throws: LiveAbilitiesServiceError.missingConnectionRequest(abilityId: "spotify")) {
-            try await service.completeEntitlement(abilityId: "spotify")
-        }
-        #expect(client.completeCalls.isEmpty)
-    }
-
-    @Test("A non-authIncomplete completion failure drops the attempt so the next connect re-begins")
-    func otherCompleteFailureDropsAttempt() async throws {
-        let client = AbilitiesStubAPIClient()
-        client.onCreateEntitlement = { _, _ in
-            try AbilitiesAPI.EntitlementInitiationResponse(
-                status: .pendingAuth,
-                redirectUrl: "https://consent.example/x",
-                connectionRequestId: "creq-1"
-            )
-        }
+        let completionGate = TestGate()
         client.onCompleteEntitlement = { _, _ in
-            throw AbilitiesAPI.EndpointError.abilityMismatch
+            await completionGate.wait()
+            return AbilitiesAPI.EntitlementCompleteResponse()
         }
         let service = makeService(client: client)
         _ = try await service.beginEntitlement(abilityId: "spotify")
 
-        await #expect(throws: AbilitiesAPI.EndpointError.abilityMismatch) {
-            try await service.completeEntitlement(abilityId: "spotify")
-        }
+        let completion = Task { try await service.completeEntitlement(abilityId: "spotify") }
+        try await Task.sleep(for: .milliseconds(50))
 
-        _ = try await service.beginEntitlement(abilityId: "spotify")
-        #expect(client.createCalls.count == 2)
+        let tap = Task { try await service.beginEntitlement(abilityId: "spotify") }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(client.createCalls.count == 1, "the tap must not mint while the round is still resolving")
+
+        await completionGate.open()
+        try await completion.value
+        let resumed = try await tap.value
+
+        #expect(resumed.status == .active, "the round it joined finished it")
+        #expect(client.createCalls.count == 1)
+        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-first"], "one round, submitted once")
     }
 
     @Test("Overlapping begins share one backend connection request")

--- a/ConvosCore/Tests/ConvosCoreTests/LiveAbilitiesServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LiveAbilitiesServiceTests.swift
@@ -245,8 +245,52 @@ struct LiveAbilitiesServiceTests {
         }
     }
 
-    @Test("Continue connecting resumes the retained attempt: no new begin, same id")
-    func continueResumesRetainedAttempt() async throws {
+    /// The reported dead end: an OAuth the member walked away from leaves a
+    /// `pendingAuth` entitlement whose consent URL expires on the
+    /// provider's clock. Re-serving that URL on the next connect tap lands
+    /// them on "link session has expired" with nothing to do about it, so
+    /// begin mints a new link session every time and completion echoes the
+    /// new round's id.
+    @Test("A later connect tap mints a fresh link session, never the stale one")
+    func laterConnectMintsAFreshSession() async throws {
+        let client = AbilitiesStubAPIClient()
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/stale",
+                connectionRequestId: "creq-stale"
+            )
+        }
+        let service = makeService(client: client)
+
+        let first = try await service.beginEntitlement(abilityId: "spotify")
+        #expect(first.redirectUrl == "https://consent.example/stale")
+
+        // The member abandoned that round; by the time they tap again the
+        // link session behind it is dead.
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/fresh",
+                connectionRequestId: "creq-fresh"
+            )
+        }
+        let second = try await service.beginEntitlement(abilityId: "spotify")
+
+        #expect(second.status == .pendingAuth)
+        #expect(second.redirectUrl == "https://consent.example/fresh", "a stored URL must never be replayed")
+        #expect(client.createCalls.count == 2, "the tap has to reach initiate to get a live session")
+
+        client.onCompleteEntitlement = { _, _ in AbilitiesAPI.EntitlementCompleteResponse() }
+        try await service.completeEntitlement(abilityId: "spotify")
+        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-fresh"], "completion echoes the round it belongs to")
+    }
+
+    /// `auth_incomplete` keeps the id for the bounded completion retry
+    /// inside one round -- but a connect tap after that retry gave up is a
+    /// new round, and gets a new session and a new id.
+    @Test("authIncomplete retries the same id, while a later connect starts over")
+    func authIncompleteRetriesTheSameIdThenStartsOver() async throws {
         let client = AbilitiesStubAPIClient()
         client.onCreateEntitlement = { _, _ in
             try AbilitiesAPI.EntitlementInitiationResponse(
@@ -261,20 +305,75 @@ struct LiveAbilitiesServiceTests {
         let service = makeService(client: client)
         _ = try await service.beginEntitlement(abilityId: "spotify")
 
-        await #expect(throws: AbilitiesAPI.EndpointError.authIncomplete(connectionStatus: "INITIALIZING")) {
+        for _ in 0..<2 {
+            await #expect(throws: AbilitiesAPI.EndpointError.authIncomplete(connectionStatus: "INITIALIZING")) {
+                try await service.completeEntitlement(abilityId: "spotify")
+            }
+        }
+        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-7", "creq-7"], "same round, same id")
+        #expect(client.createCalls.count == 1, "retrying completion never re-initiates")
+
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/y",
+                connectionRequestId: "creq-8"
+            )
+        }
+        let restarted = try await service.beginEntitlement(abilityId: "spotify")
+        #expect(restarted.redirectUrl == "https://consent.example/y")
+        #expect(client.createCalls.count == 2)
+    }
+
+    /// Restarting is cheap because initiate is idempotent per (account,
+    /// ability): if the abandoned round turned out to have completed
+    /// upstream, the restart answers `active` outright and no second
+    /// sign-in is asked for.
+    @Test("A restart whose round completed upstream answers active with no consent step")
+    func restartAnswersActiveWhenTheRoundAlreadyCompleted() async throws {
+        let client = AbilitiesStubAPIClient()
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/x",
+                connectionRequestId: "creq-1"
+            )
+        }
+        let service = makeService(client: client)
+        _ = try await service.beginEntitlement(abilityId: "spotify")
+
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(status: .active)
+        }
+        let restarted = try await service.beginEntitlement(abilityId: "spotify")
+
+        #expect(restarted.status == .active)
+        #expect(restarted.redirectUrl == nil)
+    }
+
+    /// A begin that fails on the network must not leave the superseded
+    /// round's id behind: completion would then echo an id the client has
+    /// already walked away from.
+    @Test("A failed restart drops the superseded connection-request id")
+    func failedRestartDropsTheSupersededId() async throws {
+        let client = AbilitiesStubAPIClient()
+        client.onCreateEntitlement = { _, _ in
+            try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/x",
+                connectionRequestId: "creq-old"
+            )
+        }
+        let service = makeService(client: client)
+        _ = try await service.beginEntitlement(abilityId: "spotify")
+
+        client.onCreateEntitlement = { _, _ in throw URLError(.timedOut) }
+        _ = try? await service.beginEntitlement(abilityId: "spotify")
+
+        await #expect(throws: LiveAbilitiesServiceError.missingConnectionRequest(abilityId: "spotify")) {
             try await service.completeEntitlement(abilityId: "spotify")
         }
-
-        // The Continue path: connect re-runs begin, which must serve the
-        // retained attempt instead of minting a new connection request.
-        let resumed = try await service.beginEntitlement(abilityId: "spotify")
-        #expect(resumed.status == .pendingAuth)
-        #expect(resumed.redirectUrl == "https://consent.example/x")
-        #expect(client.createCalls.count == 1)
-
-        client.onCompleteEntitlement = { _, _ in AbilitiesAPI.EntitlementCompleteResponse() }
-        try await service.completeEntitlement(abilityId: "spotify")
-        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-7", "creq-7"])
+        #expect(client.completeCalls.isEmpty)
     }
 
     @Test("A non-authIncomplete completion failure drops the attempt so the next connect re-begins")

--- a/ConvosCore/Tests/ConvosCoreTests/LiveAbilitiesServiceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/LiveAbilitiesServiceTests.swift
@@ -64,6 +64,23 @@ private final class AbilitiesStubAPIClient: TestStubAPIClient, @unchecked Sendab
 
 /// Mutable identity for tests that switch accounts mid-run. Reads and
 /// writes are sequenced by the test body itself.
+/// Counts stubbed endpoint calls so a test can wait for a specific one to
+/// have been reached before driving the next step.
+private actor CallCounter {
+    private(set) var createCount: Int = 0
+    private(set) var completeCount: Int = 0
+
+    func nextCreate() -> Int {
+        createCount += 1
+        return createCount
+    }
+
+    func nextComplete() -> Int {
+        completeCount += 1
+        return completeCount
+    }
+}
+
 /// A one-shot gate a stubbed endpoint can park on, so a test can hold one
 /// request open while it drives another.
 private actor TestGate {
@@ -97,6 +114,24 @@ private final class ScopeBox: @unchecked Sendable {
 
 @Suite("LiveAbilitiesService")
 struct LiveAbilitiesServiceTests {
+    /// Waits for a stubbed call to have been reached. The service's work runs
+    /// on tasks the test does not hold, so ordering is observed, not awaited.
+    /// The budget is generous because it is only ever spent on a genuine
+    /// failure -- the poll returns the moment the condition holds -- and the
+    /// suite runs alongside hundreds of others, where task scheduling can
+    /// stall for seconds.
+    private func settle(
+        timeout: Duration = .seconds(30),
+        until condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("condition never settled within \(timeout)")
+    }
+
     private func makeService(
         client: AbilitiesStubAPIClient,
         cache: AbilitiesCatalogDiskCache? = nil,
@@ -458,6 +493,69 @@ struct LiveAbilitiesServiceTests {
         #expect(resumed.status == .active, "the round it joined finished it")
         #expect(client.createCalls.count == 1)
         #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-first"], "one round, submitted once")
+    }
+
+    /// The ordering the resume-first pass does **not** close. Resume-first
+    /// only covers a begin arriving after a completion; here the completion
+    /// arrives after the begin got past that pass.
+    ///
+    /// Round A is outstanding when a second tap runs. Its resume attempt on A
+    /// comes back `auth_incomplete`, so the tap falls through and goes to the
+    /// network to mint round B. While that is in flight, A's authorization
+    /// finally returns and its completion captures A -- there is nothing to
+    /// join, and B does not exist yet. B is stored, then A's completion
+    /// succeeds and concludes A. If concluding A deleted whatever the ability
+    /// happens to hold, it would delete B, and the sign-in the member is
+    /// about to finish would die on `missingConnectionRequest`.
+    @Test("Concluding an older round leaves a newer round's retained id alone")
+    func concludingRoundLeavesANewerAttemptAlone() async throws {
+        let client = AbilitiesStubAPIClient()
+        let calls = CallCounter()
+        let mintGate = TestGate()
+        let completeGate = TestGate()
+
+        client.onCreateEntitlement = { _, _ in
+            let index = await calls.nextCreate()
+            if index == 2 { await mintGate.wait() }
+            let round = index == 1 ? "a" : "b"
+            return try AbilitiesAPI.EntitlementInitiationResponse(
+                status: .pendingAuth,
+                redirectUrl: "https://consent.example/\(round)",
+                connectionRequestId: "creq-\(round)"
+            )
+        }
+        client.onCompleteEntitlement = { _, _ in
+            let index = await calls.nextComplete()
+            if index == 1 {
+                throw AbilitiesAPI.EndpointError.authIncomplete(connectionStatus: "INITIALIZING")
+            }
+            if index == 2 { await completeGate.wait() }
+            return AbilitiesAPI.EntitlementCompleteResponse()
+        }
+        let service = makeService(client: client)
+        _ = try await service.beginEntitlement(abilityId: "spotify")
+
+        // The second tap: resume A, get auth_incomplete, fall through, park
+        // on the network minting B.
+        let secondTap = Task { try await service.beginEntitlement(abilityId: "spotify") }
+        try await settle { await calls.createCount == 2 }
+
+        // A's authorization returns while B is still being minted, so this
+        // completion captures A and joins nothing.
+        let firstRoundCompletion = Task { try await service.completeEntitlement(abilityId: "spotify") }
+        try await settle { await calls.completeCount == 2 }
+
+        // B lands first, then A concludes on top of it.
+        await mintGate.open()
+        let second = try await secondTap.value
+        #expect(second.redirectUrl == "https://consent.example/b")
+        await completeGate.open()
+        try await firstRoundCompletion.value
+
+        // B is still completable: the member finishes the sign-in they were
+        // sent to, and it echoes B.
+        try await service.completeEntitlement(abilityId: "spotify")
+        #expect(client.completeCalls.map(\.connectionRequestId) == ["creq-a", "creq-a", "creq-b"])
     }
 
     @Test("Overlapping begins share one backend connection request")

--- a/ConvosTests/AbilitiesBrowserSectioningTests.swift
+++ b/ConvosTests/AbilitiesBrowserSectioningTests.swift
@@ -3,12 +3,13 @@ import ConvosCore
 import XCTest
 
 /// The Connections browser's two-section split in `.composerModal`:
-/// Connected holds every entitlement the account has in any lifecycle
-/// state, Discover holds only authoritative not-entitled, and the outage
+/// Connected holds the entitlements whose authorization actually finished,
+/// Discover holds everything still connectable - not-entitled plus the
+/// `pendingAuth` records an abandoned OAuth leaves behind - and the outage
 /// section holds the rest.
 @MainActor
 final class AbilitiesBrowserSectioningTests: XCTestCase {
-    func testEntitledButNotActiveAbilitiesStayUnderConnected() async throws {
+    func testRepairableEntitlementsStayUnderConnected() async throws {
         let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .standard, artificialDelay: .zero))
         await viewModel.refresh()
 
@@ -16,13 +17,50 @@ final class AbilitiesBrowserSectioningTests: XCTestCase {
         // Spotify and an expired Coinbase, all entitled.
         let connectedIds: [String] = viewModel.entitledAbilities.map(\.id)
         XCTAssertTrue(connectedIds.contains("googlecalendar"))
-        XCTAssertTrue(connectedIds.contains("spotify"), "pendingAuth is still an entitlement the account holds")
-        XCTAssertTrue(connectedIds.contains("coinbase"), "expired is still an entitlement the account holds")
+        XCTAssertTrue(connectedIds.contains("coinbase"), "expired is a connection that existed and can be repaired")
 
         let discoverIds: [String] = viewModel.availableAbilities.map(\.id)
-        XCTAssertFalse(discoverIds.contains("spotify"))
         XCTAssertFalse(discoverIds.contains("coinbase"))
         XCTAssertTrue(discoverIds.contains("youtube"))
+    }
+
+    /// The reported dead end: an OAuth the member started and abandoned
+    /// leaves a `pendingAuth` entitlement, which used to advertise itself
+    /// under Connected with a Pending chip and a repair route that could
+    /// only re-offer the dead consent link. No account was ever linked, so
+    /// the row belongs in Discover behind a plain Connect.
+    func testPendingAuthThatNeverCompletedIsDiscoverableNotConnected() async throws {
+        let viewModel = AbilitiesListViewModel(service: MockAbilitiesService(scenario: .standard, artificialDelay: .zero))
+        await viewModel.refresh()
+
+        let spotify = try XCTUnwrap(MockAbilitiesService.standardCatalog().first { $0.id == "spotify" })
+        XCTAssertEqual(spotify.entitlement?.status, .pendingAuth, "fixture guard: the test is about this status")
+
+        XCTAssertFalse(viewModel.entitledAbilities.map(\.id).contains("spotify"))
+        XCTAssertTrue(viewModel.availableAbilities.map(\.id).contains("spotify"))
+    }
+
+    /// Membership is a total function of entitlement state, so every status
+    /// the wire contract can carry is pinned here rather than inferred from
+    /// whichever ones the mock fixture happens to produce.
+    func testEverySectionMappingIsPinned() throws {
+        let template = try XCTUnwrap(MockAbilitiesService.standardCatalog().first { $0.id == "gmail" })
+
+        let expected: [(AbilitiesAPI.EntitlementStatus, AbilitiesListViewModel.BrowserSection)] = [
+            (.active, .connected),
+            (.expired, .connected),
+            (.needsReauth, .connected),
+            (.revoked, .connected),
+            (.pendingAuth, .discover),
+        ]
+        for (status, section) in expected {
+            let entitlement = try AbilitiesAPI.Entitlement(status: status, expiresAt: nil, extensionCount: 0)
+            let ability = template.withEntitlementState(.entitled(entitlement))
+            XCTAssertEqual(AbilitiesListViewModel.section(for: ability), section, "status \(status.rawValue)")
+        }
+
+        XCTAssertEqual(AbilitiesListViewModel.section(for: template.withEntitlementState(.notEntitled)), .discover)
+        XCTAssertEqual(AbilitiesListViewModel.section(for: template.withEntitlementState(.unknown)), .statusUnknown)
     }
 
     func testNeedsReauthAbilityIsConnectedNotDiscoverable() async throws {
@@ -70,6 +108,34 @@ final class AbilitiesBrowserSectioningTests: XCTestCase {
         XCTAssertTrue(viewModel.isSearching)
     }
 
+    /// The second half of the dead end: the Connect the member reaches on
+    /// that Discover row has to open a live provider session. Each tap runs
+    /// its own initiate and authorizes with the URL that call returned, so
+    /// a tap made long after the abandoned round never re-opens the link
+    /// session that went with it.
+    func testEachConnectTapAuthorizesWithTheUrlItsOwnInitiateReturned() async throws {
+        let service = StaleLinkAbilitiesService()
+        let authorizer = RecordingAuthorizer()
+        let viewModel = AbilitiesListViewModel(service: service, authorizer: authorizer)
+        await viewModel.refresh()
+
+        let spotify = try XCTUnwrap(viewModel.availableAbilities.first { $0.id == "spotify" })
+
+        viewModel.connect(spotify)
+        try await settle { await authorizer.urls.count == 1 }
+        try await settle { !viewModel.isBusy(spotify) }
+
+        // Much later: the first consent link is dead, and the member taps
+        // the same row again.
+        viewModel.connect(spotify)
+        try await settle { await authorizer.urls.count == 2 }
+
+        let observedUrls = await authorizer.urls
+        XCTAssertEqual(observedUrls, ["https://consent.example/session-1", "https://consent.example/session-2"])
+        let observedBegins = await service.beginCount
+        XCTAssertEqual(observedBegins, 2, "a connect tap always reaches initiate for a live session")
+    }
+
     /// Everything-connected collapses Discover on its own; nothing-connected
     /// puts the hero above a full Discover. Both already shipped - pinned
     /// here so the two-section split cannot quietly regress them.
@@ -85,6 +151,20 @@ final class AbilitiesBrowserSectioningTests: XCTestCase {
         XCTAssertTrue(nothingConnected.entitledAbilities.isEmpty)
         XCTAssertFalse(nothingConnected.availableAbilities.isEmpty)
         XCTAssertTrue(nothingConnected.showsNothingConnectedHero)
+    }
+
+    /// Polls a condition inside the test's own turn: the connect flow runs
+    /// on detached tasks, so there is nothing to await directly.
+    private func settle(
+        timeout: Duration = .seconds(2),
+        until condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("condition never settled within \(timeout)")
     }
 }
 
@@ -154,5 +234,47 @@ private struct EverythingConnectedAbilitiesService: AbilitiesServiceProtocol {
 
     func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
         throw AbilitiesServiceError.accountRequired
+    }
+}
+
+/// One `pendingAuth` Spotify the member never finished authorizing, and an
+/// initiate that hands out a different link session on every call - the
+/// shape a real provider has, and the one a replayed URL would flatten.
+private actor StaleLinkAbilitiesService: AbilitiesServiceProtocol {
+    private(set) var beginCount: Int = 0
+
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        let spotify = MockAbilitiesService.standardCatalog().first { $0.id == "spotify" }
+        guard let spotify else { throw AbilitiesServiceError.unknownAbility(abilityId: "spotify") }
+        let entitlement = try AbilitiesAPI.Entitlement(status: .pendingAuth, expiresAt: nil, extensionCount: 0)
+        return AbilitiesCatalog(catalogVersion: 1, abilities: [spotify.withEntitlementState(.entitled(entitlement))])
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        beginCount += 1
+        return AbilityEntitlementInitiation(status: .pendingAuth, redirectUrl: "https://consent.example/session-\(beginCount)")
+    }
+
+    func completeEntitlement(abilityId: String) async throws {}
+
+    func revokeEntitlement(abilityId: String) async throws {}
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        []
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {}
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {}
+}
+
+/// Records what the browser session was handed, then cancels, leaving the
+/// entitlement `pendingAuth` exactly as an abandoned authorization does.
+private actor RecordingAuthorizer: AbilityAuthorizing {
+    private(set) var urls: [String] = []
+
+    func authorize(redirectUrl: String) async throws {
+        urls.append(redirectUrl)
+        throw OAuthError.cancelled
     }
 }


### PR DESCRIPTION
Stacks on #1365 (`feature/connections-browser-two-section`) — base is that branch, not `dev`. Rebase to `dev` once #1365 merges.

## The bug

User-verified live. A connection whose OAuth was started but never finished (Gmail, in the report) sits at `pendingAuth`. The browser rendered it under **Connected** with a Pending chip, and the repair route behind it replayed the redirect URL the *original* initiate had handed out. Provider link sessions expire on their own clock, so the tap landed on Composio's "Invalid or expired link / Link session has expired" page with nothing left to try.

**Not introduced by #1365.** The stored-URL replay arrived with the abilities v2 service in #1259 (`LiveAbilitiesService.beginEntitlement`, untouched by #1365) and is reachable from every connect entry point — browser Connect, the conversation toggle's repair route, and the inline connect sheet. #1365's browser only made it easier to reach.

## Fix 1 — section membership

Membership is now one total function of entitlement state, `AbilitiesListViewModel.section(for:)`, so a status added to the wire contract has to be classified rather than inherit a default.

| `entitlementState` | `status` | Section | Row affordance |
|---|---|---|---|
| `.entitled` | `active` | Connected | per-chat toggle (composer) / menu (settings) |
| `.entitled` | `expired` | Connected | badge + Reconnect |
| `.entitled` | `needsReauth` | Connected | badge + Reconnect |
| `.entitled` | `revoked` | Connected | badge + Reconnect |
| `.entitled` | `pendingAuth` | **Discover** | plain Connect |
| `.notEntitled` | — | Discover | plain Connect |
| `.unknown` | — | Status unknown | none |

`pendingAuth` is the entry that does not read the way its wire shape suggests: the backend writes it when authorization is **initiated**, not while it is being processed, so an abandoned sign-in leaves exactly the same record as one still on screen. No account was ever linked, so the row belongs in Discover. Everything else that is entitled stays under Connected — those describe connections that did exist and can be repaired in place, and the badge is what tells the member what to fix.

This narrows the addendum's §2 ruling ("`pendingAuth` sits in section A"). Its stated reason — don't ask a member to "connect" an account they already hold — does not apply to a `pendingAuth` record, because they do not hold one.

The now-unreachable "Continue connecting" menu entry is removed.

## Fix 2 — finish the outstanding round, then mint a fresh link session

The round's two halves age differently, so they get opposite policies.

The **consent URL** is never stored — `PendingAttempt` has no `redirectUrl` field at all, so replay is unrepresentable rather than merely unused. A restart always mints a new link session.

The **connection-request id** is retained and re-submitted *first*. This matters more than the original version of this PR assumed: there is **no Composio webhook**, and the entitlement row flips only on a complete this client sends. A member whose completion retries ran out while Composio was still INITIALIZING would otherwise sign in a second time, and the original — by then ACTIVE — connection could never be completed at all. So a connect tap on a `pendingAuth` ability re-submits the retained id silently; if it lands, the round finishes with no consent step, and only if it fails (or there is no id) does a fresh initiate run.

A side effect worth naming: a connect tap arriving while a completion is in flight now joins that completion instead of opening a competing round against the same ability. That is also what keeps a concluding round from concluding over a newer one's retained id.

`removeAttempt` now requires the connection-request id to match, not just the scope epoch — a completion that outlives the surface which started it (the composer modal's connect deliberately survives dismissal) must not delete an attempt a later begin stored in its place, which would strand the next sign-in on "session expired". Revoke keeps its unconditional discard, being the one case that invalidates every round.

The S2 semantics from the base branch are preserved: a `pendingAuth` initiation with a nil redirect URL is still a malformed response, not an auth-less ability.

## Fix 3 — accept the backend's own OAuth `active` response

`EntitlementInitiationResponse` required `redirectUrl == nil && connectionRequestId == nil` for `active`, and threw `incoherentEntitlementState` otherwise. `entitlement-post.ts` links **unconditionally** before it consults the entitlement row, so an OAuth ability whose row is already active answers `active` while still carrying the request the endpoint minted on the way through. The client threw on that — an error surfaced on a connection that genuinely works, repeated on every retry, with a fresh orphaned request each time.

`active` is now accepted in both legal shapes and its auth fields are ignored; `pending_auth` stays strict, because it is genuinely unusable without them. The service does not retain the unused id (nothing will authorize that round) and hands the caller no URL for a status with nothing to authorize.

This validator predates the PR, but the change made the shape materially reachable: before it, the resume short-circuit meant a re-begin on a retained attempt never hit the wire.

## Tests, mutation-checked

New / rewritten:

- `AbilitiesBrowserSectioningTests` — `pendingAuth`-never-authed renders in Discover, not Connected; the full status→section table is pinned explicitly; each connect tap authorizes with the URL its own initiate returned.
- `LiveAbilitiesServiceTests` — both branches of the tap: a *dead* round falls through to a fresh link session, a *slow-but-finished* round completes with no new initiate and no consent step. Plus: `auth_incomplete` retries the same id inside the round and the next tap retries it once more before minting; both shapes of an `active` initiation decode and leave nothing to authorize; a tap during an in-flight completion joins it rather than racing it.
- `AbilitiesEndpointsContractTests` — `active` with populated auth fields decodes; `pending_auth` with null auth fields still throws.

Mutation results:

- Mutant A (`pendingAuth` mapped back to Connected) → 3 sectioning tests fail.
- Mutant B (resume short-circuit restored, stored URL replayed) → 4 service tests fail with 9 issues, including `(second.redirectUrl → ".../stale") == ".../fresh"` and `createCalls.count → 1) == 2`.
- Mutant C (complete-first attempt removed) → 3 service tests fail with 8 issues, including `(resumed.status → .pendingAuth) == .active` and `createCalls.count → 2) == 1`.
- Mutant D (strict `active` validation restored) → 2 tests fail, both `Caught error: .incoherentEntitlementState`.
- Mutant E (id comparison dropped from `removeAttempt`) → the ordering test fails with `Caught error: .missingConnectionRequest` — the exact error the member would hit.

The id comparison is load-bearing, not defence in depth. Complete-first closes only the *begin after a completion* ordering; the reverse stays reachable — a begin gets past its resume pass while round A is retained and is on the network minting B when A's authorization returns, so that completion captured A before B existed, joins nothing, and concludes A while B is what the ability holds. `concludingRoundLeavesANewerAttemptAlone` stages exactly that.

## Gates

- `swiftlint --strict` clean; `swiftformat` no-op.
- `swift test --package-path ConvosCore`: 1939/1939 pass.
- App abilities tests on the simulator: 43/43 pass, with the type-check gate fully armed and zero long-type-check warnings anywhere in the build.

## Spec

Addendum §2 carried the ratified ruling that `pendingAuth` sits under Connected. That is now amended in the addendum itself (§11, dated, Louis-driven from the live finding), including the accepted cost — a member inside the post-consent processing window sees Connect rather than a Pending chip — and its mitigation, which is Fix 2: that tap completes the round instantly with no second sign-in.

## Out of scope

Abandoned Composio connection requests accumulate with no cleanup path, and `composio.service.ts`'s `listForUser` throws past `LIST_PAGE_LIMIT = 10` rather than returning a partial list, which would eventually break `complete`. That is a backend concern and is not addressed here.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send unfinished OAuth back to Discover and mint fresh consent links
> - Reclassifies `pendingAuth` abilities from Connected to Discover via a new `BrowserSection` enum and `section(for:)` mapping in `AbilitiesListViewModel`; these rows now show a Connect button instead of a repair action
> - Reworks `LiveAbilitiesService.beginEntitlement` to silently complete any retained round before minting a new session, and stops storing replayable consent URLs in `PendingAttempt` (now holds only `connectionRequestId`)\- Relaxes `EntitlementInitiationResponse.validate` to accept `.active` initiations that carry auth fields, instead of rejecting them
> - Fixes a race in `completeEntitlement` and `removeAttempt` where completing an older round could delete a newer round's retained id; `revokeEntitlement` now unconditionally discards any retained round via `discardAttempt`
> - Behavioral Change: `entitledAbilities` no longer includes `pendingAuth`; `availableAbilities` now includes it. Connect taps always use a fresh consent URL from a new initiate call rather than a cached one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d47c8aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->