### PR TITLE
Inset a browsed Home page for the sheet, not just for its resting height

### DIFF
--- a/Convos/Conversation Detail/Conversation Sheet/ConversationSheetGeometry.swift
+++ b/Convos/Conversation Detail/Conversation Sheet/ConversationSheetGeometry.swift
@@ -41,4 +41,19 @@ final class ConversationSheetGeometry {
         guard containerHeight > 0 else { return covered }
         return min(covered, max(containerHeight, restingHeight))
     }
+
+    /// The same clearance, minus the part a surface has already reserved by
+    /// padding its own viewport down to the resting height.
+    ///
+    /// The browsed pages pushed over the Home cannot take the whole clearance
+    /// as viewport padding the way `homeBottomClearance` is taken as an inset:
+    /// resizing a `WKWebView` reflows the page, so a drag would reflow it every
+    /// frame. They pad by the resting height instead - fixed, so it never
+    /// reflows - and take what the sheet covers *beyond* resting as a scroll
+    /// inset, which costs nothing to change. Padding plus inset comes to
+    /// `homeBottomClearance` exactly, so a pushed page scrolls clear of the
+    /// sheet at the same point the Home behind it does.
+    var clearanceBeyondResting: CGFloat {
+        max(homeBottomClearance - restingHeight, 0)
+    }
 }

--- a/Convos/Conversation Detail/Home/HomeBrowserPageView.swift
+++ b/Convos/Conversation Detail/Home/HomeBrowserPageView.swift
@@ -17,9 +17,12 @@ struct HomeBrowserEntry: Identifiable, Hashable {
 /// scrolls clear of both.
 struct HomeBrowserPageView: View {
     let entry: HomeBrowserEntry
-    /// The sheet's live geometry, whose resting height becomes this page's
-    /// bottom viewport padding. Read here rather than handed in as a number -
-    /// see `ConversationSheetGeometry`.
+    /// The sheet's live geometry, which this page clears at its bottom in two
+    /// parts: the resting height as viewport padding, and whatever the sheet
+    /// covers beyond that as a scroll inset. Read here rather than handed in as
+    /// a number - the read is what keeps a pushed page tracking a sheet that
+    /// moves after it was pushed, which nothing else refreshes it for. See
+    /// `ConversationSheetGeometry`.
     var sheetGeometry: ConversationSheetGeometry = ConversationSheetGeometry()
     /// Fired when this page requests navigation away from its own URL; the
     /// host pushes another page for it.
@@ -30,6 +33,12 @@ struct HomeBrowserPageView: View {
             HomeWebView(
                 url: entry.url,
                 topContentInset: proxy.safeAreaInsets.top,
+                // What the sheet covers past its resting height, which the
+                // padding below has already cleared. A page is pushed with the
+                // sheet at compact as often as at collapsed - a Space link
+                // settles it there - and the padding alone would leave that
+                // half of the page covered with nowhere to scroll it out to.
+                bottomContentInset: sheetGeometry.clearanceBeyondResting,
                 onNavigationRequest: onNavigationRequest
             )
             // Pad the viewport itself rather than relying on the scroll
@@ -38,8 +47,9 @@ struct HomeBrowserPageView: View {
             // reaches their content and the sheet covers the page bottom.
             // The raised background shows through the strip like a footer.
             // Resting height, not live coverage: resizing a WKWebView reflows
-            // the page, so tracking every drag frame would jank — the padding
-            // clears the collapsed sheet and an expanded sheet simply covers.
+            // the page, so tracking every drag frame would jank. The rest of
+            // the sheet's coverage rides on the scroll inset above, which
+            // changes without reflowing anything.
             .padding(.bottom, sheetGeometry.restingHeight)
             .ignoresSafeArea(edges: .vertical)
         }


### PR DESCRIPTION
A page pushed over the Home padded its viewport by the sheet's resting height and stopped there. Anything the sheet covered past collapsed was covered for good: no scroll inset, so nowhere to scroll the rest of the page out to.

That is the common case rather than the corner. `routeSpaceLink` settles the sheet at `compact` — half the screen — *before* it pushes the page, so the page arrives with half of itself behind the sheet and no way to read it.

The Home behind it never had this problem. `HomeLayoutView` hands the whole of `homeBottomClearance` to the web view as its bottom content inset and follows the sheet live. A pushed page can't do the same with padding: resizing a `WKWebView` reflows the page, so tracking a drag would reflow it every frame.

## The fix

Split the clearance in two:

- the **resting height** stays viewport padding — fixed, so it never reflows;
- whatever the sheet covers **beyond** resting becomes the scroll inset, which costs nothing to change.

The two sum to `homeBottomClearance` exactly, so a browsed page now scrolls clear of the sheet at the same point the Home behind it does. New `ConversationSheetGeometry.clearanceBeyondResting` names that second part so a future pushed surface doesn't have to rederive it.

At `collapsed` the inset is zero and nothing changes.

It also reaches the app-style artifact pages, which is what the padding was there for in the first place: their fixed-height layout can now be scrolled up out from under a raised sheet instead of just sitting under it.

## Notes

- Pushed pages track the sheet because they read the `@Observable` geometry directly — `HomeBrowserNavigationHost` only ever refreshes the *root*'s `rootView`, never the pushed ones. That's now stated in the property's doc comment, so a future pushed view doesn't get handed a plain number instead.
- Dropping the sheet from compact back to collapsed shrinks the inset and can leave the page scrolled a touch past its new bottom until the next interaction. That is pre-existing behaviour on the root Home (same `HomeWebView.updateUIView` path), so this leaves both surfaces at parity rather than changing the root too.

## Testing

`Convos (Dev)` builds clean off this branch (`-configuration Dev`, iPhone 17 sim) — no errors and no type-check warnings, which the 100ms budget plus warnings-as-errors would have surfaced. SwiftLint clean via the pre-commit hook.

Not verified on screen: confirming the pixels means opening a conversation with a Space, tapping a Space link, and dragging the sheet to compact. Worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789786724&installation_model_id=20076&pr_number=1371&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1371&signature=5040c9cb4800cbab450b73aea7a7e03f0df91e436270f63b874f344673c7257c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `clearanceBeyondResting` to `ConversationSheetGeometry` and pass it as bottom inset to `HomeWebView`
> - Adds `clearanceBeyondResting` computed property on `ConversationSheetGeometry`, returning `homeBottomClearance` minus `restingHeight` clamped at zero.
> - `HomeBrowserPageView` now passes this value as `bottomContentInset` to `HomeWebView`, while keeping the fixed bottom viewport padding at `restingHeight`.
> - This lets page content scroll clear of the sheet as it extends past resting height, without triggering `WKWebView` reflow during drag.
> - Risk: incorrect `clearanceBeyondResting` math could cause content under-scroll or over-scroll when the sheet is expanded beyond `restingHeight`; verify the clamp and subtraction in `ConversationSheetGeometry`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75fb882.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->