### PR TITLE
Bring back swiping between the conversation's tabs

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -3,6 +3,7 @@ import ConvosCore
 import ConvosCoreiOS
 import ConvosMetrics
 import SwiftUI
+import SwiftUIIntrospect
 
 struct ConversationView<MessagesBottomBar: View>: View {
     @Bindable var viewModel: ConversationViewModel
@@ -64,9 +65,6 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// The conversation sheet's selected tab, the single source of truth for
     /// both the backing view behind the sheet and the bar the sheet hosts.
     @State private var selectedTab: ConversationTab = .group
-    /// Tabs the user has visited. The agent DM mounts on first visit and stays
-    /// mounted (hidden, not torn down) so tab switches never reload it.
-    @State private var visitedTabs: Set<ConversationTab> = [.group]
     /// Guards the one-time seed of `selectedTab` from `initialAgentDmInboxId`.
     @State private var didSeedInitialTab: Bool = false
     /// The in-flight write clearing the group's unread flag, held so a collapse
@@ -393,10 +391,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
         selectTab(.agent)
     }
 
-    /// Programmatic tab selection: keeps `visitedTabs` in sync (the
-    /// `onChange(of: selectedTab)` hook does the same for user taps).
+    /// Programmatic tab selection. Every page is mounted, so this is only the
+    /// write - `onChange(of: selectedTab)` does the rest for taps and swipes
+    /// alike.
     private func selectTab(_ tab: ConversationTab) {
-        visitedTabs.insert(tab)
         selectedTab = tab
     }
 
@@ -760,13 +758,15 @@ private extension ConversationView {
     /// claiming the incoming one so the keyboard hands over instead of
     /// dropping.
     private func handleSelectedTabChange(from oldTab: ConversationTab, to newTab: ConversationTab) {
-        visitedTabs.insert(newTab)
         transferKeyboard(to: newTab)
         // A right-swipe can both start a reply and switch away; cancel the
         // in-flight reply swipe so the tab change doesn't fire one.
-        if oldTab == .group {
-            contextMenuState.cancelInFlightSwipe()
-        }
+        // A right-swipe can both start a reply and carry the pager to another
+        // tab. Cancel the in-flight swipe on the lane being left so the tab
+        // change never lands a reply, and on the one being entered so a partial
+        // drag does not survive into it.
+        contextMenuState.cancelInFlightSwipe()
+        agentContextMenuState.cancelInFlightSwipe()
         // The group is "being viewed" only while its tab is selected. Off
         // the tab, read receipts must stop (the user isn't reading the
         // transcript) and the group has to leave the active-conversation
@@ -1341,23 +1341,66 @@ private extension ConversationView {
     /// so a Space page is not reloaded every time the user looks away.
     @ViewBuilder
     var pageHost: some View {
-        ZStack {
-            groupPage
-            agentPage
-            contextPage
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+                ForEach(availableTabs) { tab in
+                    page(for: tab)
+                        // Sized against the scroll view's container rather than
+                        // a `GeometryReader`: the reader measures zero on the
+                        // first layout pass, which left every page zero-width
+                        // and the pager resting on the last one instead of the
+                        // tab the conversation opened on.
+                        .containerRelativeFrame(.horizontal)
+                        .id(tab)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.paging)
+        .scrollPosition(id: pagerSelection)
+        // A long-press menu owns the screen while it is up, and a drag that
+        // paged out from under it would leave the menu pointing at a message
+        // on another tab.
+        .scrollDisabled(isPagingDisabled)
+        .introspect(.scrollView, on: .iOS(.v26)) { (scrollView: UIScrollView) in
+            scrollView.bounces = false
+        }
+    }
+
+    /// The pager's position, bridged onto the tab the rest of the screen reads.
+    /// Writes land the same way a tap on the segmented control does, so a swipe
+    /// and a tap go through one path.
+    private var pagerSelection: Binding<ConversationTab?> {
+        Binding(
+            get: { selectedTab },
+            set: { newValue in
+                guard let newValue, newValue != selectedTab else { return }
+                selectedTab = newValue
+            }
+        )
+    }
+
+    /// True while either transcript has its long-press menu up.
+    private var isPagingDisabled: Bool {
+        contextMenuState.isPresented || agentContextMenuState.isPresented
+    }
+
+    @ViewBuilder
+    private func page(for tab: ConversationTab) -> some View {
+        switch tab {
+        case .group: groupPage
+        case .agent: agentPage
+        case .context: contextPage
         }
     }
 
     private var groupPage: some View {
-        let isActive: Bool = selectedTab == .group
-        return messagesView(focus: $focusState)
-            .opacity(isActive ? 1 : 0)
-            .allowsHitTesting(isActive)
+        messagesView(focus: $focusState)
     }
 
     @ViewBuilder
     private var agentPage: some View {
-        if visitedTabs.contains(.agent), let agentDmSession {
+        if let agentDmSession {
             let isActive: Bool = selectedTab == .agent
             AgentDmPageView(
                 session: agentDmSession,
@@ -1379,8 +1422,6 @@ private extension ConversationView {
                     }
                 },
             )
-            .opacity(isActive ? 1 : 0)
-            .allowsHitTesting(isActive)
         }
     }
 
@@ -1390,17 +1431,12 @@ private extension ConversationView {
     /// above it, so pushing a page never slides the segmented control away.
     @ViewBuilder
     private var contextPage: some View {
-        if visitedTabs.contains(.context) {
-            let isActive: Bool = selectedTab == .context
-            HomeBrowserNavigationHost(
-                entries: $homeBrowserEntries,
-                root: { AnyView(spaceSurface) },
-                page: { entry in AnyView(homeBrowserPage(for: entry)) }
-            )
-            .ignoresSafeArea()
-            .opacity(isActive ? 1 : 0)
-            .allowsHitTesting(isActive)
-        }
+        HomeBrowserNavigationHost(
+            entries: $homeBrowserEntries,
+            root: { AnyView(spaceSurface) },
+            page: { entry in AnyView(homeBrowserPage(for: entry)) }
+        )
+        .ignoresSafeArea()
     }
 
     /// One page in the Context tab's browsing chain.


### PR DESCRIPTION
The pre-sheet pager let you swipe between the conversation's surfaces; the tab rewrite in #1385 left only the segmented control. The pages are a horizontal paging scroll view again, bound to the same `selectedTab` the control writes — a swipe and a tap go through one path, so read state, keyboard hand-off and lane claims are all unchanged.

## The two things the old pager knew

**A right-swipe can both start a reply and carry the pager to another tab.** `MessageContextMenuState.cancelInFlightSwipe` still exists for exactly this — it bumps a token the message cells watch — and the tab change now calls it on *both* transcripts: the one being left, so the change never lands a stray reply, and the one being entered, so a partial drag doesn't survive into it. (Before this, it was called on the group lane only.)

**Paging is disabled while either transcript's long-press menu is up.** A drag that paged out from under the menu would leave it pointing at a message on a tab that's no longer showing.

## Two consequences worth reviewing

**Every page mounts now**, rather than on first visit. A pager needs a slot to scroll to, and a page that mounts on arrival shows a frame of nothing on the way in. This is what the pre-sheet pager did, so `visitedTabs` is gone along with the opacity gating the ZStack needed — but it does mean the agent DM and the Space web view mount when the conversation opens rather than lazily.

**Pages size with `containerRelativeFrame`, not a `GeometryReader`.** The reader measures zero on the first layout pass, which left every page zero-width and the pager resting on the *last* tab instead of the one the conversation opened on. That was a real bug I hit and fixed while building this.

## Verification

Confirmed by introspecting the pager's scroll view on device: `content=(1206, 720)`, `bounds=(402, 874)`, `isScrollEnabled=true` — three pages, scrollable — and the content offset tracks `selectedTab` (opening a conversation whose DM held the unread landed at offset 402, the Agent page, matching the chip).

**Not verified: the swipe gesture itself.** Synthetic swipes through the QA automation server don't reliably drive UIScrollView paging, so the end-to-end gesture needs a real finger. Worth a moment's attention on whether the transcript's swipe-to-reply and the pager fight each other in practice.

406 unit tests pass; the single failure is pre-existing on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789933523&installation_model_id=20076&pr_number=1393&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1393&signature=e33d7e8c779971184dc89e1ffa03fbfdd510619f5908dc26d64e3e77fa36b624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore horizontal swipe paging between `ConversationView` tabs
> - Replaces the `ZStack` of conditionally visible pages in `pageHost` with a horizontally paging `ScrollView` that mounts all tabs at once, using `scrollTargetBehavior(.paging)` and a `scrollPosition` binding synced to `selectedTab`.
> - Removes the `visitedTabs` set so group, agent, and context pages are always mounted; the pager now governs visibility and interaction instead of per-page opacity and hit-testing modifiers.
> - Uses `SwiftUIIntrospect` to disable `UIScrollView` bouncing, and disables paging while a group or agent long-press context menu is presented via `isPagingDisabled`.
> - Switching tabs now cancels in-flight reply swipes in both `contextMenuState` and `agentContextMenuState` via `cancelInFlightSwipe`.
> - Behavioral Change: agent and context pages mount as soon as an agent session exists rather than on first visit, which means their view lifecycles start earlier than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 993b916.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->