### PR TITLE
fix(participation): explain paused messages are dropped

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -36,7 +36,7 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
         switch self {
         case .speakFreely: "Chime in any time"
         case .mentionsOnly: "Only speaks if you @mention or say name"
-        case .paused: "Go offline, use no credits"
+        case .paused: "Won't see messages sent while paused, even later"
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -415,6 +415,9 @@ private func summaryFromFirstMetadataChange(
     case .participationMode:
         guard let newValue = metadataChange.newValue,
               let mode = ConversationParticipationMode(rawValue: newValue) else { return nil }
+        if mode == .paused {
+            return "\(creatorDisplayName) paused the agents. They won't see messages sent while paused, even later"
+        }
         return "\(creatorDisplayName) set the participation mode to \"\(mode.title)\""
     case .metadata, .unknown:
         return nil

--- a/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
@@ -238,4 +238,22 @@ struct ParticipationModeSyncTests {
 
         #expect(update.summary == "Shane set the participation mode to \"Listen mode\"")
     }
+
+    @Test("a paused update warns that messages will not be seen later")
+    func pausedUpdateExplainsDroppedMessages() throws {
+        let update = ConversationUpdate(
+            creator: .mock(isCurrentUser: false, name: "Shane"),
+            addedMembers: [],
+            removedMembers: [],
+            metadataChanges: [
+                .init(
+                    field: .participationMode,
+                    oldValue: ConversationParticipationMode.speakFreely.rawValue,
+                    newValue: ConversationParticipationMode.paused.rawValue
+                )
+            ]
+        )
+
+        #expect(update.summary == "Shane paused the agents. They won't see messages sent while paused, even later")
+    }
 }


### PR DESCRIPTION
## Summary
- clarify in the participation picker that agents never see messages sent while paused
- make the in-group paused status explain that those messages are not caught up later
- add regression coverage for the paused transcript copy

## Why
Paused inbound chat is dropped outright rather than queued or replayed after resuming. The previous copy only described the agent as offline and left that behavior ambiguous.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789827269&installation_model_id=20076&pr_number=1374&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1374&signature=1c6f5b3e08a3ada9955277214ee2d96202656d3b0e3d3a2f4932c2f5cf318d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update paused participation captions to warn about dropped messages
> - Changes `AgentParticipationLevel.caption` for `.paused` to state "Won't see messages sent while paused, even later".
> - Updates `summaryFromFirstMetadataChange` to produce a specific warning summary when participation mode is set to `paused`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc266fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->