### PR TITLE
Let the paused-agents update wrap, and shorten it

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/TextTitleContentView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/TextTitleContentView.swift
@@ -16,7 +16,7 @@ public struct TextTitleContentView: View {
     }
 
     public var body: some View {
-        let content = HStack(spacing: DesignConstants.Spacing.stepX) {
+        let content = HStack(alignment: .top, spacing: DesignConstants.Spacing.stepX) {
             if let profile {
                 MessageAvatarView(
                     profile: profile,
@@ -26,9 +26,10 @@ public struct TextTitleContentView: View {
             }
 
             Text(title)
-                .lineLimit(1)
                 .font(.caption)
                 .foregroundStyle(.colorTextSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .transition(.blurReplace)
         .frame(maxWidth: .infinity, alignment: .center)

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -416,7 +416,7 @@ private func summaryFromFirstMetadataChange(
         guard let newValue = metadataChange.newValue,
               let mode = ConversationParticipationMode(rawValue: newValue) else { return nil }
         if mode == .paused {
-            return "\(creatorDisplayName) paused the agents. They won't see messages sent while paused, even later"
+            return "\(creatorDisplayName) paused the agents. They'll never see messages sent while paused"
         }
         return "\(creatorDisplayName) set the participation mode to \"\(mode.title)\""
     case .metadata, .unknown:

--- a/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
@@ -254,6 +254,6 @@ struct ParticipationModeSyncTests {
             ]
         )
 
-        #expect(update.summary == "Shane paused the agents. They won't see messages sent while paused, even later")
+        #expect(update.summary == "Shane paused the agents. They'll never see messages sent while paused")
     }
 }


### PR DESCRIPTION
The paused-agents system message shipped in #1374 is long enough to truncate mid-word in the transcript ("You paused the agents. They won't see messages sent whil…").

Two changes so it can't clip again:

- **Shorter copy** — "…paused the agents. They'll never see messages sent while paused". Same meaning as "even later", fewer characters.
- **Wraps instead of truncating** — `TextTitleContentView` drops `.lineLimit(1)`, gains `.multilineTextAlignment(.center)` + `.fixedSize(horizontal: false, vertical: true)`, and aligns the HStack `.top` so the 16pt avatar sits on the first line. The update cell is already `.estimated` in `DefaultMessagesLayoutDelegate`, so it self-sizes to the wrapped height. The view's other callers (date headers, "No comments yet", the builder footer) are short single lines and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCDxsxXirDRRmLazFkx8cv

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789833461&installation_model_id=20076&pr_number=1377&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1377&signature=7ee3bc87a51d9cff8b1af69f62829b120721fdd3abf2a190658ef8d8a855dc89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->