### PR TITLE
fix(qa): count the child query without tripping empty_count

### DIFF
--- a/QAAutomationServer/QAAutomationServer.swift
+++ b/QAAutomationServer/QAAutomationServer.swift
@@ -178,7 +178,7 @@ enum ElementInfoBuilder {
 
         if depth < maxDepth {
             let childElements = element.children(matching: .any)
-            if childElements.count > 0 && childElements.count < 50 {
+            if (1..<50).contains(childElements.count) {
                 children = (0..<childElements.count).compactMap { i in
                     let child = childElements.element(boundBy: i)
                     guard child.exists else { return nil }


### PR DESCRIPTION
`dev` currently fails `swiftlint --strict`, so the SwiftLint job fails on every branch cut from it — #1363 included — regardless of what that branch changed.

The line came in with #1366, which restored this target's ability to compile at all (`XCUIElementQuery` has no `isEmpty`, so the child walk did not build). The follow-up commit that satisfied the lint rule was pushed after that PR was merged and so did not travel with it.

Comparing a count to zero is exactly what `empty_count` exists to prevent, and this is the case it cannot help with. A range check asks the same question without the comparison.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789772486&installation_model_id=20076&pr_number=1368&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1368&signature=09568ad79644da4a44f0cb0e2eabe968dd2963844c8050969a445bb0fb4c25b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix child element count guard in `ElementInfoBuilder.build` to avoid empty count edge case
> Replaces the `childElements.count > 0 && childElements.count < 50` guard with `(1..<50).contains(childElements.count)` in [QAAutomationServer.swift](https://github.com/xmtplabs/convos-ios/pull/1368/files#diff-a03ae2adc2566691d5ca5719b000e080fecc51fafce9b4adf1267d111a9f81bb). The new range check is semantically equivalent but avoids a potential pitfall where an empty count could satisfy part of the original compound condition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c45cc41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->