### PR TITLE
Offer to add an agent from the Context tab

### DIFF
--- a/Convos/Conversation Detail/AddAgentPromptView.swift
+++ b/Convos/Conversation Detail/AddAgentPromptView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// The offer shown on a conversation with no agent: a button to add one, and a
+/// line saying what it is for (Figma 7488:14502).
+///
+/// Shared by the Agent tab and the Context tab so the two cannot drift. Neither
+/// a background nor the chrome's clearance belongs here - the Agent tab centres
+/// this on its own dark surface and the Context tab on the conversation's
+/// ambient wash, so each host supplies its own.
+struct AddAgentPromptView: View {
+    /// Asks the conversation's session to provision an agent.
+    let onAddAgent: () -> Void
+    /// Distinguishes the two hosts' buttons for QA; the label is identical.
+    var accessibilityIdentifier: String
+
+    var body: some View {
+        VStack(spacing: DesignConstants.Spacing.step3x) {
+            Button(action: onAddAgent) {
+                Text("Add an agent")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextPrimaryInverted)
+                    .padding(.horizontal, DesignConstants.Spacing.step3x)
+                    .frame(height: Constant.buttonHeight)
+                    .background(.colorLava, in: .rect(cornerRadius: Constant.buttonRadius))
+            }
+            .accessibilityIdentifier(accessibilityIdentifier)
+            Text("To help the group out")
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.colorLava)
+        }
+    }
+
+    private enum Constant {
+        static let buttonHeight: CGFloat = 36.0
+        static let buttonRadius: CGFloat = 24.0
+    }
+}
+
+#Preview {
+    AddAgentPromptView(onAddAgent: {}, accessibilityIdentifier: "preview-add-agent")
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.colorBackgroundSurfaceless)
+}

--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -158,30 +158,16 @@ struct AgentDmPageView: View {
         // An agent that is already a member is only missing its DM, which the
         // agent creates moments later; a join still in flight is the same wait
         // one step earlier. Both read as "preparing".
-        if session.agentInboxId != nil || session.isJoiningAgent {
-            return .preparing
-        }
-        return .noAgent
+        return session.hasNoAgent ? .noAgent : .preparing
     }
 
     /// Offered when the conversation has no agent at all (Figma 7488:14502).
     /// Centered in the band the reader can see, below the floating top chrome.
     private var addAgentState: some View {
-        VStack(spacing: DesignConstants.Spacing.step3x) {
-            Button(action: session.requestAgentJoin) {
-                Text("Add an agent")
-                    .font(.footnote)
-                    .foregroundStyle(.colorTextPrimaryInverted)
-                    .padding(.horizontal, DesignConstants.Spacing.step3x)
-                    .frame(height: Constant.addAgentButtonHeight)
-                    .background(.colorLava, in: .rect(cornerRadius: Constant.addAgentButtonRadius))
-            }
-            .accessibilityIdentifier("agent-dm-add-agent-button")
-            Text("To help the group out")
-                .font(.footnote)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.colorLava)
-        }
+        AddAgentPromptView(
+            onAddAgent: session.requestAgentJoin,
+            accessibilityIdentifier: "agent-dm-add-agent-button"
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         // Inset past the floating top chrome so this centers in what the
         // reader can see rather than behind the segmented control. The
@@ -547,7 +533,5 @@ struct AgentDmPageView: View {
         static let progressWidth: CGFloat = 120.0
         static let progressHeight: CGFloat = 8.0
         static let progressTrackOpacity: Double = 0.3
-        static let addAgentButtonHeight: CGFloat = 36.0
-        static let addAgentButtonRadius: CGFloat = 24.0
     }
 }

--- a/Convos/Conversation Detail/AgentDmSession.swift
+++ b/Convos/Conversation Detail/AgentDmSession.swift
@@ -89,6 +89,14 @@ final class AgentDmSession {
     /// pending flag is `@ObservationIgnored` and only turns over once the join
     /// registers, so on its own the tab would sit on the offer for a beat
     /// after the tap.
+    /// True while the conversation has no agent to talk to and none on the way.
+    ///
+    /// The Agent tab and the Context tab both offer to add one, and they must
+    /// agree about when: this is the single definition they share.
+    var hasNoAgent: Bool {
+        dmViewModel == nil && agentInboxId == nil && !isJoiningAgent
+    }
+
     var isJoiningAgent: Bool {
         isRequestingAgent || isProvisioningDefaultAgent || originViewModel.isAgentJoinPending
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1443,13 +1443,35 @@ private extension ConversationView {
     }
 
     /// The Context tab's root: the conversation's Space web surface.
+    @ViewBuilder
     var spaceSurface: some View {
-        HomeLayoutView(
-            webURL: viewModel.conversation.spaceURL,
-            onNavigationRequest: { url in
-                pushHomeBrowserPage(for: url)
+        // A Space is something the agent builds, so with no agent there is
+        // nothing here to wait for - the preparing state would spin forever.
+        // The tab offers the same way in as the Agent tab does, from the same
+        // signal, so the two never disagree about whether one is missing.
+        if agentDmSession?.hasNoAgent == true {
+            AddAgentPromptView(
+                onAddAgent: { agentDmSession?.requestAgentJoin() },
+                accessibilityIdentifier: "context-add-agent-button"
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.top, ConversationChromeMetrics.contentClearance)
+            .background {
+                ZStack {
+                    Color.colorBackgroundSurfaceless
+                    Color.colorBackgroundSubtle
+                }
+                .ignoresSafeArea()
             }
-        )
+            .accessibilityIdentifier("context-no-agent")
+        } else {
+            HomeLayoutView(
+                webURL: viewModel.conversation.spaceURL,
+                onNavigationRequest: { url in
+                    pushHomeBrowserPage(for: url)
+                }
+            )
+        }
     }
 
     /// The single host seam for the composer's connections capability: the


### PR DESCRIPTION
A Space is something the agent builds, so a conversation without an agent has nothing for the Context tab to wait for — it sat on the preparing state indefinitely. The tab now makes the same offer the Agent tab does: **Add an agent**, with *To help the group out* beneath it.

## Shared, not duplicated

Two small extractions so the tabs can't drift:

- **`AddAgentPromptView`** — the button and its caption, rendered by both tabs. Neither a background nor the chrome's clearance lives in it; the Agent tab centres it on its dark surface and Context on the conversation's ambient wash, so each host supplies its own.
- **`AgentDmSession.hasNoAgent`** — one definition of "there is no agent and none on the way". The Agent tab's `Phase` now reads it too, so the two tabs answer the question identically instead of each testing `agentInboxId`/`isJoiningAgent` themselves.

## Verification

The Agent tab's own no-agent path is unchanged behaviourally and still resolves through the same predicate.

For Context, every conversation on my simulator has an agent, so I could not reach the state naturally. I verified the **rendering** by temporarily forcing the branch and screenshotting — the prompt centres correctly below the chrome on the ambient wash — then reverted the force. The **predicate** is verified by sharing: it is the same signal the Agent tab uses, which I confirmed reports `has-agent` on all four conversations tested.

405 unit tests pass. The one failure, `ConversationViewModelDoneRevokeTests.testApproveAllTogglesOff…`, is pre-existing and fails identically on `dev`.

## Copy note

The caption reads **"To help the group out"** — matching the Agent tab verbatim, since the ask was for the two to be the same. The request said "to help the group chat"; if that was intended as new copy rather than a paraphrase, it is a one-line change in `AddAgentPromptView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789917864&installation_model_id=20076&pr_number=1390&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1390&signature=cfc97fde2662a16cbf15ff1c75a2dbe7104f197ceb96f4c4f91ec3f7cc0c27c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Add an agent' prompt to Context tab and `AgentDmPageView`
> - Adds a new reusable `AddAgentPromptView` SwiftUI component with a tappable button and secondary helper text
> - Introduces `AgentDmSession.hasNoAgent` as the shared condition (no `dmViewModel`, no `agentInboxId`, not joining) used by both the Agent and Context tabs
> - `ConversationView.spaceSurface` now renders `AddAgentPromptView` instead of `HomeLayoutView` when `hasNoAgent` is true; tapping the button calls `requestAgentJoin()`
> - `AgentDmPageView` replaces its local no-agent UI with the same `AddAgentPromptView`, wiring `onAddAgent` to `session.requestAgentJoin`
> - Risk: `ConversationView.spaceSurface` previously always showed the Space surface; it now conditionally hides it when `agentDmSession?.hasNoAgent == true`, so any callers relying on the Space surface appearing before an agent joins will see the prompt instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc7905b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->