### PR TITLE
feat(home): draw a Space link's card from the live page

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/LinkPreviewBubbleView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/LinkPreviewBubbleView.swift
@@ -35,6 +35,8 @@ struct LinkPreviewCardView: View {
     @State private var ogImageURL: String?
     @State private var ogSiteName: String?
     @State private var cachedImage: UIImage?
+    @State private var spaceSnapshot: UIImage?
+    @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var imageAspectRatio: CGFloat?
     @State private var hasFetchedMetadata: Bool = false
 
@@ -56,7 +58,16 @@ struct LinkPreviewCardView: View {
     /// of the placeholder after it had been measured. A Space page names no
     /// image today, so that was every card an agent posts.
     private var expectsImage: Bool {
-        preview.imageURL != nil || ogImageURL != nil
+        // A Space page always has a picture coming - its own - so the slot is
+        // held from the first layout rather than appearing under the title
+        // once the capture lands.
+        isSpacePage || preview.imageURL != nil || ogImageURL != nil
+    }
+
+    /// The picture to draw: a Space page's own capture, or whatever the
+    /// link's metadata pointed at.
+    private var displayImage: UIImage? {
+        isSpacePage ? spaceSnapshot : cachedImage
     }
 
     /// Whether this card points at the group's own Space, which is the page
@@ -84,7 +95,7 @@ struct LinkPreviewCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0.0) {
             ZStack {
-                if let image = cachedImage {
+                if let image = displayImage {
                     Image(uiImage: image)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
@@ -100,7 +111,10 @@ struct LinkPreviewCardView: View {
                 }
             }
             .frame(maxWidth: .infinity)
-            .modifier(ImageAreaModifier(hasKnownRatio: cachedImage != nil || preview.imageAspectRatio != nil, aspectRatio: clampedAspectRatio))
+            .modifier(ImageAreaModifier(
+                hasKnownRatio: isSpacePage || displayImage != nil || preview.imageAspectRatio != nil,
+                aspectRatio: clampedAspectRatio
+            ))
             .clipped()
             .background(.colorBackgroundMedia)
 
@@ -134,6 +148,32 @@ struct LinkPreviewCardView: View {
         .accessibilityHint(isSpacePage ? "Opens this page in the group's space" : "Opens \(preview.displayHost)")
         .task {
             await fetchOpenGraphMetadata()
+        }
+        .task(id: spaceSnapshotIdentity) {
+            await loadSpaceSnapshot()
+        }
+    }
+
+    /// Re-captures when the page or the appearance changes, and not otherwise.
+    private var spaceSnapshotIdentity: String? {
+        guard isSpacePage, let url = preview.resolvedURL else { return nil }
+        return url.absoluteString + (colorScheme == .dark ? "-dark" : "-light")
+    }
+
+    /// Draws the Space page itself rather than an image it declares.
+    ///
+    /// The cached capture is taken synchronously first so a card that has one
+    /// draws it on its first layout, then the renderer is asked - which returns
+    /// that same capture immediately and refreshes behind it if it has aged.
+    private func loadSpaceSnapshot() async {
+        guard isSpacePage, let url = preview.resolvedURL else { return }
+        let appearance: UIUserInterfaceStyle = colorScheme == .dark ? .dark : .light
+
+        if let cached = SpacePageSnapshotRenderer.shared.cachedSnapshot(for: url, appearance: appearance) {
+            spaceSnapshot = cached
+        }
+        if let image = await SpacePageSnapshotRenderer.shared.snapshot(for: url, appearance: appearance) {
+            spaceSnapshot = image
         }
     }
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/SpacePageSnapshotRenderer.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/SpacePageSnapshotRenderer.swift
@@ -1,0 +1,279 @@
+#if canImport(UIKit)
+import ConvosCore
+import ConvosLogging
+import UIKit
+import WebKit
+
+/// Draws a Space link's card picture from the live page.
+///
+/// A Space page publishes no `og:image`, and a file committed beside it would
+/// be a photograph of one moment in a document the agent rewrites all day. The
+/// page itself is the only thing that is always current, so the card shows the
+/// page: loaded off-screen at phone width, captured across the top, and handed
+/// back on the next card that asks for it.
+///
+/// Freshness is stale-while-revalidate. A card shows whatever was captured
+/// last, immediately, and a capture older than `refreshInterval` starts a new
+/// one behind it - so a page that changed shows its old picture for one appearance
+/// rather than an empty slot for every appearance.
+@MainActor
+public final class SpacePageSnapshotRenderer {
+    public static let shared: SpacePageSnapshotRenderer = SpacePageSnapshotRenderer()
+
+    /// Laid out at a phone's size so the page settles into the same responsive
+    /// layout the Home shows it in, then captured across the top at the card's
+    /// aspect. Laying out at the capture height instead would hand the page a
+    /// 200pt viewport, which is not a shape it is ever asked to render at.
+    private static let layoutSize: CGSize = CGSize(width: 390.0, height: 844.0)
+    private static let captureAspectRatio: CGFloat = 1.91
+    private static var captureRect: CGRect {
+        CGRect(
+            x: 0.0,
+            y: 0.0,
+            width: layoutSize.width,
+            height: (layoutSize.width / captureAspectRatio).rounded()
+        )
+    }
+
+    /// `takeSnapshot` re-rasterizes the render tree to this width, so text and
+    /// CSS stay vector-crisp rather than being an upscaled bitmap.
+    private static let snapshotOutputWidth: CGFloat = 780.0
+
+    private static let cacheKeyPrefix: String = "space-page-snapshot-v1-"
+    private static let loadTimeout: TimeInterval = 15.0
+    /// How long a capture is trusted before a card showing it also starts a
+    /// fresh one behind it.
+    private static let refreshInterval: TimeInterval = 300.0
+    /// Longest wait for the page's own script to put something inside the root
+    /// element. A Space page is client-rendered: navigation finishing means the
+    /// shell arrived, not that there is anything to photograph yet.
+    private static let contentTimeout: TimeInterval = 8.0
+    private static let contentPollInterval: TimeInterval = 0.15
+    /// Breathing room after the root fills so WebKit paints what just mounted.
+    private static let paintDelay: TimeInterval = 0.4
+
+    /// Reports whether the page's own render has produced anything yet.
+    private static let readinessScript: String = """
+    (function() {
+        var root = document.getElementById('space-root');
+        if (!root) { return false; }
+        return root.childElementCount > 0;
+    })();
+    """
+
+    private var inflight: [String: Task<UIImage?, Never>] = [:]
+    private var lastCapturedAt: [String: Date] = [:]
+
+    private init() {}
+
+    // MARK: - API
+
+    /// The last capture of this page, if there is one. Synchronous so a cell
+    /// can draw its picture on the first layout rather than a frame later.
+    public func cachedSnapshot(for url: URL, appearance: UIUserInterfaceStyle) -> UIImage? {
+        ImageCache.shared.image(for: Self.cacheKey(for: url, appearance: appearance))
+    }
+
+    /// The picture for this page, capturing one if there is nothing cached.
+    ///
+    /// Returns the cached capture straight away when there is one. If it has
+    /// aged past `refreshInterval` a new capture starts behind the return, and
+    /// the next card to ask gets the newer picture.
+    public func snapshot(for url: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        let key = Self.cacheKey(for: url, appearance: appearance)
+
+        if let cached = await ImageCache.shared.imageAsync(for: key) {
+            if Self.isStale(lastCapturedAt[key]) {
+                startCapture(url: url, appearance: appearance, key: key)
+            }
+            return cached
+        }
+
+        return await startCapture(url: url, appearance: appearance, key: key).value
+    }
+
+    @discardableResult
+    private func startCapture(
+        url: URL,
+        appearance: UIUserInterfaceStyle,
+        key: String
+    ) -> Task<UIImage?, Never> {
+        if let existing = inflight[key] { return existing }
+
+        let task = Task<UIImage?, Never> { [weak self] in
+            guard let self else { return nil }
+            let image = await render(url: url, appearance: appearance)
+            if let image {
+                ImageCache.shared.cacheImage(image, for: key, storageTier: .cache)
+                lastCapturedAt[key] = Date()
+            }
+            inflight[key] = nil
+            return image
+        }
+        inflight[key] = task
+        return task
+    }
+
+    private static func isStale(_ capturedAt: Date?) -> Bool {
+        // Nothing recorded means the capture predates this launch, which is
+        // reason enough to take a fresh one behind the cached picture.
+        guard let capturedAt else { return true }
+        return Date().timeIntervalSince(capturedAt) > refreshInterval
+    }
+
+    static func cacheKey(for url: URL, appearance: UIUserInterfaceStyle) -> String {
+        cacheKeyPrefix + url.absoluteString + "-" + (appearance == .dark ? "dark" : "light")
+    }
+
+    // MARK: - Rendering
+
+    private func render(url: URL, appearance: UIUserInterfaceStyle) async -> UIImage? {
+        guard let window = Self.offscreenWindow() else {
+            Log.error("SpacePageSnapshotRenderer: no offscreen window; skipping capture")
+            return nil
+        }
+
+        let webView = WKWebView(
+            frame: CGRect(origin: .zero, size: Self.layoutSize),
+            configuration: WKWebViewConfiguration()
+        )
+        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.bounces = false
+        webView.isOpaque = true
+        webView.isUserInteractionEnabled = false
+        // Decides what `prefers-color-scheme` resolves to inside the page,
+        // which the WebView's own traits drive whether or not it is on screen.
+        webView.overrideUserInterfaceStyle = appearance
+        window.addSubview(webView)
+        defer { webView.removeFromSuperview() }
+
+        guard await load(url: url, in: webView) else { return nil }
+        guard await waitForContent(in: webView) else {
+            Log.error("SpacePageSnapshotRenderer: page never rendered: \(url.host() ?? "?")")
+            return nil
+        }
+        await Self.sleep(seconds: Self.paintDelay)
+
+        return await capture(from: webView)
+    }
+
+    private func load(url: URL, in webView: WKWebView) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let delegate = SnapshotNavigationDelegate { success in
+                continuation.resume(returning: success)
+            }
+            objc_setAssociatedObject(webView, &Self.delegateAssocKey, delegate, .OBJC_ASSOCIATION_RETAIN)
+            webView.navigationDelegate = delegate
+            webView.load(URLRequest(url: url))
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.loadTimeout) { [weak delegate, weak webView] in
+                if delegate?.finish(success: false) == true {
+                    Log.error("SpacePageSnapshotRenderer: load timed out")
+                    webView?.stopLoading()
+                }
+            }
+        }
+    }
+
+    /// Waits for the page's script to mount something. Navigation finishing
+    /// only means the shell HTML arrived; the shell is an empty root element.
+    private func waitForContent(in webView: WKWebView) async -> Bool {
+        let deadline = Date().addingTimeInterval(Self.contentTimeout)
+        while Date() < deadline {
+            if await Self.evaluateReadiness(in: webView) { return true }
+            await Self.sleep(seconds: Self.contentPollInterval)
+        }
+        return false
+    }
+
+    private static func evaluateReadiness(in webView: WKWebView) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            webView.evaluateJavaScript(readinessScript) { result, _ in
+                continuation.resume(returning: (result as? Bool) ?? false)
+            }
+        }
+    }
+
+    private func capture(from webView: WKWebView) async -> UIImage? {
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = Self.captureRect
+        configuration.snapshotWidth = NSNumber(value: Double(Self.snapshotOutputWidth))
+
+        return await withCheckedContinuation { (continuation: CheckedContinuation<UIImage?, Never>) in
+            webView.takeSnapshot(with: configuration) { image, error in
+                if let error {
+                    Log.error("SpacePageSnapshotRenderer: snapshot failed: \(error)")
+                }
+                continuation.resume(returning: image)
+            }
+        }
+    }
+
+    // MARK: - Offscreen host
+
+    /// A WebView only paints while it is in a window, so captures happen in one
+    /// parked far off-screen. Hiding it or zeroing its alpha would let UIKit
+    /// skip the rendering this exists to get.
+    private static func offscreenWindow() -> UIWindow? {
+        if let existing = sharedOffscreenWindow { return existing }
+        guard !ComposerHostContext.isAppExtension else { return nil }
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState != .unattached }
+        guard let scene else { return nil }
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(
+            x: -100_000.0,
+            y: -100_000.0,
+            width: layoutSize.width,
+            height: layoutSize.height
+        )
+        window.windowLevel = .normal - 1
+        window.isUserInteractionEnabled = false
+        window.isHidden = false
+        sharedOffscreenWindow = window
+        return window
+    }
+
+    private static var sharedOffscreenWindow: UIWindow?
+    private nonisolated(unsafe) static var delegateAssocKey: UInt8 = 0
+
+    private static func sleep(seconds: TimeInterval) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+}
+
+/// Reports load completion exactly once, whichever way it ends.
+private final class SnapshotNavigationDelegate: NSObject, WKNavigationDelegate {
+    private var completion: ((Bool) -> Void)?
+
+    init(completion: @escaping (Bool) -> Void) {
+        self.completion = completion
+    }
+
+    /// Returns whether this call was the one that finished the load.
+    @discardableResult
+    func finish(success: Bool) -> Bool {
+        guard let completion else { return false }
+        self.completion = nil
+        completion(success)
+        return true
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+        finish(success: true)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation?, withError error: Error) {
+        finish(success: false)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation?,
+        withError error: Error
+    ) {
+        finish(success: false)
+    }
+}
+#endif


### PR DESCRIPTION
Follow-up to #1363, now that it has landed.

A Space page publishes no share image, so its card in the transcript is a title over an empty slot.

Publishing one from the backend is the obvious fix and it is the wrong one: the agent rewrites these pages all day, so any image stored as a file is a photograph of one moment. The card would show the previous version of a page directly beneath a line saying it just changed. xmtplabs/convos-assistants#3491 opened that `og:image` slot and is now closed for this reason. `og:image` still matters for links pasted *outside* Convos, where a static picture is the ceiling of what the protocol offers — but that wants a renderer keyed to the deployment, which does not exist yet.

Inside Convos the card is our own UI in an app with a warm WebKit stack, so it can show the page as it is right now.

`SpacePageSnapshotRenderer` loads the page off-screen at a phone's size — the same layout the Home settles into, rather than a card-shaped viewport the page is never asked to render at — and captures across the top at the card's aspect, re-rasterized at 2x so text stays vector-crisp rather than upscaled.

Waiting for `didFinish` is not enough. A Space page is client-rendered: navigation completing means the shell arrived, and the shell is an empty root element. The renderer polls until the page's own script has mounted something, then gives WebKit a moment to paint what mounted.

Captures are stale-while-revalidate. A card draws the last capture immediately, and one older than five minutes starts a fresh capture behind it — so a changed page costs one appearance of a slightly old picture rather than an empty slot on every appearance. The slot is reserved from the first layout for Space pages, since a picture is always coming: no growing or shrinking after the cell has been measured, which is the failure mode #1366 traps.

Verified on the simulator, driven through `QAAutomationServer` rather than by hand: posting a Space link into a group renders the card with the page's own content in the image slot. Screenshot in the thread.

**Known gap, deliberately not addressed here:** a link is only treated as a Space page when it matches *that conversation's* space, and an agent DM carries no space of its own — so a Space link posted in the agent DM still renders as an ordinary link. That is where these links most often appear in practice. Worth deciding whether an agent DM should inherit its group's space; it is a data question, not a rendering one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789780644&installation_model_id=20076&pr_number=1369&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1369&signature=6bec6c13a8852655d82c684ec2806fcd647a3c5aae7a0a49b0986fc9769b4616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live snapshot rendering for Space link preview cards
> - Introduces `SpacePageSnapshotRenderer` to capture live Space pages in an offscreen `WKWebView` with stale-while-revalidate caching keyed by URL and color scheme.
> - Updates `LinkPreviewBubbleView` to display these live snapshots, using cache synchronously and refreshing in the background.
> - Risk: Space link previews now proactively reserve image space and trigger background webview loads via `SpacePageSnapshotRenderer`, which may impact memory and load times.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ee90ead. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->