### PR TITLE
Name the agent in the chat-scoped browser's subtitle

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -219,7 +219,7 @@ struct AbilitiesListView: View {
                     .font(.convosTitle)
                     .tracking(Font.convosTitleTracking)
                     .foregroundStyle(.colorTextPrimary)
-                Text("Give agents new powers in your convos")
+                Text(mode.headerSubtitle)
                     .font(.subheadline)
                     .foregroundStyle(.colorTextPrimary)
             }

--- a/Convos/Abilities/ConnectionsBrowserMode.swift
+++ b/Convos/Abilities/ConnectionsBrowserMode.swift
@@ -52,6 +52,24 @@ enum ConnectionsBrowserMode: Hashable, Identifiable {
         return nil
     }
 
+    /// The browser's header subtitle. The account-level list sells the
+    /// feature; the chat-scoped one names the agent the connections are
+    /// being turned on for.
+    ///
+    /// A blank name falls back to a generic phrasing rather than leaving a
+    /// gap mid-sentence. Empty is a real value here, not a defensive
+    /// hypothetical: the display name is whatever the profile had resolved
+    /// to when the modal was presented, and `AbilitiesListScreen` already
+    /// builds its agent descriptor with `mode.agentDisplayName ?? ""`.
+    var headerSubtitle: String {
+        guard case .composerModal(_, _, let agentDisplayName) = self else {
+            return "Give agents new powers in your convos"
+        }
+        let trimmedName: String = agentDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name: String = trimmedName.isEmpty ? "your agent" : trimmedName
+        return "Choose what \(name) can use in this chat"
+    }
+
     /// Deliberately excludes `agentDisplayName`: the modal is presented
     /// with `fullScreenCover(item:)`, so folding a renameable value into
     /// identity would tear the modal down and re-present it the moment the

--- a/ConvosTests/ConnectionsBrowserModeTests.swift
+++ b/ConvosTests/ConnectionsBrowserModeTests.swift
@@ -23,6 +23,30 @@ final class ConnectionsBrowserModeTests: XCTestCase {
         XCTAssertEqual(mode.agentDisplayName, "Caley")
     }
 
+    /// The chat-scoped browser names the agent it is turning connections on
+    /// for; the account-level one keeps its own copy byte for byte.
+    func testHeaderSubtitleNamesTheAgentOnlyInTheModal() {
+        let modal: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-1",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley"
+        )
+        XCTAssertEqual(modal.headerSubtitle, "Choose what Caley can use in this chat")
+        XCTAssertEqual(ConnectionsBrowserMode.appSettings.headerSubtitle, "Give agents new powers in your convos")
+    }
+
+    /// A name that has not resolved yet must never leave a gap mid-sentence.
+    func testHeaderSubtitleFallsBackWhenTheAgentHasNoUsableName() {
+        for name in ["", "   "] {
+            let mode: ConnectionsBrowserMode = .composerModal(
+                conversationId: "dm-1",
+                agentInboxId: "agent-1",
+                agentDisplayName: name
+            )
+            XCTAssertEqual(mode.headerSubtitle, "Choose what your agent can use in this chat")
+        }
+    }
+
     func testModeIdentitiesAreDistinct() {
         let settings: ConnectionsBrowserMode = .appSettings
         let modal: ConnectionsBrowserMode = .composerModal(


### PR DESCRIPTION
Stacks on #1367 (`fix/pending-auth-fresh-link`) — base is that branch. Ratified copy change from Louis; no logic change.

## What ships

| Mode | Subtitle |
|---|---|
| `.composerModal` | `Choose what <agentDisplayName> can use in this chat` |
| `.composerModal`, name blank | `Choose what your agent can use in this chat` |
| `.appSettings` | `Give agents new powers in your convos` (byte-untouched) |

The browser opened from a composer is turning connections on for one agent in one chat, and its subtitle said neither. App Settings has no agent to name, so it keeps the account-level copy.

## Where it lives

On `ConnectionsBrowserMode`, not the view. The mode already carries `agentDisplayName` (added in #1365), and the blank-name handling belongs next to the payload that can be blank: the name is whatever the profile had resolved to when the modal was presented, and `AbilitiesListScreen` already builds its agent descriptor with `mode.agentDisplayName ?? ""`. Empty is a real value here, not a defensive hypothetical — hence the fallback rather than a gap mid-sentence. Whitespace-only names take the fallback too.

The view reads a single typed `String` property; nothing conditional was added to a modifier chain.

## Tests

`ConnectionsBrowserModeTests` gains two: the named form plus `.appSettings` staying byte-identical, and the fallback for `""` and `"   "`. No existing test pinned the old copy (`grep` across Swift, YAML and Markdown found one occurrence, in the view).

## Gates

- `swiftlint --strict` and `swiftformat` clean on the touched files.
- `Convos (Dev)` test target: 45/45 pass, `** TEST SUCCEEDED **`, zero long-type-check warnings with the 1000 ms gate armed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789827322&installation_model_id=20076&pr_number=1375&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1375&signature=f47adcaf639e9adf437c11edc8735c8d7dfe60a44f93570d6748b8bb008018be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Name the agent in `ConnectionsBrowserMode.headerSubtitle`
> - Replaces the static subtitle in [AbilitiesListView.swift](https://github.com/xmtplabs/convos-ios/pull/1375/files#diff-3cf3f424294144da687f79adab8ba19720705c566bd5647aef0ae14b79edf04f) with the new `ConnectionsBrowserMode.headerSubtitle` property.
> - The property inserts the agent's display name for `.composerModal` (falling back to 'your agent' if empty) and uses a generic string for `.appSettings` in [ConnectionsBrowserMode.swift](https://github.com/xmtplabs/convos-ios/pull/1375/files#diff-714a612d489e1d16262575e06dce8a3c9f9015043401686dcbd527ab553284a2).
> - Adds unit tests for the naming behavior and fallback logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3101d3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->