### PR TITLE
[PROTOTYPE - DO NOT MERGE] Variant test: pin DeepSeek V4 Flash across 3 model vectors

### DIFF
--- a/Convos/Config/config.pr.json
+++ b/Convos/Config/config.pr.json
@@ -14,5 +14,6 @@
   "siweDomain": "dev.convos.org",
   "siweUri": "https://dev.convos.org",
   "siweChainId": 1,
-  "posthogHost": "https://us.i.posthog.com"
+  "posthogHost": "https://us.i.posthog.com",
+  "pinnedAgentVariantSlug": "pr-3516"
 }

--- a/prototype.yml
+++ b/prototype.yml
@@ -1,0 +1,4 @@
+prototypeId: "a-small-test-agent-variant-that-pins-deepseek-v4-flash-across-th"
+side: "app"
+requestedLifetime: "2026-08-27T15:30:03.623Z"
+whatToTest: "A small test agent variant that pins DeepSeek V4 Flash across three model vectors (main model, cron model, delegation model) to verify the variant machinery is actually propagating config changes into the runtime, rather than the shared dev worker's defaults."


### PR DESCRIPTION
Prototype-only variant smoke test (not for merge). Pins this PR build's agent creation to `pr-3516` (xmtplabs/convos-assistants#3516), the ephemeral runtime that pins DeepSeek V4 Flash across model.default, cron.model, and delegation.model — a distinctive config fingerprint used to confirm the variant runtime actually served this PR's config rather than the shared dev worker's defaults.

Proposed by fabri@xmtp.com via ConvosOS.