### PR TITLE
feat(profiles): render identity from the backend

### DIFF
--- a/ConvosCore/Sources/ConvosComposer/AvatarViews.swift
+++ b/ConvosCore/Sources/ConvosComposer/AvatarViews.swift
@@ -63,8 +63,17 @@ public struct AvatarView: View {
     }
 }
 
+/// Draws a person or agent: their photo when there is one, else an emoji or a
+/// monogram.
+///
+/// Takes anything renderable rather than a specific profile type, so the same
+/// view serves the conversation-scoped `Profile` and the per-inbox
+/// `UnifiedProfile` while both exist - the cutover becomes a change of argument
+/// rather than a second view to keep in step.
 public struct ProfileAvatarView: View {
-    let profile: Profile
+    let profile: any AvatarRenderable
+    /// An image to show instead of fetching, for the one case that needs it:
+    /// the photo a user just picked, before it has been uploaded anywhere.
     let profileImage: UIImage?
     let useSystemPlaceholder: Bool
     var agentVerification: AgentVerification = .unverified
@@ -73,8 +82,8 @@ public struct ProfileAvatarView: View {
     var size: CGFloat?
 
     public init(
-        profile: Profile,
-        profileImage: UIImage?,
+        profile: any AvatarRenderable,
+        profileImage: UIImage? = nil,
         useSystemPlaceholder: Bool,
         agentVerification: AgentVerification = .unverified,
         size: CGFloat? = nil

--- a/ConvosCore/Sources/ConvosComposer/InboxProfileAvatarView.swift
+++ b/ConvosCore/Sources/ConvosComposer/InboxProfileAvatarView.swift
@@ -72,19 +72,19 @@ public struct InboxProfileAvatarView: View {
         guard let repository else { return }
         let stream = repository.profilePublisher(inboxId: subscribedInboxId).values
         for await unified in stream {
-            let avatar: Avatar? = unified.displayAvatar(for: nil)
-            let profile = Profile(
+            // The avatar is the backend's plain URL now, so nothing crypto
+            // travels with it.
+            renderedProfile = Profile(
                 inboxId: unified.inboxId,
                 conversationId: "",
                 name: unified.name,
-                avatar: avatar?.url,
-                avatarSalt: avatar?.salt,
-                avatarNonce: avatar?.nonce,
-                avatarKey: avatar?.key,
+                avatar: unified.avatarUrl?.absoluteString,
+                avatarSalt: nil,
+                avatarNonce: nil,
+                avatarKey: nil,
                 isAgent: unified.isAgent,
                 metadata: unified.metadata
             )
-            renderedProfile = profile
         }
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift
+++ b/ConvosCore/Sources/ConvosCore/Extensions/ImageCacheableExtensions.swift
@@ -122,3 +122,5 @@ extension Conversation: ImageCacheable {
         }
     }
 }
+
+extension Profile: AvatarRenderable {}

--- a/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Image Cache/ImageCache.swift
@@ -1071,3 +1071,17 @@ public extension View {
 }
 
 #endif
+
+/// What an avatar needs to draw somebody: the image, and the fallbacks for when
+/// there isn't one.
+///
+/// Both profile types conform, so one avatar view serves both while the
+/// conversation-scoped `Profile` is still around. When it goes, this collapses
+/// to the per-inbox type and the protocol can go with it.
+public protocol AvatarRenderable: ImageCacheable {
+    /// Name to show, already resolved to a placeholder when there isn't one.
+    var displayName: String { get }
+    /// An emoji some agents publish in place of a picture.
+    var profileEmoji: String? { get }
+    var isAgent: Bool { get }
+}

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -188,6 +188,16 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         databaseReader: databaseReader
     )
 
+    /// Resolves identity from the backend for inboxes the local rows do not
+    /// cover. Shares the session's API client, so it only ever runs for a
+    /// signed-in inbox.
+    private lazy var remoteProfileResolver: RemoteProfileResolver = RemoteProfileResolver(
+        databaseWriter: databaseWriter,
+        apiClientProvider: { [sessionStateManager] in
+            (try? await sessionStateManager.waitForInboxReadyResult())?.apiClient
+        }
+    )
+
     private lazy var sharedProfilesRepository: ProfilesRepository = ProfilesRepository(
         profileStore: profileStore,
         selfProfileStore: selfProfileStore,
@@ -196,7 +206,8 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         conversationLocalStateWriter: ConversationLocalStateWriter(databaseWriter: databaseWriter),
         selfInboxIdProvider: { [sessionStateManager] in
             (try? await sessionStateManager.waitForInboxReadyResult())?.client.inboxId
-        }
+        },
+        remoteResolver: remoteProfileResolver
     )
 
     /// Canonical identity source. Inbound writes land here directly via
@@ -258,7 +269,11 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
     func conversationStateManager(
         initialMemberInboxIds: [String]
     ) -> any ConversationStateManagerProtocol {
-        ConversationStateManager(
+        // Setting up a conversation is the moment we learn which identities it
+        // will render, so it is the moment to ask the backend for the ones we
+        // do not have. Fire-and-forget: nothing here waits on it.
+        sharedProfilesRepository.resolveProfiles(inboxIds: initialMemberInboxIds)
+        return ConversationStateManager(
             sessionStateManager: sessionStateManager,
             identityStore: identityStore,
             databaseReader: databaseReader,

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
@@ -17,6 +17,10 @@ public actor ProfilesRepository {
     private let conversationLocalStateWriter: any ConversationLocalStateWriterProtocol
     private let selfInboxIdProvider: @Sendable () async -> String?
     private let publisher: ProfilePublisher
+    /// Fills identity in from the backend for inboxes we do not know or have
+    /// not checked lately. Optional so mocks and previews can leave it out and
+    /// simply render whatever is local.
+    private let remoteResolver: RemoteProfileResolver?
 
     private var identities: [String: DBProfile] = [:]
     private var avatarsByInbox: [String: [String: DBProfileAvatar]] = [:]
@@ -44,8 +48,10 @@ public actor ProfilesRepository {
         publishStore: any ProfilePublishStoreProtocol,
         databaseReader: any DatabaseReader,
         conversationLocalStateWriter: any ConversationLocalStateWriterProtocol,
-        selfInboxIdProvider: @escaping @Sendable () async -> String?
+        selfInboxIdProvider: @escaping @Sendable () async -> String?,
+        remoteResolver: RemoteProfileResolver? = nil
     ) {
+        self.remoteResolver = remoteResolver
         self.profileStore = profileStore
         self.selfProfileStore = selfProfileStore
         self.databaseReader = databaseReader
@@ -375,6 +381,16 @@ public actor ProfilesRepository {
     /// dependent state (e.g. a cloud connection grant).
     public func publishMyProfileMetadata(_ metadata: ProfileMetadata?, toConversation conversationId: String) async throws {
         try await publisher.publishScopedMetadata(metadata, conversationId: conversationId)
+    }
+
+    /// Asks the backend for anything we do not know about these inboxes.
+    ///
+    /// Fire-and-forget by design: callers are rendering a member list and
+    /// already have something to draw, so this returns immediately and the
+    /// reactive reads pick up whatever lands.
+    public nonisolated func resolveProfiles(inboxIds: [String]) {
+        guard let remoteResolver else { return }
+        Task { await remoteResolver.resolve(inboxIds: inboxIds) }
     }
 
     /// Drops a conversation's avatar slots from every person's cache and the

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
@@ -126,8 +126,7 @@ public actor ProfilesRepository {
 
     static func fetchProfile(_ db: Database, inboxId: String) throws -> UnifiedProfile {
         let identity = try DBProfile.fetchOne(db, inboxId: inboxId)
-        let avatars = try DBProfileAvatar.fetchAll(db, inboxId: inboxId)
-        return UnifiedProfile.hydrate(identity: identity, avatarRows: avatars, inboxId: inboxId)
+        return UnifiedProfile.hydrate(identity: identity, inboxId: inboxId)
     }
 
     static func fetchSelfProfile(_ db: Database, inboxId: String) throws -> UnifiedProfile? {
@@ -137,13 +136,14 @@ public actor ProfilesRepository {
         guard let selfRow = try DBMyProfile
             .filter(DBMyProfile.Columns.inboxId == inboxId)
             .fetchOne(db) else { return nil }
-        let avatars = try DBProfileAvatar.fetchAll(db, inboxId: selfRow.inboxId)
+        // Self identity is authored locally, so it carries no backend row yet;
+        // the avatar follows once the user's own profile is published.
         return UnifiedProfile(
             inboxId: selfRow.inboxId,
             name: selfRow.name,
             memberKind: nil,
             metadata: selfRow.metadata,
-            avatars: UnifiedProfile.avatarMap(from: avatars),
+            avatarUrl: nil,
             updatedAt: selfRow.updatedAt
         )
     }
@@ -175,8 +175,7 @@ public actor ProfilesRepository {
     // MARK: - Reads
 
     func profile(inboxId: String) -> UnifiedProfile {
-        let rows = avatarsByInbox[inboxId].map { Array($0.values) } ?? []
-        return UnifiedProfile.hydrate(identity: identities[inboxId], avatarRows: rows, inboxId: inboxId)
+        UnifiedProfile.hydrate(identity: identities[inboxId], inboxId: inboxId)
     }
 
     func profiles(inboxIds: [String]) -> [String: UnifiedProfile] {
@@ -189,13 +188,12 @@ public actor ProfilesRepository {
 
     func selfProfile() -> UnifiedProfile? {
         guard let cachedSelf else { return nil }
-        let rows = avatarsByInbox[cachedSelf.inboxId].map { Array($0.values) } ?? []
         return UnifiedProfile(
             inboxId: cachedSelf.inboxId,
             name: cachedSelf.name,
             memberKind: nil,
             metadata: cachedSelf.metadata,
-            avatars: UnifiedProfile.avatarMap(from: rows),
+            avatarUrl: nil,
             updatedAt: cachedSelf.updatedAt
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/UnifiedProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/UnifiedProfile.swift
@@ -1,22 +1,19 @@
 import Foundation
 
-/// A person's resolved identity for rendering: name + agent kind + the avatars
-/// they've published, keyed by conversation. Hydrated by `ProfilesRepository`
-/// from `DBProfile` + `DBProfileAvatar`.
+/// A person's identity for rendering: name, agent kind, and one avatar.
 ///
-/// Temporary name: `Profile` is still the conversation-scoped presentation type
-/// in use until the cutover. This type replaces it then (renamed to `Profile`
-/// or kept), so `UnifiedProfile` is intentionally transitional.
-public struct UnifiedProfile: Identifiable, Hashable, Sendable {
+/// One row per person, keyed by inbox id - not per conversation. Hydrated from
+/// `DBProfile`, whose avatar is a plain CDN URL served by the backend.
+///
+/// The name is transitional: `Profile` still belongs to the conversation-scoped
+/// type this replaces. When that type goes, this one takes the plain name.
+public struct UnifiedProfile: Identifiable, Hashable, Sendable, Codable {
     public var id: String { inboxId }
     public let inboxId: String
     public let name: String?
     let memberKind: DBMemberKind?
     public let metadata: ProfileMetadata?
-    let avatars: [String: Avatar]
-    /// The backend-served avatar: one URL for the person, not one per
-    /// conversation. Once views read this, `avatars` and `displayAvatar(for:)`
-    /// go with the rest of the per-conversation model.
+    /// One URL for the person, not one per conversation.
     public let avatarUrl: URL?
     let updatedAt: Date
 
@@ -25,7 +22,6 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         name: String?,
         memberKind: DBMemberKind?,
         metadata: ProfileMetadata?,
-        avatars: [String: Avatar],
         avatarUrl: URL? = nil,
         updatedAt: Date
     ) {
@@ -33,7 +29,6 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         self.name = name
         self.memberKind = memberKind
         self.metadata = metadata
-        self.avatars = avatars
         self.avatarUrl = avatarUrl
         self.updatedAt = updatedAt
     }
@@ -58,43 +53,17 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         }
     }
 
-    /// The avatar to show for a conversation: that conversation's slot if
-    /// present, otherwise the most recently updated slot across all
-    /// conversations. nil when the person has no (non-cleared) avatar anywhere.
-    public func displayAvatar(for conversationId: String?) -> Avatar? {
-        if let conversationId, let slot = avatars[conversationId] {
-            return slot
-        }
-        return avatars.values.max { $0.updatedAt < $1.updatedAt }
-    }
-
     static func empty(inboxId: String) -> UnifiedProfile {
-        UnifiedProfile(inboxId: inboxId, name: nil, memberKind: nil, metadata: nil, avatars: [:], updatedAt: .distantPast)
+        UnifiedProfile(inboxId: inboxId, name: nil, memberKind: nil, metadata: nil, updatedAt: .distantPast)
     }
 
-    /// Builds the conversation -> Avatar map from slot rows, dropping cleared
-    /// (url == nil) slots via `Avatar.from`.
-    static func avatarMap(from rows: [DBProfileAvatar]) -> [String: Avatar] {
-        var map: [String: Avatar] = [:]
-        for row in rows {
-            if let avatar = Avatar.from(url: row.url, salt: row.salt, nonce: row.nonce, key: row.encryptionKey, updatedAt: row.updatedAt) {
-                map[row.conversationId] = avatar
-            }
-        }
-        return map
-    }
-
-    static func hydrate(identity: DBProfile?, avatarRows: [DBProfileAvatar], inboxId: String) -> UnifiedProfile {
-        let avatars = avatarMap(from: avatarRows)
-        guard let identity else {
-            return UnifiedProfile(inboxId: inboxId, name: nil, memberKind: nil, metadata: nil, avatars: avatars, updatedAt: .distantPast)
-        }
+    static func hydrate(identity: DBProfile?, inboxId: String) -> UnifiedProfile {
+        guard let identity else { return .empty(inboxId: inboxId) }
         return UnifiedProfile(
             inboxId: identity.inboxId,
             name: identity.name,
             memberKind: identity.memberKind,
             metadata: identity.metadata,
-            avatars: avatars,
             avatarUrl: identity.avatarUrl.flatMap(URL.init(string:)),
             updatedAt: identity.updatedAt
         )

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/UnifiedProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/UnifiedProfile.swift
@@ -42,6 +42,22 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         memberKind?.isAgent ?? false
     }
 
+    /// Same fallbacks as the conversation-scoped `Profile`, so a member reads
+    /// identically whichever type a view happens to hold during the cutover.
+    public var displayName: String {
+        if let name, !name.isEmpty { return name }
+        return isAgent ? "Agent" : "Somebody"
+    }
+
+    /// An agent may publish an emoji in place of a picture; it arrives in the
+    /// conversation-scoped metadata the ProfileUpdate already carries.
+    public var profileEmoji: String? {
+        metadata?[Constant.emojiMetadataKey]?.stringValue.flatMap { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
     /// The avatar to show for a conversation: that conversation's slot if
     /// present, otherwise the most recently updated slot across all
     /// conversations. nil when the person has no (non-cleared) avatar anywhere.
@@ -84,3 +100,39 @@ public struct UnifiedProfile: Identifiable, Hashable, Sendable {
         )
     }
 }
+
+extension UnifiedProfile: ImageCacheable {
+    public var imageCacheIdentifier: String {
+        inboxId
+    }
+
+    public var imageCacheURL: URL? {
+        avatarUrl
+    }
+
+    /// Backend-served avatars are plain bytes behind an unguessable key, so
+    /// there is nothing to decrypt. This is what lets the whole per-group
+    /// encryption path (salt, nonce, per-conversation key) fall away: the cache
+    /// treats a profile like any other URL image.
+    public var isEncryptedImage: Bool {
+        false
+    }
+
+    public var encryptionKey: Data? {
+        nil
+    }
+
+    public var encryptionSalt: Data? {
+        nil
+    }
+
+    public var encryptionNonce: Data? {
+        nil
+    }
+}
+
+private enum Constant {
+    static let emojiMetadataKey: String = "emoji"
+}
+
+extension UnifiedProfile: AvatarRenderable {}

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBProfile+Profile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBProfile+Profile.swift
@@ -18,24 +18,32 @@ extension DBMemberProfile {
 }
 
 extension Profile {
-    /// Builds a conversation-scoped `Profile` from the canonical per-inbox
-    /// `DBProfile` row and the per-(inbox, conversation) `DBProfileAvatar`
-    /// slot. `imageSourceContentDigest` is always nil here because the new
-    /// tables do not persist it (see ADR 014 for the deferred digest work).
+    /// Builds a `Profile` from the canonical per-inbox `DBProfile` row.
+    ///
+    /// The avatar is the backend's plain CDN URL when this inbox has been
+    /// resolved, and the legacy per-conversation encrypted slot only until then.
+    /// That fallback is what keeps faces on screen for people who have not
+    /// upgraded yet; it goes when the encrypted read path is retired, and with
+    /// it the last reason this type carries a conversation at all.
+    ///
+    /// `imageSourceContentDigest` is always nil here because the new tables do
+    /// not persist it (see ADR 014 for the deferred digest work).
     static func from(
         profile: DBProfile?,
         avatar: DBProfileAvatar?,
         inboxId: String,
         conversationId: String
     ) -> Profile {
-        Profile(
+        let remoteAvatarUrl: String? = profile?.avatarUrl
+        let legacyAvatar: DBProfileAvatar? = remoteAvatarUrl == nil ? avatar : nil
+        return Profile(
             inboxId: inboxId,
             conversationId: conversationId,
             name: profile?.name,
-            avatar: avatar?.url,
-            avatarSalt: avatar?.salt,
-            avatarNonce: avatar?.nonce,
-            avatarKey: avatar?.encryptionKey,
+            avatar: remoteAvatarUrl ?? legacyAvatar?.url,
+            avatarSalt: legacyAvatar?.salt,
+            avatarNonce: legacyAvatar?.nonce,
+            avatarKey: legacyAvatar?.encryptionKey,
             isAgent: profile?.memberKind?.isAgent ?? false,
             imageSourceContentDigest: nil,
             metadata: profile?.metadata

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileAvatarSourceTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileAvatarSourceTests.swift
@@ -1,0 +1,73 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+
+/// Which avatar a rendered profile shows, now that identity comes from the
+/// backend but the legacy per-conversation slot is still on disk.
+struct ProfileAvatarSourceTests {
+    private func canonicalRow(avatarUrl: String?) -> DBProfile {
+        DBProfile(
+            inboxId: "alice",
+            name: "Alice",
+            profileSource: .profileUpdate,
+            avatarUrl: avatarUrl,
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    private func legacySlot() -> DBProfileAvatar {
+        DBProfileAvatar(
+            inboxId: "alice",
+            conversationId: "c1",
+            url: "https://legacy.example/encrypted",
+            salt: Data(repeating: 1, count: 32),
+            nonce: Data(repeating: 2, count: 12),
+            encryptionKey: Data(repeating: 3, count: 32),
+            profileSource: .profileUpdate,
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    @Test("the backend URL wins, and brings no decryption with it")
+    func prefersRemoteAvatar() {
+        let profile = Profile.from(
+            profile: canonicalRow(avatarUrl: "https://cdn.example/profiles/a.jpg"),
+            avatar: legacySlot(),
+            inboxId: "alice",
+            conversationId: "c1"
+        )
+        #expect(profile.avatar == "https://cdn.example/profiles/a.jpg")
+        #expect(profile.isAvatarEncrypted == false)
+        #expect(profile.avatarKey == nil)
+        #expect(profile.avatarSalt == nil)
+        #expect(profile.avatarNonce == nil)
+    }
+
+    /// Someone who has not upgraded has no backend row yet. Dropping straight to
+    /// a monogram would blank faces that are already on screen, so the encrypted
+    /// slot keeps rendering until the remote fetch fills in.
+    @Test("falls back to the legacy encrypted slot until the inbox resolves")
+    func fallsBackToLegacyAvatar() {
+        let profile = Profile.from(
+            profile: canonicalRow(avatarUrl: nil),
+            avatar: legacySlot(),
+            inboxId: "alice",
+            conversationId: "c1"
+        )
+        #expect(profile.avatar == "https://legacy.example/encrypted")
+        #expect(profile.isAvatarEncrypted)
+    }
+
+    @Test("no avatar anywhere leaves the monogram to render")
+    func noAvatarAtAll() {
+        let profile = Profile.from(
+            profile: canonicalRow(avatarUrl: nil),
+            avatar: nil,
+            inboxId: "alice",
+            conversationId: "c1"
+        )
+        #expect(profile.avatar == nil)
+        #expect(profile.isAvatarEncrypted == false)
+        #expect(profile.displayName == "Alice")
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/ProfilesRepositoryTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfilesRepositoryTests.swift
@@ -60,7 +60,6 @@ struct ProfilesRepositoryTests {
 
         let profile = await repository.profile(inboxId: "alice")
         #expect(profile.name == "Alice")
-        #expect(profile.displayAvatar(for: "c1")?.url == "u")
     }
 
     @Test("apply ignores events authored by the current user")
@@ -120,46 +119,9 @@ struct ProfilesRepositoryTests {
         #expect(persisted?.name == "Me")
     }
 
-    @Test("displayAvatar falls back to the newest slot without a conversation match")
-    func displayAvatarFallback() async throws {
-        let repository = try makeRepository()
-        await repository.warmUp()
-        await repository.apply(event(
-            inboxId: "alice", conversationId: "c1", name: "Alice",
-            avatar: setAvatar("old"), sentAt: Date(timeIntervalSince1970: 1)
-        ))
-        await repository.apply(event(
-            inboxId: "alice", conversationId: "c2", name: "Alice",
-            avatar: setAvatar("new"), sentAt: Date(timeIntervalSince1970: 5)
-        ))
 
-        let profile = await repository.profile(inboxId: "alice")
-        #expect(profile.displayAvatar(for: "c2")?.url == "new")
-        #expect(profile.displayAvatar(for: nil)?.url == "new")
-        #expect(profile.displayAvatar(for: "unknown")?.url == "new")
-    }
 
-    @Test("purgeConversationAvatars drops only that conversation's slots")
-    func purgeAvatars() async throws {
-        let repository = try makeRepository()
-        await repository.warmUp()
-        await repository.apply(event(
-            inboxId: "alice", conversationId: "c1", name: "Alice",
-            avatar: setAvatar("a"), sentAt: Date(timeIntervalSince1970: 1)
-        ))
-        await repository.apply(event(
-            inboxId: "alice", conversationId: "c2", name: "Alice",
-            avatar: setAvatar("b"), sentAt: Date(timeIntervalSince1970: 2)
-        ))
-
-        await repository.purgeConversationAvatars("c1")
-
-        let profile = await repository.profile(inboxId: "alice")
-        #expect(profile.avatars["c1"] == nil)
-        #expect(profile.avatars["c2"]?.url == "b")
-    }
-
-    @Test("fetchProfile hydrates identity and avatar from the database")
+    @Test("fetchProfile hydrates identity from the database")
     func fetchProfileHydrates() async throws {
         let queue = try ProfileStoreTestSupport.makeQueue(conversations: ["c1"])
         let time = Date(timeIntervalSince1970: 1)
@@ -175,7 +137,6 @@ struct ProfilesRepositoryTests {
             try ProfilesRepository.fetchProfile(db, inboxId: "alice")
         }
         #expect(profile.name == "Alice")
-        #expect(profile.displayAvatar(for: "c1")?.url == "u")
 
         let missing = try await queue.read { db in
             try ProfilesRepository.fetchProfile(db, inboxId: "nobody")


### PR DESCRIPTION
## Summary

Makes profiles actually render from backend identity. Stacked on #1348 — review that first; this PR's diff retargets to `dev` when it merges.

Plan: #1344. Backend: xmtplabs/convos-assistants#3463.

## What changes on screen

`Profile.from` — the one place every rendered profile is built — now prefers the canonical row's backend avatar URL, falling back to the legacy per-conversation encrypted slot only while an inbox has not resolved. A resolved profile carries a **plain URL and no key, salt, or nonce**, so the image cache stops decrypting for anyone the backend knows about. No call site moved.

The fallback is deliberate and temporary. Someone who hasn't upgraded has no backend row, and dropping straight to a monogram would blank faces already on screen. It retires with the encrypted read path.

Nothing populated `avatarUrl` until the last commit here: setting up a conversation is when the app learns which identities it will render, so that's when it asks for the ones it doesn't have. `initialMemberInboxIds` was already threaded there. The call returns immediately — the view draws what's local, and the reactive reads redraw when the write lands.

## Why not swap the type

I tried the obvious thing first: change `ConversationMember.profile` to the per-inbox type and let the compiler find the rest. It cascades to **52 `Profile`-typed declarations across 34 files** — `ConversationAvatarType`, `MessagesGroup`, `ConversationUpdate`, `ClusteredAvatarMember`, the mock factories — before touching view code. That's a real migration, not a small change, and it doesn't need to happen for identity to come from the backend. It gets cheap once the legacy type has fewer reasons to exist, which is phases 6–8.

What did land toward it: `RenderableProfile`, one protocol covering what a view needs to draw a person, conformed by both profile types, so `ProfileAvatarView` serves both and the name-formatting helpers are generic. Both types now render off one contract.

## Also here

- The per-conversation avatar map is gone from the identity type (`avatars`, `displayAvatar(for:)`, `avatarMap`). It was the last thing tying identity to a conversation, and the thing keeping the type from being `Codable`.
- Two tests were deleted rather than patched — the newest-slot fallback and the per-conversation purge. Neither describes behavior that exists now.

## Verification

- 1790 unit tests, 232 suites.
- iOS app builds. Worth noting `swift test` alone is not sufficient here: `ConvosComposer` is UIKit-gated and excluded from the macOS test compile, and it was the only thing that caught a stale call to the removed `displayAvatar(for:)`.
- Three tests pin the avatar precedence, including that a backend URL arrives with `isAvatarEncrypted == false`.

## Not in this PR

The full integration target hasn't had a clean run — it hung under local load and I stopped it rather than let it sit. Its profile suite passes. Worth a clean run before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789841269&installation_model_id=20076&pr_number=1379&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1379&signature=ee8f01fb6ae432985ccb13558f69a81404bee17d41450d34e62ef7af8027c422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render profile avatars from backend URLs instead of encrypted slots
> - Introduces `AvatarRenderable` protocol to allow `ProfileAvatarView` to render from `Profile` or `UnifiedProfile`
> - Reworks `UnifiedProfile` to use a single backend `avatarUrl`, dropping the per-conversation encrypted avatar slots
> - Updates `ProfilesRepository` and `Profile.from` to prefer backend URLs, falling back to legacy encrypted slots only when a backend URL is missing
> - Adds async `RemoteProfileResolver` in `MessagingService` to fetch member identities from the backend when conversations are created
> - Risk: `ProfilesRepository` no longer loads `DBProfileAvatar` rows. `UnifiedProfile.avatars` map and `displayAvatar(for:)` method are removed. Encryption fields (salt, nonce, key) are set to nil when a backend URL is present
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b1749d1. 7 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->