### PR TITLE
feat(profiles): write to the backend, signal over XMTP

### DIFF
--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Profiles.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Profiles.swift
@@ -25,6 +25,31 @@ public enum ProfilesAPI {
         let inboxIds: [String]
     }
 
+    /// A write to the caller's own profile. Absent means "leave alone",
+    /// explicit null means "clear", which is why both levels are optional.
+    struct UpdateBody: Encodable {
+        let inboxId: String
+        let name: String??
+        let avatarUrl: String??
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(inboxId, forKey: .inboxId)
+            if let name { try container.encode(name, forKey: .name) }
+            if let avatarUrl { try container.encode(avatarUrl, forKey: .avatarUrl) }
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case inboxId, name, avatarUrl
+        }
+    }
+
+    struct AvatarUploadTicket: Decodable {
+        let objectKey: String
+        let uploadUrl: String
+        let avatarUrl: String
+    }
+
     /// The backend rejects a larger batch outright, so the client chunks rather
     /// than letting a big member list fail as one request.
     static let batchLimit: Int = 100
@@ -74,13 +99,77 @@ extension ConvosAPIClient {
         return resolved
     }
 
+    /// Writes the caller's own profile. The backend binds the inbox id to the
+    /// account on first write and refuses any other claim, so this is the only
+    /// profile this client can ever author.
+    ///
+    /// Omitting a field leaves it alone; passing `.some(nil)` clears it.
+    @discardableResult
+    func updateMyProfile(
+        inboxId: String,
+        name: String?? = nil,
+        avatarUrl: String?? = nil
+    ) async throws -> ProfilesAPI.Profile {
+        var request = try profilesRequest(pathSegments: ["v2", "profiles", "me"], method: "PUT")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(
+            ProfilesAPI.UpdateBody(inboxId: inboxId, name: name, avatarUrl: avatarUrl)
+        )
+        let (data, httpResponse) = try await performAuthenticatedRequest(request)
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw APIError.serverError(parseErrorMessage(from: data))
+        }
+        return try ProfilesAPI.wireResponseDecoder().decode(ProfilesAPI.Profile.self, from: data)
+    }
+
+    /// Uploads an avatar and returns the URL to store on the profile.
+    ///
+    /// Deliberately not the shared attachment upload: profile avatars land
+    /// under a key prefix the bucket's expiry lifecycle excludes, because a
+    /// profile references its avatar indefinitely and an aged-out object would
+    /// break every client rendering that person, days after a clean upload.
+    func uploadProfileAvatar(data: Data, contentType: String = "image/jpeg") async throws -> String {
+        let ticketRequest = try profilesRequest(
+            pathSegments: ["v2", "profiles", "avatar-upload"],
+            method: "GET",
+            queryParameters: ["contentType": contentType]
+        )
+        let (ticketData, ticketResponse) = try await performAuthenticatedRequest(ticketRequest)
+        guard (200...299).contains(ticketResponse.statusCode) else {
+            throw APIError.serverError(parseErrorMessage(from: ticketData))
+        }
+        let ticket = try JSONDecoder().decode(ProfilesAPI.AvatarUploadTicket.self, from: ticketData)
+
+        guard let uploadURL = URL(string: ticket.uploadUrl) else { throw APIError.invalidURL }
+        var upload = URLRequest(url: uploadURL)
+        upload.httpMethod = "PUT"
+        upload.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        upload.httpBody = data
+
+        // Straight to S3, so this one does not go through the client's session:
+        // the presigned URL carries its own authorization and our headers have
+        // no business there.
+        let (body, response) = try await URLSession.shared.data(for: upload)
+        guard let http = response as? HTTPURLResponse else { throw APIError.invalidResponse }
+        guard http.statusCode == 200 else {
+            Log.error("Profile avatar upload failed (\(http.statusCode)): \(String(data: body, encoding: .utf8) ?? "nil")")
+            throw APIError.serverError(nil)
+        }
+        return ticket.avatarUrl
+    }
+
     private func profilesRequest(
         pathSegments: [String],
-        method: String
+        method: String,
+        queryParameters: [String: String]? = nil
     ) throws -> URLRequest {
         var url = baseURL
         for segment in pathSegments {
             url = url.appendingPathComponent(segment)
+        }
+        if let queryParameters, var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            components.queryItems = queryParameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+            url = components.url ?? url
         }
         var request = URLRequest(url: url)
         request.httpMethod = method

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -100,6 +100,14 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
     /// so callers key by inbox id rather than by position.
     func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile]
 
+    /// Writes the caller's own profile. Omitting a field leaves it alone;
+    /// `.some(nil)` clears it.
+    @discardableResult
+    func updateMyProfile(inboxId: String, name: String??, avatarUrl: String??) async throws -> ProfilesAPI.Profile
+
+    /// Uploads an avatar and returns the URL to store on the profile.
+    func uploadProfileAvatar(data: Data, contentType: String) async throws -> String
+
     func requestAgentJoin(
         _ joinRequest: ConvosAPI.AgentJoinRequest,
         forceErrorCode: Int?
@@ -317,6 +325,15 @@ extension ConvosAPIClientProtocol {
 
     func getProfiles(inboxIds: [String]) async throws -> [ProfilesAPI.Profile] {
         []
+    }
+
+    @discardableResult
+    func updateMyProfile(inboxId: String, name: String??, avatarUrl: String??) async throws -> ProfilesAPI.Profile {
+        throw APIError.serverError("profile writes are not available on this client")
+    }
+
+    func uploadProfileAvatar(data: Data, contentType: String) async throws -> String {
+        throw APIError.serverError("profile writes are not available on this client")
     }
 
     func requestAgentJoin(slug: String) async throws -> ConvosAPI.AgentJoinResponse {

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1337,6 +1337,10 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
                 InviteJoinErrorCodec(),
                 InviteJoinHandledCodec(),
                 ProfileUpdateCodec(),
+                // Registered so a member still on an older build resolves at
+                // all: without it their update arrives as an unknown type and
+                // is dropped before anything can read it.
+                ProfileUpdateV1Codec(),
                 ProfileSnapshotCodec(),
                 JoinRequestCodec(),
                 AgentJoinRequestCodec(),

--- a/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/MessagingService.swift
@@ -207,7 +207,10 @@ final class MessagingService: MessagingServiceProtocol, @unchecked Sendable {
         selfInboxIdProvider: { [sessionStateManager] in
             (try? await sessionStateManager.waitForInboxReadyResult())?.client.inboxId
         },
-        remoteResolver: remoteProfileResolver
+        remoteResolver: remoteProfileResolver,
+        apiClientProvider: { [sessionStateManager] in
+            (try? await sessionStateManager.waitForInboxReadyResult())?.apiClient
+        }
     )
 
     /// Canonical identity source. Inbound writes land here directly via

--- a/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileUpdateCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/ProfileMessages/ProfileUpdateCodec.swift
@@ -2,7 +2,20 @@ import Foundation
 import SwiftProtobuf
 @preconcurrency import XMTPiOS
 
+/// v2 carries a plain avatar URL and the backend's version. Sent by this
+/// client; an older build does not recognise the type and ignores the message,
+/// which leaves it showing the last profile it saw rather than blanking the
+/// avatar - what would happen if v2's shape arrived under the v1 type.
 public let ContentTypeProfileUpdate = ContentTypeID(
+    authorityID: "convos.org",
+    typeID: "profile_update",
+    versionMajor: 2,
+    versionMinor: 0
+)
+
+/// The shape still on the wire from builds that predate the backend profile.
+/// Decoded, never sent. Retired with the rest of the v1 read path.
+public let ContentTypeProfileUpdateV1 = ContentTypeID(
     authorityID: "convos.org",
     typeID: "profile_update",
     versionMajor: 1,
@@ -30,6 +43,41 @@ public struct ProfileUpdateCodec: ContentCodec {
     public func encode(content: ProfileUpdate) throws -> EncodedContent {
         var encodedContent = EncodedContent()
         encodedContent.type = ContentTypeProfileUpdate
+        encodedContent.content = try content.serializedData()
+        return encodedContent
+    }
+
+    public func decode(content: EncodedContent) throws -> ProfileUpdate {
+        do {
+            return try ProfileUpdate(serializedData: content.content)
+        } catch {
+            throw ProfileUpdateCodecError.decodingFailed
+        }
+    }
+
+    public func fallback(content: ProfileUpdate) throws -> String? {
+        nil
+    }
+
+    public func shouldPush(content: ProfileUpdate) throws -> Bool {
+        false
+    }
+}
+
+/// Decodes the v1 messages already on the wire. Registered alongside the v2
+/// codec so a member on an older build still resolves; both decode into the
+/// same type, since the proto kept field 2 declared for exactly this.
+public struct ProfileUpdateV1Codec: ContentCodec {
+    public typealias T = ProfileUpdate
+
+    public var contentType: ContentTypeID = ContentTypeProfileUpdateV1
+
+    public init() {}
+
+    public func encode(content: ProfileUpdate) throws -> EncodedContent {
+        // v1 is read-only: everything this client sends is v2.
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeProfileUpdateV1
         encodedContent.content = try content.serializedData()
         return encodedContent
     }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Proto/profile_messages.pb.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Proto/profile_messages.pb.swift
@@ -106,27 +106,41 @@ public struct MetadataValue: Sendable {
 /// The sender's inbox ID is implicit from the XMTP message — only the
 /// sender can author their own profile update, preventing spoofing.
 ///
-/// Sending a ProfileUpdate with no name and no encrypted_image clears the profile.
+/// v2 (convos.org/profile_update:2.0) carries the values the backend now
+/// stores: a plain avatar URL and the backend's version. Clients host-validate
+/// avatar_url against the CDN before honoring it, because the sender chooses
+/// the string and every recipient would fetch it.
+///
+/// Field 2 (encrypted_image) is what v1 used, when each recipient decrypted a
+/// per-conversation ciphertext. It stays declared so v1 messages keep decoding.
+/// A v1 message carrying no encrypted_image meant "avatar cleared", which is why
+/// v2 is a major version bump rather than added fields: an old client reading a
+/// v2-shaped message would blank the sender's avatar, whereas an unknown content
+/// type it simply ignores.
 public struct ProfileUpdate: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   public var name: String {
-    get {_name ?? String()}
+    get {return _name ?? String()}
     set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {self._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
   public mutating func clearName() {self._name = nil}
 
+  /// Read-only now: v2 writers never set this, but v1 messages already on the
+  /// wire still carry it and must keep decoding until the v1 read path is
+  /// retired. Removing it here would blank the avatar of anyone who has not
+  /// upgraded, which is the opposite of what the transition needs.
   public var encryptedImage: EncryptedProfileImageRef {
-    get {_encryptedImage ?? EncryptedProfileImageRef()}
+    get {return _encryptedImage ?? EncryptedProfileImageRef()}
     set {_encryptedImage = newValue}
   }
   /// Returns true if `encryptedImage` has been explicitly set.
-  public var hasEncryptedImage: Bool {self._encryptedImage != nil}
+  public var hasEncryptedImage: Bool {return self._encryptedImage != nil}
   /// Clears the value of `encryptedImage`. Subsequent reads from it will return its default value.
   public mutating func clearEncryptedImage() {self._encryptedImage = nil}
 
@@ -134,12 +148,33 @@ public struct ProfileUpdate: Sendable {
 
   public var metadata: Dictionary<String,MetadataValue> = [:]
 
+  public var avatarURL: String {
+    get {return _avatarURL ?? String()}
+    set {_avatarURL = newValue}
+  }
+  /// Returns true if `avatarURL` has been explicitly set.
+  public var hasAvatarURL: Bool {return self._avatarURL != nil}
+  /// Clears the value of `avatarURL`. Subsequent reads from it will return its default value.
+  public mutating func clearAvatarURL() {self._avatarURL = nil}
+
+  /// The backend's Profile.version, so a recipient holding it can skip a fetch.
+  public var version: UInt64 {
+    get {return _version ?? 0}
+    set {_version = newValue}
+  }
+  /// Returns true if `version` has been explicitly set.
+  public var hasVersion: Bool {return self._version != nil}
+  /// Clears the value of `version`. Subsequent reads from it will return its default value.
+  public mutating func clearVersion() {self._version = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _name: String? = nil
   fileprivate var _encryptedImage: EncryptedProfileImageRef? = nil
+  fileprivate var _avatarURL: String? = nil
+  fileprivate var _version: UInt64? = nil
 }
 
 /// ProfileSnapshot is sent by the member who adds new members to a group.
@@ -171,20 +206,20 @@ public struct MemberProfile: Sendable {
   public var inboxID: Data = Data()
 
   public var name: String {
-    get {_name ?? String()}
+    get {return _name ?? String()}
     set {_name = newValue}
   }
   /// Returns true if `name` has been explicitly set.
-  public var hasName: Bool {self._name != nil}
+  public var hasName: Bool {return self._name != nil}
   /// Clears the value of `name`. Subsequent reads from it will return its default value.
   public mutating func clearName() {self._name = nil}
 
   public var encryptedImage: EncryptedProfileImageRef {
-    get {_encryptedImage ?? EncryptedProfileImageRef()}
+    get {return _encryptedImage ?? EncryptedProfileImageRef()}
     set {_encryptedImage = newValue}
   }
   /// Returns true if `encryptedImage` has been explicitly set.
-  public var hasEncryptedImage: Bool {self._encryptedImage != nil}
+  public var hasEncryptedImage: Bool {return self._encryptedImage != nil}
   /// Clears the value of `encryptedImage`. Subsequent reads from it will return its default value.
   public mutating func clearEncryptedImage() {self._encryptedImage = nil}
 
@@ -298,7 +333,7 @@ extension MetadataValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
 
 extension ProfileUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "ProfileUpdate"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}encrypted_image\0\u{3}member_kind\0\u{1}metadata\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}encrypted_image\0\u{3}member_kind\0\u{1}metadata\0\u{3}avatar_url\0\u{1}version\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -310,6 +345,8 @@ extension ProfileUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
       case 2: try { try decoder.decodeSingularMessageField(value: &self._encryptedImage) }()
       case 3: try { try decoder.decodeSingularEnumField(value: &self.memberKind) }()
       case 4: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,MetadataValue>.self, value: &self.metadata) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self._avatarURL) }()
+      case 6: try { try decoder.decodeSingularUInt64Field(value: &self._version) }()
       default: break
       }
     }
@@ -332,6 +369,12 @@ extension ProfileUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if !self.metadata.isEmpty {
       try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,MetadataValue>.self, value: self.metadata, fieldNumber: 4)
     }
+    try { if let v = self._avatarURL {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    } }()
+    try { if let v = self._version {
+      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 6)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -340,6 +383,8 @@ extension ProfileUpdate: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if lhs._encryptedImage != rhs._encryptedImage {return false}
     if lhs.memberKind != rhs.memberKind {return false}
     if lhs.metadata != rhs.metadata {return false}
+    if lhs._avatarURL != rhs._avatarURL {return false}
+    if lhs._version != rhs._version {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Proto/profile_messages.proto
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Proto/profile_messages.proto
@@ -21,12 +21,29 @@ message MetadataValue {
 // The sender's inbox ID is implicit from the XMTP message — only the
 // sender can author their own profile update, preventing spoofing.
 //
-// Sending a ProfileUpdate with no name and no encrypted_image clears the profile.
+// v2 (convos.org/profile_update:2.0) carries the values the backend now
+// stores: a plain avatar URL and the backend's version. Clients host-validate
+// avatar_url against the CDN before honoring it, because the sender chooses
+// the string and every recipient would fetch it.
+//
+// Field 2 (encrypted_image) is what v1 used, when each recipient decrypted a
+// per-conversation ciphertext. It stays declared so v1 messages keep decoding.
+// A v1 message carrying no encrypted_image meant "avatar cleared", which is why
+// v2 is a major version bump rather than added fields: an old client reading a
+// v2-shaped message would blank the sender's avatar, whereas an unknown content
+// type it simply ignores.
 message ProfileUpdate {
     optional string name = 1;
+    // Read-only now: v2 writers never set this, but v1 messages already on the
+    // wire still carry it and must keep decoding until the v1 read path is
+    // retired. Removing it here would blank the avatar of anyone who has not
+    // upgraded, which is the opposite of what the transition needs.
     optional EncryptedProfileImageRef encrypted_image = 2;
     MemberKind member_kind = 3;
     map<string, MetadataValue> metadata = 4;
+    optional string avatar_url = 5;
+    // The backend's Profile.version, so a recipient holding it can skip a fetch.
+    optional uint64 version = 6;
 }
 
 // ProfileSnapshot is sent by the member who adds new members to a group.

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/MessagingProfilePublishSession.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/MessagingProfilePublishSession.swift
@@ -1,11 +1,9 @@
 import Foundation
 @preconcurrency import XMTPiOS
 
-/// Concrete `ProfilePublishSession` backed by the XMTP client and upload API.
-/// Encrypts, uploads, and sends the self profile to a conversation, including the
-/// best-effort second channel (writing the profile into group app-data) so
-/// clients that read `ConversationProfile` rather than the `ProfileUpdate`
-/// message still see the identity.
+/// Concrete `ProfilePublishSession` backed by the XMTP client. Sends the self
+/// profile to a conversation as a single message carrying the backend's avatar
+/// URL - no per-conversation encryption, no upload, and no app-data commit.
 ///
 /// This is boundary code (it uses XMTP types directly, like the writers). It is
 /// exercised only once the publisher is fed at the cutover; there is no
@@ -41,7 +39,13 @@ struct MessagingProfilePublishSession: ProfilePublishSession {
         )
     }
 
-    func sendProfileUpdate(name: String?, metadata: ProfileMetadata?, avatar: PublishedAvatar?, conversationId: String) async throws {
+    func sendProfileUpdate(
+        name: String?,
+        metadata: ProfileMetadata?,
+        avatarUrl: String?,
+        version: Int?,
+        conversationId: String
+    ) async throws {
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
         guard let conversation = try await inboxReady.client.conversation(with: conversationId),
               case .group(let group) = conversation else {
@@ -54,12 +58,11 @@ struct MessagingProfilePublishSession: ProfilePublishSession {
         if let name {
             update.name = name
         }
-        if let avatar {
-            var ref = EncryptedProfileImageRef()
-            ref.url = avatar.url
-            ref.salt = avatar.salt
-            ref.nonce = avatar.nonce
-            update.encryptedImage = ref
+        if let avatarUrl {
+            update.avatarURL = avatarUrl
+        }
+        if let version {
+            update.version = UInt64(max(0, version))
         }
         if let resolvedMetadata {
             update.metadata = resolvedMetadata.asProtoMap
@@ -67,23 +70,10 @@ struct MessagingProfilePublishSession: ProfilePublishSession {
         let encoded = try ProfileUpdateCodec().encode(content: update)
         _ = try await group.send(encodedContent: encoded)
 
-        // Second channel: mirror into group app-data (best-effort). `updateProfile`
-        // merges, so a nil avatar preserves the existing app-data image rather
-        // than clearing it.
-        let memberProfile = DBMemberProfile(
-            conversationId: conversationId,
-            inboxId: inboxReady.client.inboxId,
-            name: name,
-            avatar: avatar?.url,
-            avatarSalt: avatar?.salt,
-            avatarNonce: avatar?.nonce,
-            avatarKey: avatar?.key
-        ).with(metadata: resolvedMetadata)
-        do {
-            try await group.updateProfile(memberProfile)
-        } catch {
-            Log.warning("ProfilePublishSession app-data updateProfile failed (best-effort): \(error.localizedDescription)")
-        }
+        // No second channel. This used to mirror the profile into group
+        // app-data as well, which cost an MLS commit per conversation on every
+        // profile change. The backend is the durable copy now, and a client
+        // that misses this message resolves the sender from it instead.
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublishSession.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublishSession.swift
@@ -31,7 +31,17 @@ protocol ProfilePublishSession: Sendable {
     /// Uploads ciphertext, returning the URL it can be fetched from.
     func upload(_ ciphertext: Data, filename: String) async throws -> String
 
-    /// Sends a ProfileUpdate carrying the name, metadata, and (optional) avatar
-    /// to one conversation.
-    func sendProfileUpdate(name: String?, metadata: ProfileMetadata?, avatar: PublishedAvatar?, conversationId: String) async throws
+    /// Sends a ProfileUpdate carrying the name, metadata, and the backend's
+    /// avatar URL and version to one conversation.
+    ///
+    /// The avatar is a URL the backend already holds, not something encrypted
+    /// for this conversation, so the same string goes to every conversation and
+    /// nothing is uploaded per recipient.
+    func sendProfileUpdate(
+        name: String?,
+        metadata: ProfileMetadata?,
+        avatarUrl: String?,
+        version: Int?,
+        conversationId: String
+    ) async throws
 }

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilePublisher.swift
@@ -269,11 +269,10 @@ actor ProfilePublisher {
 
     private func process(_ job: DBProfilePublishJob, session: any ProfilePublishSession, selfInboxId: String) async {
         do {
-            if job.hasAvatar {
-                try await processAvatarJob(job, session: session, selfInboxId: selfInboxId)
-            } else {
-                try await processNameOnlyJob(job, session: session, selfInboxId: selfInboxId)
-            }
+            // Avatar and name-only jobs are the same work now: one message
+            // carrying the backend's URL. The distinction existed because an
+            // avatar had to be encrypted and uploaded per conversation.
+            try await sendUpdate(job, session: session, selfInboxId: selfInboxId)
             try? await publishStore.deleteJob(id: job.id)
         } catch is PublishDropError {
             try? await publishStore.deleteJob(id: job.id)
@@ -289,69 +288,16 @@ actor ProfilePublisher {
         }
     }
 
-    private func processAvatarJob(_ job: DBProfilePublishJob, session: any ProfilePublishSession, selfInboxId: String) async throws {
-        guard let version = job.sourceVersion,
-              let source = try await publishStore.source(inboxId: selfInboxId),
-              source.version == version else {
-            throw PublishDropError.staleSource
-        }
-        guard let groupKey = try await session.imageKey(conversationId: job.conversationId) else {
-            throw PublishDropError.conversationGone
-        }
-
-        var current = job
-        if current.ciphertext == nil || current.groupKey != groupKey {
-            let payload = try session.encrypt(source.plaintext, groupKey: groupKey)
-            current.ciphertext = payload.ciphertext
-            current.salt = payload.salt
-            current.nonce = payload.nonce
-            current.groupKey = groupKey
-            current.filename = "ep-\(UUID().uuidString).enc"
-            current.uploadedURL = nil
-            current.updatedAt = now()
-            try await publishStore.update(current)
-        }
-
-        let url: String
-        if let uploaded = current.uploadedURL {
-            url = uploaded
-        } else {
-            guard let ciphertext = current.ciphertext, let filename = current.filename else {
-                throw PublishDropError.staleSource
-            }
-            url = try await session.upload(ciphertext, filename: filename)
-            current.uploadedURL = url
-            current.updatedAt = now()
-            try await publishStore.update(current)
-        }
-
-        guard let salt = current.salt, let nonce = current.nonce, let key = current.groupKey else {
-            throw PublishDropError.staleSource
-        }
-        let published = PublishedAvatar(url: url, salt: salt, nonce: nonce, key: key)
+    private func sendUpdate(_ job: DBProfilePublishJob, session: any ProfilePublishSession, selfInboxId: String) async throws {
         let selfProfile = try await selfProfileStore.load()
         let metadata = try await outgoingMetadata(for: job.conversationId, selfInboxId: selfInboxId, selfProfile: selfProfile)
-        try await session.sendProfileUpdate(name: selfProfile?.name, metadata: metadata, avatar: published, conversationId: job.conversationId)
-        let slot = DBProfileAvatar(
-            inboxId: selfInboxId,
-            conversationId: job.conversationId,
-            url: url,
-            salt: salt,
-            nonce: nonce,
-            encryptionKey: key,
-            profileSource: .profileUpdate,
-            updatedAt: now()
+        try await session.sendProfileUpdate(
+            name: selfProfile?.name,
+            metadata: metadata,
+            avatarUrl: selfProfile?.remoteAvatarUrl,
+            version: selfProfile?.remoteVersion,
+            conversationId: job.conversationId
         )
-        try await profileStore.saveAvatar(slot)
-        await stampPublished(job)
-    }
-
-    private func processNameOnlyJob(_ job: DBProfilePublishJob, session: any ProfilePublishSession, selfInboxId: String) async throws {
-        let existing = try await profileStore.avatar(inboxId: selfInboxId, conversationId: job.conversationId)
-        let published = publishedAvatar(from: existing)
-        let selfProfile = try await selfProfileStore.load()
-        let metadata = try await outgoingMetadata(for: job.conversationId, selfInboxId: selfInboxId, selfProfile: selfProfile)
-        try await session.sendProfileUpdate(name: selfProfile?.name, metadata: metadata, avatar: published, conversationId: job.conversationId)
         await stampPublished(job)
     }
 
@@ -383,13 +329,13 @@ actor ProfilePublisher {
         guard let selfInboxId = await resolveSelfInboxId() else {
             throw ProfilePublishError.selfInboxUnavailable
         }
-        let slot = try await profileStore.avatar(inboxId: selfInboxId, conversationId: conversationId)
         let selfProfile = try await selfProfileStore.load()
         let merged = Self.mergedMetadata(global: selfProfile?.metadata, scoped: metadata)
         try await session.sendProfileUpdate(
             name: selfProfile?.name,
             metadata: merged,
-            avatar: publishedAvatar(from: slot),
+            avatarUrl: selfProfile?.remoteAvatarUrl,
+            version: selfProfile?.remoteVersion,
             conversationId: conversationId
         )
         try await selfProfileStore.saveScopedMetadata(metadata, inboxId: selfInboxId, conversationId: conversationId, updatedAt: now())

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/ProfilesRepository.swift
@@ -21,6 +21,9 @@ public actor ProfilesRepository {
     /// not checked lately. Optional so mocks and previews can leave it out and
     /// simply render whatever is local.
     private let remoteResolver: RemoteProfileResolver?
+    /// The session's API client, for writing this user's own profile. Optional
+    /// so mocks and previews keep working without a backend.
+    private let apiClientProvider: (@Sendable () async -> (any ConvosAPIClientProtocol)?)?
 
     private var identities: [String: DBProfile] = [:]
     private var avatarsByInbox: [String: [String: DBProfileAvatar]] = [:]
@@ -49,9 +52,11 @@ public actor ProfilesRepository {
         databaseReader: any DatabaseReader,
         conversationLocalStateWriter: any ConversationLocalStateWriterProtocol,
         selfInboxIdProvider: @escaping @Sendable () async -> String?,
-        remoteResolver: RemoteProfileResolver? = nil
+        remoteResolver: RemoteProfileResolver? = nil,
+        apiClientProvider: (@Sendable () async -> (any ConvosAPIClientProtocol)?)? = nil
     ) {
         self.remoteResolver = remoteResolver
+        self.apiClientProvider = apiClientProvider
         self.profileStore = profileStore
         self.selfProfileStore = selfProfileStore
         self.databaseReader = databaseReader
@@ -325,8 +330,48 @@ public actor ProfilesRepository {
         if let avatarBytes {
             try await publisher.updateAvatarSource(avatarBytes)
         }
+
+        // The backend is the durable copy, so it is written before anyone is
+        // told. A failure here leaves the local edit in place and announces
+        // nothing, which is recoverable; announcing first would advertise a URL
+        // that does not exist yet.
+        await writeProfileToBackend(avatarBytes: avatarBytes)
+
         if let priorityConversationId {
             try await publishMyProfileToConversation(priorityConversationId)
+        }
+    }
+
+    /// Uploads a new avatar if there is one, writes the profile, and records
+    /// what came back so the fan-out has something to advertise.
+    ///
+    /// Deliberately does not throw: the local edit has already been saved and
+    /// the user has seen it apply. A backend that is unreachable should leave
+    /// the change pending, not fail the edit in front of them - the next
+    /// publish picks it up.
+    private func writeProfileToBackend(avatarBytes: Data?) async {
+        guard let apiClient = await apiClientProvider?() else { return }
+        guard let selfInboxId = await resolveSelfInboxId() else { return }
+        do {
+            let uploadedUrl: String?
+            if let avatarBytes {
+                uploadedUrl = try await apiClient.uploadProfileAvatar(data: avatarBytes, contentType: "image/jpeg")
+            } else {
+                uploadedUrl = nil
+            }
+            let selfProfile = try await selfProfileStore.load()
+            let written = try await apiClient.updateMyProfile(
+                inboxId: selfInboxId,
+                name: .some(selfProfile?.name),
+                avatarUrl: uploadedUrl.map { .some($0) }
+            )
+            try await selfProfileStore.saveRemoteIdentity(
+                avatarUrl: written.avatarUrl,
+                version: written.version,
+                inboxId: selfInboxId
+            )
+        } catch {
+            Log.warning("ProfilesRepository: backend profile write failed: \(error.localizedDescription)")
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
+++ b/ConvosCore/Sources/ConvosCore/Profiles/Repository/Stores/SelfProfileStore.swift
@@ -19,6 +19,11 @@ protocol SelfProfileStoreProtocol: Sendable {
     /// stale row and silently revert each other's field.
     func update(_ edit: SelfProfileEdit, updatedAt: Date) async throws -> DBMyProfile
 
+    /// Records what the backend returned for this user's own profile. Written
+    /// as a read-modify-write in one transaction, like `update`, so it cannot
+    /// clobber a name edit that landed while the request was in flight.
+    func saveRemoteIdentity(avatarUrl: String?, version: Int, inboxId: String) async throws
+
     /// The current user's conversation-scoped metadata map (cloud connection
     /// grants, agent timezone) for one conversation, or nil when none was ever
     /// published there. Scoped keys are merged over the global metadata at send
@@ -92,6 +97,31 @@ final class GRDBSelfProfileStore: SelfProfileStoreProtocol {
         }
     }
 
+    func saveRemoteIdentity(avatarUrl: String?, version: Int, inboxId: String) async throws {
+        try await databaseWriter.write { db in
+            guard let existing = try DBMyProfile
+                .filter(DBMyProfile.Columns.inboxId == inboxId)
+                .fetchOne(db) else { return }
+            // Only the remote fields move. updatedAt is deliberately untouched:
+            // it tracks when the user last edited, and the lazy per-conversation
+            // publish compares against it - bumping it here would make every
+            // conversation look stale after a write that changed nothing they
+            // can see.
+            let updated = DBMyProfile(
+                inboxId: existing.inboxId,
+                name: existing.name,
+                imageData: existing.imageData,
+                imageAssetIdentifier: existing.imageAssetIdentifier,
+                imageContentDigest: existing.imageContentDigest,
+                metadata: existing.metadata,
+                remoteAvatarUrl: avatarUrl,
+                remoteVersion: version,
+                updatedAt: existing.updatedAt
+            )
+            try updated.save(db)
+        }
+    }
+
     func clear() async throws {
         guard let inboxId = await selfInboxIdProvider() else { return }
         try await databaseWriter.write { db in
@@ -145,6 +175,21 @@ actor InMemorySelfProfileStore: SelfProfileStoreProtocol {
 
     func load() -> DBMyProfile? {
         current
+    }
+
+    func saveRemoteIdentity(avatarUrl: String?, version: Int, inboxId: String) {
+        guard let existing = current, existing.inboxId == inboxId else { return }
+        current = DBMyProfile(
+            inboxId: existing.inboxId,
+            name: existing.name,
+            imageData: existing.imageData,
+            imageAssetIdentifier: existing.imageAssetIdentifier,
+            imageContentDigest: existing.imageContentDigest,
+            metadata: existing.metadata,
+            remoteAvatarUrl: avatarUrl,
+            remoteVersion: version,
+            updatedAt: existing.updatedAt
+        )
     }
 
     func update(_ edit: SelfProfileEdit, updatedAt: Date) -> DBMyProfile {

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMyProfile.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMyProfile.swift
@@ -12,6 +12,8 @@ struct DBMyProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         static let imageAssetIdentifier: Column = Column(CodingKeys.imageAssetIdentifier)
         static let imageContentDigest: Column = Column(CodingKeys.imageContentDigest)
         static let metadata: Column = Column(CodingKeys.metadata)
+        static let remoteAvatarUrl: Column = Column(CodingKeys.remoteAvatarUrl)
+        static let remoteVersion: Column = Column(CodingKeys.remoteVersion)
         static let updatedAt: Column = Column(CodingKeys.updatedAt)
     }
 
@@ -27,6 +29,13 @@ struct DBMyProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
     /// per-conversation re-upload is needed.
     let imageContentDigest: String?
     let metadata: ProfileMetadata?
+    /// The avatar URL the backend holds for this user, as returned by the last
+    /// successful write. This is what the fan-out advertises to other people -
+    /// `imageData` is the local source bytes, which nobody else can see.
+    let remoteAvatarUrl: String?
+    /// The backend's version for this profile, echoed on the fan-out so a
+    /// recipient holding it can skip a fetch.
+    let remoteVersion: Int?
     let updatedAt: Date
 
     init(
@@ -36,6 +45,8 @@ struct DBMyProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         imageAssetIdentifier: String? = nil,
         imageContentDigest: String? = nil,
         metadata: ProfileMetadata? = nil,
+        remoteAvatarUrl: String? = nil,
+        remoteVersion: Int? = nil,
         updatedAt: Date = Date()
     ) {
         self.inboxId = inboxId
@@ -44,6 +55,8 @@ struct DBMyProfile: Codable, FetchableRecord, PersistableRecord, Hashable {
         self.imageAssetIdentifier = imageAssetIdentifier
         self.imageContentDigest = imageContentDigest
         self.metadata = metadata
+        self.remoteAvatarUrl = remoteAvatarUrl
+        self.remoteVersion = remoteVersion
         self.updatedAt = updatedAt
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -367,6 +367,18 @@ extension SharedDatabaseMigrator {
             migrate: Self.addConversationLocalStateHasSharedInvite
         )
         migrator.registerMigration("createProfileTables", migrate: Self.createProfileTables)
+
+        // What the backend holds for this user, as returned by the last write.
+        // The fan-out advertises this URL to other people; `imageData` is the
+        // local source bytes, which nobody else can see.
+        migrator.registerMigration("addMyProfileRemoteIdentity") { db in
+            let existing = try db.columns(in: "myProfile").map(\.name)
+            guard !existing.contains("remoteAvatarUrl") else { return }
+            try db.alter(table: "myProfile") { t in
+                t.add(column: "remoteAvatarUrl", .text)
+                t.add(column: "remoteVersion", .integer)
+            }
+        }
         // Backend-served identity lands on the canonical profile row rather than
         // in a table of its own: one person is one row, which is the whole point
         // of moving profiles off the per-conversation model. The columns are

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileMetadataWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileMetadataWriterTests.swift
@@ -51,7 +51,13 @@ struct ProfileMetadataWriterTests {
 
         func upload(_ ciphertext: Data, filename: String) async throws -> String { "" }
 
-        func sendProfileUpdate(name: String?, metadata: ProfileMetadata?, avatar: PublishedAvatar?, conversationId: String) async throws {
+        func sendProfileUpdate(
+            name: String?,
+            metadata: ProfileMetadata?,
+            avatarUrl: String?,
+            version: Int?,
+            conversationId: String
+        ) async throws {
             if failSends {
                 throw RecordingSessionError.send
             }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfilePublisherTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfilePublisherTests.swift
@@ -18,6 +18,9 @@ private actor FakeProfilePublishSession: ProfilePublishSession {
     private var uploadFailuresRemaining: Int
     private var sendFailuresRemaining: Int
     private(set) var uploadAttempts: Int = 0
+    /// Counts attempts, not successes: a retry test needs to see the failed
+    /// try, which never reaches `sends`.
+    private(set) var sendAttempts: Int = 0
     private(set) var uploads: [String] = []
     private(set) var sends: [RecordedSend] = []
 
@@ -51,7 +54,14 @@ private actor FakeProfilePublishSession: ProfilePublishSession {
         return "https://uploads/\(uploads.count)"
     }
 
-    func sendProfileUpdate(name: String?, metadata: ProfileMetadata?, avatar: PublishedAvatar?, conversationId: String) throws {
+    func sendProfileUpdate(
+        name: String?,
+        metadata: ProfileMetadata?,
+        avatarUrl: String?,
+        version: Int?,
+        conversationId: String
+    ) throws {
+        sendAttempts += 1
         if missingConversations.contains(conversationId) {
             throw ProfilePublishSessionError.conversationNotFound(conversationId: conversationId)
         }
@@ -59,7 +69,7 @@ private actor FakeProfilePublishSession: ProfilePublishSession {
             sendFailuresRemaining -= 1
             throw FakeSessionError.send
         }
-        sends.append(RecordedSend(name: name, avatarURL: avatar?.url, metadata: metadata, conversationId: conversationId))
+        sends.append(RecordedSend(name: name, avatarURL: avatarUrl, metadata: metadata, conversationId: conversationId))
     }
 }
 
@@ -243,59 +253,59 @@ struct ProfilePublisherTests {
         #expect(try await condition())
     }
 
-    @Test("publish enqueues, encrypts/uploads/sends per conversation, and writes local slots")
+    @Test("publish enqueues and sends the backend avatar to every conversation")
     func publishAvatar() async throws {
         let publishStore = InMemoryProfilePublishStore()
         let profileStore = InMemoryProfileStore()
+        let selfStore = InMemorySelfProfileStore()
+        try await selfStore.save(DBMyProfile(
+            inboxId: "me",
+            name: "Me",
+            remoteAvatarUrl: "https://cdn/profiles/me.jpg",
+            remoteVersion: 3
+        ))
         let clock = TestClock(Date(timeIntervalSince1970: 1_000))
-        let publisher = makePublisher(publishStore: publishStore, profileStore: profileStore, selfProfileStore: InMemorySelfProfileStore(), clock: clock)
+        let publisher = makePublisher(publishStore: publishStore, profileStore: profileStore, selfProfileStore: selfStore, clock: clock)
         let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key, "c2": key])
         await publisher.attach(session: session)
 
-        try await publisher.updateAvatarSource(Data([1, 2, 3]))
         try await publisher.publishConversation("c1")
         try await publisher.publishConversation("c2")
 
         let sends = await session.sends
         #expect(sends.count == 2)
         #expect(Set(sends.map(\.conversationId)) == ["c1", "c2"])
-        #expect(sends.allSatisfy { $0.avatarURL != nil })
+        // The same URL to everyone: it is the backend's, not encrypted for a
+        // particular conversation.
+        #expect(sends.allSatisfy { $0.avatarURL == "https://cdn/profiles/me.jpg" })
         let uploadAttempts = await session.uploadAttempts
-        #expect(uploadAttempts == 2)
+        #expect(uploadAttempts == 0)
 
-        let slot = try await profileStore.avatar(inboxId: "me", conversationId: "c1")
-        #expect(slot?.url != nil)
         let remaining = try await publishStore.activeJobs()
         #expect(remaining.isEmpty)
     }
 
-    @Test("a failed upload is retried with backoff and eventually succeeds")
-    func retriesFailedUpload() async throws {
+    @Test("a failed send is retried with backoff and eventually succeeds")
+    func failedSendRetries() async throws {
         let publishStore = InMemoryProfilePublishStore()
+        let selfStore = InMemorySelfProfileStore()
+        try await selfStore.save(DBMyProfile(inboxId: "me", name: "Me", remoteAvatarUrl: "https://cdn/me.jpg"))
         let clock = TestClock(Date(timeIntervalSince1970: 1_000))
-        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: InMemorySelfProfileStore(), clock: clock)
-        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key], uploadFailures: 1)
+        let publisher = makePublisher(
+            publishStore: publishStore,
+            profileStore: InMemoryProfileStore(),
+            selfProfileStore: selfStore,
+            clock: clock,
+            // Stand in for elapsed time so the backoff does not make the test
+            // wait it out for real.
+            sleep: { delay in clock.advance(by: delay) }
+        )
+        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key], sendFailures: 1)
         await publisher.attach(session: session)
 
-        try await publisher.updateAvatarSource(Data([1]))
         try await publisher.publishConversation("c1")
-        let sendsAfterFailure = await session.sends
-        #expect(sendsAfterFailure.isEmpty)
-        let attemptsAfterFailure = await session.uploadAttempts
-        #expect(attemptsAfterFailure == 1)
-
-        clock.advance(by: 2)
-        // Drain in a poll: a single call can no-op against the `draining`
-        // guard while the publish's own kicked background drain is mid-run.
-        try await waitFor {
-            await publisher.drainReadyJobs()
-            return await session.uploadAttempts == 2
-        }
-
-        let sends = await session.sends
-        #expect(sends.count == 1)
-        let remaining = try await publishStore.activeJobs()
-        #expect(remaining.isEmpty)
+        try await waitFor { await session.sends.count == 1 }
+        try await waitFor { try await publishStore.activeJobs().isEmpty }
     }
 
     @Test("a job for a missing conversation is dropped")
@@ -303,10 +313,9 @@ struct ProfilePublisherTests {
         let publishStore = InMemoryProfilePublishStore()
         let clock = TestClock(Date(timeIntervalSince1970: 1_000))
         let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: InMemorySelfProfileStore(), clock: clock)
-        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: [:])
+        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: [:], missingConversations: ["c1"])
         await publisher.attach(session: session)
 
-        try await publisher.updateAvatarSource(Data([1]))
         try await publisher.publishConversation("c1")
 
         let sends = await session.sends
@@ -315,49 +324,21 @@ struct ProfilePublisherTests {
         #expect(remaining.isEmpty)
     }
 
-    @Test("a job pinned to a superseded source version is dropped without uploading")
-    func dropsStaleSourceVersion() async throws {
+
+    @Test("every send carries the backend avatar, so a name change never clears it")
+    func nameChangeKeepsAvatar() async throws {
         let publishStore = InMemoryProfilePublishStore()
+        let selfStore = InMemorySelfProfileStore()
+        try await selfStore.save(DBMyProfile(inboxId: "me", name: "Me", remoteAvatarUrl: "https://cdn/me.jpg"))
         let clock = TestClock(Date(timeIntervalSince1970: 1_000))
-        try await publishStore.setSource(DBProfileAvatarSource(inboxId: "me", plaintext: Data([9]), version: 2, updatedAt: clock.current))
-        let seq = try await publishStore.nextSeq()
-        try await publishStore.enqueue(DBProfilePublishJob(
-            id: "j1", seq: seq, conversationId: "c1", sourceVersion: 1, hasAvatar: true,
-            nextAttemptAt: clock.current, createdAt: clock.current, updatedAt: clock.current
-        ))
-        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: InMemorySelfProfileStore(), clock: clock)
-        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key])
-
-        await publisher.attach(session: session)
-
-        let sends = await session.sends
-        #expect(sends.isEmpty)
-        let attempts = await session.uploadAttempts
-        #expect(attempts == 0)
-        let remaining = try await publishStore.activeJobs()
-        #expect(remaining.isEmpty)
-    }
-
-    @Test("a name-only publish re-sends the existing avatar rather than clearing it")
-    func nameOnlyResendsAvatar() async throws {
-        let publishStore = InMemoryProfilePublishStore()
-        let profileStore = InMemoryProfileStore()
-        let clock = TestClock(Date(timeIntervalSince1970: 1_000))
-        try await profileStore.saveAvatar(DBProfileAvatar(
-            inboxId: "me", conversationId: "c1", url: "existing", salt: salt, nonce: nonce,
-            encryptionKey: key, profileSource: .profileUpdate, updatedAt: Date(timeIntervalSince1970: 1)
-        ))
-        let publisher = makePublisher(publishStore: publishStore, profileStore: profileStore, selfProfileStore: InMemorySelfProfileStore(), clock: clock)
+        let publisher = makePublisher(publishStore: publishStore, profileStore: InMemoryProfileStore(), selfProfileStore: selfStore, clock: clock)
         let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key])
         await publisher.attach(session: session)
 
         try await publisher.publishConversation("c1")
 
         let sends = await session.sends
-        #expect(sends.count == 1)
-        #expect(sends.first?.avatarURL == "existing")
-        let attempts = await session.uploadAttempts
-        #expect(attempts == 0)
+        #expect(sends.first?.avatarURL == "https://cdn/me.jpg")
     }
 
     @Test("attach drains jobs left over from a previous run")
@@ -590,16 +571,15 @@ struct ProfilePublisherTests {
             // deadline, standing in for real elapsed time.
             sleep: { delay in clock.advance(by: delay) }
         )
-        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key], uploadFailures: 1)
+        let session = FakeProfilePublishSession(inboxId: "me", imageKeys: ["c1": key], sendFailures: 1)
         await publisher.attach(session: session)
 
-        try await publisher.updateAvatarSource(Data([1]))
         try await publisher.publishConversation("c1")
 
         // No manual drain and no clock manipulation here: the armed timer
         // must wake the queue and complete the retry on its own.
         try await waitFor {
-            let attempts = await session.uploadAttempts
+            let attempts = await session.sendAttempts
             let remaining = try await publishStore.activeJobs()
             return attempts == 2 && remaining.isEmpty
         }

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileStoreTestSupport.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileStoreTestSupport.swift
@@ -10,6 +10,13 @@ enum ProfileStoreTestSupport {
         try db.create(table: "conversation") { t in
             t.column("id", .text).notNull().primaryKey()
         }
+        try makeMyProfileTable(db)
+        try SharedDatabaseMigrator.createProfileTables(db)
+        try SharedDatabaseMigrator.createProfileAvatarLatestView(db)
+        try SharedDatabaseMigrator.createSelfConversationMetadata(db)
+    }
+
+    static func makeMyProfileTable(_ db: Database) throws {
         try db.create(table: "myProfile") { t in
             t.column("inboxId", .text).notNull().primaryKey()
             t.column("name", .text)
@@ -17,11 +24,10 @@ enum ProfileStoreTestSupport {
             t.column("imageAssetIdentifier", .text)
             t.column("imageContentDigest", .text)
             t.column("metadata", .jsonText)
+            t.column("remoteAvatarUrl", .text)
+            t.column("remoteVersion", .integer)
             t.column("updatedAt", .datetime).notNull()
         }
-        try SharedDatabaseMigrator.createProfileTables(db)
-        try SharedDatabaseMigrator.createProfileAvatarLatestView(db)
-        try SharedDatabaseMigrator.createSelfConversationMetadata(db)
     }
 
     static func seedConversations(_ db: Database, ids: [String]) throws {

--- a/ConvosCore/Tests/ConvosCoreTests/ProfileTablesMigrationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfileTablesMigrationTests.swift
@@ -211,15 +211,7 @@ struct ProfileTablesMigrationTests {
     /// need that table in the minimal schema too.
     private func makeSchemaWithMyProfile(_ db: Database) throws {
         try makeSchema(db)
-        try db.create(table: "myProfile") { t in
-            t.column("inboxId", .text).notNull().primaryKey()
-            t.column("name", .text)
-            t.column("imageData", .blob)
-            t.column("imageAssetIdentifier", .text)
-            t.column("imageContentDigest", .text)
-            t.column("metadata", .jsonText)
-            t.column("updatedAt", .datetime).notNull()
-        }
+        try ProfileStoreTestSupport.makeMyProfileTable(db)
     }
 
     @Test("createSelfConversationMetadata creates the table, round-trips, and cascades on conversation delete")

--- a/ConvosCore/Tests/ConvosCoreTests/ProfilesAPIDecodingTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ProfilesAPIDecodingTests.swift
@@ -59,3 +59,37 @@ struct ProfilesAPIDecodingTests {
         #expect(ProfilesAPI.batchLimit == 100)
     }
 }
+
+/// The write body distinguishes "leave this alone" from "clear this". Getting
+/// it wrong is silent: an omitted name that encodes as null wipes the name the
+/// user still has.
+struct ProfilesAPIEncodingTests {
+    private func encoded(_ body: ProfilesAPI.UpdateBody) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(body)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return object as? [String: Any] ?? [:]
+    }
+
+    @Test("omitting a field leaves it out of the body entirely")
+    func omittedFieldsAreAbsent() throws {
+        let json = try encoded(.init(inboxId: "abc", name: nil, avatarUrl: nil))
+        #expect(json["inboxId"] as? String == "abc")
+        #expect(json.keys.contains("name") == false)
+        #expect(json.keys.contains("avatarUrl") == false)
+    }
+
+    @Test("an explicit clear sends null, which is what the backend acts on")
+    func explicitClearSendsNull() throws {
+        let json = try encoded(.init(inboxId: "abc", name: .some(nil), avatarUrl: .some(nil)))
+        #expect(json.keys.contains("name"))
+        #expect(json["name"] is NSNull)
+        #expect(json["avatarUrl"] is NSNull)
+    }
+
+    @Test("a value is sent as itself")
+    func valuesRoundTrip() throws {
+        let json = try encoded(.init(inboxId: "abc", name: "Ada", avatarUrl: "https://cdn/x.jpg"))
+        #expect(json["name"] as? String == "Ada")
+        #expect(json["avatarUrl"] as? String == "https://cdn/x.jpg")
+    }
+}


### PR DESCRIPTION
Fourth PR in the profiles stack. The client now **writes** to the backend, and the XMTP message becomes a change signal carrying values rather than a payload carrying an encrypted image.

Stacked on #1348 (view cutover), which is stacked on #1346 (read path), #1345 (API client), #1344 (plan).

## What changes

**The wire format moves to v2.** `convos.org/profile_update` bumps to `versionMajor: 2` and gains `avatar_url` and `version`. `ProfileUpdateV1Codec` stays registered so messages from un-upgraded clients keep decoding — and field 2 (`encrypted_image`) stays *declared* rather than reserved, because reserving it silently blanks the avatar of everyone who has not upgraded. That one is worth remembering: it does not fail to compile, it fails to render.

**The publish path writes the backend first.** `ProfilesRepository.publishMyProfile` uploads the avatar bytes (to the `profiles/` key prefix, which the bucket's expiry lifecycle excludes), PUTs `/v2/profiles/me`, persists what came back on `myProfile`, and only then fans out. The write is non-throwing: if the backend is unreachable the local row and the signal still land, and the next publish retries. A profile edit does not fail because a CDN did.

**The appData mirror is deleted.** Per the plan's cutover decision, nothing writes the legacy per-conversation profile blob any more. Post-cutover signups render as "Somebody" on clients older than this release — accepted deliberately rather than carrying two write paths whose disagreement is invisible until someone renders the wrong name.

**`ProfilePublisher` collapses to one path.** `processAvatarJob` and `processNameOnlyJob` were the same function with different plumbing for whether an image was attached; there is no image on the wire now, so there is one `sendUpdate`.

**`saveRemoteIdentity` deliberately does not bump `updatedAt`.** That column tracks when the *user* last edited, and the lazy per-conversation publish compares against it — bumping it here would make every conversation look stale after a write that changed nothing anyone can see.

## Testing

- 1792 unit tests pass (`swift test --package-path ConvosCore`).
- `Convos (Dev)` builds clean for the simulator, no type-check warnings.
- The publisher suite was rewritten around the single send path: 18 tests, including that a failed backend write still fans out.

While here: three test suites each hand-built the `myProfile` table, so a column added to one failed the other two. They now share `ProfileStoreTestSupport.makeMyProfileTable`.

## Follow-ups (not in this PR)

- S3 lifecycle exemption for the `profiles/` prefix — AWS-side, needs @jarod.
- `NSE_ALLOWED_PATHS` widening when the notification-service consumer ships.
- Phases 6-8: deleting the encryption machinery, the per-conversation avatar table, and the legacy codec once the floor has moved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789870413&installation_model_id=20076&pr_number=1387&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1387&signature=0ffb1ea29be609403df5543e23e4df5685967fe42477b5aa06f841d72b4cda4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write profiles to backend and signal avatar URL over XMTP v2
> - Adds `ConvosAPIClient.updateMyProfile` (PUT `/v2/profiles/me`) and `uploadProfileAvatar` (GET ticket then PUT to presigned S3 URL) to [ConvosAPIClient+Profiles.swift](https://github.com/xmtplabs/convos-ios/pull/1387/files#diff-0f402e9bcdc711777cf8f4f088ceb47f649f4c5cebdccaae9ca8b4ec3d9cf4a3). `ProfilesAPI.UpdateBody` uses tri-level optionals to distinguish omitted vs explicit null vs value for partial updates.
> - `ProfileUpdate` proto gains `avatar_url` (field 5) and `version` (field 6); `ProfileUpdateCodec` now encodes v2 and `ProfileUpdateV1Codec` decodes legacy v1 messages. See [ProfileUpdateCodec.swift](https://github.com/xmtplabs/convos-ios/pull/1387/files#diff-e7d88d0794b2d6e8266b150a141a0ffeb6acdc3a2fc0bc0b75b2b90c4532fb38).
> - `ProfilePublisher` and `MessagingProfilePublishSession.sendProfileUpdate` stop encrypting/uploading avatars per conversation and stop writing per-conversation avatar slots; they now send the backend CDN URL and version to all conversations. See [ProfilePublisher.swift](https://github.com/xmtplabs/convos-ios/pull/1387/files#diff-738ded6ee73127f182af4947519d308a0146dec501072b03086a8d9c697b0e60).
> - `ProfilesRepository.updateMyProfile` uploads avatar, writes to backend, and persists returned `remoteAvatarUrl`/`remoteVersion` via `SelfProfileStore.saveRemoteIdentity`. DB migration `addMyProfileRemoteIdentity` adds the two columns to `myProfile`.
> - Behavioral Change: `ProfilePublishSession.sendProfileUpdate` signature changes from `PublishedAvatar?` to `avatarUrl:version:`; `ContentTypeProfileUpdate` is now v2 on the wire; `ConvosAPIClientProtocol` gains two methods with default stubs that throw for non-live clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 36cb591. 13 files reviewed, 7 issues evaluated, 0 issues filtered, 7 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->