### PR TITLE
fix(variant): bind the pick before the flow can provision

### DIFF
--- a/Convos/Conversations List/ConversationsViewModel.swift
+++ b/Convos/Conversations List/ConversationsViewModel.swift
@@ -523,6 +523,18 @@ final class ConversationsViewModel {
     /// `onStartConvo` so the variant picker can run ahead of it and then
     /// continue into the same flow.
     func startNewConversation(agentVariantSlug: String? = nil) {
+        // Bind the pick to the conversation this flow is about to adopt,
+        // before the flow starts. The warm cache hands out a conversation it
+        // prepared earlier, and that conversation's default agent is
+        // provisioned the moment it is adopted — concurrently with the
+        // `.ready` handler that would otherwise write this binding. Writing it
+        // here means the assignment is already on disk whenever the
+        // provisioner resolves, so a pick can't lose that race and land its
+        // agent on the default runtime. `.ready` still binds as the backstop
+        // for a cold create, where no prepared conversation exists yet.
+        if let agentVariantSlug, let prepared = session.peekPreparedConversationId() {
+            AgentVariantAssignmentStore.shared.assignIfUnset(slug: agentVariantSlug, to: prepared)
+        }
         newConversationViewModel = NewConversationViewModel(
             session: session,
             mode: .newConversation,


### PR DESCRIPTION
Follow-up to #1378. A picked variant still built its agent on the default runtime, confirmed on device against current `dev` (which already carries both of #1378's fixes).

The warm cache hands compose a conversation it prepared earlier, and adopting one provisions that conversation's default agent concurrently with the `.ready` handler that writes the variant binding. Nothing orders the two, and the provisioner won:

```
18:34:16  AgentVariant: new conversation starting under variant pr-3516
18:34:16  AgentVariant: 7468406321… has no assignment, using none    <- provision resolves here
18:34:16  [PERF] NewConversation.ready: 249ms (origin: existing)
18:34:16  AgentVariant: conversation 7468406321… bound to variant pr-3516
18:34:22  Default agent: provisioned into conversation 7468406321…
18:34:23  AgentVariant: 7468406321… routing to assigned variant pr-3516
```

`runDefaultAgentProvision` reads the variant when it starts and only logs once it finishes, so it had already resolved to `nil` six seconds before that `provisioned` line. The agent came up on `convos-assistants-dev` with no variant descriptor, while every later call on the conversation routed correctly — the split-brain the log's last two lines show.

Binding at the pick removes the race instead of narrowing it: the assignment is written before the creation flow exists, so any provisioner that resolves afterwards reads it. The `.ready` binding stays as the backstop for a cold create, where no prepared conversation is waiting.

Verified `BUILD SUCCEEDED` and installed on device; the behavioral check (agent landing on `ephemeral-pr-3516` instead of `dev`) is the next step and is not yet confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGnQGVRbGwV8dRe94ZoC6T

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789843355&installation_model_id=20076&pr_number=1380&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1380&signature=310c3233f5ddbbc0aa44faa127538160b83da020b01ff60bafda97e2e1b5a14f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind agent variant to prepared conversation before provisioning in `ConversationsViewModel.startNewConversation`
> When an `agentVariantSlug` is present and `session.peekPreparedConversationId()` returns an ID, the variant is now assigned to that prepared conversation via `AgentVariantAssignmentStore.shared.assignIfUnset` before `NewConversationViewModel` is created. This ensures the variant binding is in place before the flow can provision the conversation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abb6781.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->