### PR TITLE
feat(contacts): add the agent model dropdown under Chat

### DIFF
--- a/Convos/Contacts/ContactDetailView.swift
+++ b/Convos/Contacts/ContactDetailView.swift
@@ -370,6 +370,7 @@ struct ContactDetailView: View {
                     // way to interact.
                     canSendMessage: session != nil && (!isVerifiedAgent || isAgentTemplate || canStartAgentDm),
                     showChat: !mode.isCurrentUser,
+                    showModelPicker: !mode.isCurrentUser && (isVerifiedAgent || isAgentTemplate),
                     isAgent: isVerifiedAgent || isAgentTemplate,
                     showShare: agentTemplateShareURL != nil,
                     showRemove: mode.isScopedToConversation
@@ -846,6 +847,9 @@ private struct ContactDetailActions: View {
     let isApplyingBlockChange: Bool
     let canSendMessage: Bool
     let showChat: Bool
+    /// Shows the model dropdown under Chat. Agents only - a human contact
+    /// doesn't run on a model.
+    let showModelPicker: Bool
     /// Drives the chat CTA copy: "New chat" for agents (tapping spawns a
     /// fresh conversation), "Chat" for human members (tapping routes to a
     /// DM with that person).
@@ -890,6 +894,9 @@ private struct ContactDetailActions: View {
             }
             if showChat {
                 chatButton
+            }
+            if showModelPicker {
+                ContactDetailModelRow(contactDisplayName: contactDisplayName)
             }
             if showShare {
                 shareRow
@@ -1020,6 +1027,117 @@ private struct ContactDetailActionRow: View {
                 .foregroundStyle(.colorTextSecondary)
                 .padding(.horizontal, DesignConstants.Spacing.step4x)
         }
+    }
+}
+
+// MARK: - Agent model picker
+
+/// The model an agent runs on. Only `claudeSonnet` is live; the rest are
+/// placeholders the design calls for so the menu reads as a roadmap instead
+/// of a one-item list. They render disabled with a "Soon" subtitle until
+/// their backends land.
+private enum ContactDetailAgentModel: String, CaseIterable, Identifiable {
+    case claudeSonnet
+    case chatGPTSol
+    case geminiX
+    case grok
+    case openSource
+
+    var id: String {
+        return rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .claudeSonnet: return "Claude Sonnet"
+        case .chatGPTSol: return "ChatGPT Sol"
+        case .geminiX: return "Gemini X"
+        case .grok: return "Grok 4.6"
+        case .openSource: return "Open Source Models"
+        }
+    }
+
+    /// Second line of the menu item: what you get today on the live model,
+    /// "Soon" on the ones that aren't wired up.
+    var subtitle: String {
+        return isAvailable ? "Included" : "Soon"
+    }
+
+    var isAvailable: Bool {
+        return self == .claudeSonnet
+    }
+}
+
+/// The model dropdown under an agent's Chat button: the canonical action-row
+/// shape (rounded fill on top, small grey caption below) wrapping a native
+/// menu instead of a button. Nothing is selectable yet - the agent's model is
+/// fixed and every alternative is disabled - so the row is display-only and
+/// carries no selection state.
+private struct ContactDetailModelRow: View {
+    let contactDisplayName: String
+
+    /// Fixed for now. Becomes real state when the other models land.
+    private let selectedModel: ContactDetailAgentModel = .claudeSonnet
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepX) {
+            Menu {
+                menuContent
+            } label: {
+                rowLabel
+            }
+            .accessibilityLabel("Model for \(contactDisplayName)")
+            .accessibilityIdentifier("contact-detail-model-menu")
+            Text("Model")
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .padding(.horizontal, DesignConstants.Spacing.step4x)
+        }
+    }
+
+    private var menuContent: some View {
+        return Section("Agent Model") {
+            ForEach(ContactDetailAgentModel.allCases) { model in
+                menuItem(for: model)
+            }
+        }
+    }
+
+    /// The live model gets the selected checkmark and an empty action - it's
+    /// already what the agent runs on, so tapping it is intentionally inert.
+    /// Everything else is disabled.
+    @ViewBuilder
+    private func menuItem(for model: ContactDetailAgentModel) -> some View {
+        let noop = {}
+        if model == selectedModel {
+            Button(action: noop) {
+                Text(model.title)
+                Text(model.subtitle)
+                Image(systemName: "checkmark")
+            }
+        } else {
+            Button(action: noop) {
+                Text(model.title)
+                Text(model.subtitle)
+            }
+            .disabled(true)
+        }
+    }
+
+    private var rowLabel: some View {
+        return HStack(spacing: DesignConstants.Spacing.step2x) {
+            Text(selectedModel.title)
+                .font(.body)
+                .foregroundStyle(.colorTextPrimary)
+            Spacer(minLength: 0.0)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.footnote)
+                .foregroundStyle(.colorTextSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, DesignConstants.Spacing.step4x)
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .background(Capsule().fill(.colorFillMinimal))
     }
 }
 


### PR DESCRIPTION
Adds the agent model dropdown from the Convos 26 design to an agent's contact card.

Design: [dropdown](https://www.figma.com/design/m2Te49zs8hriZdzmtLVTEu/Convos-26?node-id=8019-37872&m=dev) · [menu](https://www.figma.com/design/m2Te49zs8hriZdzmtLVTEu/Convos-26?node-id=8010-28245&m=dev)

## What

A model row sits directly under the Chat button, reusing the canonical action-row shape already used by Remove/Block — rounded `colorFillMinimal` capsule with a small grey caption below — so it matches its siblings rather than introducing a new control style. The trailing `chevron.up.chevron.down` follows the existing `AgentVariantSelector` menu-label pattern.

Tapping it opens a native `Menu` titled **Agent Model**:

| Model | Subtitle | State |
|---|---|---|
| Claude Sonnet | Included | selected (checkmark) |
| ChatGPT Sol | Soon | disabled |
| Gemini X | Soon | disabled |
| Grok 4.6 | Soon | disabled |
| Open Source Models | Soon | disabled |

Listing the unbuilt models disabled-with-"Soon" is deliberate — it makes the menu read as a roadmap instead of a one-item picker.

Nothing is selectable yet, so the row carries no selection state. `selectedModel` is the seam: when the other models land it becomes real state and this type likely moves out of `ContactDetailView.swift`.

Gated to agents (`isVerifiedAgent || isAgentTemplate`) and hidden on your own card — a human contact doesn't run on a model.

## Notes for review

- **The checkmark is leading, not trailing.** SwiftUI hoists an `Image(systemName: "checkmark")` in a menu-item label into the `UIMenu` state gutter, which is exactly what the design draws. Verified on device rather than assumed.
- **Colors are concrete asset tokens on purpose.** `Menu` tints its label with the accent color, and hierarchical styles (`.primary` / `.secondary`) resolve against that tint and come out blue. `.colorTextPrimary` / `.colorTextSecondary` are `Color("…", bundle: .module)`, so they render black/grey correctly. Worth knowing before anyone "simplifies" these to `.primary`.

## Verification

- `xcodebuild` `Convos (Dev)` / `Dev` — BUILD SUCCEEDED, 0 errors; SwiftLint clean.
- Menu rendering confirmed on an iOS 26 simulator and compared against both Figma frames: header, checkmark placement, subtitles, and disabled styling all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789919199&installation_model_id=20076&pr_number=1391&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1391&signature=afb062c03b2893aee16ccacceadf677b291b1a3b5ddf1cca252de3fe973819c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent model dropdown to ContactDetailView under Chat
> - Adds a `showModelPicker` flag to `ContactDetailActions` in [ContactDetailView.swift](https://github.com/xmtplabs/convos-ios/pull/1391/files#diff-fa54c9aca0b6a99cd254f52934d6ffb2f3d79b79ff6ee084feb9ebda7d8d03a4) that renders a model picker for verified agents or agent templates when not viewing the current user
> - Introduces the `ContactDetailAgentModel` enum to define the available model options, with only `claudeSonnet` currently active while others display a "Soon" subtitle
> - Adds the `ContactDetailModelRow` view that renders the model menu row beneath the Chat button with appropriate accessibility labels
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa630c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->