### PR TITLE
Rework the connection detail around where a connection is used

### DIFF
--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -26,15 +26,28 @@ struct AbilitiesListScreen: View {
     /// `ConnectionsBrowserMode`). Membership predicates are the same in
     /// both modes.
     private let mode: ConnectionsBrowserMode
+    /// Where the detail push reads its Agents/Convos sections from.
+    /// Supplied by the entry point so previews and tests can serve
+    /// fixtures without reaching for the process-wide accessor.
+    private let usageSource: any ConnectionUsageSourcing
     @Environment(\.dismiss) private var dismiss: DismissAction
 
     /// Takes the whole selection so the service and its authorizer are
     /// latched together for the screen's lifetime -- the halves must never
     /// be resolved at different times (see `AbilitiesSelection`).
-    init(selection: AbilitiesSelection, mode: ConnectionsBrowserMode) {
+    init(
+        selection: AbilitiesSelection,
+        mode: ConnectionsBrowserMode,
+        usageSource: any ConnectionUsageSourcing
+    ) {
         self.selection = selection
         self.mode = mode
-        let listViewModel = AbilitiesListViewModel(service: selection.service, authorizer: selection.authorizer)
+        self.usageSource = usageSource
+        let listViewModel = AbilitiesListViewModel(
+            service: selection.service,
+            authorizer: selection.authorizer,
+            usageSource: usageSource
+        )
         let conversationViewModel = Self.makeConversationViewModel(listViewModel, selection: selection, mode: mode)
         if let conversationViewModel {
             Self.wireActivation(list: listViewModel, conversation: conversationViewModel)
@@ -122,7 +135,8 @@ struct AbilitiesListScreen: View {
             viewModel: viewModel,
             selection: selection,
             mode: mode,
-            conversationViewModel: conversationViewModel
+            conversationViewModel: conversationViewModel,
+            usageSource: usageSource
         )
         .modifier(ConversationAbilitiesSheetsModifier(viewModel: conversationViewModel))
     }
@@ -166,10 +180,11 @@ struct AbilitiesListScreen: View {
 /// here: it presents the scoped `AbilityConnectSheet` instead, which reuses
 /// this screen's view model for the connect machinery.
 ///
-/// Entitled rows push `AbilityDetailScreen` (delegations list) in
-/// `.appSettings` only. Available, state-unknown, and `.composerModal`
-/// Connected rows stay non-navigable - the last because a `Toggle` inside
-/// a `NavigationLink` fights the row's tap target.
+/// Connected rows push `AbilityDetailScreen` (where the connection is in
+/// use) in both modes: `.appSettings` through a plain `NavigationLink`,
+/// `.composerModal` through the row's own disclosure, because a `Toggle`
+/// inside a `NavigationLink` fights the row's tap target. Available and
+/// state-unknown rows stay non-navigable.
 struct AbilitiesListView: View {
     @Bindable var viewModel: AbilitiesListViewModel
     /// Latched pair handed down to ability detail pushes.
@@ -179,6 +194,13 @@ struct AbilitiesListView: View {
     /// The per-chat toggle state for `.composerModal`; nil renders the
     /// account-level accessory instead.
     var conversationViewModel: ConversationAbilitiesViewModel?
+    /// Handed to the detail push; see `AbilitiesListScreen.usageSource`.
+    var usageSource: any ConnectionUsageSourcing = EmptyConnectionUsageSource()
+    /// The Connected row the member tapped through to, in
+    /// `.composerModal`. The row cannot be a `NavigationLink` there (its
+    /// toggle would fight the link's tap target), so the disclosure drives
+    /// this instead.
+    @State private var detailAbility: AbilitiesAPI.Ability?
 
     var body: some View {
         catalogList
@@ -188,6 +210,9 @@ struct AbilitiesListView: View {
             .refreshable { await viewModel.refresh() }
             .selfSizingSheet(item: $viewModel.pendingAuthorization, onDismiss: handleAuthorizationDismissed) { context in
                 authorizationSheet(context)
+            }
+            .navigationDestination(item: $detailAbility) { ability in
+                AbilityDetailScreen(ability: ability, usageSource: usageSource)
             }
     }
 
@@ -395,7 +420,7 @@ struct AbilitiesListView: View {
 
     private func navigableEntitledRow(_ ability: AbilitiesAPI.Ability) -> some View {
         NavigationLink {
-            AbilityDetailScreen(ability: ability, selection: selection)
+            AbilityDetailScreen(ability: ability, usageSource: usageSource)
         } label: {
             abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
                 entitledAccessory(ability)
@@ -403,18 +428,58 @@ struct AbilitiesListView: View {
         }
     }
 
-    /// Chat-scoped Connected row: status badge plus the shared per-chat
-    /// toggle, and nothing else. No `ellipsis` menu (Disconnect is
-    /// app-wide, and this surface only extends and withdraws grants) and
-    /// no detail push - the toggle needs the row's tap target, and the
-    /// push is where a disconnect would sneak back in.
+    /// Chat-scoped Connected row: the shared per-chat toggle plus a
+    /// disclosure into the connection's detail. No `ellipsis` menu
+    /// (Disconnect is app-wide, and this surface only extends and withdraws
+    /// grants) and no app-wide status tag (see
+    /// `ConnectionsBrowserMode.showsConnectedStatusTag`).
+    ///
+    /// The row is deliberately not a `NavigationLink`: a `Toggle` inside one
+    /// fights the link's tap target. The label and the chevron are their own
+    /// buttons, the toggle sits between them, and each keeps its own hit
+    /// area - tapping the row pushes the detail, tapping the toggle writes
+    /// the grant.
     private func scopedEntitledRow(
         _ ability: AbilitiesAPI.Ability,
         conversationViewModel: ConversationAbilitiesViewModel
     ) -> some View {
-        abilityRowContent(ability, subtitle: entitledSubtitle(for: ability)) {
+        let disclosureAction: () -> Void = { detailAbility = ability }
+        return HStack(spacing: DesignConstants.Spacing.step2x) {
+            scopedRowLabelButton(ability, action: disclosureAction)
             scopedEntitledAccessory(ability, conversationViewModel: conversationViewModel)
+            scopedRowDisclosureButton(ability, action: disclosureAction)
         }
+        .accessibilityIdentifier("ability-row-\(ability.id)")
+    }
+
+    private func scopedRowLabelButton(
+        _ ability: AbilitiesAPI.Ability,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                AbilityIconView(ability: ability)
+                abilityRowTitles(ability, subtitle: entitledSubtitle(for: ability))
+                Spacer()
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("ability-open-\(ability.id)")
+    }
+
+    private func scopedRowDisclosureButton(
+        _ ability: AbilitiesAPI.Ability,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: "chevron.right")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.colorTextTertiary)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("ability-disclosure-\(ability.id)")
     }
 
     private func availableRow(_ ability: AbilitiesAPI.Ability) -> some View {
@@ -436,25 +501,35 @@ struct AbilitiesListView: View {
     ) -> some View {
         HStack(spacing: DesignConstants.Spacing.step2x) {
             AbilityIconView(ability: ability)
-            VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-                Text(ability.displayName.resolved())
-                    .font(.body)
-                    .foregroundStyle(.colorTextPrimary)
-                Text(subtitle)
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextSecondary)
-                    .lineLimit(1)
-            }
+            abilityRowTitles(ability, subtitle: subtitle)
             Spacer()
             accessory()
         }
         .accessibilityIdentifier("ability-row-\(ability.id)")
     }
 
+    private func abilityRowTitles(_ ability: AbilitiesAPI.Ability, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+            Text(ability.displayName.resolved())
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+            Text(subtitle)
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+                .lineLimit(1)
+        }
+    }
+
     /// The entitled row's second line: how broadly the entitlement is in
     /// use, falling back to the server subtitle when unextended.
+    ///
+    /// The count comes from the same read the detail screen lists, never
+    /// from the entitlement's `extensionCount`: the server counts every
+    /// conversation holding an extension, including ones this client cannot
+    /// show, so the subtitle used to claim convos the detail screen then
+    /// could not name.
     private func entitledSubtitle(for ability: AbilitiesAPI.Ability) -> String {
-        let count: Int = ability.entitlement?.extensionCount ?? 0
+        let count: Int = viewModel.conversationCount(forAbilityId: ability.id)
         switch count {
         case 0: return ability.subtitle.resolved()
         case 1: return "Used in 1 convo"
@@ -476,8 +551,9 @@ struct AbilitiesListView: View {
         }
     }
 
-    /// The badge still reports the app-wide entitlement status; the toggle
-    /// beside it reports this chat. Two different facts, so both render.
+    /// The app-wide status tag is withheld here: this surface answers "is
+    /// it on in this convo", which the toggle already says, and the row now
+    /// leads somewhere the app-wide status is spelled out.
     @ViewBuilder
     private func scopedEntitledAccessory(
         _ ability: AbilitiesAPI.Ability,
@@ -487,7 +563,7 @@ struct AbilitiesListView: View {
             ProgressView()
         } else {
             HStack(spacing: DesignConstants.Spacing.step2x) {
-                if let entitlement = ability.entitlement {
+                if mode.showsConnectedStatusTag, let entitlement = ability.entitlement {
                     AbilityStatusBadge(status: entitlement.status)
                 }
                 scopedToggle(ability, conversationViewModel: conversationViewModel)
@@ -580,31 +656,48 @@ struct AbilitiesListView: View {
 
 #Preview("Standard") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService()), mode: .appSettings)
+        AbilitiesListScreen(
+            selection: AbilitiesSelection(service: MockAbilitiesService()),
+            mode: .appSettings,
+            usageSource: PreviewConnectionUsageSource()
+        )
     }
 }
 
 #Preview("Composer modal") {
     AbilitiesListScreen(
         selection: AbilitiesSelection(service: MockAbilitiesService()),
-        mode: .composerModal(conversationId: "mock-conversation-1", agentInboxId: "mock-agent-inbox-1", agentDisplayName: "Caley")
+        mode: .composerModal(conversationId: "mock-conversation-1", agentInboxId: "mock-agent-inbox-1", agentDisplayName: "Caley"),
+        usageSource: PreviewConnectionUsageSource()
     )
 }
 
 #Preview("Entitlements unavailable") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailable)), mode: .appSettings)
+        AbilitiesListScreen(
+            selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailable)),
+            mode: .appSettings,
+            usageSource: PreviewConnectionUsageSource()
+        )
     }
 }
 
 #Preview("Cold-start outage") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart)), mode: .appSettings)
+        AbilitiesListScreen(
+            selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .entitlementsUnavailableColdStart)),
+            mode: .appSettings,
+            usageSource: PreviewConnectionUsageSource()
+        )
     }
 }
 
 #Preview("Device only") {
     NavigationStack {
-        AbilitiesListScreen(selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .deviceOnly)), mode: .appSettings)
+        AbilitiesListScreen(
+            selection: AbilitiesSelection(service: MockAbilitiesService(scenario: .deviceOnly)),
+            mode: .appSettings,
+            usageSource: PreviewConnectionUsageSource()
+        )
     }
 }

--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -444,10 +444,14 @@ struct AbilitiesListView: View {
         conversationViewModel: ConversationAbilitiesViewModel
     ) -> some View {
         let disclosureAction: () -> Void = { detailAbility = ability }
+        // Twice the row's own spacing, so the chevron reads as its own tap
+        // target rather than as part of the toggle.
+        let disclosureGap: CGFloat = DesignConstants.Spacing.step2x
         return HStack(spacing: DesignConstants.Spacing.step2x) {
             scopedRowLabelButton(ability, action: disclosureAction)
             scopedEntitledAccessory(ability, conversationViewModel: conversationViewModel)
             scopedRowDisclosureButton(ability, action: disclosureAction)
+                .padding(.leading, disclosureGap)
         }
         .accessibilityIdentifier("ability-row-\(ability.id)")
     }

--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -59,7 +59,7 @@ struct AbilitiesListScreen: View {
     /// Points the list view model's catalog and activation callbacks at
     /// the per-chat view model.
     ///
-    /// The captures are **strong on purpose**. `@State` releases the
+    /// The catalog and activation captures are **strong on purpose**. `@State` releases the
     /// per-chat view model the moment the modal is dismissed, but a
     /// connect already in flight still has to write its grant: dismissing
     /// before `beginEntitlement` returns would otherwise connect the
@@ -76,6 +76,13 @@ struct AbilitiesListScreen: View {
         }
         list.onEntitlementActivated = { abilityId in
             conversation.enableAfterConnect(abilityId: abilityId)
+        }
+        // The reverse edge, captured weakly like the other one: a toggle
+        // here changes which convos the connection is in, which is what the
+        // list's "Used in N convos" counts.
+        conversation.onOptInsMutated = { [weak list] in
+            guard let list else { return }
+            Task { await list.refreshUsage() }
         }
     }
 

--- a/Convos/Abilities/AbilitiesListView.swift
+++ b/Convos/Abilities/AbilitiesListView.swift
@@ -201,6 +201,7 @@ struct AbilitiesListView: View {
     /// The per-chat toggle state for `.composerModal`; nil renders the
     /// account-level accessory instead.
     var conversationViewModel: ConversationAbilitiesViewModel?
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize: DynamicTypeSize
     /// Handed to the detail push; see `AbilitiesListScreen.usageSource`.
     var usageSource: any ConnectionUsageSourcing = EmptyConnectionUsageSource()
     /// The Connected row the member tapped through to, in
@@ -463,6 +464,10 @@ struct AbilitiesListView: View {
         .accessibilityIdentifier("ability-row-\(ability.id)")
     }
 
+    /// Carries the whole disclosure for assistive technology: its children
+    /// combine into one element, and the chevron beside it is hidden. Two
+    /// buttons running the same action would otherwise be announced twice,
+    /// the second of them unnamed.
     private func scopedRowLabelButton(
         _ ability: AbilitiesAPI.Ability,
         action: @escaping () -> Void
@@ -476,9 +481,17 @@ struct AbilitiesListView: View {
             .contentShape(.rect)
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Opens connection details")
         .accessibilityIdentifier("ability-open-\(ability.id)")
     }
 
+    /// A second tap target for the same action, and a decorative one for
+    /// assistive technology: the label button beside it is the announced
+    /// element (see `scopedRowLabelButton`). Hidden rather than merged
+    /// because the toggle sits between them, so no container can combine
+    /// the two without reordering the row.
     private func scopedRowDisclosureButton(
         _ ability: AbilitiesAPI.Ability,
         action: @escaping () -> Void
@@ -490,6 +503,7 @@ struct AbilitiesListView: View {
                 .contentShape(.rect)
         }
         .buttonStyle(.plain)
+        .accessibilityHidden(true)
         .accessibilityIdentifier("ability-disclosure-\(ability.id)")
     }
 
@@ -505,29 +519,49 @@ struct AbilitiesListView: View {
         }
     }
 
+    /// Side by side at reading sizes; stacked at accessibility ones, where
+    /// a status capsule and a Connect button on the same line leave the
+    /// title a measure narrow enough to hyphenate mid-word.
+    @ViewBuilder
     private func abilityRowContent(
         _ ability: AbilitiesAPI.Ability,
         subtitle: String,
         @ViewBuilder accessory: () -> some View
     ) -> some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
-            AbilityIconView(ability: ability)
-            abilityRowTitles(ability, subtitle: subtitle)
-            Spacer()
-            accessory()
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(alignment: .leading, spacing: DesignConstants.Spacing.step2x) {
+                HStack(spacing: DesignConstants.Spacing.step2x) {
+                    AbilityIconView(ability: ability)
+                    abilityRowTitles(ability, subtitle: subtitle)
+                    Spacer(minLength: 0.0)
+                }
+                accessory()
+            }
+            .accessibilityIdentifier("ability-row-\(ability.id)")
+        } else {
+            HStack(spacing: DesignConstants.Spacing.step2x) {
+                AbilityIconView(ability: ability)
+                abilityRowTitles(ability, subtitle: subtitle)
+                Spacer()
+                accessory()
+            }
+            .accessibilityIdentifier("ability-row-\(ability.id)")
         }
-        .accessibilityIdentifier("ability-row-\(ability.id)")
     }
 
     private func abilityRowTitles(_ ability: AbilitiesAPI.Ability, subtitle: String) -> some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+        // One line is right at reading sizes and loses the whole fact at
+        // accessibility ones, where "Used in 1 convo" truncated to "Used
+        // in 1...".
+        let subtitleLineLimit: Int = dynamicTypeSize.isAccessibilitySize ? 3 : 1
+        return VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
             Text(ability.displayName.resolved())
                 .font(.body)
                 .foregroundStyle(.colorTextPrimary)
             Text(subtitle)
                 .font(.footnote)
                 .foregroundStyle(.colorTextSecondary)
-                .lineLimit(1)
+                .lineLimit(subtitleLineLimit)
         }
     }
 
@@ -636,6 +670,10 @@ struct AbilitiesListView: View {
                 Text("Connect")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.colorTextPrimary)
+                    // Same rule as the status capsule: the action keeps its
+                    // word whole and the title column absorbs the growth.
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
                     .padding(.horizontal, DesignConstants.Spacing.step3x)
                     .padding(.vertical, DesignConstants.Spacing.stepX)
                     .background(Capsule().fill(Color.colorFillMinimal))

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -60,7 +60,7 @@ final class AbilitiesListViewModel {
     /// keeps rendering the previous account's connections.
     private var snapshotEpoch: UInt64
 
-    private(set) var usageByAbilityId: [String: ConnectionUsage] = [:]
+    private(set) var usageSnapshot: ConnectionUsageSnapshot = .empty
 
     init(
         service: any AbilitiesServiceProtocol,
@@ -209,7 +209,7 @@ final class AbilitiesListViewModel {
     /// would list them. Zero until the usage read lands, which is why the
     /// row falls back to the server subtitle rather than to "0 convos".
     func conversationCount(forAbilityId abilityId: String) -> Int {
-        usageByAbilityId[abilityId]?.conversations.count ?? 0
+        usageSnapshot.usage(forAbilityId: abilityId).conversations.count
     }
 
     /// Re-reads usage outside the catalog refresh. The per-chat toggle
@@ -220,9 +220,9 @@ final class AbilitiesListViewModel {
     }
 
     private func refreshUsage(epoch: UInt64) async {
-        let usage: [String: ConnectionUsage] = await usageSource.usageByAbilityId()
+        let snapshot: ConnectionUsageSnapshot = await usageSource.usageSnapshot()
         guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return }
-        usageByAbilityId = usage
+        usageSnapshot = snapshot
     }
 
     /// The one place `catalog` is published, so every host holding a
@@ -245,7 +245,7 @@ final class AbilitiesListViewModel {
         // ability ids repeat across accounts, so a surviving cache renders
         // the previous account's counts under the new account's rows for
         // as long as the read takes - forever, if it never completes.
-        usageByAbilityId = [:]
+        usageSnapshot = .empty
         busyAbilityIds = []
         pendingAuthorization = nil
         parkedActivations = []

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -212,6 +212,13 @@ final class AbilitiesListViewModel {
         usageByAbilityId[abilityId]?.conversations.count ?? 0
     }
 
+    /// Re-reads usage outside the catalog refresh. The per-chat toggle
+    /// writes grants this view model never sees, so its rows would keep
+    /// counting the convos the connection was in before the tap.
+    func refreshUsage() async {
+        await refreshUsage(epoch: accountEpoch.value)
+    }
+
     private func refreshUsage(epoch: UInt64) async {
         let usage: [String: ConnectionUsage] = await usageSource.usageByAbilityId()
         guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return }
@@ -234,6 +241,11 @@ final class AbilitiesListViewModel {
         guard current != snapshotEpoch else { return }
         snapshotEpoch = current
         catalog = nil
+        // Cleared with the catalog, not after the next usage read lands:
+        // ability ids repeat across accounts, so a surviving cache renders
+        // the previous account's counts under the new account's rows for
+        // as long as the read takes - forever, if it never completes.
+        usageByAbilityId = [:]
         busyAbilityIds = []
         pendingAuthorization = nil
         parkedActivations = []

--- a/Convos/Abilities/AbilitiesListViewModel.swift
+++ b/Convos/Abilities/AbilitiesListViewModel.swift
@@ -50,19 +50,27 @@ final class AbilitiesListViewModel {
     /// Browser-session authorizer for the live transport. Nil (mock mode)
     /// keeps the stub authorization sheet as the approval step.
     private let authorizer: (any AbilityAuthorizing)?
+    /// Where a Connected row's "Used in N convos" comes from. The same
+    /// source the detail screen lists, so the count and the list are the
+    /// same rows -- see `ConnectionUsageSourcing`.
+    private let usageSource: any ConnectionUsageSourcing
     private let accountEpoch: AbilitiesAccountEpoch
     /// The account generation the published catalog belongs to. A wipe
     /// notifies no view model, so without this a screen open across one
     /// keeps rendering the previous account's connections.
     private var snapshotEpoch: UInt64
 
+    private(set) var usageByAbilityId: [String: ConnectionUsage] = [:]
+
     init(
         service: any AbilitiesServiceProtocol,
         authorizer: (any AbilityAuthorizing)? = nil,
-        accountEpoch: AbilitiesAccountEpoch = .shared
+        accountEpoch: AbilitiesAccountEpoch = .shared,
+        usageSource: any ConnectionUsageSourcing = EmptyConnectionUsageSource()
     ) {
         self.service = service
         self.authorizer = authorizer
+        self.usageSource = usageSource
         self.accountEpoch = accountEpoch
         self.snapshotEpoch = accountEpoch.value
     }
@@ -194,6 +202,20 @@ final class AbilitiesListViewModel {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+        await refreshUsage(epoch: epoch)
+    }
+
+    /// The conversations this ability is enabled in, as the detail screen
+    /// would list them. Zero until the usage read lands, which is why the
+    /// row falls back to the server subtitle rather than to "0 convos".
+    func conversationCount(forAbilityId abilityId: String) -> Int {
+        usageByAbilityId[abilityId]?.conversations.count ?? 0
+    }
+
+    private func refreshUsage(epoch: UInt64) async {
+        let usage: [String: ConnectionUsage] = await usageSource.usageByAbilityId()
+        guard epoch == accountEpoch.value, epoch == snapshotEpoch else { return }
+        usageByAbilityId = usage
     }
 
     /// The one place `catalog` is published, so every host holding a

--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -46,6 +46,10 @@ enum AbilitiesServices {
     /// the actor-based service handles its own concurrency.
     nonisolated(unsafe) private static var liveService: LiveAbilitiesService?
     nonisolated(unsafe) private static var catalogCache: AbilitiesCatalogDiskCache?
+    /// The session's conversations, read fresh on every call. Captured as a
+    /// closure rather than a retained repository so the read happens off the
+    /// main actor at the moment the detail screen asks for it.
+    nonisolated(unsafe) private static var conversationsProvider: (@Sendable () async -> [Conversation])?
     private static let mockService: MockAbilitiesService = MockAbilitiesService()
     /// One escalation mock app-wide so grants made in a conversation are
     /// visible in the ability detail's delegations list. Both selection
@@ -71,6 +75,20 @@ enum AbilitiesServices {
         )
     }
 
+    /// Where the connection detail screen's Agents and Convos sections come
+    /// from. Live mode fans out over the session's conversations (the
+    /// backend serves no inverse of the per-conversation opt-in read); mock
+    /// mode and any surface reached before `configure` use the fixture
+    /// source, so the screen never renders another account's rows.
+    @MainActor
+    static var connectionUsageSource: any ConnectionUsageSourcing {
+        guard useLiveBackend, let liveService else {
+            return PreviewConnectionUsageSource(service: mockService)
+        }
+        guard let conversationsProvider else { return EmptyConnectionUsageSource() }
+        return ConversationConnectionUsageSource(service: liveService, conversations: conversationsProvider)
+    }
+
     /// Wires the live service to the backend and the session's messaging
     /// stack. Called once from `ConvosApp.init`; built eagerly so flipping
     /// the mock/live toggle later picks it up without a relaunch. The V1
@@ -86,6 +104,10 @@ enum AbilitiesServices {
         )
         let cache = AbilitiesCatalogDiskCache(environmentName: environment.name)
         catalogCache = cache
+        conversationsProvider = {
+            let repository = session.conversationsRepository(for: [.allowed, .unknown])
+            return (try? await repository.fetchAll()) ?? []
+        }
         liveService = LiveAbilitiesService(
             apiClient: ConvosAPIClientFactory.client(environment: environment),
             callbackURLScheme: ConfigManager.shared.appUrlScheme,

--- a/Convos/Abilities/AbilitiesServices.swift
+++ b/Convos/Abilities/AbilitiesServices.swift
@@ -49,7 +49,7 @@ enum AbilitiesServices {
     /// The session's conversations, read fresh on every call. Captured as a
     /// closure rather than a retained repository so the read happens off the
     /// main actor at the moment the detail screen asks for it.
-    nonisolated(unsafe) private static var conversationsProvider: (@Sendable () async -> [Conversation])?
+    nonisolated(unsafe) private static var conversationsProvider: (@Sendable () async throws -> [Conversation])?
     private static let mockService: MockAbilitiesService = MockAbilitiesService()
     /// One escalation mock app-wide so grants made in a conversation are
     /// visible in the ability detail's delegations list. Both selection
@@ -106,7 +106,7 @@ enum AbilitiesServices {
         catalogCache = cache
         conversationsProvider = {
             let repository = session.conversationsRepository(for: [.allowed, .unknown])
-            return (try? await repository.fetchAll()) ?? []
+            return try await repository.fetchAll()
         }
         liveService = LiveAbilitiesService(
             apiClient: ConvosAPIClientFactory.client(environment: environment),

--- a/Convos/Abilities/AbilityDetailView.swift
+++ b/Convos/Abilities/AbilityDetailView.swift
@@ -1,19 +1,19 @@
 import ConvosCore
 import SwiftUI
 
-/// Owns the ability detail view model via `@State`, so it is created once
-/// per navigation push and survives re-evaluation of the presenting
+/// Owns the connection detail view model via `@State`, so it is created
+/// once per navigation push and survives re-evaluation of the presenting
 /// builder. Entry points must push this wrapper: constructing
 /// `AbilityDetailViewModel` inline in a navigation destination would hand
 /// `AbilityDetailView` a fresh model on every parent invalidation,
-/// silently dropping loaded delegations (and the list's `.task`, keyed to
-/// view identity, would not re-fire for the replacement). Same rationale
-/// as `AbilitiesListScreen`.
+/// silently dropping loaded usage (and the list's `.task`, keyed to view
+/// identity, would not re-fire for the replacement). Same rationale as
+/// `AbilitiesListScreen`.
 struct AbilityDetailScreen: View {
     @State private var viewModel: AbilityDetailViewModel
 
-    init(ability: AbilitiesAPI.Ability, selection: AbilitiesSelection) {
-        _viewModel = State(initialValue: AbilityDetailViewModel(ability: ability, selection: selection))
+    init(ability: AbilitiesAPI.Ability, usageSource: any ConnectionUsageSourcing) {
+        _viewModel = State(initialValue: AbilityDetailViewModel(ability: ability, usageSource: usageSource))
     }
 
     var body: some View {
@@ -21,30 +21,42 @@ struct AbilityDetailScreen: View {
     }
 }
 
-/// One ability's detail: identity header plus every delegation granted
-/// against it, split into active and earlier, with owner-initiated
-/// revocation on active rows.
+/// One connection's detail: identity header plus where the connection is in
+/// use, in three sections -- the agents holding it, the people it has been
+/// delegated to, and the conversations it is enabled in.
 ///
-/// Reachable only from `AbilitiesListView`'s entitled rows, which are
-/// themselves only reachable from surfaces already gated by the Abilities
-/// V2 flag -- no extra flag check needed here.
+/// Entry points (both push it inside a `NavigationStack` the caller already
+/// supplies, and both render the identical screen -- there is no per-surface
+/// variant here, so no mode enum of its own):
+/// - the app-wide Connections list (`ConnectionsBrowserMode.appSettings`),
+///   from `AbilitiesListView.navigableEntitledRow`;
+/// - the per-convo Connections browser
+///   (`ConnectionsBrowserMode.composerModal`), from the Connected row's
+///   disclosure, which is a separate tap target from the row's toggle.
+///
+/// People always leads with the owner's own row ("You") and holds nothing
+/// else yet: delegation to other members arrives with the Entitlement Actor
+/// Model, and its rows append below the owner when they do.
+///
+/// Rows carry an explicit `colorBackgroundRaised` surface over the screen's
+/// `colorBackgroundRaisedSecondary`, the same pairing conversation member
+/// rows use. Without it the rows inherit the system grouped-row material,
+/// which reads as a card in light mode and as nothing at all in dark.
 struct AbilityDetailView: View {
     @Bindable var viewModel: AbilityDetailViewModel
 
     var body: some View {
         List {
             headerSection
-            if let errorMessage = viewModel.errorMessage {
-                errorBanner(errorMessage)
-            }
-            delegationsSection
-            earlierSection
+            agentsSection
+            peopleSection
+            conversationsSection
         }
         .scrollContentBackground(.hidden)
         .background(.colorBackgroundRaisedSecondary)
         .navigationTitle(viewModel.ability.displayName.resolved())
         .navigationBarTitleDisplayMode(.inline)
-        .overlay { emptyStateOverlay }
+        .overlay { loadingOverlay }
         .task { await viewModel.refresh() }
         .accessibilityIdentifier("ability-detail-\(viewModel.ability.id)")
     }
@@ -70,33 +82,58 @@ struct AbilityDetailView: View {
                 }
             }
         }
+        .listRowBackground(Color.colorBackgroundRaised)
     }
 
     @ViewBuilder
-    private var delegationsSection: some View {
-        if !viewModel.activeDelegations.isEmpty {
-            Section {
-                ForEach(viewModel.activeDelegations) { delegation in
-                    activeDelegationRow(delegation)
+    private var agentsSection: some View {
+        Section {
+            if viewModel.agents.isEmpty {
+                emptyRow("No agents are using this yet", identifier: "connection-detail-agents-empty")
+            } else {
+                ForEach(viewModel.agents) { agent in
+                    usageRow(agent.displayName, identifier: "connection-detail-agent-\(agent.inboxId)")
                 }
-            } header: {
-                sectionHeader("Delegations")
             }
+        } header: {
+            sectionHeader("Agents")
         }
+        .listRowBackground(Color.colorBackgroundRaised)
+    }
+
+    /// Never empty: the owner's own row always leads it. Delegated people
+    /// append below once anything writes them.
+    private var peopleSection: some View {
+        Section {
+            ForEach(viewModel.people) { person in
+                usageRow(person.displayName, identifier: "connection-detail-person-\(person.inboxId)")
+            }
+        } header: {
+            sectionHeader("People")
+        }
+        .listRowBackground(Color.colorBackgroundRaised)
     }
 
     @ViewBuilder
-    private var earlierSection: some View {
-        if !viewModel.pastDelegations.isEmpty {
-            Section {
-                ForEach(viewModel.pastDelegations) { delegation in
-                    delegationRow(delegation)
+    private var conversationsSection: some View {
+        Section {
+            if viewModel.conversations.isEmpty {
+                emptyRow("Not turned on in any convo yet", identifier: "connection-detail-convos-empty")
+            } else {
+                ForEach(viewModel.conversations) { conversation in
+                    usageRow(
+                        conversation.displayName,
+                        identifier: "connection-detail-convo-\(conversation.conversationId)"
+                    )
                 }
-            } header: {
-                sectionHeader("Earlier")
             }
+        } header: {
+            sectionHeader("Convos")
         }
+        .listRowBackground(Color.colorBackgroundRaised)
     }
+
+    // MARK: - Rows
 
     private func sectionHeader(_ title: String) -> some View {
         Text(title)
@@ -104,72 +141,24 @@ struct AbilityDetailView: View {
             .foregroundStyle(.colorTextSecondary)
     }
 
-    private func errorBanner(_ message: String) -> some View {
-        Section {
-            Text(message)
-                .font(.footnote)
-                .foregroundStyle(.colorCaution)
-        }
+    private func usageRow(_ title: String, identifier: String) -> some View {
+        Text(title)
+            .font(.body)
+            .foregroundStyle(.colorTextPrimary)
+            .accessibilityIdentifier(identifier)
+    }
+
+    private func emptyRow(_ title: String, identifier: String) -> some View {
+        Text(title)
+            .font(.footnote)
+            .foregroundStyle(.colorTextSecondary)
+            .accessibilityIdentifier(identifier)
     }
 
     @ViewBuilder
-    private var emptyStateOverlay: some View {
-        if viewModel.delegations.isEmpty, !viewModel.isLoading {
-            ContentUnavailableView(
-                "No delegations",
-                systemImage: "person.badge.key",
-                description: Text("When an agent asks to use \(viewModel.ability.displayName.resolved()), what you allow shows up here.")
-            )
-        }
-    }
-
-    // MARK: - Rows
-
-    /// Active rows carry the revoke affordances (swipe + context menu);
-    /// past rows are inert.
-    private func activeDelegationRow(_ delegation: AbilityDelegation) -> some View {
-        let revokeAction = { viewModel.revoke(delegation) }
-        return delegationRow(delegation)
-            .swipeActions(edge: .trailing) {
-                Button("Revoke", role: .destructive, action: revokeAction)
-                    .accessibilityIdentifier("delegation-revoke-\(delegation.id)")
-            }
-            .contextMenu {
-                Button("Revoke", role: .destructive, action: revokeAction)
-            }
-    }
-
-    private func delegationRow(_ delegation: AbilityDelegation) -> some View {
-        HStack(spacing: DesignConstants.Spacing.step2x) {
-            delegationRowTitles(delegation)
-            Spacer()
-            AbilityDelegationStateChip(state: delegation.effectiveState())
-        }
-        .accessibilityIdentifier("delegation-row-\(delegation.id)")
-    }
-
-    private func delegationRowTitles(_ delegation: AbilityDelegation) -> some View {
-        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
-            Text(delegation.conversationName)
-                .font(.body)
-                .foregroundStyle(.colorTextPrimary)
-            Text("\(delegation.agentDisplayName) - \(viewModel.bundlesSummary(for: delegation))")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
-                .lineLimit(1)
-            Text(scopeLine(delegation))
-                .font(.footnote)
-                .foregroundStyle(.colorTextTertiary)
-        }
-    }
-
-    private func scopeLine(_ delegation: AbilityDelegation) -> String {
-        switch delegation.scope {
-        case .oneShot:
-            return "Just once"
-        case .expiring(let expiry):
-            let formatted: String = expiry.formatted(date: .abbreviated, time: .omitted)
-            return "Until \(formatted)"
+    private var loadingOverlay: some View {
+        if viewModel.isLoading, !viewModel.hasLoadedOnce {
+            ProgressView()
         }
     }
 }
@@ -180,13 +169,7 @@ struct AbilityDetailView: View {
     let gcal = MockAbilitiesService.standardCatalog().first { $0.id == "googlecalendar" }
     if let gcal {
         NavigationStack {
-            AbilityDetailScreen(
-                ability: gcal,
-                selection: AbilitiesSelection(
-                    service: MockAbilitiesService(),
-                    escalation: MockAbilityEscalationService(scenario: .populated)
-                )
-            )
+            AbilityDetailScreen(ability: gcal, usageSource: PreviewConnectionUsageSource())
         }
     }
 }
@@ -195,13 +178,7 @@ struct AbilityDetailView: View {
     let youtube = MockAbilitiesService.standardCatalog().first { $0.id == "youtube" }
     if let youtube {
         NavigationStack {
-            AbilityDetailScreen(
-                ability: youtube,
-                selection: AbilitiesSelection(
-                    service: MockAbilitiesService(),
-                    escalation: MockAbilityEscalationService(scenario: .quiet)
-                )
-            )
+            AbilityDetailScreen(ability: youtube, usageSource: PreviewConnectionUsageSource())
         }
     }
 }

--- a/Convos/Abilities/AbilityDetailView.swift
+++ b/Convos/Abilities/AbilityDetailView.swift
@@ -81,15 +81,20 @@ struct AbilityDetailView: View {
                     AbilityStatusBadge(status: entitlement.status)
                 }
             }
+            // One element, read in the order it is laid out: as three
+            // separate texts the status landed between the name and the
+            // subtitle.
+            .accessibilityElement(children: .combine)
         }
         .listRowBackground(Color.colorBackgroundRaised)
+        .listSectionMargins(.top, DesignConstants.Spacing.step3x)
     }
 
     @ViewBuilder
     private var agentsSection: some View {
         Section {
             if viewModel.agents.isEmpty {
-                emptyRow("No agents are using this yet", identifier: "connection-detail-agents-empty")
+                emptyRow(agentsEmptyTitle, identifier: "connection-detail-agents-empty")
             } else {
                 ForEach(viewModel.agents) { agent in
                     usageRow(agent.displayName, identifier: "connection-detail-agent-\(agent.inboxId)")
@@ -118,7 +123,7 @@ struct AbilityDetailView: View {
     private var conversationsSection: some View {
         Section {
             if viewModel.conversations.isEmpty {
-                emptyRow("Not turned on in any convo yet", identifier: "connection-detail-convos-empty")
+                emptyRow(conversationsEmptyTitle, identifier: "connection-detail-convos-empty")
             } else {
                 ForEach(viewModel.conversations) { conversation in
                     usageRow(
@@ -131,6 +136,18 @@ struct AbilityDetailView: View {
             sectionHeader("Convos")
         }
         .listRowBackground(Color.colorBackgroundRaised)
+    }
+
+    // MARK: - Copy
+
+    /// A read that reached no conversation cannot claim the connection is
+    /// unused: it says what it knows, which is nothing.
+    private var agentsEmptyTitle: String {
+        viewModel.isUnavailable ? Constant.unavailableTitle : "No agents are using this yet"
+    }
+
+    private var conversationsEmptyTitle: String {
+        viewModel.isUnavailable ? Constant.unavailableTitle : "Not turned on in any convo yet"
     }
 
     // MARK: - Rows
@@ -160,6 +177,10 @@ struct AbilityDetailView: View {
         if viewModel.isLoading, !viewModel.hasLoadedOnce {
             ProgressView()
         }
+    }
+
+    private enum Constant {
+        static let unavailableTitle: String = "Can't check this right now"
     }
 }
 

--- a/Convos/Abilities/AbilityDetailViewModel.swift
+++ b/Convos/Abilities/AbilityDetailViewModel.swift
@@ -16,6 +16,10 @@ final class AbilityDetailViewModel {
     let ability: AbilitiesAPI.Ability
 
     private(set) var usage: ConnectionUsage = .empty
+    /// True when the read could not reach a single conversation. The
+    /// sections then say they could not check rather than reporting that
+    /// nothing uses the connection.
+    private(set) var isUnavailable: Bool = false
     private(set) var isLoading: Bool = false
     private(set) var hasLoadedOnce: Bool = false
 
@@ -34,7 +38,9 @@ final class AbilityDetailViewModel {
 
     func refresh() async {
         isLoading = true
-        usage = await usageSource.usage(forAbilityId: ability.id)
+        let snapshot: ConnectionUsageSnapshot = await usageSource.usageSnapshot()
+        usage = snapshot.usage(forAbilityId: ability.id)
+        isUnavailable = snapshot.isUnavailable
         isLoading = false
         hasLoadedOnce = true
     }

--- a/Convos/Abilities/AbilityDetailViewModel.swift
+++ b/Convos/Abilities/AbilityDetailViewModel.swift
@@ -16,9 +16,10 @@ final class AbilityDetailViewModel {
     let ability: AbilitiesAPI.Ability
 
     private(set) var usage: ConnectionUsage = .empty
-    /// True when the read could not reach a single conversation. The
-    /// sections then say they could not check rather than reporting that
-    /// nothing uses the connection.
+    /// True when the read reached nothing: either the conversation list
+    /// itself failed, or every conversation refused. The sections then say
+    /// they could not check rather than reporting that nothing uses the
+    /// connection.
     private(set) var isUnavailable: Bool = false
     private(set) var isLoading: Bool = false
     private(set) var hasLoadedOnce: Bool = false

--- a/Convos/Abilities/AbilityDetailViewModel.swift
+++ b/Convos/Abilities/AbilityDetailViewModel.swift
@@ -2,75 +2,40 @@ import ConvosCore
 import Foundation
 import Observation
 
-/// Drives the ability detail screen: the delegations granted against one
-/// ability across conversations, with owner-initiated revocation.
-/// Pull-only: the list refreshes on appear and after its own mutations,
-/// matching how `ConversationAbilitiesViewModel.refresh()` works.
+/// Drives the connection detail screen: where one connection is in use --
+/// the agents holding it, the people it has been delegated to, and the
+/// conversations it is enabled in. Pull-only: the sections refresh on
+/// appear, matching how `ConversationAbilitiesViewModel.refresh()` works.
+///
+/// People always leads with the owner's own row and holds nothing else for
+/// now (see `ConnectionUsage.people`); delegated people append below it
+/// once the Entitlement Actor Model lands, so filling the section is a
+/// change of source, not of screen.
 @MainActor @Observable
 final class AbilityDetailViewModel {
     let ability: AbilitiesAPI.Ability
 
-    private(set) var delegations: [AbilityDelegation] = []
+    private(set) var usage: ConnectionUsage = .empty
     private(set) var isLoading: Bool = false
-    private(set) var errorMessage: String?
-    private var isMutating: Bool = false
+    private(set) var hasLoadedOnce: Bool = false
 
-    private let selection: AbilitiesSelection
+    private let usageSource: any ConnectionUsageSourcing
 
-    init(ability: AbilitiesAPI.Ability, selection: AbilitiesSelection) {
+    init(ability: AbilitiesAPI.Ability, usageSource: any ConnectionUsageSourcing) {
         self.ability = ability
-        self.selection = selection
+        self.usageSource = usageSource
     }
 
-    /// Delegations whose derived state is active, newest first.
-    var activeDelegations: [AbilityDelegation] {
-        let now = Date()
-        return delegations
-            .filter { (delegation: AbilityDelegation) -> Bool in delegation.effectiveState(at: now) == .active }
-            .sorted { (lhs: AbilityDelegation, rhs: AbilityDelegation) -> Bool in lhs.grantedAt > rhs.grantedAt }
-    }
-
-    /// Everything consumed, expired, or revoked, newest first.
-    var pastDelegations: [AbilityDelegation] {
-        let now = Date()
-        return delegations
-            .filter { (delegation: AbilityDelegation) -> Bool in delegation.effectiveState(at: now) != .active }
-            .sorted { (lhs: AbilityDelegation, rhs: AbilityDelegation) -> Bool in lhs.grantedAt > rhs.grantedAt }
-    }
+    var agents: [ConnectionUsageAgent] { usage.agents }
+    /// The owner always leads, so the section is never empty; delegated
+    /// people append below once anything writes them.
+    var people: [ConnectionUsagePerson] { [.owner] + usage.people }
+    var conversations: [ConnectionUsageConversation] { usage.conversations }
 
     func refresh() async {
         isLoading = true
-        delegations = await selection.escalation.delegations(abilityId: ability.id)
+        usage = await usageSource.usage(forAbilityId: ability.id)
         isLoading = false
-    }
-
-    /// Mutate-then-refresh, copying `ConversationAbilitiesViewModel`'s
-    /// withdraw shape: the service is the source of truth for the row's
-    /// new state.
-    func revoke(_ delegation: AbilityDelegation) {
-        guard !isMutating else { return }
-        isMutating = true
-        errorMessage = nil
-        Task {
-            do {
-                try await selection.escalation.revoke(delegationId: delegation.id)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-            isMutating = false
-            await refresh()
-        }
-    }
-
-    /// Resolves bundle ids against the ability's bundle metadata, falling
-    /// back to the raw id for anything the manifest no longer lists.
-    func bundlesSummary(for delegation: AbilityDelegation) -> String {
-        let titlesById: [String: String] = ability.bundles.reduce(into: [:]) { partial, bundle in
-            partial[bundle.id] = bundle.title.resolved()
-        }
-        let titles: [String] = delegation.bundleIds.map { (bundleId: String) -> String in
-            titlesById[bundleId] ?? bundleId
-        }
-        return titles.joined(separator: ", ")
+        hasLoadedOnce = true
     }
 }

--- a/Convos/Abilities/AbilityRowComponents.swift
+++ b/Convos/Abilities/AbilityRowComponents.swift
@@ -98,6 +98,11 @@ struct AbilityStatusBadge: View {
         Text(label)
             .font(.caption.weight(.medium))
             .foregroundStyle(labelColor)
+            // A one-word status must never hyphenate: at accessibility text
+            // sizes the capsule wrapped "Active" into "Ac-tive". The row's
+            // title column is the flexible one, not this.
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, DesignConstants.Spacing.step2x)
             .padding(.vertical, DesignConstants.Spacing.stepHalf)
             .background(Capsule().fill(Color.colorFillMinimal))
@@ -151,6 +156,11 @@ struct AbilityDelegationStateChip: View {
         Text(label)
             .font(.caption.weight(.medium))
             .foregroundStyle(labelColor)
+            // A one-word status must never hyphenate: at accessibility text
+            // sizes the capsule wrapped "Active" into "Ac-tive". The row's
+            // title column is the flexible one, not this.
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, DesignConstants.Spacing.step2x)
             .padding(.vertical, DesignConstants.Spacing.stepHalf)
             .background(Capsule().fill(Color.colorFillMinimal))

--- a/Convos/Abilities/ConnectionUsage.swift
+++ b/Convos/Abilities/ConnectionUsage.swift
@@ -168,12 +168,19 @@ struct PreviewConnectionUsageSource: ConnectionUsageSourcing {
 /// `maxConcurrentReads` reads are in flight. A conversation whose read
 /// fails contributes nothing rather than failing the screen: a partial
 /// answer beats an error where the alternative is a count with no names.
+/// Losing the conversation list itself is the different case: the provider
+/// throws, and the snapshot is unavailable rather than empty.
 struct ConversationConnectionUsageSource: ConnectionUsageSourcing {
     let service: any AbilitiesServiceProtocol
-    let conversations: @Sendable () async -> [Conversation]
+    let conversations: @Sendable () async throws -> [Conversation]
 
     func usageSnapshot() async -> ConnectionUsageSnapshot {
-        let candidates: [Conversation] = await conversations().filter(Self.mayHoldAbilities)
+        // A conversation-store read that fails is ignorance about the whole
+        // account, not an account without conversations. Collapsing it into
+        // an empty list here would render "nothing uses this" over a
+        // database error.
+        guard let all: [Conversation] = try? await conversations() else { return .unavailable }
+        let candidates: [Conversation] = all.filter(Self.mayHoldAbilities)
         guard !candidates.isEmpty else { return .empty }
         let reads: [Read] = await readAll(candidates)
         // Every conversation refused: an empty map here is ignorance, not

--- a/Convos/Abilities/ConnectionUsage.swift
+++ b/Convos/Abilities/ConnectionUsage.swift
@@ -1,0 +1,307 @@
+import ConvosCore
+import Foundation
+
+/// One agent that has been handed a connection, identified by its
+/// immutable inbox id (the same key extensions bind to).
+struct ConnectionUsageAgent: Identifiable, Hashable, Sendable {
+    let inboxId: String
+    let displayName: String
+
+    var id: String { inboxId }
+}
+
+/// One person who can use a connection: its owner, and -- once delegation
+/// exists -- everyone they have handed it to.
+struct ConnectionUsagePerson: Identifiable, Hashable, Sendable {
+    let inboxId: String
+    let displayName: String
+    /// The connection's owner, i.e. the local member. Always the first row
+    /// in the People section, which is why it is a flag rather than an
+    /// inbox-id comparison the detail screen would have to make.
+    let isOwner: Bool
+
+    var id: String { inboxId }
+
+    init(inboxId: String, displayName: String, isOwner: Bool = false) {
+        self.inboxId = inboxId
+        self.displayName = displayName
+        self.isOwner = isOwner
+    }
+
+    /// The local member's row, labelled the way every other self row in the
+    /// app is.
+    static let owner: ConnectionUsagePerson = ConnectionUsagePerson(
+        inboxId: "connection-usage-owner",
+        displayName: "You",
+        isOwner: true
+    )
+}
+
+/// One conversation the connection is enabled in.
+struct ConnectionUsageConversation: Identifiable, Hashable, Sendable {
+    let conversationId: String
+    let displayName: String
+
+    var id: String { conversationId }
+}
+
+/// Where one connection is in use, as the detail screen renders it.
+///
+/// `people` carries **delegated** people only, and is empty today:
+/// delegation to other members arrives with the Entitlement Actor Model,
+/// and the wire already carries the rows behind it (`conversationAbilities`
+/// drops every entry that is not `extendedByMe`). The owner's own row is
+/// added by the detail view model, so the People section is never empty
+/// whatever a source serves.
+struct ConnectionUsage: Equatable, Sendable {
+    var agents: [ConnectionUsageAgent]
+    var people: [ConnectionUsagePerson]
+    var conversations: [ConnectionUsageConversation]
+
+    static let empty: ConnectionUsage = ConnectionUsage(agents: [], people: [], conversations: [])
+
+    var isEmpty: Bool {
+        agents.isEmpty && people.isEmpty && conversations.isEmpty
+    }
+}
+
+/// Resolves where connections are in use. The seam exists so the browser
+/// and the detail screen can be driven from a session-backed source in the
+/// app, a fixture in previews, and a stub in tests.
+///
+/// The whole-catalog read is the primitive, and the single-ability read is
+/// derived from it, so the browser row's "Used in N convos" and the detail
+/// screen's Convos section can never disagree: they are the same rows,
+/// counted and listed. Deriving the count from the entitlement's
+/// server-side `extensionCount` instead is what let the subtitle claim a
+/// conversation the list could not show.
+protocol ConnectionUsageSourcing: Sendable {
+    func usageByAbilityId() async -> [String: ConnectionUsage]
+}
+
+extension ConnectionUsageSourcing {
+    func usage(forAbilityId abilityId: String) async -> ConnectionUsage {
+        await usageByAbilityId()[abilityId] ?? .empty
+    }
+}
+
+/// Serves nothing. Previews and any surface reached before
+/// `AbilitiesServices.configure` render zero states rather than stale rows.
+struct EmptyConnectionUsageSource: ConnectionUsageSourcing {
+    func usageByAbilityId() async -> [String: ConnectionUsage] {
+        [:]
+    }
+}
+
+/// Fixture source for previews and the debug mock path: the mock service's
+/// extension fixtures crossed with named stand-in conversations, so both
+/// render the same shape the session-backed source produces.
+struct PreviewConnectionUsageSource: ConnectionUsageSourcing {
+    private let underlying: ConversationConnectionUsageSource
+
+    init(service: any AbilitiesServiceProtocol = MockAbilitiesService(artificialDelay: .zero)) {
+        underlying = ConversationConnectionUsageSource(
+            service: service,
+            conversations: { Self.conversations }
+        )
+    }
+
+    func usageByAbilityId() async -> [String: ConnectionUsage] {
+        await underlying.usageByAbilityId()
+    }
+
+    /// Named after `MockAbilitiesService.standardExtensions()`'s ids so the
+    /// fixture opt-ins resolve to conversations with real-looking titles.
+    static let conversations: [Conversation] = [
+        mockConversation(id: "mock-conversation-1", name: "Weekend trip"),
+        mockConversation(id: "mock-conversation-2", name: "Standup notes"),
+        mockConversation(id: "mock-conversation-3", name: "No agent here", agentName: nil),
+    ]
+
+    private static func mockConversation(id: String, name: String, agentName: String? = "Caley") -> Conversation {
+        var members: [ConversationMember] = [.mock(isCurrentUser: true)]
+        if let agentName {
+            members.append(
+                ConversationMember(
+                    profile: .mock(inboxId: "mock-agent-inbox-1", conversationId: id, name: agentName),
+                    role: .member,
+                    isCurrentUser: false,
+                    isAgent: true
+                )
+            )
+        }
+        return .mock(id: id, name: name, members: members)
+    }
+}
+
+/// Derives a connection's usage by fanning out over the caller's
+/// conversations.
+///
+/// The backend serves no inverse of the per-conversation opt-in read: there
+/// is `GET /v2/conversations/{id}/abilities`, but nothing that answers
+/// "which conversations hold this ability", and the entitlement carries a
+/// count (`extensionCount`) with no ids. Nothing is persisted client-side
+/// either, so the names can only come from asking each conversation.
+///
+/// Two things keep that honest. Only conversations carrying an agent member
+/// are asked at all -- an ability is extended to an agent, so a
+/// conversation without one can never hold a row -- and at most
+/// `maxConcurrentReads` reads are in flight. A conversation whose read
+/// fails contributes nothing rather than failing the screen: a partial
+/// answer beats an error where the alternative is a count with no names.
+struct ConversationConnectionUsageSource: ConnectionUsageSourcing {
+    let service: any AbilitiesServiceProtocol
+    let conversations: @Sendable () async -> [Conversation]
+
+    func usageByAbilityId() async -> [String: ConnectionUsage] {
+        let candidates: [Conversation] = await conversations().filter(Self.mayHoldAbilities)
+        guard !candidates.isEmpty else { return [:] }
+        let reads: [Read] = await readAll(candidates)
+        var usage: [String: ConnectionUsage] = [:]
+        for abilityId in Self.abilityIds(in: reads) {
+            let matches: [Match] = Self.matches(forAbilityId: abilityId, in: reads)
+            usage[abilityId] = ConnectionUsage(
+                agents: Self.agents(from: matches),
+                people: [],
+                conversations: Self.conversations(from: matches)
+            )
+        }
+        return usage
+    }
+
+    /// One conversation's opt-ins, as read.
+    private struct Read: Sendable {
+        let conversation: Conversation
+        let rows: [ConversationAbility]
+    }
+
+    /// One conversation that holds a given ability, with the rows proving it.
+    private struct Match: Sendable {
+        let conversation: Conversation
+        let rows: [ConversationAbility]
+    }
+
+    /// Which conversations are worth a request.
+    ///
+    /// An opt-in binds to an agent's inbox id, so a conversation that has
+    /// never had an agent cannot hold one; a draft has no server-side
+    /// conversation to hold one against. Everything else is asked,
+    /// including conversations whose member list has not loaded yet -- an
+    /// over-tight predicate here is exactly how the count and the list came
+    /// to disagree, and the cost of one extra read is smaller than the cost
+    /// of a row that cannot be shown.
+    private static func mayHoldAbilities(_ conversation: Conversation) -> Bool {
+        guard !conversation.isDraft else { return false }
+        if conversation.isAgentDm || conversation.hasHadVerifiedAgent { return true }
+        return conversation.members.contains { (member: ConversationMember) -> Bool in member.isAgent }
+    }
+
+    /// Every ability id anyone opted into, in first-seen order.
+    private static func abilityIds(in reads: [Read]) -> [String] {
+        var seen: Set<String> = []
+        var ids: [String] = []
+        for read in reads {
+            for row in read.rows where !seen.contains(row.abilityId) {
+                seen.insert(row.abilityId)
+                ids.append(row.abilityId)
+            }
+        }
+        return ids
+    }
+
+    private static func matches(forAbilityId abilityId: String, in reads: [Read]) -> [Match] {
+        reads.compactMap { (read: Read) -> Match? in
+            let rows: [ConversationAbility] = read.rows.filter { (row: ConversationAbility) -> Bool in
+                row.abilityId == abilityId
+            }
+            guard !rows.isEmpty else { return nil }
+            return Match(conversation: read.conversation, rows: rows)
+        }
+    }
+
+    /// Reads in fixed-size batches and preserves the repository's ordering:
+    /// each batch carries its slot in `candidates`, so results land where
+    /// they were requested regardless of which read finishes first.
+    private func readAll(_ candidates: [Conversation]) async -> [Read] {
+        var reads: [Read] = []
+        var start: Int = 0
+        while start < candidates.count {
+            let end: Int = min(start + Constant.maxConcurrentReads, candidates.count)
+            let batch: [Conversation] = Array(candidates[start..<end])
+            reads.append(contentsOf: await readBatch(batch))
+            start = end
+        }
+        return reads
+    }
+
+    private func readBatch(_ batch: [Conversation]) async -> [Read] {
+        var byIndex: [Int: Read] = [:]
+        await withTaskGroup(of: (Int, Read?).self) { group in
+            for (index, conversation) in batch.enumerated() {
+                group.addTask {
+                    let read: Read? = await self.read(conversation)
+                    return (index, read)
+                }
+            }
+            for await (index, read) in group {
+                guard let read else { continue }
+                byIndex[index] = read
+            }
+        }
+        return byIndex.keys.sorted().compactMap { (index: Int) -> Read? in byIndex[index] }
+    }
+
+    private func read(_ conversation: Conversation) async -> Read? {
+        do {
+            let rows: [ConversationAbility] = try await service.conversationAbilities(conversationId: conversation.id)
+            return Read(conversation: conversation, rows: rows)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Deduped by inbox id, first appearance wins: the same agent reached
+    /// from two conversations is one agent.
+    private static func agents(from matches: [Match]) -> [ConnectionUsageAgent] {
+        var seen: Set<String> = []
+        var agents: [ConnectionUsageAgent] = []
+        for match in matches {
+            for row in match.rows where !seen.contains(row.agentInboxId) {
+                seen.insert(row.agentInboxId)
+                agents.append(
+                    ConnectionUsageAgent(
+                        inboxId: row.agentInboxId,
+                        displayName: displayName(forAgentInboxId: row.agentInboxId, in: match.conversation)
+                    )
+                )
+            }
+        }
+        return agents
+    }
+
+    /// The agent's name as this conversation knows it; an agent whose
+    /// profile has not resolved falls back to the generic label rather than
+    /// rendering an inbox id.
+    private static func displayName(forAgentInboxId inboxId: String, in conversation: Conversation) -> String {
+        let member: ConversationMember? = conversation.members.first { (member: ConversationMember) -> Bool in
+            member.profile.inboxId == inboxId
+        }
+        guard let member else { return Constant.unknownAgentName }
+        let name: String = member.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? Constant.unknownAgentName : name
+    }
+
+    private static func conversations(from matches: [Match]) -> [ConnectionUsageConversation] {
+        matches.map { (match: Match) -> ConnectionUsageConversation in
+            ConnectionUsageConversation(
+                conversationId: match.conversation.id,
+                displayName: match.conversation.displayName
+            )
+        }
+    }
+
+    private enum Constant {
+        static let maxConcurrentReads: Int = 4
+        static let unknownAgentName: String = "Agent"
+    }
+}

--- a/Convos/Abilities/ConnectionUsage.swift
+++ b/Convos/Abilities/ConnectionUsage.swift
@@ -65,6 +65,25 @@ struct ConnectionUsage: Equatable, Sendable {
     }
 }
 
+/// One read of where every connection is in use.
+///
+/// `isUnavailable` is the difference between "nothing uses this" and "we
+/// could not find out": with every conversation read failing, an empty map
+/// is not a fact about the account. The surfaces render the two
+/// differently -- silence about a connection the agent may well be using
+/// is the misleading kind of empty.
+struct ConnectionUsageSnapshot: Equatable, Sendable {
+    var usageByAbilityId: [String: ConnectionUsage]
+    var isUnavailable: Bool
+
+    static let empty: ConnectionUsageSnapshot = ConnectionUsageSnapshot(usageByAbilityId: [:], isUnavailable: false)
+    static let unavailable: ConnectionUsageSnapshot = ConnectionUsageSnapshot(usageByAbilityId: [:], isUnavailable: true)
+
+    func usage(forAbilityId abilityId: String) -> ConnectionUsage {
+        usageByAbilityId[abilityId] ?? .empty
+    }
+}
+
 /// Resolves where connections are in use. The seam exists so the browser
 /// and the detail screen can be driven from a session-backed source in the
 /// app, a fixture in previews, and a stub in tests.
@@ -76,20 +95,20 @@ struct ConnectionUsage: Equatable, Sendable {
 /// server-side `extensionCount` instead is what let the subtitle claim a
 /// conversation the list could not show.
 protocol ConnectionUsageSourcing: Sendable {
-    func usageByAbilityId() async -> [String: ConnectionUsage]
+    func usageSnapshot() async -> ConnectionUsageSnapshot
 }
 
 extension ConnectionUsageSourcing {
     func usage(forAbilityId abilityId: String) async -> ConnectionUsage {
-        await usageByAbilityId()[abilityId] ?? .empty
+        await usageSnapshot().usage(forAbilityId: abilityId)
     }
 }
 
 /// Serves nothing. Previews and any surface reached before
 /// `AbilitiesServices.configure` render zero states rather than stale rows.
 struct EmptyConnectionUsageSource: ConnectionUsageSourcing {
-    func usageByAbilityId() async -> [String: ConnectionUsage] {
-        [:]
+    func usageSnapshot() async -> ConnectionUsageSnapshot {
+        .empty
     }
 }
 
@@ -106,8 +125,8 @@ struct PreviewConnectionUsageSource: ConnectionUsageSourcing {
         )
     }
 
-    func usageByAbilityId() async -> [String: ConnectionUsage] {
-        await underlying.usageByAbilityId()
+    func usageSnapshot() async -> ConnectionUsageSnapshot {
+        await underlying.usageSnapshot()
     }
 
     /// Named after `MockAbilitiesService.standardExtensions()`'s ids so the
@@ -153,10 +172,14 @@ struct ConversationConnectionUsageSource: ConnectionUsageSourcing {
     let service: any AbilitiesServiceProtocol
     let conversations: @Sendable () async -> [Conversation]
 
-    func usageByAbilityId() async -> [String: ConnectionUsage] {
+    func usageSnapshot() async -> ConnectionUsageSnapshot {
         let candidates: [Conversation] = await conversations().filter(Self.mayHoldAbilities)
-        guard !candidates.isEmpty else { return [:] }
+        guard !candidates.isEmpty else { return .empty }
         let reads: [Read] = await readAll(candidates)
+        // Every conversation refused: an empty map here is ignorance, not
+        // an answer, and the surfaces must say so rather than report that
+        // nothing uses the connection.
+        guard !reads.isEmpty else { return .unavailable }
         var usage: [String: ConnectionUsage] = [:]
         for abilityId in Self.abilityIds(in: reads) {
             let matches: [Match] = Self.matches(forAbilityId: abilityId, in: reads)
@@ -166,7 +189,7 @@ struct ConversationConnectionUsageSource: ConnectionUsageSourcing {
                 conversations: Self.conversations(from: matches)
             )
         }
-        return usage
+        return ConnectionUsageSnapshot(usageByAbilityId: usage, isUnavailable: false)
     }
 
     /// One conversation's opt-ins, as read.

--- a/Convos/Abilities/ConnectionsBrowserMode.swift
+++ b/Convos/Abilities/ConnectionsBrowserMode.swift
@@ -53,21 +53,28 @@ enum ConnectionsBrowserMode: Hashable, Identifiable {
     }
 
     /// The browser's header subtitle. The account-level list sells the
-    /// feature; the chat-scoped one names the agent the connections are
-    /// being turned on for.
+    /// feature; the chat-scoped one says what this screen is for.
     ///
-    /// A blank name falls back to a generic phrasing rather than leaving a
-    /// gap mid-sentence. Empty is a real value here, not a defensive
-    /// hypothetical: the display name is whatever the profile had resolved
-    /// to when the modal was presented, and `AbilitiesListScreen` already
-    /// builds its agent descriptor with `mode.agentDisplayName ?? ""`.
+    /// The chat-scoped copy is fixed and names no agent: the display name is
+    /// whatever the profile had resolved to when the modal was presented, so
+    /// interpolating it made the subtitle change under the reader (and needed
+    /// a fallback branch for the blank case).
     var headerSubtitle: String {
-        guard case .composerModal(_, _, let agentDisplayName) = self else {
-            return "Give agents new powers in your convos"
+        switch self {
+        case .appSettings: "Give agents new powers in your convos"
+        case .composerModal: "Choose your agent's capabilities in this convo"
         }
-        let trimmedName: String = agentDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let name: String = trimmedName.isEmpty ? "your agent" : trimmedName
-        return "Choose what \(name) can use in this chat"
+    }
+
+    /// Whether a Connected row shows the app-wide entitlement status tag.
+    /// The account-level list is where that status is the point; the
+    /// chat-scoped browser is about this convo, and the row there already
+    /// carries a toggle and a disclosure.
+    var showsConnectedStatusTag: Bool {
+        switch self {
+        case .appSettings: true
+        case .composerModal: false
+        }
     }
 
     /// Deliberately excludes `agentDisplayName`: the modal is presented

--- a/Convos/Abilities/ConversationAbilitiesViewModel.swift
+++ b/Convos/Abilities/ConversationAbilitiesViewModel.swift
@@ -190,6 +190,10 @@ final class ConversationAbilitiesViewModel {
     /// Where a row without a usable entitlement routes its repair. Set by
     /// the host after construction when the host owns the connect flow.
     var entitlementRecoveryRoute: EntitlementRecoveryRoute = .inlineSheet
+    /// Fires once every extend or withdraw has settled and the opt-ins have
+    /// been re-read. The Connections browser hosting these toggles counts
+    /// convos from its own read, which this mutation just invalidated.
+    var onOptInsMutated: (() -> Void)?
 
     private var service: any AbilitiesServiceProtocol { selection.service }
 
@@ -679,6 +683,7 @@ final class ConversationAbilitiesViewModel {
             }
             isBusy = false
             await refresh()
+            onOptInsMutated?()
             // The refresh clears errorMessage on success; re-assert the
             // mutation failure so the bounced-back toggle is explained.
             if let mutationError {
@@ -729,6 +734,7 @@ final class ConversationAbilitiesViewModel {
             }
             isBusy = false
             await refresh()
+            onOptInsMutated?()
             if let mutationError {
                 errorMessage = mutationError
             }

--- a/Convos/Abilities/ConversationAbilityToggleControl.swift
+++ b/Convos/Abilities/ConversationAbilityToggleControl.swift
@@ -48,6 +48,10 @@ struct ConversationAbilityToggleControl: View {
                 .labelsHidden()
                 .tint(.colorGreen)
                 .disabled(isDisabled)
+                // The visible row names the connection; the switch itself
+                // carries no label, so assistive technology would announce
+                // an anonymous switch beside it.
+                .accessibilityLabel("\(row.ability.displayName.resolved()) in this convo")
         }
     }
 

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -261,7 +261,11 @@ struct AppSettingsView: View {
     @ViewBuilder
     private var connectionsDestination: some View {
         if FeatureFlags.shared.isAbilitiesV2Enabled {
-            AbilitiesListScreen(selection: AbilitiesServices.selection, mode: .appSettings)
+            AbilitiesListScreen(
+                selection: AbilitiesServices.selection,
+                mode: .appSettings,
+                usageSource: AbilitiesServices.connectionUsageSource
+            )
         } else {
             ConnectionsListView(viewModel: viewModel.connectionsListViewModel)
         }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -721,7 +721,11 @@ private extension ConversationView {
     func connectionsBrowserPresentation(_ content: some View) -> some View {
         content
             .fullScreenCover(item: $connectionsBrowserContext) { mode in
-                AbilitiesListScreen(selection: AbilitiesServices.selection, mode: mode)
+                AbilitiesListScreen(
+                    selection: AbilitiesServices.selection,
+                    mode: mode,
+                    usageSource: AbilitiesServices.connectionUsageSource
+                )
             }
     }
 

--- a/ConvosTests/ConnectionUsageTests.swift
+++ b/ConvosTests/ConnectionUsageTests.swift
@@ -1,0 +1,277 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+/// The connection detail screen's three sections, derived by fanning out
+/// over the caller's conversations because the backend serves no inverse of
+/// the per-conversation opt-in read.
+final class ConnectionUsageTests: XCTestCase {
+    func testConversationsSectionNamesEveryConvoHoldingTheAbility() async {
+        let source = Self.makeSource(conversations: Self.standardConversations)
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        XCTAssertEqual(usage.conversations.map(\.displayName), ["Weekend trip", "Standup notes"])
+        XCTAssertEqual(usage.conversations.map(\.conversationId), ["mock-conversation-1", "mock-conversation-2"])
+    }
+
+    /// The fixture extends Coinbase to conversation one only, so the second
+    /// conversation must not come along for the ride.
+    func testConversationsSectionExcludesConvosWithoutTheAbility() async {
+        let source = Self.makeSource(conversations: Self.standardConversations)
+
+        let usage = await source.usage(forAbilityId: "coinbase")
+
+        XCTAssertEqual(usage.conversations.map(\.conversationId), ["mock-conversation-1"])
+    }
+
+    func testAbilityNobodyEnabledProducesNoSections() async {
+        let source = Self.makeSource(conversations: Self.standardConversations)
+
+        let usage = await source.usage(forAbilityId: "youtube")
+
+        XCTAssertTrue(usage.isEmpty)
+    }
+
+    /// One agent reached from two conversations is one agent, named the way
+    /// its conversation knows it.
+    func testAgentsSectionDedupesTheSameAgentAcrossConvos() async {
+        let source = Self.makeSource(conversations: Self.standardConversations)
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        XCTAssertEqual(usage.agents.map(\.inboxId), ["mock-agent-inbox-1"])
+        XCTAssertEqual(usage.agents.map(\.displayName), ["Caley"])
+    }
+
+    func testAgentsSectionListsEveryDistinctAgent() async {
+        let service = MockAbilitiesService(artificialDelay: .zero)
+        try? await service.extendAbility(
+            conversationId: "mock-conversation-2",
+            abilityId: "googlecalendar",
+            agentInboxId: "second-agent",
+            bundleIds: ["calendar.events"]
+        )
+        let conversations: [Conversation] = [
+            Self.conversation(id: "mock-conversation-1", name: "Weekend trip", agents: [("mock-agent-inbox-1", "Caley")]),
+            Self.conversation(
+                id: "mock-conversation-2",
+                name: "Standup notes",
+                agents: [("mock-agent-inbox-1", "Caley"), ("second-agent", "Rosetta")]
+            ),
+        ]
+        let source = ConversationConnectionUsageSource(service: service, conversations: { conversations })
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        XCTAssertEqual(usage.agents.map(\.inboxId), ["mock-agent-inbox-1", "second-agent"])
+        XCTAssertEqual(usage.agents.map(\.displayName), ["Caley", "Rosetta"])
+    }
+
+    /// An opt-in binds to an agent's inbox id, so a conversation that has
+    /// never had an agent cannot hold one and is not worth a request. A
+    /// draft has no server-side conversation to hold one against either.
+    func testConversationsThatCannotHoldAnOptInAreNeverRead() async {
+        let service = RecordingAbilitiesService(underlying: MockAbilitiesService(artificialDelay: .zero))
+        let conversations: [Conversation] = Self.standardConversations + [
+            Self.conversation(id: "mock-conversation-9", name: "People only", agents: []),
+            Self.conversation(id: "draft-mock-conversation-8", name: "Draft", agents: [("mock-agent-inbox-1", "Caley")]),
+        ]
+        let source = ConversationConnectionUsageSource(service: service, conversations: { conversations })
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        let read: [String] = await service.readConversationIds
+        XCTAssertEqual(Set(read), ["mock-conversation-1", "mock-conversation-2"])
+        XCTAssertEqual(usage.conversations.count, 2)
+    }
+
+    /// A conversation whose members have not loaded yet is still asked: an
+    /// over-tight predicate here is what let the browser's count claim a
+    /// convo the detail screen could not name.
+    func testAConversationWithAnUnloadedMemberListIsStillRead() async {
+        let service = RecordingAbilitiesService(underlying: MockAbilitiesService(artificialDelay: .zero))
+        var mutable: Conversation = .mock(
+            id: "mock-conversation-2",
+            name: "Members not loaded",
+            members: [.mock(isCurrentUser: true)]
+        )
+        mutable.isAgentDm = true
+        let unloaded: Conversation = mutable
+        let source = ConversationConnectionUsageSource(service: service, conversations: { [unloaded] })
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        let read: [String] = await service.readConversationIds
+        XCTAssertEqual(read, ["mock-conversation-2"])
+        XCTAssertEqual(usage.conversations.map(\.conversationId), ["mock-conversation-2"])
+        XCTAssertEqual(usage.agents.map(\.displayName), ["Agent"], "an unresolved agent is labelled, never rendered as an inbox id")
+    }
+
+    /// No source writes a delegated person yet: delegation to other members
+    /// arrives with the Entitlement Actor Model, and until then no fixture,
+    /// however populated, may put a row there.
+    func testNoDelegatedPeopleAreEverSourced() async {
+        let source = Self.makeSource(conversations: Self.standardConversations)
+
+        for abilityId in ["googlecalendar", "coinbase", "youtube"] {
+            let usage = await source.usage(forAbilityId: abilityId)
+            XCTAssertTrue(usage.people.isEmpty, "ability \(abilityId)")
+        }
+    }
+
+    /// The People section is never empty: the owner's own row leads it
+    /// whatever the source serves, including an ability nobody enabled
+    /// anywhere and a source that answers nothing at all.
+    @MainActor
+    func testPeopleAlwaysLeadsWithTheOwnersOwnRow() async throws {
+        let ability = try XCTUnwrap(MockAbilitiesService.standardCatalog().first { $0.id == "youtube" })
+        let sources: [any ConnectionUsageSourcing] = [
+            Self.makeSource(conversations: Self.standardConversations),
+            EmptyConnectionUsageSource(),
+        ]
+
+        for source in sources {
+            let viewModel = AbilityDetailViewModel(ability: ability, usageSource: source)
+            await viewModel.refresh()
+            XCTAssertEqual(viewModel.people.map(\.displayName), ["You"])
+            XCTAssertEqual(viewModel.people.first?.isOwner, true)
+        }
+    }
+
+    /// A read that throws contributes nothing rather than failing the
+    /// screen: the surviving conversations still get named.
+    func testAFailedReadDropsOnlyItsOwnConversation() async {
+        let service = RecordingAbilitiesService(
+            underlying: MockAbilitiesService(artificialDelay: .zero),
+            failingConversationIds: ["mock-conversation-1"]
+        )
+        let source = ConversationConnectionUsageSource(service: service, conversations: { Self.standardConversations })
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        XCTAssertEqual(usage.conversations.map(\.conversationId), ["mock-conversation-2"])
+    }
+
+    /// The reported mismatch: the browser row said "Used in 2 convos" while
+    /// the detail screen could name one. The subtitle read the entitlement's
+    /// server-side `extensionCount`, which counts conversations this client
+    /// has no row for. Both now come from one read, so the count is the
+    /// length of the list by construction.
+    @MainActor
+    func testTheBrowserCountIsExactlyWhatTheDetailScreenLists() async throws {
+        let service = MockAbilitiesService(artificialDelay: .zero)
+        let visible: [Conversation] = [
+            Self.conversation(id: "mock-conversation-1", name: "Weekend trip", agents: [("mock-agent-inbox-1", "Caley")])
+        ]
+        let usageSource = ConversationConnectionUsageSource(service: service, conversations: { visible })
+        let listViewModel = AbilitiesListViewModel(service: service, usageSource: usageSource)
+
+        await listViewModel.refresh()
+        let detailViewModel = AbilityDetailViewModel(
+            ability: try XCTUnwrap(listViewModel.entitledAbilities.first { $0.id == "googlecalendar" }),
+            usageSource: usageSource
+        )
+        await detailViewModel.refresh()
+
+        let serverCount: Int = detailViewModel.ability.entitlement?.extensionCount ?? 0
+        XCTAssertEqual(serverCount, 2, "fixture guard: the backend still counts a convo this client cannot show")
+        XCTAssertEqual(detailViewModel.conversations.count, 1)
+        XCTAssertEqual(listViewModel.conversationCount(forAbilityId: "googlecalendar"), detailViewModel.conversations.count)
+    }
+
+    func testNoConversationsProducesEmptyUsage() async {
+        let source = Self.makeSource(conversations: [])
+
+        let usage = await source.usage(forAbilityId: "googlecalendar")
+
+        XCTAssertEqual(usage, .empty)
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeSource(conversations: [Conversation]) -> ConversationConnectionUsageSource {
+        ConversationConnectionUsageSource(
+            service: MockAbilitiesService(artificialDelay: .zero),
+            conversations: { conversations }
+        )
+    }
+
+    /// Mirrors `MockAbilitiesService.standardExtensions()`: Google Calendar
+    /// in both conversations, Coinbase in the first only.
+    private static var standardConversations: [Conversation] {
+        [
+            conversation(id: "mock-conversation-1", name: "Weekend trip", agents: [("mock-agent-inbox-1", "Caley")]),
+            conversation(id: "mock-conversation-2", name: "Standup notes", agents: [("mock-agent-inbox-1", "Caley")]),
+        ]
+    }
+
+    fileprivate static func conversation(id: String, name: String, agents: [(String, String)]) -> Conversation {
+        var members: [ConversationMember] = [.mock(isCurrentUser: true)]
+        for agent in agents {
+            members.append(
+                ConversationMember(
+                    profile: .mock(inboxId: agent.0, conversationId: id, name: agent.1),
+                    role: .member,
+                    isCurrentUser: false,
+                    isAgent: true
+                )
+            )
+        }
+        return .mock(id: id, name: name, members: members)
+    }
+}
+
+/// Records which conversations were actually read, and can fail chosen
+/// ones. Only `conversationAbilities` is exercised; the rest forwards.
+private actor RecordingAbilitiesService: AbilitiesServiceProtocol {
+    private let underlying: MockAbilitiesService
+    private let failingConversationIds: Set<String>
+    private(set) var readConversationIds: [String] = []
+
+    init(underlying: MockAbilitiesService, failingConversationIds: Set<String> = []) {
+        self.underlying = underlying
+        self.failingConversationIds = failingConversationIds
+    }
+
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        try await underlying.fetchCatalog()
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        try await underlying.beginEntitlement(abilityId: abilityId)
+    }
+
+    func completeEntitlement(abilityId: String) async throws {
+        try await underlying.completeEntitlement(abilityId: abilityId)
+    }
+
+    func revokeEntitlement(abilityId: String) async throws {
+        try await underlying.revokeEntitlement(abilityId: abilityId)
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        readConversationIds.append(conversationId)
+        if failingConversationIds.contains(conversationId) {
+            throw AbilitiesServiceError.unknownAbility(abilityId: conversationId)
+        }
+        return try await underlying.conversationAbilities(conversationId: conversationId)
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        try await underlying.extendAbility(
+            conversationId: conversationId,
+            abilityId: abilityId,
+            agentInboxId: agentInboxId,
+            bundleIds: bundleIds
+        )
+    }
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
+        try await underlying.withdrawAbility(
+            conversationId: conversationId,
+            abilityId: abilityId,
+            agentInboxId: agentInboxId
+        )
+    }
+}

--- a/ConvosTests/ConnectionUsageTests.swift
+++ b/ConvosTests/ConnectionUsageTests.swift
@@ -275,3 +275,96 @@ private actor RecordingAbilitiesService: AbilitiesServiceProtocol {
         )
     }
 }
+
+/// The browser row's "Used in N convos" is a cache: it survives neither a
+/// per-chat toggle (which changes what it counts) nor an account change
+/// (which changes whose convos they are).
+@MainActor
+final class ConnectionUsageCacheTests: XCTestCase {
+    private static let agent: ConversationAgentDescriptor = ConversationAgentDescriptor(
+        inboxId: "mock-agent-inbox-1",
+        displayName: "Caley"
+    )
+
+    /// Toggling the connection off for this convo drops it from the count
+    /// the browser row shows. Without the mutation callback the detail
+    /// screen updated and the row it was pushed from did not.
+    func testTogglingOffInThisConvoUpdatesTheBrowserCount() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let conversations: [Conversation] = Self.conversations
+        let usageSource = ConversationConnectionUsageSource(
+            service: service,
+            conversations: { conversations }
+        )
+        let listViewModel = AbilitiesListViewModel(service: service, usageSource: usageSource)
+        let conversationViewModel = ConversationAbilitiesViewModel(
+            conversationId: "mock-conversation-2",
+            agents: [Self.agent],
+            selection: AbilitiesSelection(service: service)
+        )
+        AbilitiesListScreen.wireActivation(list: listViewModel, conversation: conversationViewModel)
+        await listViewModel.refresh()
+        await conversationViewModel.refresh()
+        XCTAssertEqual(listViewModel.conversationCount(forAbilityId: "googlecalendar"), 2)
+
+        let row = try XCTUnwrap(conversationViewModel.rows.first { $0.ability.id == "googlecalendar" })
+        XCTAssertTrue(row.isOn, "fixture guard: the toggle starts on in this convo")
+        conversationViewModel.toggle(row)
+
+        try await Self.waitUntil { listViewModel.conversationCount(forAbilityId: "googlecalendar") == 1 }
+        XCTAssertEqual(listViewModel.conversationCount(forAbilityId: "googlecalendar"), 1)
+    }
+
+    /// An account wipe must not leave the previous account's counts under
+    /// the new account's rows. Ability ids repeat across accounts, so the
+    /// cache is checked at the exact moment the new catalog publishes --
+    /// clearing it once the next usage read lands would be too late.
+    func testTheCountsDoNotSurviveAnAccountChange() async throws {
+        let service = MockAbilitiesService(scenario: .standard, artificialDelay: .zero)
+        let epoch = AbilitiesAccountEpoch()
+        let conversations: [Conversation] = Self.conversations
+        let usageSource = ConversationConnectionUsageSource(
+            service: service,
+            conversations: { conversations }
+        )
+        let viewModel = AbilitiesListViewModel(service: service, accountEpoch: epoch, usageSource: usageSource)
+        await viewModel.refresh()
+        XCTAssertEqual(viewModel.conversationCount(forAbilityId: "googlecalendar"), 2)
+
+        epoch.advance()
+        var countAtPublish: Int?
+        viewModel.onCatalogCommitted = { _ in
+            countAtPublish = viewModel.conversationCount(forAbilityId: "googlecalendar")
+        }
+        await viewModel.refresh()
+
+        XCTAssertEqual(countAtPublish, 0, "the new account's rows must not render the previous account's counts")
+    }
+
+    private static var conversations: [Conversation] {
+        [
+            conversation(id: "mock-conversation-1", name: "Weekend trip"),
+            conversation(id: "mock-conversation-2", name: "Standup notes"),
+        ]
+    }
+
+    private static func conversation(id: String, name: String) -> Conversation {
+        let members: [ConversationMember] = [
+            .mock(isCurrentUser: true),
+            ConversationMember(
+                profile: .mock(inboxId: agent.inboxId, conversationId: id, name: agent.displayName),
+                role: .member,
+                isCurrentUser: false,
+                isAgent: true
+            ),
+        ]
+        return .mock(id: id, name: name, members: members)
+    }
+
+    private static func waitUntil(_ predicate: () -> Bool) async throws {
+        for _ in 0..<200 {
+            if predicate() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}

--- a/ConvosTests/ConnectionUsageTests.swift
+++ b/ConvosTests/ConnectionUsageTests.swift
@@ -411,7 +411,45 @@ final class ConnectionUsageAvailabilityTests: XCTestCase {
         let snapshot = await source.usageSnapshot()
 
         XCTAssertFalse(snapshot.isUnavailable)
+        XCTAssertEqual(snapshot, .empty, "a successful read of no conversations is the empty answer, not an outage")
     }
+
+    /// Losing the conversation list is ignorance about the whole account.
+    /// The per-conversation reads here would all succeed -- only the list
+    /// read fails -- so an empty snapshot could only come from swallowing
+    /// that error, which is what rendered a database failure as "nothing
+    /// uses this".
+    func testAFailedConversationListReadIsUnavailableRatherThanUnused() async {
+        let service = MockAbilitiesService(artificialDelay: .zero)
+        let source = ConversationConnectionUsageSource(
+            service: service,
+            conversations: { throw ConversationListReadFailure() }
+        )
+
+        let snapshot = await source.usageSnapshot()
+
+        XCTAssertTrue(snapshot.isUnavailable)
+        XCTAssertTrue(snapshot.usage(forAbilityId: "googlecalendar").isEmpty)
+    }
+
+    @MainActor
+    func testTheDetailScreenCarriesAFailedConversationListRead() async {
+        let ability = MockAbilitiesService.standardCatalog().first { $0.id == "googlecalendar" }
+        guard let ability else { return XCTFail("fixture guard: the standard catalog holds this ability") }
+        let source = ConversationConnectionUsageSource(
+            service: MockAbilitiesService(artificialDelay: .zero),
+            conversations: { throw ConversationListReadFailure() }
+        )
+        let viewModel = AbilityDetailViewModel(ability: ability, usageSource: source)
+
+        await viewModel.refresh()
+
+        XCTAssertTrue(viewModel.isUnavailable, "the screen says it cannot check rather than reporting no usage")
+        XCTAssertTrue(viewModel.agents.isEmpty)
+        XCTAssertTrue(viewModel.conversations.isEmpty)
+    }
+
+    private struct ConversationListReadFailure: Error {}
 
     @MainActor
     func testTheDetailScreenCarriesTheUnavailableFlag() async {

--- a/ConvosTests/ConnectionUsageTests.swift
+++ b/ConvosTests/ConnectionUsageTests.swift
@@ -224,7 +224,7 @@ final class ConnectionUsageTests: XCTestCase {
 
 /// Records which conversations were actually read, and can fail chosen
 /// ones. Only `conversationAbilities` is exercised; the rest forwards.
-private actor RecordingAbilitiesService: AbilitiesServiceProtocol {
+fileprivate actor RecordingAbilitiesService: AbilitiesServiceProtocol {
     private let underlying: MockAbilitiesService
     private let failingConversationIds: Set<String>
     private(set) var readConversationIds: [String] = []
@@ -366,5 +366,114 @@ final class ConnectionUsageCacheTests: XCTestCase {
             if predicate() { return }
             try await Task.sleep(for: .milliseconds(10))
         }
+    }
+}
+
+/// "Nothing uses this" and "we could not find out" are different answers,
+/// and the second one must never be rendered as the first.
+final class ConnectionUsageAvailabilityTests: XCTestCase {
+    func testEveryReadFailingIsReportedAsUnavailableRatherThanUnused() async {
+        let service = AlwaysFailingAbilitiesService()
+        let conversations: [Conversation] = [Self.agentConversation(id: "mock-conversation-1")]
+        let source = ConversationConnectionUsageSource(service: service, conversations: { conversations })
+
+        let snapshot = await source.usageSnapshot()
+
+        XCTAssertTrue(snapshot.isUnavailable)
+        XCTAssertTrue(snapshot.usage(forAbilityId: "googlecalendar").isEmpty)
+    }
+
+    /// One conversation answering is enough to report a fact: the surfaces
+    /// show what landed instead of refusing to say anything.
+    func testAPartialReadIsStillAnAnswer() async {
+        let service = RecordingAbilitiesService(
+            underlying: MockAbilitiesService(artificialDelay: .zero),
+            failingConversationIds: ["mock-conversation-1"]
+        )
+        let conversations: [Conversation] = [
+            Self.agentConversation(id: "mock-conversation-1"),
+            Self.agentConversation(id: "mock-conversation-2"),
+        ]
+        let source = ConversationConnectionUsageSource(service: service, conversations: { conversations })
+
+        let snapshot = await source.usageSnapshot()
+
+        XCTAssertFalse(snapshot.isUnavailable)
+        XCTAssertEqual(snapshot.usage(forAbilityId: "googlecalendar").conversations.count, 1)
+    }
+
+    /// An account with no conversation worth asking is a fact, not an
+    /// outage: the sections say the connection is unused.
+    func testNothingToReadIsNotAnOutage() async {
+        let service = AlwaysFailingAbilitiesService()
+        let source = ConversationConnectionUsageSource(service: service, conversations: { [] })
+
+        let snapshot = await source.usageSnapshot()
+
+        XCTAssertFalse(snapshot.isUnavailable)
+    }
+
+    @MainActor
+    func testTheDetailScreenCarriesTheUnavailableFlag() async {
+        let ability = MockAbilitiesService.standardCatalog().first { $0.id == "googlecalendar" }
+        guard let ability else { return XCTFail("fixture guard: the standard catalog holds this ability") }
+        let conversations: [Conversation] = [Self.agentConversation(id: "mock-conversation-1")]
+        let source = ConversationConnectionUsageSource(
+            service: AlwaysFailingAbilitiesService(),
+            conversations: { conversations }
+        )
+        let viewModel = AbilityDetailViewModel(ability: ability, usageSource: source)
+
+        await viewModel.refresh()
+
+        XCTAssertTrue(viewModel.isUnavailable)
+        XCTAssertTrue(viewModel.agents.isEmpty)
+        XCTAssertEqual(viewModel.people.map(\.displayName), ["You"], "the owner row is local truth, not a read")
+    }
+
+    private static func agentConversation(id: String) -> Conversation {
+        let members: [ConversationMember] = [
+            .mock(isCurrentUser: true),
+            ConversationMember(
+                profile: .mock(inboxId: "mock-agent-inbox-1", conversationId: id, name: "Caley"),
+                role: .member,
+                isCurrentUser: false,
+                isAgent: true
+            ),
+        ]
+        return .mock(id: id, name: "Convo \(id)", members: members)
+    }
+}
+
+/// Every conversation read refuses.
+private actor AlwaysFailingAbilitiesService: AbilitiesServiceProtocol {
+    private let underlying: MockAbilitiesService = MockAbilitiesService(artificialDelay: .zero)
+
+    func fetchCatalog() async throws -> AbilitiesCatalog {
+        try await underlying.fetchCatalog()
+    }
+
+    func beginEntitlement(abilityId: String) async throws -> AbilityEntitlementInitiation {
+        try await underlying.beginEntitlement(abilityId: abilityId)
+    }
+
+    func completeEntitlement(abilityId: String) async throws {
+        try await underlying.completeEntitlement(abilityId: abilityId)
+    }
+
+    func revokeEntitlement(abilityId: String) async throws {
+        try await underlying.revokeEntitlement(abilityId: abilityId)
+    }
+
+    func conversationAbilities(conversationId: String) async throws -> [ConversationAbility] {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func extendAbility(conversationId: String, abilityId: String, agentInboxId: String, bundleIds: [String]) async throws {
+        throw AbilitiesServiceError.accountRequired
+    }
+
+    func withdrawAbility(conversationId: String, abilityId: String, agentInboxId: String) async throws {
+        throw AbilitiesServiceError.accountRequired
     }
 }

--- a/ConvosTests/ConnectionsBrowserModeTests.swift
+++ b/ConvosTests/ConnectionsBrowserModeTests.swift
@@ -23,28 +23,32 @@ final class ConnectionsBrowserModeTests: XCTestCase {
         XCTAssertEqual(mode.agentDisplayName, "Caley")
     }
 
-    /// The chat-scoped browser names the agent it is turning connections on
-    /// for; the account-level one keeps its own copy byte for byte.
-    func testHeaderSubtitleNamesTheAgentOnlyInTheModal() {
-        let modal: ConnectionsBrowserMode = .composerModal(
-            conversationId: "dm-1",
-            agentInboxId: "agent-1",
-            agentDisplayName: "Caley"
-        )
-        XCTAssertEqual(modal.headerSubtitle, "Choose what Caley can use in this chat")
-        XCTAssertEqual(ConnectionsBrowserMode.appSettings.headerSubtitle, "Give agents new powers in your convos")
-    }
-
-    /// A name that has not resolved yet must never leave a gap mid-sentence.
-    func testHeaderSubtitleFallsBackWhenTheAgentHasNoUsableName() {
-        for name in ["", "   "] {
+    /// The chat-scoped copy is fixed: it names no agent, so a name that has
+    /// not resolved (or has just changed) cannot move it. The account-level
+    /// one keeps its own copy byte for byte.
+    func testHeaderSubtitleIsConstantInTheModalWhateverTheAgentIsCalled() {
+        for name in ["Caley", "", "   "] {
             let mode: ConnectionsBrowserMode = .composerModal(
                 conversationId: "dm-1",
                 agentInboxId: "agent-1",
                 agentDisplayName: name
             )
-            XCTAssertEqual(mode.headerSubtitle, "Choose what your agent can use in this chat")
+            XCTAssertEqual(mode.headerSubtitle, "Choose your agent's capabilities in this convo")
         }
+        XCTAssertEqual(ConnectionsBrowserMode.appSettings.headerSubtitle, "Give agents new powers in your convos")
+    }
+
+    /// The app-wide entitlement status is the account list's business; the
+    /// chat-scoped browser withholds the tag and lets the toggle and the
+    /// detail push carry the row.
+    func testOnlyTheAccountLevelListShowsTheConnectedStatusTag() {
+        let modal: ConnectionsBrowserMode = .composerModal(
+            conversationId: "dm-1",
+            agentInboxId: "agent-1",
+            agentDisplayName: "Caley"
+        )
+        XCTAssertTrue(ConnectionsBrowserMode.appSettings.showsConnectedStatusTag)
+        XCTAssertFalse(modal.showsConnectedStatusTag)
     }
 
     func testModeIdentitiesAreDistinct() {


### PR DESCRIPTION
## What

The connection detail screen (`Convos/Abilities/AbilityDetailView.swift`) listed delegations. Nothing live writes those: escalation has only `MockAbilityEscalationService`, behind a default-off debug toggle, so the screen was empty in every real session. It now answers what the entry points actually raise -- where is this connection in use -- in three sections:

- **Agents** -- real data: the agents holding the connection, deduped by inbox id, named as their conversation knows them.
- **People** -- always leads with the owner's own row ("You"); delegated people append below it when the Entitlement Actor Model lands.
- **Convos** -- real data: the conversations the connection is enabled in.

The per-convo browser's Connected rows gain a disclosure into the same screen, drop the app-wide `Active` tag, and take a fixed header subtitle.

## How the rows are derived

The backend serves no inverse of the per-conversation opt-in read -- there is `GET /v2/conversations/{id}/abilities` and nothing answering "which conversations hold this ability" -- and nothing is persisted client-side. `ConversationConnectionUsageSource` (`Convos/Abilities/ConnectionUsage.swift`) therefore fans out over the conversations that can hold an opt-in (non-draft, agent-bearing), four reads in flight; one failed read costs only its own conversation.

## Count and list now agree

The browser row's "Used in N convos" came from the entitlement's server-side `extensionCount`, which counts conversations this client has no row for -- reported in review as a row claiming two convos while the detail screen could name one. Both now come from the same read (`AbilitiesListViewModel.conversationCount(forAbilityId:)`), so the count is the length of the list by construction.

## Tap targets

The `.composerModal` row cannot be a `NavigationLink` -- a `Toggle` inside one fights the link's tap target. The label and the chevron are separate buttons with the toggle between them: tapping the row pushes the detail, tapping the toggle writes the grant. Per-surface differences ride the existing `ConnectionsBrowserMode` (new `showsConnectedStatusTag`); the detail screen itself is identical from both entry points, so it grows no mode enum of its own.

## Dark mode

Detail rows carry an explicit `colorBackgroundRaised` surface over the screen's `colorBackgroundRaisedSecondary` (the pairing `ConversationMemberView` uses). Without it they inherited the system grouped-row material and read as nothing in dark mode.

## Tests

`ConvosTests/ConnectionUsageTests.swift` (new) and `ConvosTests/ConnectionsBrowserModeTests.swift`: agents/convos mapping, agent dedupe across convos, abilities excluded per conversation, unaskable conversations never read, a conversation with an unloaded member list still read, one failed read not sinking the rest, People always leading with the owner row, no delegated people sourced, count == list, mode-driven status-tag visibility and header copy.

Every behavioural test was mutation-checked: each assertion was confirmed to fail against a deliberately broken implementation.

## Verification

`swiftlint --strict` and `swiftformat --lint` clean tree-wide; `Convos (Dev)` simulator build succeeds with zero long-type-check warnings; `swift test --package-path ConvosCore` 1962 tests pass; the app test target runs 406 tests with the two failures that already fail on `dev` unchanged. Verified on a signed-in simulator against real backend data in light and dark.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789846870&installation_model_id=20076&pr_number=1382&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1382&signature=b7d0c4c668df0c59b3d23e85f7bb7dcd4cd9cb8ac0c02d9f981c532326217677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rework connection detail to show where a connection is used instead of delegations
> - Replaces delegation-based state in `AbilityDetailViewModel` with a usage model (`ConnectionUsage`) that aggregates agents, people, and conversations per ability from per-conversation ability reads
> - Introduces `ConversationConnectionUsageSource` which fans out across conversations in batches (max 4 concurrent), dedupes agents by `inboxId`, filters out drafts and non-agent conversations, and reports an `.unavailable` snapshot on total failure
> - `AbilitiesListViewModel` now caches a `ConnectionUsageSnapshot` after catalog refresh and exposes `conversationCount(forAbilityId:)`; per-chat opt-in mutations trigger `refreshUsage()` via an `onOptInsMutated` callback
> - Composer-modal rows gain separate tap targets for the toggle and detail disclosure, adapt layout at accessibility text sizes, and hide the app-wide status tag; badge and chip labels are pinned to single line
> - Behavioral Change: `AbilityDetailScreen` and `AbilitiesListScreen` initializers now require `usageSource: any ConnectionUsageSourcing` instead of `selection: AbilitiesSelection`; delegation mutation (`revoke`) and bundle title resolution are removed from the detail view model. The `entitledSubtitle` count now reads from the usage snapshot rather than `ability.entitlement?.extensionCount`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 557edeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->