### PR TITLE
fix(variant): route a picked variant's default agent to its runtime

### DIFF
--- a/Convos/Agent Builder/AgentVariantAssignmentStore.swift
+++ b/Convos/Agent Builder/AgentVariantAssignmentStore.swift
@@ -59,3 +59,47 @@ final class AgentVariantAssignmentStore {
         static let assignmentsKey: String = "agentVariantAssignmentsByConversation"
     }
 }
+
+extension ConversationReadyResult.Origin {
+    /// Whether a creation flow's variant pick belongs to the conversation it
+    /// just settled on.
+    ///
+    /// `.created` is the cold path — the flow minted the conversation. But the
+    /// common path is `.existing`: compose adopts a conversation prepared ahead
+    /// of the pick (`prepareNewConversation()`), and that row is just as much
+    /// this flow's own. Binding only on `.created` dropped the pick on every
+    /// warm-cache create, and the join then read the global selector — usually
+    /// nothing — so the agent quietly built on the default runtime.
+    ///
+    /// Only `.joined` is somebody else's conversation, superseding the one this
+    /// flow was going to create; the pick was never made for it. Invite and
+    /// scanner flows carry no pick at all (`agentVariantSlug` is nil), so they
+    /// stay unbound regardless of which origin they report.
+    var bindsCreationFlowVariantPick: Bool {
+        switch self {
+        case .created, .existing: return true
+        case .joined: return false
+        }
+    }
+}
+
+/// The one place that answers "which variant does this conversation's agent
+/// traffic route to". Every caller — the join, the join-status poll, the
+/// participation read and mirror, and the warm-cache default-agent provision —
+/// resolves through here, so none of them can drift onto the global selector
+/// while the others read the conversation's own binding.
+@MainActor
+enum AgentVariantResolution {
+    static func slug(for conversationId: String) -> String? {
+        guard !ConfigManager.shared.currentEnvironment.isProduction else {
+            return FeatureFlags.shared.effectiveAgentVariantSlug
+        }
+        if let assigned = AgentVariantAssignmentStore.shared.slug(for: conversationId) {
+            Log.info("AgentVariant: \(conversationId) routing to assigned variant \(assigned)")
+            return assigned
+        }
+        let fallback = FeatureFlags.shared.effectiveAgentVariantSlug
+        Log.info("AgentVariant: \(conversationId) has no assignment, using \(fallback ?? "none")")
+        return fallback
+    }
+}

--- a/Convos/Conversation Creation/NewConversationViewModel.swift
+++ b/Convos/Conversation Creation/NewConversationViewModel.swift
@@ -1395,12 +1395,12 @@ extension NewConversationViewModel {
             }
 
             // Bind this flow's variant pick to the conversation now that it
-            // has an id, before any agent join reads it. Only for a
-            // conversation this flow created: a `.joined` result is somebody
-            // else's existing conversation that superseded ours, and the pick
-            // was made for the conversation we were going to create, not that
-            // one.
-            if result.origin == .created {
+            // has an id, before any agent join reads it. Both a freshly
+            // created conversation and one this flow adopted from the prepared
+            // cache are its own; only a `.joined` result is somebody else's
+            // conversation that superseded ours, and the pick was made for the
+            // conversation we were going to create, not that one.
+            if result.origin.bindsCreationFlowVariantPick {
                 AgentVariantAssignmentStore.shared.assignIfUnset(
                     slug: agentVariantSlug,
                     to: result.conversationId

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4514,16 +4514,7 @@ extension ConversationViewModel {
     /// be enabled there) and the API client strips any variant on prod.
     @MainActor
     private static func selectedAgentVariantSlug(for conversationId: String) -> String? {
-        guard !ConfigManager.shared.currentEnvironment.isProduction else {
-            return FeatureFlags.shared.effectiveAgentVariantSlug
-        }
-        if let assigned = AgentVariantAssignmentStore.shared.slug(for: conversationId) {
-            Log.info("AgentVariant: \(conversationId) routing to assigned variant \(assigned)")
-            return assigned
-        }
-        let fallback = FeatureFlags.shared.effectiveAgentVariantSlug
-        Log.info("AgentVariant: \(conversationId) has no assignment, using \(fallback ?? "none")")
-        return fallback
+        AgentVariantResolution.slug(for: conversationId)
     }
 
     /// The agent-variant slug bound to THIS conversation — the per-conversation

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -275,11 +275,12 @@ struct ConvosApp: App {
     }
 
     /// Routes cache-time default-agent joins to the same variant as every other
-    /// agent call. Read live at join time; hops to the main actor because
-    /// FeatureFlags is main-actor-isolated.
+    /// agent call: the conversation's own binding first, the global selector
+    /// only as a fallback. Read live at join time; hops to the main actor
+    /// because the resolution is main-actor-isolated.
     private static func wireDefaultAgentVariantProvider() {
-        SessionManager.defaultAgentVariantIdProvider = {
-            await MainActor.run { FeatureFlags.shared.effectiveAgentVariantSlug }
+        SessionManager.defaultAgentVariantIdProvider = { conversationId in
+            await MainActor.run { AgentVariantResolution.slug(for: conversationId) }
         }
     }
 

--- a/Convos/ConvosApp.swift
+++ b/Convos/ConvosApp.swift
@@ -282,6 +282,12 @@ struct ConvosApp: App {
         SessionManager.defaultAgentVariantIdProvider = { conversationId in
             await MainActor.run { AgentVariantResolution.slug(for: conversationId) }
         }
+        // With the selector on, a conversation's agent has to wait for the pick
+        // that conversation was created under; the warm cache would otherwise
+        // build it before the picker is even on screen.
+        SessionManager.deferCacheTimeDefaultAgent = {
+            await MainActor.run { FeatureFlags.shared.isAgentVariantSelectorEnabled }
+        }
     }
 
     var body: some Scene {

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+DefaultConversationAgent.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+DefaultConversationAgent.swift
@@ -65,7 +65,13 @@ extension SessionManager {
     /// whose pin or selection changes mid-session applies it to the next
     /// provision. Nil (no app layer, e.g. tests) keeps joins on the default
     /// runtime, as does production via the API client's prod-safe strip.
-    public nonisolated(unsafe) static var defaultAgentVariantIdProvider: (@Sendable () async -> String?)?
+    ///
+    /// Takes the conversation because a variant is bound per conversation: the
+    /// pick made while creating this one must beat whatever the global selector
+    /// happens to hold now, exactly as every other agent call resolves it.
+    /// Resolving globally here is what sent picked-variant agents to the
+    /// default runtime while the rest of the conversation's calls routed right.
+    public nonisolated(unsafe) static var defaultAgentVariantIdProvider: (@Sendable (String) async -> String?)?
 
     /// Every conversation gets a bare default agent (no template) pre-added
     /// while it still sits hidden in the warm cache. Disabled for unit tests,
@@ -122,7 +128,7 @@ extension SessionManager {
                 Log.debug("Default agent: conversation \(conversationId) already has a second member, skipping provision")
                 return
             }
-            let variantId = await Self.defaultAgentVariantIdProvider?()
+            let variantId = await Self.defaultAgentVariantIdProvider?(conversationId)
             let ownerProfileName = await currentOwnerProfileName()
             do {
                 try await provisionDefaultAgent(

--- a/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+DefaultConversationAgent.swift
+++ b/ConvosCore/Sources/ConvosCore/Sessions/SessionManager+DefaultConversationAgent.swift
@@ -85,11 +85,27 @@ extension SessionManager {
         }
     }
 
+    /// Hook the app layer installs to hold the warm cache's default-agent
+    /// provision until the conversation is adopted. The cache provisions at
+    /// preparation time, which is before a creation flow exists to pick a
+    /// variant, so a prepared conversation's agent would always be built on
+    /// whatever runtime was current when the row was minted — the pick could
+    /// never apply to the one agent the conversation ships with. Holding it
+    /// costs the pre-warm latency, so only the dev variant selector asks for
+    /// it; `commitClaimedConversation` ensures the agent at adoption, after the
+    /// variant is bound.
+    public nonisolated(unsafe) static var deferCacheTimeDefaultAgent: (@Sendable () async -> Bool)?
+
     /// Wires the warm cache so every conversation it finishes preparing gets
-    /// the default agent provisioned into it, best-effort, in the background.
+    /// the default agent provisioned into it, best-effort, in the background —
+    /// unless the app layer is holding that provision for a variant pick.
     func wireDefaultAgentProvisioner() {
         Task { [weak self, unusedConversationCache] in
             await unusedConversationCache.configureAgentProvisioner { [weak self] conversationId in
+                if await Self.deferCacheTimeDefaultAgent?() == true {
+                    Log.debug("Default agent: holding cache-time provision for \(conversationId) until adoption")
+                    return
+                }
                 await self?.ensureDefaultAgentInConversation(id: conversationId)
             }
         }

--- a/ConvosTests/AgentVariantResolutionTests.swift
+++ b/ConvosTests/AgentVariantResolutionTests.swift
@@ -53,6 +53,44 @@ final class AgentVariantResolutionTests: XCTestCase {
         XCTAssertNil(FeatureFlags.shared.effectiveAgentVariantSlug)
     }
 
+    /// The compose flow usually settles on a conversation prepared before the
+    /// pick was made, which reports `.existing`. Binding only on `.created`
+    /// silently dropped the pick on that path, and the agent built on the
+    /// default runtime while the picker showed the variant as selected.
+    func testAdoptedConversationStillBindsTheVariantPick() {
+        XCTAssertTrue(ConversationReadyResult.Origin.created.bindsCreationFlowVariantPick)
+        XCTAssertTrue(ConversationReadyResult.Origin.existing.bindsCreationFlowVariantPick)
+    }
+
+    /// A joined conversation superseded the one this flow was creating, so the
+    /// pick was never made for it.
+    func testJoinedConversationDoesNotInheritTheVariantPick() {
+        XCTAssertFalse(ConversationReadyResult.Origin.joined.bindsCreationFlowVariantPick)
+    }
+
+    /// A conversation's own binding outranks the global selector for every
+    /// caller, the warm-cache default-agent provision included — that provision
+    /// is the one that reached for the global slug and stranded picked agents
+    /// on the default worker.
+    func testConversationBindingBeatsTheGlobalSelection() {
+        FeatureFlags.shared.isAgentVariantSelectorEnabled = true
+        FeatureFlags.shared.selectedAgentVariant = variant(slug: "globally-selected")
+        let conversationId = "conversation-under-test"
+        AgentVariantAssignmentStore.shared.assign(slug: "picked-at-create", to: conversationId)
+        defer { AgentVariantAssignmentStore.shared.assign(slug: nil, to: conversationId) }
+
+        XCTAssertEqual(AgentVariantResolution.slug(for: conversationId), "picked-at-create")
+    }
+
+    /// An unbound conversation still follows the selector, so turning the dev
+    /// toggle on remains a way to route without going through the picker.
+    func testUnboundConversationFallsBackToTheGlobalSelection() {
+        FeatureFlags.shared.isAgentVariantSelectorEnabled = true
+        FeatureFlags.shared.selectedAgentVariant = variant(slug: "globally-selected")
+
+        XCTAssertEqual(AgentVariantResolution.slug(for: "never-bound"), "globally-selected")
+    }
+
     private func variant(slug: String) -> ConvosAPI.AgentVariant {
         ConvosAPI.AgentVariant(
             slug: slug,


### PR DESCRIPTION
Picking a variant in the compose sheet had no effect: the agent built on the shared dev worker while the picker showed the variant as selected. Device logs caught both halves of it in the same second — `AgentVariant: new conversation starting under variant pr-3516` immediately followed by `AgentVariant: <id> has no assignment, using none`, and the resulting agent landed on `convos-assistants-dev` with an empty `metadata` (no variant descriptor stamped).

**The pick was discarded at binding.** It bound only for a `.created` result, but compose usually settles on a conversation prepared ahead of the pick, which reports `.existing` (`NewConversation.ready: 245ms (origin: existing)`). `assignIfUnset` never ran, and the join fell through to the global selector — normally empty, because the sheet writes its pick to the conversation, not to `FeatureFlags`.

**The default agent would not have read the binding regardless.** `defaultAgentVariantIdProvider` took no conversation and resolved the global selection, so the one agent every new conversation gets was routed by whatever the selector happened to hold. It now takes the conversation id.

To stop the two from drifting apart again, the resolution lives in one place (`AgentVariantResolution.slug(for:)`) that `ConversationViewModel` and the app-layer wiring both call.

Verified `BUILD SUCCEEDED` for `Convos (Dev)` and installed on the convos-dev simulator. The four tests in `AgentVariantResolutionTests` are new and have not been executed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGnQGVRbGwV8dRe94ZoC6T

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789836436&installation_model_id=20076&pr_number=1378&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1378&signature=9ed8a0a58ab3d37401dff9359aa324dfe8fb1a12ade27b162384f316278eab3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix picked variant's default agent routing to its runtime
> - Adds `ConversationReadyResult.Origin.bindsCreationFlowVariantPick` so `.existing` conversations (adopted from cache) bind the creation flow's variant pick, not just `.created` ones; `.joined` remains unbound
> - Introduces `AgentVariantResolution.slug(for:)` to centralize per-conversation variant slug resolution, replacing inline logic in [ConversationViewModel.swift](https://github.com/xmtplabs/convos-ios/pull/1378/files#diff-d056b0b131534648b6d13cddafd053be956f5d23d035ad2538db85a8cc370d8d) and [ConvosApp.swift](https://github.com/xmtplabs/convos-ios/pull/1378/files#diff-de23c5a6e10cb84b89d91ed62b707b654c28566f38cc339af8b3cbbf6e003014)
> - Changes `SessionManager.defaultAgentVariantIdProvider` from `() async -> String?` to `(String) async -> String?` so provisioning resolves the variant per-conversation instead of globally
> - Adds `SessionManager.deferCacheTimeDefaultAgent` so the app layer can skip warm-cache default-agent provisioning when the dev variant selector is enabled
> - Behavioral Change: `SessionManager.defaultAgentVariantIdProvider` signature changed — all callers must now pass a `conversationId`; warm-cache provisioning is skipped when `deferCacheTimeDefaultAgent` returns true, so cache-time conversations may temporarily lack a default agent until adoption
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8fdb15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->