### PR TITLE
fix(conversation): conversation info, duplicate back button, and chrome scrim height

### DIFF
--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -61,7 +61,11 @@ struct NewConversationView: View {
             viewModel: viewModel.conversationViewModel,
             focusCoordinator: focusCoordinator,
             insetsTopSafeArea: insetsTopSafeArea,
-            sidebarColumnWidth: $sidebarWidth
+            sidebarColumnWidth: $sidebarWidth,
+            // The shell renders the centered indicator for this flow (see
+            // `MainTabView.activeConvoVM`). Rendering a second one here would
+            // duplicate the shared matched-geometry id and crash the push.
+            rendersConversationIndicator: false
         ) { focusBinding, coordinator in
             ConditionalNavigationStack(embedsStack: embedsNavigationStack) {
                 @Bindable var viewModel = viewModel

--- a/Convos/Conversation Creation/NewConversationView.swift
+++ b/Convos/Conversation Creation/NewConversationView.swift
@@ -119,7 +119,13 @@ struct NewConversationView: View {
                         }
                     }
                 }
-                .navigationBarBackButtonHidden(!embedsNavigationStack && onClose != nil)
+                // `isBrowsingHome` also hides it: while Context has browser
+                // pages pushed, `ConversationView` puts its own pop-a-page
+                // back button in the leading slot. That view's own
+                // `navigationBarBackButtonHidden` can't win here - this
+                // modifier is the outer one on the same destination - so
+                // without the check both back buttons render side by side.
+                .navigationBarBackButtonHidden((!embedsNavigationStack && onClose != nil) || isBrowsingHome)
                 .background(.colorBackgroundSurfaceless)
                 .sheet(isPresented: $viewModel.presentingJoinConversationSheet) {
                     JoinConversationView(viewModel: viewModel.qrScannerViewModel, allowsDismissal: true) { scannedCode in

--- a/Convos/Conversation Detail/ConversationTopChrome.swift
+++ b/Convos/Conversation Detail/ConversationTopChrome.swift
@@ -30,15 +30,20 @@ enum ConversationChromeMetrics {
     static let controlHeight: CGFloat = 32.0
     /// Space below the control before a page's content may start.
     static let controlBottomPadding: CGFloat = DesignConstants.Spacing.step3x
-    /// How far the scrim takes to fade from full strength to nothing (Figma
-    /// 8007:27603 draws its wash as a 153pt band).
+    /// How far the scrim takes to fade from full strength to nothing.
     ///
-    /// The design starts that ramp at the status bar's bottom edge, which puts
-    /// the wash at roughly half strength by the time it reaches the segmented
-    /// control - not enough to read the control against a transcript scrolling
-    /// under it. So the length is the design's; the start is not. See
-    /// `scrimHoldFraction`.
-    static let scrimRampLength: CGFloat = 153.0
+    /// Figma (8007:27603) draws the wash as a 153pt band starting at the status
+    /// bar's bottom edge. Starting it there puts the wash at roughly half
+    /// strength by the time it reaches the segmented control - not enough to
+    /// read the control against a transcript scrolling under it - so the ramp
+    /// starts at the control's bottom instead (see `scrimHeight`).
+    ///
+    /// Moving the start down without shortening the ramp pushed the wash's end
+    /// ~40pt past where it should sit, which reads as a wash running on too
+    /// long below the control. The ramp is the knob rather than the hold:
+    /// shortening the hold would take the strength out from under the control,
+    /// which is the thing the deviation exists to protect.
+    static let scrimRampLength: CGFloat = 113.0
 
     /// The whole chrome's height below the safe area, for a surface that
     /// reserves all of it.

--- a/Convos/MainTabView.swift
+++ b/Convos/MainTabView.swift
@@ -465,8 +465,16 @@ struct MainTabView: View {
     /// The conversation the shared overlay is showing, if any. Drives its
     /// morph between the leading pill (when nil) and the centered
     /// conversation indicator (when non-nil).
+    /// Falls back to the compose flow's conversation so a freshly created
+    /// convo still gets the shell's centered indicator. The indicator a pushed
+    /// `ConversationPresenter` renders sits below this overlay and never
+    /// receives taps, so without the fallback the pill on a newly created
+    /// convo rendered but did nothing - conversation info never opened.
+    /// `NewConversationView` passes `rendersConversationIndicator: false` so
+    /// only one of the two is ever built.
     private var activeConvoVM: ConversationViewModel? {
         conversationsViewModel.selectedConversationViewModel
+            ?? conversationsViewModel.newConversationViewModel?.conversationViewModel
     }
 
     private enum Constant {


### PR DESCRIPTION
Three fixes to the conversation top chrome. They're separate bugs but sit in the same few files and stack cleanly, so they're one PR rather than three conflicting branches.

## 1. Conversation info never opened on a newly created convo (`fe1ce990`)

Tapping the conversation indicator on a freshly created Convos did nothing.

Two views can draw that pill. The shell's centered indicator in `MainTabView` is the one that receives taps; the one a pushed `ConversationPresenter` renders sits below the shell's full-screen overlay and never gets them. The shell only showed its indicator for `selectedConversationViewModel`, which is nil during the compose flow — so a pushed new convo fell through to the presenter's inert pill. It rendered correctly and did nothing.

`activeConvoVM` now falls back to the compose flow's conversation, and `NewConversationView` stands its own indicator down via the existing `rendersConversationIndicator` seam. Only one is ever built — two share a matched-geometry id and hard-crash the push (confirmed the hard way).

## 2. Duplicate back button on Context browser pages (`f0c9e314`)

Tapping a link in the Context tab of a new convo rendered two back buttons.

`ConversationView` already handles this: while home browser pages are showing it puts a pop-a-page chevron in the leading slot and calls `navigationBarBackButtonHidden(isBrowsingHome)`. But in the compose flow `NewConversationView` wraps it and applies its *own* `navigationBarBackButtonHidden` to the same destination, so the outer modifier wins and the inner one never takes effect. `NewConversationView` already stands its close (X) down while browsing — it just never hid the system back button to match. Folded `isBrowsingHome` into that condition.

## 3. Chrome scrim ran 40pt past the control (`794ceff7`)

Figma draws the wash as a 153pt band starting at the status bar's bottom edge. The scrim deliberately starts its ramp at the *control's* bottom instead, so the wash holds full strength under the segmented control — but it kept the full 153pt ramp after moving the start down ~92pt, pushing the end that much further down.

Ramp 153pt → 113pt. The hold is untouched: it's what keeps the control readable over a scrolling transcript, and a prior 60pt version is recorded in the comments as cutting off mid-transcript.

On a 59pt top safe area the wash now ends at 264pt instead of 304pt — 40pt higher, hold unchanged.

## Verification

Driven on an iOS 26 simulator through the in-app QA automation server (`QAAutomationServer`, :8615), using raw coordinate taps rather than accessibility taps so the results reflect real hit-testing. Tap coordinates were calibrated against a known control first.

| Check | Result |
|---|---|
| New Convos pushed → tap indicator | info opens |
| Dismiss → tap again | info opens |
| Conversation opened from list → tap indicator | info opens |
| Context at Home root | system back button only |
| Context browser page | `home-browser-back` only |
| Pop the page | returns to Home root, system button back |
| Build / SwiftLint | clean |

Diagnosis for #1 came from temporary logging of which indicator renders and whether the tap handler is entered — the working case always logged `shell=centered` then a tap; the broken case logged `presenter=indicator` and no tap at all. That instrumentation is not in this PR.

**Known gap:** #3's 40pt is arithmetic from the layout constants (exact), not an optical measurement — the dark Agent surface tints its wash with `colorBackgroundSurfaceless`, so the wash is invisible there and can't be sampled. It's a single constant if the number wants adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789933610&installation_model_id=20076&pr_number=1394&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1394&signature=c3f6e4d0de7c96cb9f4236d36161feacfe9c338ec5dbf13492afa9c0f8b35720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix conversation info, duplicate back button, and chrome scrim height in `ConversationTopChrome` and `NewConversationView`
> - `NewConversationView` passes `rendersConversationIndicator: false` to `ConversationPresenter` and hides the system back button when `isBrowsingHome` is true.
> - Reduces `ConversationChromeMetrics.scrimRampLength` from `153.0` to `113.0`, shortening the scrim's vertical fade extent.
> - `MainTabView.activeConvoVM` now falls back to `conversationsViewModel.newConversationViewModel?.conversationViewModel` when `selectedConversationViewModel` is nil.
> - Behavioral Change: `activeConvoVM` can now return a non-nil view model during the compose flow instead of nil; scrim consumers see a shorter ramp.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 794ceff. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->