### PR TITLE
Open the agent DM from Space webviews

### DIFF
--- a/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Convos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e48dce065f2fbaa058b5c66e388240cc8b2184047ee2355a1d710237363402f8",
+  "originHash" : "760a870db658de217772d913d9a96bc0d3a27494bea075dbb485d233516eda36",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "mpr/web-plugins",
-        "revision" : "3638574b2020ab52e73ac18c1af2acb62595d926"
+        "branch" : "saulmc/bridge-show-agent-dm",
+        "revision" : "6d04c55d74e796ee8d059ccf13264051ca8161ba"
       }
     },
     {

--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -349,6 +349,8 @@ struct AgentDmPageView: View {
             replyingToMessage: dmVm.replyingToMessage,
             replyingToAudioTranscriptText: dmVm.replyingToAudioTranscriptText,
             onCancelReply: dmVm.cancelReply,
+            pendingWidgetReplyContext: dmVm.pendingWidgetReplyContext,
+            onCancelWidgetReply: dmVm.cancelWidgetReply,
             onDisplayNameEndedEditing: {
                 dmVm.onDisplayNameEndedEditing(focusCoordinator: focusCoordinator, context: .quickEditor)
             },

--- a/Convos/Conversation Detail/AgentDmSession.swift
+++ b/Convos/Conversation Detail/AgentDmSession.swift
@@ -32,6 +32,12 @@ final class AgentDmSession {
     /// has one on the way, so the tab must wait on it rather than offer to add
     /// another. Refreshed by `refreshDefaultAgentProvisioning()`.
     private(set) var isProvisioningDefaultAgent: Bool = false
+    /// A widget reply requested via window.convos.replyToWidget. Held here
+    /// until the DM view model exists, then handed to it so the composer shows
+    /// the widget reply bar. A call can arrive during the noAgent/preparing
+    /// phases (before `dmViewModel` binds), so it is stored and applied on bind.
+    @ObservationIgnored
+    private var storedWidgetReplyContext: ContextReplyContext?
     @ObservationIgnored
     private var requestTimeoutTask: Task<Void, Never>?
     /// The in-flight read mark, held so it can be abandoned if the lane stops
@@ -55,6 +61,20 @@ final class AgentDmSession {
     func updateOrigin(_ viewModel: ConversationViewModel) {
         guard viewModel !== originViewModel else { return }
         originViewModel = viewModel
+    }
+
+    /// Attaches a widget reply (window.convos.replyToWidget) to the agent DM
+    /// composer. Applied immediately if the DM is bound, otherwise held and
+    /// applied the moment `bindIfNeeded` attaches the view model.
+    func attachWidgetReply(_ context: ContextReplyContext) {
+        storedWidgetReplyContext = context
+        applyPendingWidgetReplyIfPossible()
+    }
+
+    private func applyPendingWidgetReplyIfPossible() {
+        guard let context = storedWidgetReplyContext, let dmViewModel else { return }
+        dmViewModel.pendingWidgetReplyContext = context
+        storedWidgetReplyContext = nil
     }
 
     /// The bound agent's member row in the origin conversation, if present.
@@ -191,6 +211,8 @@ final class AgentDmSession {
         // not raise a banner. Separate from `updateActiveDmLane`, which is only
         // true while the lane is the one being read.
         updateDmOnScreen(isOnScreen: true)
+        // A replyToWidget call that arrived before the DM bound is applied now.
+        applyPendingWidgetReplyIfPossible()
     }
 
     /// The eager reconciler (or another device) can create the DM while the

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1555,6 +1555,9 @@ private extension ConversationView {
                 presentingAddFromContactsPicker = true
             },
             showMembersList: { viewModel.presentingConversationSettings = true },
+            showAgentDm: {
+                selectTab(.agent)
+            },
             replyToWidget: { id, widget in
                 selectAgentTabForWidgetReply(id: id, widget: widget)
             }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1,3 +1,4 @@
+import ConvosBridge
 import ConvosComposer
 import ConvosCore
 import ConvosCoreiOS
@@ -1553,8 +1554,21 @@ private extension ConversationView {
                 }
                 presentingAddFromContactsPicker = true
             },
-            showMembersList: { viewModel.presentingConversationSettings = true }
+            showMembersList: { viewModel.presentingConversationSettings = true },
+            replyToWidget: { id, widget in
+                selectAgentTabForWidgetReply(id: id, widget: widget)
+            }
         )
+    }
+
+    /// Routes a `window.convos.replyToWidget(id, widget)` bridge call to the
+    /// agent DM: presents the Agent tab and attaches the widget context to the
+    /// DM composer as a "widget reply" (applied once the DM binds if it is not
+    /// ready yet). The typed reply is published as a `ContextReply`.
+    private func selectAgentTabForWidgetReply(id: String, widget: WidgetRef) {
+        let context = ContextReplyContext(id: id, title: widget.title, description: widget.description)
+        agentDmSession?.attachWidgetReply(context)
+        selectTab(.agent)
     }
 
     /// The single host seam for the composer's connections capability: the

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1042,6 +1042,17 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
     /// cell showing a different message.
     var expandedMessageIds: Set<String> = []
     var replyingToMessage: AnyMessage?
+    /// The widget the user is replying to (window.convos.replyToWidget), set on
+    /// the agent DM's view model when a `replyToWidget` bridge call routes to
+    /// the agent tab. Mutually exclusive with `replyingToMessage`: the composer
+    /// shows one reply bar at a time and the send routes to `sendContextReply`.
+    var pendingWidgetReplyContext: ContextReplyContext? {
+        didSet {
+            if pendingWidgetReplyContext != nil {
+                replyingToMessage = nil
+            }
+        }
+    }
     /// Drives the invite-code sheet (`InviteCodeSheet`), presented by
     /// `ConversationPresenter` for whichever surface is showing this
     /// conversation.
@@ -3607,6 +3618,7 @@ extension ConversationViewModel {
 
         let prevMessageText = messageText
         let replyTarget = replyingToMessage
+        let widgetReplyContext = pendingWidgetReplyContext
         let prevMediaAttachments = pendingMediaAttachments
         let prevInviteURL = pendingInvite?.fullURL
         let sideConvoName = pendingInviteConvoName
@@ -3619,6 +3631,7 @@ extension ConversationViewModel {
         stopTyping()
         messageText = ""
         replyingToMessage = nil
+        pendingWidgetReplyContext = nil
         pendingMediaAttachments = []
         videoThumbnailTasks.values.forEach { $0.cancel() }
         videoThumbnailTasks.removeAll()
@@ -3667,6 +3680,7 @@ extension ConversationViewModel {
                     linkURL: prevLinkURL,
                     photoTrackingKey: nil,
                     replyTarget: trailingReplyTarget,
+                    widgetReplyContext: widgetReplyContext,
                     messageWriter: messageWriter
                 )
             } catch {
@@ -3888,6 +3902,7 @@ extension ConversationViewModel {
         linkURL: String?,
         photoTrackingKey: String?,
         replyTarget: AnyMessage?,
+        widgetReplyContext: ContextReplyContext? = nil,
         messageWriter: any OutgoingMessageWriterProtocol
     ) async throws {
         let hasAttachment = photoTrackingKey != nil
@@ -3919,7 +3934,9 @@ extension ConversationViewModel {
         }
 
         if let text {
-            if replyTarget != nil && !hasAttachment, let replyTarget {
+            if let widgetReplyContext, !hasAttachment {
+                try await messageWriter.sendContextReply(text: text, context: widgetReplyContext)
+            } else if replyTarget != nil && !hasAttachment, let replyTarget {
                 try await messageWriter.sendReply(text: text, afterPhoto: photoTrackingKey, toMessageWithClientId: replyTarget.messageId)
             } else {
                 try await messageWriter.send(text: text, afterPhoto: photoTrackingKey)
@@ -3941,7 +3958,12 @@ extension ConversationViewModel {
     }
 
     func onReply(_ message: AnyMessage) {
+        pendingWidgetReplyContext = nil
         replyingToMessage = message
+    }
+
+    func cancelWidgetReply() {
+        pendingWidgetReplyContext = nil
     }
 
     func toggleMessageExpanded(_ messageId: String) {

--- a/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
+++ b/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
@@ -15,6 +15,7 @@ struct HomeBridgeNavigation {
     }
     var showInvitePicker: @MainActor @Sendable () -> Void = {}
     var showMembersList: @MainActor @Sendable () -> Void = {}
+    var replyToWidget: @MainActor @Sendable (String, WidgetRef) -> Void = { _, _ in }
 }
 
 /// Main-actor state shared between the hosting web view (which refreshes the
@@ -62,7 +63,7 @@ enum HomeBridgePlugins {
             InvitePluginDispatcher(HomeInvitePlugin(host: host)),
             ChatPluginDispatcher(HomeChatPlugin(host: host)),
             ThingsPluginDispatcher(HomeThingsPlugin()),
-            DesktopPluginDispatcher(HomeDesktopPlugin()),
+            DesktopPluginDispatcher(HomeDesktopPlugin(host: host)),
         ]
     }
 }
@@ -170,8 +171,15 @@ private final class HomeThingsPlugin: ThingsPlugin, Sendable {
 }
 
 private final class HomeDesktopPlugin: DesktopPlugin, Sendable {
+    private let host: HomeBridgeHost
+
+    init(host: HomeBridgeHost) {
+        self.host = host
+    }
+
     func replyToWidget(id: String, widget: WidgetRef) {
-        Log.debug("bridge replyToWidget(\(id), \(widget.title))")
+        let host = host
+        Task { @MainActor in host.navigation.replyToWidget(id, widget) }
     }
 
     func popupWidget(id: String, url: String, bounds: PopupBounds) {

--- a/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
+++ b/Convos/Conversation Detail/Home/HomeBridgePlugins.swift
@@ -15,6 +15,7 @@ struct HomeBridgeNavigation {
     }
     var showInvitePicker: @MainActor @Sendable () -> Void = {}
     var showMembersList: @MainActor @Sendable () -> Void = {}
+    var showAgentDm: @MainActor @Sendable () -> Void = {}
     var replyToWidget: @MainActor @Sendable (String, WidgetRef) -> Void = { _, _ in }
 }
 
@@ -131,6 +132,11 @@ private final class HomeChatPlugin: ChatPlugin, Sendable {
     func showMembersList() {
         let host = host
         Task { @MainActor in host.navigation.showMembersList() }
+    }
+
+    func showAgentDm() {
+        let host = host
+        Task { @MainActor in host.navigation.showAgentDm() }
     }
 
     func getAgentStatus() async throws -> AgentStatus {

--- a/Convos/Conversation Detail/Messages/MessagesView.swift
+++ b/Convos/Conversation Detail/Messages/MessagesView.swift
@@ -78,6 +78,8 @@ struct MessagesView<BottomBarContent: View>: View {
     let replyingToMessage: AnyMessage?
     var replyingToAudioTranscriptText: String?
     let onCancelReply: () -> Void
+    var pendingWidgetReplyContext: ContextReplyContext?
+    var onCancelWidgetReply: () -> Void = {}
     let onDisplayNameEndedEditing: () -> Void
     let onProfileSettings: () -> Void
     let onLoadPreviousMessages: () -> Void
@@ -358,6 +360,11 @@ struct MessagesView<BottomBarContent: View>: View {
                             // own tree, so inject the resolver directly on the
                             // bar (same reason the context-menu overlay does).
                             .environment(\.agentShareResolver, agentShareResolver)
+                        } else if let pendingWidgetReplyContext {
+                            WidgetReplyComposerBar(
+                                context: pendingWidgetReplyContext,
+                                onDismiss: onCancelWidgetReply
+                            )
                         }
                     },
                     quickEditView: { placeholderText, isImagePickerPresented in

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "28dfd1ca67a57621dbd11fe70e5e00d3317acd3a9c2d5c0220582f5b8dfa43f9",
+  "originHash" : "6875eef64b19bd4afbeb4fb2d6ddd6155c00c3ddf1e871e95a7df87facf9620c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "mpr/web-plugins",
-        "revision" : "3638574b2020ab52e73ac18c1af2acb62595d926"
+        "branch" : "saulmc/bridge-show-agent-dm",
+        "revision" : "6d04c55d74e796ee8d059ccf13264051ca8161ba"
       }
     },
     {

--- a/ConvosCore/Package.resolved
+++ b/ConvosCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6875eef64b19bd4afbeb4fb2d6ddd6155c00c3ddf1e871e95a7df87facf9620c",
+  "originHash" : "8b8345083361fc44f618f6b3928fe85538271ce22e49a04e53097d5b172c8493",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtplabs/convos-shared.git",
       "state" : {
-        "branch" : "saulmc/bridge-show-agent-dm",
-        "revision" : "6d04c55d74e796ee8d059ccf13264051ca8161ba"
+        "branch" : "main",
+        "revision" : "1dc9ad8ca75beadae0194bccbe164dced4532e90"
       }
     },
     {

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -39,9 +39,8 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        // Temporary pin: the ConvosBridge product only exists on the web-plugins
-        // branch so far; revert to branch: "main" once that PR merges in convos-shared.
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "mpr/web-plugins"),
+        // Temporary pin: showAgentDm is on this branch until its convos-shared PR lands.
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "saulmc/bridge-show-agent-dm"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),

--- a/ConvosCore/Package.swift
+++ b/ConvosCore/Package.swift
@@ -39,8 +39,7 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.1.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.1"),
         .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.57.1"),
-        // Temporary pin: showAgentDm is on this branch until its convos-shared PR lands.
-        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "saulmc/bridge-show-agent-dm"),
+        .package(url: "https://github.com/xmtplabs/convos-shared.git", branch: "main"),
         .package(path: "../ConvosLogging"),
         .package(path: "../ConvosInvites"),
         .package(path: "../ConvosAppData"),

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/ContextReplyReferenceView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/ContextReplyReferenceView.swift
@@ -1,0 +1,83 @@
+#if canImport(UIKit)
+import ConvosCore
+import SwiftUI
+import UIKit
+
+/// The reference card shown above a message that replies to a widget
+/// (window.convos.replyToWidget). Mirrors `ReplyReferenceView`'s aesthetic -
+/// the turn-up-left glyph over a bordered preview card - but keys off a
+/// `ContextReplyContext` (widget title + description) instead of a parent
+/// message.
+struct ContextReplyReferenceView: View {
+    let context: ContextReplyContext
+    let isOutgoing: Bool
+
+    var body: some View {
+        VStack(alignment: isOutgoing ? .trailing : .leading, spacing: DesignConstants.Spacing.stepX) {
+            Image(systemName: "arrowshape.turn.up.left.fill")
+                .font(DesignConstants.Fonts.caption3)
+                .foregroundStyle(.tertiary)
+                .padding(.leading, isOutgoing ? 0.0 : DesignConstants.Spacing.step3x)
+                .padding(.trailing, isOutgoing ? DesignConstants.Spacing.step3x : 0.0)
+
+            HStack(spacing: 0) {
+                if isOutgoing {
+                    Spacer()
+                        .frame(minWidth: 50)
+                        .layoutPriority(-1)
+                }
+                card
+                if !isOutgoing {
+                    Spacer()
+                        .frame(minWidth: 50)
+                        .layoutPriority(-1)
+                }
+            }
+        }
+        .padding(.top, DesignConstants.Spacing.stepX)
+        .padding(.bottom, DesignConstants.Spacing.stepX)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Reply to \(context.title): \(context.description)")
+    }
+
+    private var card: some View {
+        VStack(alignment: .leading, spacing: 1.0) {
+            Text(context.title)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.colorTextPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if !context.description.isEmpty {
+                Text(context.description)
+                    .font(.caption)
+                    .foregroundStyle(.colorTextSecondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .padding(.horizontal, DesignConstants.Spacing.step3x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .frame(maxWidth: 220.0, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: Constant.bubbleCornerRadius)
+                .strokeBorder(.colorBorderSubtle, lineWidth: 1.0)
+        )
+    }
+}
+
+#Preview("Context Reply - Outgoing") {
+    ContextReplyReferenceView(
+        context: ContextReplyContext(id: "w1", title: "Weather", description: "Sunny, 24 degrees in San Francisco"),
+        isOutgoing: true
+    )
+    .padding()
+}
+
+#Preview("Context Reply - Incoming") {
+    ContextReplyReferenceView(
+        context: ContextReplyContext(id: "w2", title: "Calendar", description: "Standup at 10am"),
+        isOutgoing: false
+    )
+    .padding()
+}
+#endif

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupItemView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupItemView.swift
@@ -83,6 +83,15 @@ struct MessagesGroupItemView: View {
                     ? DesignConstants.Spacing.step4x
                     : 0.0)
                 .padding(.trailing, trailingPadding)
+            } else if let widgetContext = message.widgetContext {
+                ContextReplyReferenceView(
+                    context: widgetContext,
+                    isOutgoing: message.sender.isCurrentUser
+                )
+                .padding(.leading, !message.sender.isCurrentUser && message.content.isFullBleedAttachment
+                    ? DesignConstants.Spacing.step4x
+                    : 0.0)
+                .padding(.trailing, trailingPadding)
             }
             messageContent
             if let voiceMemoTranscript, !isAudioAttachment {

--- a/ConvosCore/Sources/ConvosComposer/WidgetReplyComposerBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/WidgetReplyComposerBar.swift
@@ -1,0 +1,72 @@
+#if canImport(UIKit)
+import ConvosCore
+import SwiftUI
+
+/// The composer accessory shown while the user is replying to a widget
+/// (window.convos.replyToWidget). Mirrors `ReplyComposerBar` - the
+/// turn-up-left glyph, a two-line title/preview, and a dismiss button - but
+/// keys off a `ContextReplyContext` (widget title + description) instead of a
+/// parent message.
+public struct WidgetReplyComposerBar: View {
+    let context: ContextReplyContext
+    let onDismiss: () -> Void
+
+    public init(context: ContextReplyContext, onDismiss: @escaping () -> Void) {
+        self.context = context
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        HStack(spacing: DesignConstants.Spacing.step2x) {
+            VStack(alignment: .leading, spacing: 2.0) {
+                HStack(spacing: 4.0) {
+                    Image(systemName: "arrowshape.turn.up.left.fill")
+                        .font(DesignConstants.Fonts.caption3)
+                        .foregroundStyle(.colorTextTertiary)
+                    Text(context.title)
+                        .font(.caption)
+                        .foregroundStyle(.colorTextSecondary)
+                        .lineLimit(1)
+                }
+
+                Text(context.description)
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextPrimary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            let action = { onDismiss() }
+            Button(action: action) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.colorTextTertiary)
+                    .font(.title2)
+                    .padding(.horizontal, 3.0)
+            }
+            .accessibilityLabel("Cancel widget reply")
+            .accessibilityIdentifier("cancel-widget-reply-button")
+        }
+        .padding(.leading, DesignConstants.Spacing.step4x)
+        .padding(.trailing, DesignConstants.Spacing.step2x)
+        .padding(.vertical, DesignConstants.Spacing.step2x)
+        .fixedSize(horizontal: false, vertical: true)
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 26.0))
+        .padding(.horizontal, DesignConstants.Spacing.step4x)
+        .padding(.bottom, DesignConstants.Spacing.stepHalf)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Replying to \(context.title): \(context.description)")
+        .accessibilityIdentifier("widget-reply-composer-bar")
+    }
+}
+
+#Preview("Widget Reply Composer Bar") {
+    VStack {
+        Spacer()
+        WidgetReplyComposerBar(
+            context: ContextReplyContext(id: "w1", title: "Weather", description: "Sunny, 24 degrees in San Francisco"),
+            onDismiss: {}
+        )
+    }
+}
+#endif

--- a/ConvosCore/Sources/ConvosCore/Custom Content Types/ContextReplyCodec.swift
+++ b/ConvosCore/Sources/ConvosCore/Custom Content Types/ContextReplyCodec.swift
@@ -1,0 +1,165 @@
+import Foundation
+import XMTPiOS
+
+/// The widget a `ContextReply` is associated with. Mirrors the web bridge's
+/// `WidgetRef` (title + description) plus the widget id from the
+/// `replyToWidget(id:widget:)` call. Kept free of any bridge types so
+/// ConvosCore stays platform-independent.
+public struct ContextReplyContext: Codable, Hashable, Sendable {
+    public let id: String
+    public let title: String
+    public let description: String
+
+    public init(id: String, title: String, description: String) {
+        self.id = id
+        self.title = title
+        self.description = description
+    }
+}
+
+/// A message the user composed while replying to a widget. Works like XMTP's
+/// `Reply`: it wraps any kind of content the user can send (text, attachment,
+/// remote attachment, ...) and associates it with the widget `context` instead
+/// of a parent message.
+public struct ContextReply {
+    public var context: ContextReplyContext
+    public var content: Any
+    public var contentType: ContentTypeID
+
+    public init(context: ContextReplyContext, content: Any, contentType: ContentTypeID) {
+        self.context = context
+        self.content = content
+        self.contentType = contentType
+    }
+}
+
+public let ContentTypeContextReply = ContentTypeID(authorityID: "convos.org", typeID: "context_reply", versionMajor: 1, versionMinor: 0)
+
+public enum ContextReplyCodecError: Error, LocalizedError {
+    case missingContext
+    case invalidContext
+    case unsupportedNestedContentType(ContentTypeID)
+    case mismatchedNestedContent
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingContext:
+            return "ContextReply is missing its widget context"
+        case .invalidContext:
+            return "ContextReply widget context could not be decoded"
+        case .unsupportedNestedContentType(let type):
+            return "ContextReply cannot wrap content type \(type.authorityID)/\(type.typeID)"
+        case .mismatchedNestedContent:
+            return "ContextReply nested content did not match its declared content type"
+        }
+    }
+}
+
+public struct ContextReplyCodec: ContentCodec {
+    public typealias T = ContextReply
+
+    public var contentType: ContentTypeID = ContentTypeContextReply
+
+    public init() {}
+
+    public func encode(content contextReply: ContextReply) throws -> EncodedContent {
+        var encodedContent = EncodedContent()
+        encodedContent.type = ContentTypeContextReply
+        encodedContent.parameters["context"] = try Self.encodeContext(contextReply.context)
+        encodedContent.parameters["contentType"] = contextReply.contentType.description
+        encodedContent.content = try Self.encodeNested(
+            content: contextReply.content,
+            contentType: contextReply.contentType
+        ).serializedData()
+        return encodedContent
+    }
+
+    public func decode(content: EncodedContent) throws -> ContextReply {
+        guard let contextParameter = content.parameters["context"] else {
+            throw ContextReplyCodecError.missingContext
+        }
+        let context = try Self.decodeContext(contextParameter)
+
+        let nestedEncoded = try EncodedContent(serializedData: content.content)
+        let nested = try Self.decodeNested(nestedEncoded)
+        return ContextReply(context: context, content: nested.content, contentType: nested.contentType)
+    }
+
+    public func fallback(content contextReply: ContextReply) throws -> String? {
+        "Replied to \"\(contextReply.context.title)\""
+    }
+
+    public func shouldPush(content _: ContextReply) throws -> Bool {
+        true
+    }
+
+    // MARK: - Context (de)serialization
+
+    private static func encodeContext(_ context: ContextReplyContext) throws -> String {
+        let data = try JSONEncoder().encode(context)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw ContextReplyCodecError.invalidContext
+        }
+        return json
+    }
+
+    private static func decodeContext(_ parameter: String) throws -> ContextReplyContext {
+        guard let data = parameter.data(using: .utf8) else {
+            throw ContextReplyCodecError.invalidContext
+        }
+        do {
+            return try JSONDecoder().decode(ContextReplyContext.self, from: data)
+        } catch {
+            throw ContextReplyCodecError.invalidContext
+        }
+    }
+
+    // MARK: - Nested content (de)serialization
+
+    // `Client.codecRegistry` is internal to XMTPiOS, so the codec dispatches
+    // over the same content types replies support (see handleReplyContent in
+    // DecodedMessage+DBRepresentation): text and its text-encoded variants
+    // (invite, link preview, agent share) plus inline and remote attachments.
+    private static func encodeNested(content: Any, contentType: ContentTypeID) throws -> EncodedContent {
+        switch contentType {
+        case ContentTypeText:
+            guard let text = content as? String else {
+                throw ContextReplyCodecError.mismatchedNestedContent
+            }
+            return try TextCodec().encode(content: text)
+        case ContentTypeAttachment:
+            guard let attachment = content as? Attachment else {
+                throw ContextReplyCodecError.mismatchedNestedContent
+            }
+            return try AttachmentCodec().encode(content: attachment)
+        case ContentTypeRemoteAttachment:
+            guard let remoteAttachment = content as? RemoteAttachment else {
+                throw ContextReplyCodecError.mismatchedNestedContent
+            }
+            return try RemoteAttachmentCodec().encode(content: remoteAttachment)
+        case ContentTypeMultiRemoteAttachment:
+            guard let multiRemoteAttachment = content as? MultiRemoteAttachment else {
+                throw ContextReplyCodecError.mismatchedNestedContent
+            }
+            return try MultiRemoteAttachmentCodec().encode(content: multiRemoteAttachment)
+        default:
+            throw ContextReplyCodecError.unsupportedNestedContentType(contentType)
+        }
+    }
+
+    private static func decodeNested(_ encoded: EncodedContent) throws -> (content: Any, contentType: ContentTypeID) {
+        let nestedType = encoded.type
+        switch nestedType {
+        case ContentTypeText:
+            return (try TextCodec().decode(content: encoded), ContentTypeText)
+        case ContentTypeAttachment:
+            return (try AttachmentCodec().decode(content: encoded), ContentTypeAttachment)
+        case ContentTypeRemoteAttachment:
+            return (try RemoteAttachmentCodec().decode(content: encoded), ContentTypeRemoteAttachment)
+        case ContentTypeMultiRemoteAttachment:
+            return (try MultiRemoteAttachmentCodec().decode(content: encoded), ContentTypeMultiRemoteAttachment)
+        default:
+            throw ContextReplyCodecError.unsupportedNestedContentType(nestedType)
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/ConversationStateMachine.swift
@@ -948,6 +948,11 @@ extension ConversationStateMachine {
         try await writer.sendReply(text: text, afterPhoto: trackingKey, toMessageWithClientId: parentClientMessageId)
     }
 
+    func sendContextReply(text: String, context: ContextReplyContext) async throws {
+        let writer = try await getOrCreateMessageWriter()
+        try await writer.sendContextReply(text: text, context: context)
+    }
+
     func retryFailedMessage(id: String) async throws {
         let writer = try await getOrCreateMessageWriter()
         try await writer.retryFailedMessage(id: id)

--- a/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
+++ b/ConvosCore/Sources/ConvosCore/Inboxes/SessionStateMachine.swift
@@ -1326,6 +1326,7 @@ public actor SessionStateMachine: SessionStateManagerProtocol {
             codecs: [
                 TextCodec(),
                 ReplyCodec(),
+                ContextReplyCodec(),
                 ReactionV2Codec(),
                 ReactionCodec(),
                 AttachmentCodec(),

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -11,6 +11,7 @@ public protocol MessageSender {
     func prepare(remoteAttachment: RemoteAttachment) async throws -> String
     func prepare(multiRemoteAttachment: MultiRemoteAttachment) async throws -> String
     func prepare(reply: Reply) async throws -> String
+    func prepare(contextReply: ContextReply) async throws -> String
     func prepare(builderBundleManifest: BuilderBundleManifest) async throws -> String
     /// Variants that stage the message in the local store without queueing a
     /// libxmtp send intent (`prepareMessage(noSend: true)`). A queued intent
@@ -357,6 +358,13 @@ extension XMTPiOS.Conversation: MessageSender {
         return try await prepareMessage(
             content: reply,
             options: .init(contentType: ContentTypeReply)
+        )
+    }
+
+    public func prepare(contextReply: ContextReply) async throws -> String {
+        return try await prepareMessage(
+            content: contextReply,
+            options: .init(contentType: ContentTypeContextReply)
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationStateManager.swift
@@ -132,6 +132,7 @@ public final class MockConversationStateManager: ConversationStateManagerProtoco
     public func sendReply(text: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendEagerPhotoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {}
     public func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws {}
+    public func sendContextReply(text: String, context: ContextReplyContext) async throws {}
     public func retryFailedMessage(id: String) async throws {}
     public func deleteFailedMessage(id: String) async throws {}
 

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockMessageSender.swift
@@ -49,6 +49,12 @@ public final class MockMessageSender: MessageSender, @unchecked Sendable {
         return messageId
     }
 
+    public func prepare(contextReply: ContextReply) async throws -> String {
+        let messageId = UUID().uuidString
+        preparedMessages.append(messageId)
+        return messageId
+    }
+
     public func prepare(builderBundleManifest: BuilderBundleManifest) async throws -> String {
         let messageId = UUID().uuidString
         preparedMessages.append(messageId)

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockOutgoingMessageWriter.swift
@@ -107,6 +107,10 @@ public final class MockOutgoingMessageWriter: OutgoingMessageWriterProtocol, @un
         try await send(text: text, afterPhoto: trackingKey)
     }
 
+    public func sendContextReply(text: String, context: ContextReplyContext) async throws {
+        try await send(text: text)
+    }
+
     public func retryFailedMessage(id: String) async throws {}
     public func deleteFailedMessage(id: String) async throws {}
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMessage.swift
@@ -37,6 +37,7 @@ struct DBMessage: FetchableRecord, PersistableRecord, Hashable, Codable, Sendabl
         static let linkPreview: Column = Column(CodingKeys.linkPreview)
         static let sourceMessageId: Column = Column(CodingKeys.sourceMessageId)
         static let attachmentUrls: Column = Column(CodingKeys.attachmentUrls)
+        static let contextReply: Column = Column(CodingKeys.contextReply)
     }
 
     let id: String // external
@@ -59,6 +60,12 @@ struct DBMessage: FetchableRecord, PersistableRecord, Hashable, Codable, Sendabl
     let sourceMessageId: String? // replies and reactions
     let attachmentUrls: [String]
     let update: Update?
+    // Set when this message is a reply to a widget (window.convos.replyToWidget).
+    // The message renders like a reply, keyed off this context instead of a
+    // parent message. A defaulted var so the memberwise initializer keeps a
+    // `contextReply: nil` default, leaving the many DBMessage construction sites
+    // that never carry a widget context unchanged. See ContextReplyCodec.
+    var contextReply: ContextReplyContext?
 
     var attachmentUrl: String? {
         attachmentUrls.first
@@ -126,7 +133,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -148,7 +156,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -170,7 +179,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -192,7 +202,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -214,7 +225,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -236,7 +248,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -258,7 +271,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -280,7 +294,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 
@@ -302,7 +317,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            contextReply: contextReply
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AnyMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AnyMessage.swift
@@ -32,6 +32,17 @@ public enum AnyMessage: Hashable, Equatable, Codable, Sendable, Identifiable {
         }
     }
 
+    /// The widget this message replies to, if any. A message reply and a
+    /// widget context are mutually exclusive, so `.reply` never carries one.
+    public var widgetContext: ContextReplyContext? {
+        switch self {
+        case .message(let message, _):
+            return message.widgetContext
+        case .reply:
+            return nil
+        }
+    }
+
     public var sender: ConversationMember {
         switch self {
         case .message(let message, _):

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Message.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Message.swift
@@ -12,6 +12,12 @@ public struct Message: Hashable, Codable, Sendable {
 
     public let reactions: [MessageReaction]
 
+    /// Set when this message is a reply to a widget (window.convos.replyToWidget).
+    /// The transcript renders a reference card for the widget above the message,
+    /// mirroring how a `MessageReply` renders its parent. Nil for ordinary
+    /// messages. See ContextReplyCodec.
+    public let widgetContext: ContextReplyContext?
+
     public init(
         id: String,
         sender: ConversationMember,
@@ -19,7 +25,8 @@ public struct Message: Hashable, Codable, Sendable {
         status: MessageStatus,
         content: MessageContent,
         date: Date,
-        reactions: [MessageReaction]
+        reactions: [MessageReaction],
+        widgetContext: ContextReplyContext? = nil
     ) {
         self.id = id
         self.sender = sender
@@ -28,5 +35,6 @@ public struct Message: Hashable, Codable, Sendable {
         self.content = content
         self.date = date
         self.reactions = reactions
+        self.widgetContext = widgetContext
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -520,7 +520,8 @@ extension Array where Element == DBMessage {
                     status: dbMessage.status,
                     content: messageContent,
                     date: dbMessage.date,
-                    reactions: reactions
+                    reactions: reactions,
+                    widgetContext: dbMessage.contextReply
                 )
                 return .message(message, origin)
             case .reply:

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -223,6 +223,17 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addConversationParticipationMode", migrate: Self.addConversationParticipationMode)
         migrator.registerMigration("clearCutListenParticipationMode", migrate: Self.clearCutListenParticipationMode)
         migrator.registerMigration("addConversationSpaceURLString", migrate: Self.addConversationSpaceURLString)
+        migrator.registerMigration("addMessageContextReply", migrate: Self.addMessageContextReply)
+    }
+
+    /// The widget a message replies to (window.convos.replyToWidget). Nullable
+    /// with no default: a null column is an ordinary message not associated
+    /// with any widget. Stored as JSON text because it holds a Codable
+    /// ContextReplyContext struct (see DBMessage.contextReply / ContextReplyCodec).
+    static func addMessageContextReply(_ db: Database) throws {
+        try db.alter(table: "message") { t in
+            t.add(column: "contextReply", .jsonText)
+        }
     }
 
     /// The deployed Space web URL for the conversation, mirrored from the

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationStateManager.swift
@@ -358,6 +358,10 @@ public final class ConversationStateManager: ConversationStateManagerProtocol, @
         try await stateMachine.sendReply(text: text, afterPhoto: trackingKey, toMessageWithClientId: parentClientMessageId)
     }
 
+    public func sendContextReply(text: String, context: ContextReplyContext) async throws {
+        try await stateMachine.sendContextReply(text: text, context: context)
+    }
+
     public func retryFailedMessage(id: String) async throws {
         try await stateMachine.retryFailedMessage(id: id)
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -138,6 +138,14 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
     /// Send text after a photo reply (both replying to the same parent).
     func sendReply(text: String, afterPhoto trackingKey: String?, toMessageWithClientId parentClientMessageId: String) async throws
 
+    // MARK: - Widget Replies
+
+    /// Send a text message associated with a widget (a "widget reply", from
+    /// window.convos.replyToWidget). The message is published as a
+    /// `ContextReply` wrapping the text and renders like a reply keyed off the
+    /// widget context. See ContextReplyCodec.
+    func sendContextReply(text: String, context: ContextReplyContext) async throws
+
     // MARK: - Failed Messages
 
     func retryFailedMessage(id: String) async throws
@@ -178,6 +186,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         let text: String
         let dependsOnPhotoKey: String?
         let replyContext: ReplyContext?
+        var contextReplyContext: ContextReplyContext?
         let isExistingLocalMessage: Bool
     }
 
@@ -426,18 +435,26 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         startProcessingIfNeeded()
     }
 
-    private func sendText(_ text: String, afterPhoto trackingKey: String?, replyContext: ReplyContext?, clientMessageId: String? = nil, recordsMetric: Bool = true) async throws {
+    private func sendText(
+        _ text: String,
+        afterPhoto trackingKey: String?,
+        replyContext: ReplyContext?,
+        contextReplyContext: ContextReplyContext? = nil,
+        clientMessageId: String? = nil,
+        recordsMetric: Bool = true
+    ) async throws {
         let clientMessageId: String = clientMessageId ?? UUID().uuidString
         if recordsMetric {
             trackSendMetric(clientMessageId: clientMessageId, hasText: !text.isEmpty, attachmentMimeTypes: [])
         }
-        try await saveTextToDatabase(clientMessageId: clientMessageId, text: text, replyContext: replyContext)
+        try await saveTextToDatabase(clientMessageId: clientMessageId, text: text, replyContext: replyContext, contextReplyContext: contextReplyContext)
 
         let queued = QueuedTextMessage(
             clientMessageId: clientMessageId,
             text: text,
             dependsOnPhotoKey: trackingKey,
             replyContext: replyContext,
+            contextReplyContext: contextReplyContext,
             isExistingLocalMessage: false
         )
 
@@ -2214,6 +2231,12 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         try await sendText(text, afterPhoto: trackingKey, replyContext: replyContext)
     }
 
+    // MARK: - Widget Replies
+
+    func sendContextReply(text: String, context: ContextReplyContext) async throws {
+        try await sendText(text, afterPhoto: nil, replyContext: nil, contextReplyContext: context)
+    }
+
     func sendEagerPhotoReply(trackingKey: String, toMessageWithClientId parentClientMessageId: String) async throws {
         let replyContext = try await resolveReplyContext(parentClientMessageId: parentClientMessageId)
 
@@ -2307,7 +2330,7 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
 
     // MARK: - Database Save (Optimistic)
 
-    private func saveTextToDatabase(clientMessageId: String, text: String, replyContext: ReplyContext? = nil) async throws {
+    private func saveTextToDatabase(clientMessageId: String, text: String, replyContext: ReplyContext? = nil, contextReplyContext: ContextReplyContext? = nil) async throws {
         let senderId: String
         if case .ready(let result) = sessionStateManager.currentState {
             senderId = result.client.inboxId
@@ -2363,7 +2386,8 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 linkPreview: linkPreview,
                 sourceMessageId: replyContext?.parentDbId,
                 attachmentUrls: [],
-                update: nil
+                update: nil,
+                contextReply: contextReplyContext
             )
             try localMessage.save(db)
             Log.debug("Saved text message optimistically with id: \(clientMessageId) sortId=\(sortId)")
@@ -2430,7 +2454,10 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
         }
 
         let xmtpMessageId: String
-        if let replyContext = queued.replyContext {
+        if let contextReplyContext = queued.contextReplyContext {
+            let contextReply = ContextReply(context: contextReplyContext, content: queued.text, contentType: ContentTypeText)
+            xmtpMessageId = try await sender.prepare(contextReply: contextReply)
+        } else if let replyContext = queued.replyContext {
             let reply = Reply(reference: replyContext.parentDbId, content: queued.text, contentType: ContentTypeText)
             xmtpMessageId = try await sender.prepare(reply: reply)
         } else {

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -43,6 +43,7 @@ extension XMTPiOS.DecodedMessage {
         var attachmentUrls: [String]
         var text: String?
         var update: DBMessage.Update?
+        var contextReply: ContextReplyContext?
     }
 
     func dbRepresentation() throws -> DBMessage {
@@ -55,6 +56,8 @@ extension XMTPiOS.DecodedMessage {
             components = try handleTextContent()
         case ContentTypeReply:
             components = try handleReplyContent()
+        case ContentTypeContextReply:
+            components = try handleContextReplyContent()
         case ContentTypeReaction, ContentTypeReactionV2:
             components = try handleReactionContent()
         case ContentTypeAttachment:
@@ -116,7 +119,8 @@ extension XMTPiOS.DecodedMessage {
             linkPreview: components.linkPreview,
             sourceMessageId: components.sourceMessageId,
             attachmentUrls: components.attachmentUrls,
-            update: components.update
+            update: components.update,
+            contextReply: components.contextReply
         )
     }
 
@@ -280,6 +284,111 @@ extension XMTPiOS.DecodedMessage {
                 attachmentUrls: [],
                 text: nil,
                 update: nil
+            )
+        }
+    }
+
+    // A context reply wraps any content the user can send and associates it
+    // with a widget instead of a parent message. The stored row keeps its
+    // natural content type (text, attachments, ...) and carries the widget
+    // context in `contextReply`, so it renders like a reply without joining a
+    // parent. Nested-content handling mirrors handleReplyContent.
+    private func handleContextReplyContent() throws -> DBMessageComponents {
+        let content = try content() as Any
+        guard let contextReply = content as? ContextReply else {
+            throw DecodedMessageDBRepresentationError.mismatchedContentType
+        }
+        let context = contextReply.context
+        switch contextReply.contentType {
+        case ContentTypeText:
+            guard let contentString = contextReply.content as? String else {
+                throw DecodedMessageDBRepresentationError.mismatchedContentType
+            }
+            let isContentEmoji = contentString.allCharactersEmoji
+            if !isContentEmoji, let invite = MessageInvite.from(text: contentString) {
+                return DBMessageComponents(
+                    messageType: .original,
+                    contentType: .invite,
+                    invite: invite,
+                    attachmentUrls: [],
+                    text: contentString,
+                    contextReply: context
+                )
+            }
+            if !isContentEmoji, MessageAgentShare.from(text: contentString) != nil {
+                return DBMessageComponents(
+                    messageType: .original,
+                    contentType: .agentShare,
+                    attachmentUrls: [],
+                    text: contentString,
+                    contextReply: context
+                )
+            }
+            if !isContentEmoji, let preview = LinkPreview.from(text: contentString) {
+                return DBMessageComponents(
+                    messageType: .original,
+                    contentType: .linkPreview,
+                    linkPreview: preview,
+                    attachmentUrls: [],
+                    text: contentString,
+                    contextReply: context
+                )
+            }
+            let trimmedContent = contentString.trimmingCharacters(in: .whitespacesAndNewlines)
+            return DBMessageComponents(
+                messageType: .original,
+                contentType: isContentEmoji ? .emoji : .text,
+                emoji: isContentEmoji ? trimmedContent : nil,
+                attachmentUrls: [],
+                text: isContentEmoji ? nil : contentString,
+                contextReply: context
+            )
+        case ContentTypeAttachment:
+            guard let attachment = contextReply.content as? Attachment else {
+                throw DecodedMessageDBRepresentationError.mismatchedContentType
+            }
+            let fileURL = try Self.saveInlineAttachment(data: attachment.data, messageId: id, filename: attachment.filename)
+            return DBMessageComponents(
+                messageType: .original,
+                contentType: .attachments,
+                attachmentUrls: [fileURL.absoluteString],
+                text: nil,
+                contextReply: context
+            )
+        case ContentTypeRemoteAttachment:
+            guard let remoteAttachment = contextReply.content as? RemoteAttachment else {
+                throw DecodedMessageDBRepresentationError.mismatchedContentType
+            }
+            let inferredMimeType: String? = remoteAttachment.filename.flatMap { filename in
+                let ext = (filename as NSString).pathExtension.lowercased()
+                guard !ext.isEmpty else { return nil }
+                return UTType(filenameExtension: ext)?.preferredMIMEType
+            }
+            let stored = StoredRemoteAttachment(
+                url: remoteAttachment.url,
+                contentDigest: remoteAttachment.contentDigest,
+                secret: remoteAttachment.secret,
+                salt: remoteAttachment.salt,
+                nonce: remoteAttachment.nonce,
+                filename: remoteAttachment.filename,
+                mimeType: inferredMimeType
+            )
+            let json = (try? stored.toJSON()) ?? remoteAttachment.url
+            return DBMessageComponents(
+                messageType: .original,
+                contentType: .attachments,
+                attachmentUrls: [json],
+                text: nil,
+                contextReply: context
+            )
+        default:
+            Log.error("Unhandled context reply contentType \(contextReply.contentType)")
+            return DBMessageComponents(
+                messageType: .original,
+                contentType: .text,
+                attachmentUrls: [],
+                text: nil,
+                contextReply: context
             )
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ContextReplyCodecTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ContextReplyCodecTests.swift
@@ -1,0 +1,89 @@
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+@Suite("ContextReply codec")
+struct ContextReplyCodecTests {
+    private let context = ContextReplyContext(
+        id: "widget-1",
+        title: "Weather",
+        description: "Sunny, 24 degrees"
+    )
+
+    @Test("round-trips a text reply with its widget context")
+    func roundTripText() throws {
+        let codec = ContextReplyCodec()
+        let contextReply = ContextReply(context: context, content: "Looks great!", contentType: ContentTypeText)
+
+        let encoded = try codec.encode(content: contextReply)
+        #expect(encoded.type == ContentTypeContextReply)
+
+        let decoded = try codec.decode(content: encoded)
+        #expect(decoded.context == context)
+        #expect(decoded.contentType == ContentTypeText)
+        #expect(decoded.content as? String == "Looks great!")
+    }
+
+    @Test("round-trips a remote-attachment reply, proving any content nests")
+    func roundTripRemoteAttachment() throws {
+        let codec = ContextReplyCodec()
+        let remoteAttachment = try RemoteAttachment(
+            url: "https://example.com/asset",
+            contentDigest: "digest",
+            secret: Data(repeating: 1, count: 32),
+            salt: Data(repeating: 2, count: 32),
+            nonce: Data(repeating: 3, count: 16),
+            scheme: .https,
+            contentLength: 10,
+            filename: "photo.jpg"
+        )
+        let contextReply = ContextReply(
+            context: context,
+            content: remoteAttachment,
+            contentType: ContentTypeRemoteAttachment
+        )
+
+        let encoded = try codec.encode(content: contextReply)
+        let decoded = try codec.decode(content: encoded)
+        #expect(decoded.context == context)
+        #expect(decoded.contentType == ContentTypeRemoteAttachment)
+        let decodedAttachment = try #require(decoded.content as? RemoteAttachment)
+        #expect(decodedAttachment.url == "https://example.com/asset")
+        #expect(decodedAttachment.filename == "photo.jpg")
+    }
+
+    @Test("fallback names the widget so clients without the codec see context")
+    func fallback() throws {
+        let codec = ContextReplyCodec()
+        let contextReply = ContextReply(context: context, content: "Hi", contentType: ContentTypeText)
+        #expect(try codec.fallback(content: contextReply) == "Replied to \"Weather\"")
+    }
+
+    @Test("pushes so all devices receive the reply")
+    func pushes() throws {
+        let codec = ContextReplyCodec()
+        let contextReply = ContextReply(context: context, content: "Hi", contentType: ContentTypeText)
+        #expect(try codec.shouldPush(content: contextReply) == true)
+    }
+
+    @Test("missing context parameter is rejected")
+    func missingContextRejected() {
+        let codec = ContextReplyCodec()
+        var missing = EncodedContent()
+        missing.type = ContentTypeContextReply
+        missing.content = (try? TextCodec().encode(content: "Hi").serializedData()) ?? Data()
+        #expect(throws: ContextReplyCodecError.self) {
+            try codec.decode(content: missing)
+        }
+    }
+
+    @Test("unsupported nested content type is rejected on encode")
+    func unsupportedNestedRejected() {
+        let codec = ContextReplyCodec()
+        let contextReply = ContextReply(context: context, content: "Hi", contentType: ContentTypeReaction)
+        #expect(throws: ContextReplyCodecError.self) {
+            try codec.encode(content: contextReply)
+        }
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -353,6 +353,10 @@ class TestableMockMessageSender: MessageSender {
         ""
     }
 
+    func prepare(contextReply: ContextReply) async throws -> String {
+        ""
+    }
+
     func prepare(builderBundleManifest: BuilderBundleManifest) async throws -> String {
         ""
     }

--- a/ConvosCore/Tests/Fixtures/pairing-vectors.json
+++ b/ConvosCore/Tests/Fixtures/pairing-vectors.json
@@ -2,8 +2,8 @@
   "codecs" : {
     "device_removed" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
-      "contentJSON" : "{\"schemaVersion\":1,\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"removedAt\":1750000200}",
+      "contentBase64" : "eyJyZXZva2VkSW5zdGFsbGF0aW9uSWQiOiJiMTk0NmFjOTI0OTJkMjM0N2M2MjM1YjRkMjYxMTE4NCIsInNjaGVtYVZlcnNpb24iOjEsInJlbW92ZWRBdCI6MTc1MDAwMDIwMH0=",
+      "contentJSON" : "{\"revokedInstallationId\":\"b1946ac92492d2347c6235b4d2611184\",\"schemaVersion\":1,\"removedAt\":1750000200}",
       "contentType" : "convos.org/device_removed:1.0",
       "typeId" : "device_removed",
       "versionMajor" : 1,
@@ -11,8 +11,8 @@
     },
     "identity_share" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJpbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpbml0aWF0b3JEZXZpY2VOYW1lIjoiQ2FtZXJvbidzIGlQaG9uZSIsInNjaGVtYVZlcnNpb24iOjEsImlzc3VlZEF0IjoxNzUwMDAwMTAwLCJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIn0=",
-      "contentJSON" : "{\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"displayName\":\"Cameron\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"schemaVersion\":1,\"issuedAt\":1750000100,\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\"}",
+      "contentBase64" : "eyJpbWFnZUFzc2V0SWRlbnRpZmllciI6Imh0dHBzOlwvXC9hc3NldHMuY29udm9zLm9yZ1wvYXZhdGFyXC9hYmMxMjMuanBnIiwiaW5pdGlhdG9yRGV2aWNlTmFtZSI6IkNhbWVyb24ncyBpUGhvbmUiLCJpbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsInByaXZhdGVLZXlEYXRhIjoiSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpSWlJaUlpST0iLCJkaXNwbGF5TmFtZSI6IkNhbWVyb24iLCJpc3N1ZWRBdCI6MTc1MDAwMDEwMCwic2NoZW1hVmVyc2lvbiI6MX0=",
+      "contentJSON" : "{\"imageAssetIdentifier\":\"https:\\/\\/assets.convos.org\\/avatar\\/abc123.jpg\",\"initiatorDeviceName\":\"Cameron's iPhone\",\"inboxId\":\"3f9a1c0e5b7d2846a1f30c9e4d8b6752e0a4c9137fb5628d0e3a7c14b9d5f682\",\"privateKeyData\":\"IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=\",\"displayName\":\"Cameron\",\"issuedAt\":1750000100,\"schemaVersion\":1}",
       "contentType" : "convos.org/identity_share:1.0",
       "typeId" : "identity_share",
       "versionMajor" : 1,
@@ -20,8 +20,8 @@
     },
     "pairing_join_request" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJzbHVnIjoiZXlKbGVIQnBjbVZ6UVhRaU9qRTNOVEF3TURBeE1qQXNJbTV2Ym1ObElqb2lRVUpGYVUwd1VsWmFibVZKYldGeE4zcE9NM1ZjTDNjOVBTSXNJbWx1YVhScFlYUnZja0ZrWkhKbGMzTWlPaUl3ZURFNVpUZGxNemMyWlRkak1qRXpZamRsTjJVM1pUUTJZMk0zTUdFMVpHUXdPRFprWVdabU1tRWlMQ0p6YVdkdVlYUjFjbVVpT2lJcldHWmpPVkF4YlVjNVRtRXhYQzlpZEZOSVZWbGFWVzlQT1RaWWR6TkVZbEE1YUd0WWFVWllNM1ZSWTA1T1hDOVhUVW80WEM4eWIzQkRUbTVUV1dOd1JFZFFRVXB6YmpoRFNHaDBRMnRvTUdjeFl6TXphelIyYUhjOUlpd2ljMk5vWlcxaFZtVnljMmx2YmlJNk1Td2lhWE56ZFdWa1FYUWlPakUzTlRBd01EQXdNREFzSW1sdWFYUnBZWFJ2Y2tsdVltOTRTV1FpT2lJelpqbGhNV013WlRWaU4yUXlPRFEyWVRGbU16QmpPV1UwWkRoaU5qYzFNbVV3WVRSak9URXpOMlppTlRZeU9HUXdaVE5oTjJNeE5HSTVaRFZtTmpneUluMCIsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIn0=",
-      "contentJSON" : "{\"schemaVersion\":1,\"slug\":\"eyJleHBpcmVzQXQiOjE3NTAwMDAxMjAsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0\",\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\"}",
+      "contentBase64" : "eyJzbHVnIjoiZXlKelkyaGxiV0ZXWlhKemFXOXVJam94TENKcGJtbDBhV0YwYjNKSmJtSnZlRWxrSWpvaU0yWTVZVEZqTUdVMVlqZGtNamcwTm1FeFpqTXdZemxsTkdRNFlqWTNOVEpsTUdFMFl6a3hNemRtWWpVMk1qaGtNR1V6WVRkak1UUmlPV1ExWmpZNE1pSXNJbWx1YVhScFlYUnZja0ZrWkhKbGMzTWlPaUl3ZURFNVpUZGxNemMyWlRkak1qRXpZamRsTjJVM1pUUTJZMk0zTUdFMVpHUXdPRFprWVdabU1tRWlMQ0pwYzNOMVpXUkJkQ0k2TVRjMU1EQXdNREF3TUN3aVpYaHdhWEpsYzBGMElqb3hOelV3TURBd01USXdMQ0p1YjI1alpTSTZJa0ZDUldsTk1GSldXbTVsU1cxaGNUZDZUak4xWEM5M1BUMGlMQ0p6YVdkdVlYUjFjbVVpT2lJcldHWmpPVkF4YlVjNVRtRXhYQzlpZEZOSVZWbGFWVzlQT1RaWWR6TkVZbEE1YUd0WWFVWllNM1ZSWTA1T1hDOVhUVW80WEM4eWIzQkRUbTVUV1dOd1JFZFFRVXB6YmpoRFNHaDBRMnRvTUdjeFl6TXphelIyYUhjOUluMCIsInNjaGVtYVZlcnNpb24iOjEsImpvaW5lckluYm94SWQiOiI4YzJkNDBiNmUxZjk3YTM1YzBkODJiNGU2ZjE5YTdkMzVjMGUyOGI0ZjZhMTlkNzNjNThlMDJiNGY2YTE5ZDczIiwiZGV2aWNlTmFtZSI6IlBpeGVsIDkgUHJvIn0=",
+      "contentJSON" : "{\"slug\":\"eyJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9In0\",\"schemaVersion\":1,\"joinerInboxId\":\"8c2d40b6e1f97a35c0d82b4e6f19a7d35c0e28b4f6a19d73c58e02b4f6a19d73\",\"deviceName\":\"Pixel 9 Pro\"}",
       "contentType" : "convos.org/pairing_join_request:1.0",
       "typeId" : "pairing_join_request",
       "versionMajor" : 1,
@@ -47,8 +47,8 @@
     },
     "pairing_message_pin_echo" : {
       "authorityId" : "convos.org",
-      "contentBase64" : "eyJwYXlsb2FkIjoiMTIzNDU2IiwidHlwZSI6InBpbl9lY2hvIn0=",
-      "contentJSON" : "{\"payload\":\"123456\",\"type\":\"pin_echo\"}",
+      "contentBase64" : "eyJ0eXBlIjoicGluX2VjaG8iLCJwYXlsb2FkIjoiMTIzNDU2In0=",
+      "contentJSON" : "{\"type\":\"pin_echo\",\"payload\":\"123456\"}",
       "contentType" : "convos.org/pairing_message:1.0",
       "typeId" : "pairing_message",
       "versionMajor" : 1,
@@ -241,7 +241,7 @@
     "signatureRecoveryByte" : 28,
     "signedMessage" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
     "signingPayloadHex" : "636f6e766f732d706169722d696e766974652d76310a336639613163306535623764323834366131663330633965346438623637353265306134633931333766623536323864306533613763313462396435663638320a3078313965376533373665376332313362376537653765343663633730613564643038366461666632610a00112233445566778899aabbccddeeff0a80e14e6800000000f8e14e6800000000",
-    "slug" : "eyJleHBpcmVzQXQiOjE3NTAwMDAxMjAsIm5vbmNlIjoiQUJFaU0wUlZabmVJbWFxN3pOM3VcL3c9PSIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9Iiwic2NoZW1hVmVyc2lvbiI6MSwiaXNzdWVkQXQiOjE3NTAwMDAwMDAsImluaXRpYXRvckluYm94SWQiOiIzZjlhMWMwZTViN2QyODQ2YTFmMzBjOWU0ZDhiNjc1MmUwYTRjOTEzN2ZiNTYyOGQwZTNhN2MxNGI5ZDVmNjgyIn0",
+    "slug" : "eyJzY2hlbWFWZXJzaW9uIjoxLCJpbml0aWF0b3JJbmJveElkIjoiM2Y5YTFjMGU1YjdkMjg0NmExZjMwYzllNGQ4YjY3NTJlMGE0YzkxMzdmYjU2MjhkMGUzYTdjMTRiOWQ1ZjY4MiIsImluaXRpYXRvckFkZHJlc3MiOiIweDE5ZTdlMzc2ZTdjMjEzYjdlN2U3ZTQ2Y2M3MGE1ZGQwODZkYWZmMmEiLCJpc3N1ZWRBdCI6MTc1MDAwMDAwMCwiZXhwaXJlc0F0IjoxNzUwMDAwMTIwLCJub25jZSI6IkFCRWlNMFJWWm5lSW1hcTd6TjN1XC93PT0iLCJzaWduYXR1cmUiOiIrWGZjOVAxbUc5TmExXC9idFNIVVlaVW9POTZYdzNEYlA5aGtYaUZYM3VRY05OXC9XTUo4XC8yb3BDTm5TWWNwREdQQUpzbjhDSGh0Q2toMGcxYzMzazR2aHc9In0",
     "verifyAtUnixSeconds" : 1750000001
   },
   "note" : "Golden cross-platform vectors for Linked Device Sync. Regenerate with: swift test --package-path ConvosCore --filter generatePairingVectors. JSON object key order (in `slug` and every `contentBase64`) is whatever Swift's JSONEncoder emitted — it is randomized per process and is NOT part of the contract. Consumers must decode order-insensitively and tolerate unknown keys.",

--- a/docs/architecture/messages-list.md
+++ b/docs/architecture/messages-list.md
@@ -1,0 +1,1054 @@
+# Messages List Architecture (UICollectionView)
+
+A reference for the conversation transcript: the scrolling list of message
+bubbles, date separators, system rows, invite cards, and typing/thinking
+indicators inside a conversation. It covers data flow, the data source, the
+custom layout engine, cell binding, self-sizing, scroll/keyboard behavior,
+gestures, the context menu, reactions, and insertion/update animations.
+
+Line numbers are anchors as of branch `saulmc/bridge-show-agent-dm`; they drift
+by a few lines over time, so grep the named symbol if a line is off. Unless
+noted, package paths are relative to `ConvosCore/Sources/ConvosComposer/`, and
+core model paths to `ConvosCore/Sources/ConvosCore/`.
+
+---
+
+## 0. Orientation: where everything lives
+
+The transcript is **not** a SwiftUI `List` or `ScrollView`. It is a UIKit
+`UICollectionView` driven by a **hand-written `UICollectionViewLayout`**
+(a fork/derivation of the open-source [ChatLayout] engine) and diffed with
+[DifferenceKit]. It is bridged into SwiftUI through a
+`UIViewControllerRepresentable`.
+
+Counterintuitively, almost none of it lives in the app target. The directory a
+newcomer greps first, `Convos/Conversation Detail/Messages/`, holds only the
+thin SwiftUI wrapper (`MessagesView.swift`) plus a few drawers and navigators.
+The real machinery is a self-contained UIKit chat stack in the local Swift
+package **`ConvosComposer`**.
+
+Three modules are involved:
+
+| Module | Path | Contents |
+| --- | --- | --- |
+| App target | `Convos/Conversation Detail/…` | `MessagesView` wrapper, `ConversationViewModel` (the data feed) |
+| `ConvosComposer` | `ConvosCore/Sources/ConvosComposer/…` | The collection view, custom layout, data source, cells, gestures, context menu |
+| `ConvosCore` | `ConvosCore/Sources/ConvosCore/…` | The value-type models (`MessagesListItemType`, `MessagesGroup`, `AnyMessage`), repositories, the grouping processor |
+
+Entry points, top to bottom:
+
+- `Convos/Conversation Detail/Messages/MessagesView.swift:203` — SwiftUI
+  `body`; instantiates `MessagesViewRepresentable` and hosts the composer and
+  the context-menu overlay.
+- `MessagesViewRepresentable.swift:6` — the `UIViewControllerRepresentable`
+  bridge.
+- `Messages View Controller/View Controller/MessagesViewController.swift:32` —
+  `public final class MessagesViewController: UIViewController`, the orchestrator
+  (~1800 lines).
+- `Messages Collection Layout/MessagesCollectionLayout.swift:8` —
+  `open class MessagesCollectionLayout: UICollectionViewLayout`.
+
+### Full file index
+
+Collection view / controller / data source (`ConvosComposer`):
+
+- `MessagesViewRepresentable.swift` — SwiftUI↔UIKit bridge.
+- `Messages View Controller/View Controller/MessagesViewController.swift` — the controller.
+- `Messages View Controller/View Controller/MessagesCollectionView.swift` — the `UICollectionView` subclass.
+- `Messages View Controller/View Controller/Data Source/MessagesCollectionDataSource.swift` — data-source protocol.
+- `.../Data Source/MessagesCollectionViewDataSource.swift` — concrete data source.
+- `.../Data Source/CellFactory.swift` — cell dequeue + `CellConfig` closure bundle.
+- `.../Data Source/DefaultMessagesLayoutDelegate.swift` — sizing + animation deltas.
+- `.../Cells/MessagesListItemTypeCell.swift`, `.../Cells/TypingIndicatorCollectionCell.swift` — the two cell classes.
+- `Messages View Controller/Helpers/UICollectionView+DifferenceKit.swift` — the staged-changeset applier.
+- `Messages View Controller/Helpers/SetActor.swift` — deferred/serialized update actor.
+- `Messages View Controller/Helpers/ManualAnimator.swift` — `CADisplayLink`-driven scroll animator.
+- `Messages View Controller/Constants.swift` — bubble geometry constants.
+
+Custom layout engine (`ConvosComposer/Messages Collection Layout/`):
+
+- `MessagesCollectionLayout.swift`, `MessagesLayoutStateController.swift`,
+  `MessagesLayoutAttributes.swift`, `MessagesLayoutInvalidationContext.swift`,
+  `MessagesLayoutPositionSnapshot.swift`, `MessagesLayoutDelegate.swift`,
+  `MessagesLayoutSettings.swift`, and `Models/` (`ItemModel`, `SectionModel`,
+  `LayoutModel`, `ItemSize`, `ItemPath`, `ItemKind`, `ChangeItem`).
+
+Diffing conformances:
+
+- `MessagesListView/MessagesListItemType.swift` — `MessagesListItemType: Differentiable`.
+- `Messages View Controller/Message Models/MessagesCollectionSection.swift` — `DifferentiableSection`.
+- `Messages View Controller/Message Models/MessageTypes.swift` — `AnyMessage`/`DateGroup`/`Invite`/`ConversationUpdate` conformances.
+
+SwiftUI bubble content (`ConvosComposer/MessagesListView/`):
+
+- `MessagesGroupView.swift`, `MessagesGroupItemView.swift`, and
+  `Messages List Items/*` (`MessageBubble`, `ReplyReferenceView`,
+  `ReactionIndicatorView`, `TypingIndicatorView`, etc.).
+
+Core models (`ConvosCore/Sources/ConvosCore/Storage/Models/`):
+
+- `MessagesListItemType.swift`, `MessagesGroup.swift`, `MessagesListProcessor.swift`.
+
+Data feed:
+
+- `Storage/Repositories/MessagesRepository.swift`,
+  `Storage/Repositories/MessagesListRepository.swift`,
+  `Convos/Conversation Detail/ConversationViewModel.swift`.
+
+> **Contrast:** the *Conversations list* screen
+> (`Convos/Conversations List/View Controller/`) is a different feature and
+> *does* use Apple's `UICollectionViewDiffableDataSource`. The *messages*
+> transcript documented here does not — it deliberately uses DifferenceKit +
+> the custom layout instead.
+
+---
+
+## 1. End-to-end data flow
+
+A single change in the database eventually becomes a `performBatchUpdates` on
+the collection view. The whole path:
+
+```
+GRDB ValueObservation (SQL: db.composeMessages)
+  -> Combine publisher, .throttle(0.3s, latest)              MessagesRepository
+  -> MessagesListProcessor.process(...)  (grouping)          MessagesListRepository
+  -> CurrentValueSubject<[MessagesListItemType]>             MessagesListRepository
+  -> ConversationViewModel.messages   (@Observable)          ConversationViewModel
+  -> MessagesView (SwiftUI re-render)                        app target
+  -> MessagesViewRepresentable.updateUIViewController        bridge
+  -> messagesViewController.state = .init(messages: ...)     controller
+  -> state.didSet -> processUpdates -> performUpdate         controller
+  -> StagedChangeset(source, target).flattenIfPossible()     DifferenceKit
+  -> collectionView.reload(using: changeSet)                 UICollectionView+DifferenceKit
+  -> performBatchUpdates: insert / delete / reconfigure      custom layout animates
+```
+
+Stage by stage:
+
+- **GRDB → Combine.** `MessagesRepository.conversationMessagesResultPublisher`
+  (`MessagesRepository.swift:362`) is a `CombineLatest` of the conversation id
+  and the current fetch limit, each `.removeDuplicates()`, mapped through a
+  `ValueObservation.tracking { db in db.composeMessages(...) }`, `.publisher(in:)`,
+  `.switchToLatest()`. The primary rate limiter is
+  `.throttle(for: .seconds(0.3), scheduler: .main, latest: true)`
+  (`MessagesRepository.swift:435`).
+- **Grouping.** `MessagesListRepository` (`MessagesListRepository.swift:156`
+  `startObserving()`) maps each result through `MessagesListProcessor`, which
+  turns raw `[AnyMessage]` into `[MessagesListItemType]` — grouping consecutive
+  same-sender messages into `MessagesGroup`s, inserting date separators and
+  system rows, attaching agent contact cards, applying the builder-summary
+  cutoff, and filtering hidden bundle ids. The result is pushed into a
+  `CurrentValueSubject<[MessagesListItemType], Never>`
+  (`MessagesListRepository.swift:61`), exposed as `messagesListPublisher`
+  (`:122`).
+- **ViewModel.** `ConversationViewModel` holds the `@Observable`
+  `var messages: [MessagesListItemType]` (`ConversationViewModel.swift:504`).
+  `primeInitialMessages(...)` (`:1424`) synchronously paints an initial batch so
+  the transcript is on screen at open, and `observe()` (`:1680`) subscribes to
+  `messagesListPublisher` (`.dropFirst()` so the prime is not double-applied),
+  assigning `self.messages` on the main queue.
+- **SwiftUI → controller.** Because the VM is `@Observable`, assigning
+  `messages` re-renders `MessagesView`, which re-invokes
+  `MessagesViewRepresentable.updateUIViewController`
+  (`MessagesViewRepresentable.swift:220`), whose final act is
+  `messagesViewController.state = .init(conversation:messages:...)` (`:289`).
+  Setting `state` is what triggers the diff.
+
+The representable does **no** diffing. It hands the entire processed array into
+`state`; DifferenceKit computes the actual delta downstream.
+
+---
+
+## 2. The item model and diffing identity
+
+### `MessagesListItemType`
+
+`public enum MessagesListItemType`
+(`Storage/Models/MessagesListItemType.swift:45`) is the single element type of
+the list. Cases: `.messages(MessagesGroup)`, `.date(DateGroup)`, `.update(...)`,
+`.invite(Invite)`, `.conversationInfo(Conversation)`, `.agentOutOfCredits`,
+`.agentJoinStatus`, `.agentPresentInfo`, `.connectionEvent`,
+`.capabilityConnect`, `.agentBuilderSummary`, `.agentActivating`,
+`.agentDmInfo`, `.typingIndicator(typers:)`.
+
+Its stable string `id` (`:69`) is the identity used for diffing. Two design
+notes worth knowing, both documented inline:
+
+- `.invite` returns the constant `"invite"` (`:85`) — the transcript hosts at
+  most one invite card (index 0), so its identity is the *slot*, not the
+  payload. Keying on the payload made every invite change an animated
+  delete+insert that cross-faded two cards and restarted the Scan camera; a
+  constant id makes those in-place reconfigurations instead.
+- `.typingIndicator` returns the constant `"typing-indicator"` (`:107`).
+
+Other computed helpers used by the pipeline: `alignment` (`:172`, see §6),
+`shouldAnimate` (`origin == .inserted`, `:168`), `cellReuseIdentifier` /
+`allCellReuseIdentifiers` (`:183`/`:216`), and `lastMessageId` / the array
+extension `lastMessageId` (`:235`/`:255`, used by the scroll-to-bottom decision).
+
+### `MessagesGroup`
+
+`MessagesGroup` (`Storage/Models/MessagesGroup.swift:3`) is a value type with a
+stable `let id: String` but a hand-written `==` (`:147`) and `hash(into:)`
+(`:174`) that compare the group's `rawMessages`, `readByMembers`,
+`voiceMemoTranscripts`, `thinkingByMessageId`, reactions (via `AnyMessage`),
+`agentContactCard`, and a dozen presentation flags. This is what makes an
+edit / reaction / status change / read-receipt inside an existing group flip the
+group's content-equality while keeping its identity — the basis for an in-place
+reconfigure rather than a delete+insert (see §4).
+
+`MessagesListProcessor` (`Storage/Models/MessagesListProcessor.swift`) also
+**splits** long same-sender runs into display groups of a bounded size and marks
+them `continuesPreviousGroup` / `isContinuedBelow`, so one giant cell never has
+to build and measure dozens of bubbles at once. The view renders the split
+seamlessly (hides the sender label, tightens the seam).
+
+### DifferenceKit conformances
+
+The heart of diffing is one extension
+(`MessagesListView/MessagesListItemType.swift:10`):
+
+```swift
+extension MessagesListItemType: @retroactive Differentiable {
+    public var differenceIdentifier: Int { id.hashValue }             // identity
+    public func isContentEqual(to source: MessagesListItemType) -> Bool {
+        self == source                                                // content
+    }
+}
+```
+
+So **identity = `id.hashValue`** and **content-equality = full `Equatable ==`**.
+Same identity + different content → DifferenceKit emits an *update*; new/removed
+identity → *insert*/*delete*. `AnyMessage`, `DateGroup`, `Invite`, and
+`ConversationUpdate` have matching `@retroactive Differentiable` conformances in
+`Message Models/MessageTypes.swift:9` (`AnyMessage.differenceIdentifier =
+messageId.hashValue`, and its `==` includes reactions and status).
+
+---
+
+## 3. The SwiftUI ↔ UIKit bridge
+
+`MessagesViewRepresentable` (`MessagesViewRepresentable.swift:6`) is an
+unusually wide `UIViewControllerRepresentable` — roughly 50 stored properties
+(`:7`–`:85`): the `messages` array, the `conversation`/`invite`/
+`hasLoadedAllMessages` flags, ~30 `on…` action closures, sheet-host layout knobs
+(`bottomBarHeight`, `hasBottomBar`, `topContentInset`, `clippedTopOverflow`,
+`onContentHeightChanged`), and two imperative trigger closures.
+
+**The Coordinator holds no diffing state** (`:87`):
+
+```swift
+public class Coordinator {
+    var scrollToBottomFunction: ((Bool) -> Void)?
+    var messageInputFocusFunction: (() -> Void)?
+}
+```
+
+Its only job is to store two callbacks that forward *imperative* host actions
+into the controller.
+
+- `makeUIViewController` (`:206`) creates the controller, wires the coordinator's
+  two functions to `scrollToBottomForSend` / `messageInputDidBecomeFocused`, and
+  registers them with the host via `scrollToBottomTrigger { … }` /
+  `messageInputFocusTrigger { … }`. This is how the host can imperatively scroll
+  the transcript to the bottom (e.g. right before sending) or focus the input.
+- `updateUIViewController` (`:220`) runs on every SwiftUI render. It re-pushes
+  all closures and scalars onto the controller (most controller setters have a
+  `didSet` that forwards into the data source or triggers a reconfigure), then
+  finishes by assigning `messagesViewController.state = .init(...)` (`:289`).
+
+Two subtleties:
+
+- **Ordering matters.** `bottomBarHeight` is assigned *before* `state`
+  (`:227`–`:229`) so its deferred inset update enqueues ahead of the initial
+  load's scroll-to-bottom completion.
+- **Context-menu gating** (`:277`–`:286`): while the custom context menu is
+  presented, the controller's `view.isUserInteractionEnabled` is turned off and
+  the collection view's `panGestureRecognizer` is bounced
+  (disabled→enabled) to cancel an in-flight scroll; when the menu dismisses,
+  `restoreBottomInsetAfterContextMenu()` runs.
+
+---
+
+## 4. The data source and update pipeline
+
+### A manual data source, not a diffable one
+
+`MessagesCollectionViewDataSource`
+(`.../Data Source/MessagesCollectionViewDataSource.swift:9`) is a plain
+`@MainActor NSObject` conforming to `UICollectionViewDataSource`. It is backed by
+a stored array with a `didSet` that recomputes the layout delegate:
+
+```swift
+var sections: [MessagesCollectionSection] = [] {
+    didSet {
+        layoutDelegate = DefaultMessagesLayoutDelegate(
+            sections: sections, oldSections: layoutDelegate.sections)
+    }
+}
+```
+
+(`:10`). Recomputing on every assignment lets deletion animations read the
+pre-delete item from `oldSections` (see §7/§11). `numberOfSections`,
+`numberOfItemsInSection`, and `cellForItemAt` read straight from `sections`
+(`:80`+).
+
+The abstraction the controller depends on is the protocol
+`MessagesCollectionDataSource`
+(`.../Data Source/MessagesCollectionDataSource.swift:7`), which refines both
+`UICollectionViewDataSource` and `MessagesLayoutDelegate`. The controller holds
+`private let dataSource: MessagesCollectionDataSource` and sets
+`messagesLayout.delegate = dataSource`, so the concrete data source is *also*
+the layout's sizing/animation delegate (forwarding to `DefaultMessagesLayoutDelegate`).
+
+### One section, always
+
+There is exactly one section. `processUpdates`
+(`MessagesViewController.swift:1077`) assembles the cell array and wraps it:
+
+```swift
+let sections: [MessagesCollectionSection] = [
+    .init(id: 0, title: "", cells: cells)
+]
+```
+
+(`:1160`). `MessagesCollectionSection`
+(`Message Models/MessagesCollectionSection.swift`) is a `DifferentiableSection`
+whose `differenceIdentifier` is `id` and whose `isContentEqual` compares only
+`id` — so section content always expresses as element-level diffs, never a
+section reload.
+
+Inside `processUpdates`, the cell array starts as the processed `messages`
+verbatim, then:
+
+- prepends a leading `.conversationInfo(conversation)` cell when
+  `hasLoadedAllMessages` and the header mode allows (`:~1118`);
+- injects `.agentOutOfCredits(...)` cells after the relevant agent's last group,
+  driven by `agentPowerDepletedByInboxId` (`:~1148`);
+- clears the `.loadingPreviousMessages` flag on any update (`:~1090`).
+
+### Computing and applying the diff
+
+`performUpdate` (`MessagesViewController.swift:1213`):
+
+```swift
+let changeSet = StagedChangeset(source: dataSource.sections, target: sections)
+                    .flattenIfPossible()
+guard !changeSet.isEmpty else { completion?(); return }
+...
+collectionView.reload(
+    using: changeSet,
+    interrupt: { !$0.sectionInserted.isEmpty },
+    onInterruptedReload: { /* reloadData + restore bottom anchor */ },
+    completion: { ... },
+    setData: { data in self.dataSource.sections = data }
+)
+```
+
+`animated` is decided in `state.didSet` as
+`oldValue?.conversation.id == state.conversation.id` — switching conversations
+is unanimated; updates within a conversation animate. When not animated, the
+`reload` runs inside `UIView.performWithoutAnimation`.
+
+The `reload(using:interrupt:onInterruptedReload:completion:setData:)` helper is
+the vendored ChatLayout/DifferenceKit applier
+(`Helpers/UICollectionView+DifferenceKit.swift:10`). Per staged `Changeset` it
+opens a `performBatchUpdates`, calls `setData(changeset.data)` first (keeping the
+data source in lock-step with each staged mutation), then applies section
+deletes/inserts/reloads/moves and element deletes/inserts/moves.
+
+The load-bearing detail — **content updates become `reconfigureItems`, not
+`reloadItems`** (`:81`):
+
+```swift
+if !changeset.elementUpdated.isEmpty {
+    let indexPaths = changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) }
+    reconfigureItems(at: indexPaths)
+    (collectionViewLayout as? MessagesCollectionLayout)?.reconfigureItems(at: indexPaths)
+}
+```
+
+`reconfigureItems` keeps the existing cell (and its hosted SwiftUI view) and
+re-runs `setup(item:config:)`, an in-place update rather than a teardown. The
+custom layout's own `reconfigureItems` must be called too, because the layout
+only re-measures cells it has been told about (see the pairing note in §8).
+
+Two special paths:
+
+- **`interrupt` on section inserts.** Section inserts happen only on the initial
+  load. When the changeset contains one, the helper bails out of staged batch
+  updates and calls `onInterruptedReload`, which in the controller does
+  `reloadData()` then `messagesLayout.restoreContentOffset(...)` anchored to the
+  last footer/bottom (`MessagesViewController.swift:~1236`). So the first paint
+  is a hard reload pinned to the bottom, not an animated batch update.
+- **Off-window.** If `window == nil` the helper skips animation entirely:
+  `setData(last)` then `reloadData()`.
+
+`flattenIfPossible()` (`Helpers/UICollectionView+DifferenceKit.swift:104`)
+coalesces DifferenceKit's separate delete-stage and insert-stage into one
+`Changeset` when it is safe to (pure element delete followed by pure element
+insert, no section changes). DifferenceKit splits them to dodge
+`UICollectionView` limitations; flattening lets the custom layout see both in
+one batch so cross-animations are correct.
+
+### Changes that carry no changeset
+
+Some inputs change how a cell renders without changing any item's value, so the
+controller reconfigures visible cells by hand — always pairing
+`collectionView.reconfigureItems(at:)` **with** `messagesLayout.reconfigureItems(at:)`:
+
+- `expandedMessageIds.didSet` → `reconfigureCells(forMessageIds:)`
+  (`MessagesViewController.swift:596`) for long-body expand/collapse.
+- `agentPowerDepletedByInboxId.didSet` → `reconfigureCells(forSenderInboxIds:)`
+  then replays `self.state = state` (`:1054`).
+- `applySpaceLinkHandling(...)` → `reconfigureAllMessageCells()` (`:1040`) when
+  the conversation Space link arrives.
+
+---
+
+## 5. `SetActor`: serializing updates and interruptions
+
+Overlapping `performBatchUpdates` on a self-sizing custom layout crash or
+mis-animate. `SetActor` (`Helpers/SetActor.swift:4`) exists to serialize
+collection mutations behind interface animations.
+
+It is a set with reaction callbacks:
+`final class SetActor<Option: SetAlgebra, ReactionType>` with
+`var options: Option { didSet { optionsChanged(...) } }`. A `Reaction` has an
+`Action` (`.onEmpty`, `.onChange`, `.onInsertion(opt)`, `.onRemoval(opt)`) and an
+`ExecutionType` (`.once` / `.eternal`); `.once` reactions are removed after
+firing.
+
+The controller holds two (`MessagesViewController.swift:90`):
+
+- `currentInterfaceActions: SetActor<Set<InterfaceActions>, ReactionTypes>` —
+  in-flight UIKit activity: `.changingKeyboardFrame`, `.changingContentInsets`,
+  `.changingFrameSize`, `.sendingMessage`, `.scrollingToTop`,
+  `.scrollingToBottom`, `.updatingCollectionInIsolation`,
+  `.determiningBottomBarHeight` (`:71`).
+- `currentControllerActions: SetActor<Set<ControllerActions>, ReactionTypes>` —
+  `.loadingInitialMessages`, `.loadingPreviousMessages`, `.updatingCollection`
+  (`:82`).
+
+The gate, in `processUpdates` (`:1170`):
+
+```swift
+guard currentInterfaceActions.options.isEmpty else {
+    scheduleDelayedUpdate(for: sections, animated: animated, completion: completion)
+    return
+}
+performUpdate(...)
+```
+
+If any interface action is in flight, the update is not applied. Instead
+`scheduleDelayedUpdate` (`:1188`) registers a `.once`, `.onEmpty` reaction:
+
+```swift
+currentInterfaceActions.removeAllReactions(.delayedUpdate)          // keep only the latest
+let reaction = Reaction(type: .delayedUpdate, action: .onEmpty, executionType: .once,
+    actionBlock: { [weak self] in self?.processUpdates(...) })
+currentInterfaceActions.add(reaction: reaction)
+```
+
+The moment the interface-actions set drains to empty, the pending update
+replays. `removeAllReactions(.delayedUpdate)` first means only the latest pending
+update survives — coalescing bursts behind animations. During the diff itself the
+controller inserts `.updatingCollection` / `.updatingCollectionInIsolation` and
+clears them in the completion.
+
+If the user drags mid-update, `handleScrollViewDidScroll` calls
+`interruptCurrentUpdateAnimation()` (`:1324`), which schedules a no-op
+`performBatchUpdates` to settle the layout cleanly.
+
+---
+
+## 6. The custom layout engine
+
+`MessagesCollectionLayout` (`Messages Collection Layout/MessagesCollectionLayout.swift:8`)
+is a fully manual `UICollectionViewLayout` — not flow, not compositional. It
+overrides the class hooks so UIKit uses the custom subclasses (`:66`):
+
+```swift
+open override class var layoutAttributesClass: AnyClass { MessagesLayoutAttributes.self }
+open override class var invalidationContextClass: AnyClass { MessagesLayoutInvalidationContext.self }
+```
+
+### Why not flow / compositional
+
+Neither stock layout can simultaneously do self-sizing with estimated heights,
+bottom-anchoring (chat style), *and* scroll-position preservation when items
+insert above the viewport. This engine keeps its own source-of-truth geometry
+model and answers every `layoutAttributesForElements(in:)` query by walking it.
+There is even an explicit comment (`:365`+) noting that it must return `nil` from
+`layoutAttributesForElements(in:)` between
+`invalidateLayout(invalidateDataSourceCounts:)` and
+`prepare(forCollectionViewUpdates:)` — the same UIKit bug that
+`UICollectionViewCompositionalLayout` sidesteps with a private API (`:383`).
+
+### The dual-model state controller
+
+`MessagesLayoutStateController`
+(`MessagesLayoutStateController.swift:24`) is the geometry engine. It holds
+**two complete layout models** so it can supply correct pre- and post-batch
+attributes for animations (`:98`):
+
+```swift
+private var layoutBeforeUpdate: LayoutModel<Layout>
+private var layoutAfterUpdate: LayoutModel<Layout>?
+```
+
+The layout's `state` field (`.beforeUpdate` / `.afterUpdate`) selects which one
+each query reads. `commitUpdates()` promotes after→before when a batch completes.
+
+The model tree, top down:
+
+- **`LayoutModel`** (`Models/LayoutModel.swift`) holds
+  `sections: ContiguousArray<SectionModel>` plus identifier→index caches.
+  `assembleLayout()` is the top-level offset accumulator: it starts
+  `offsetY = settings.additionalInsets.top`, assigns each section's `offsetY`,
+  and advances by `section.height + interSectionSpacing`.
+- **`SectionModel`** (`Models/SectionModel.swift`) holds an optional zero-height
+  header/footer and `items: ContiguousArray<ItemModel>`. `assembleLayout()`
+  walks items accumulating `offsetY`; `setAndAssemble(item:at:)` computes the
+  height delta and shifts all lower items + the footer (parallelized with
+  `DispatchQueue.concurrentPerform`).
+- **`ItemModel`** (`Models/ItemModel.swift`) is a value type storing an estimated
+  `preferredSize`, an optional `calculatedSize`, `offsetY`, `calculatedOnce`,
+  `alignment`, and `interItemSpacing`. `size = calculatedSize ?? preferredSize`.
+
+So a cell's absolute Y = `additionalInsets.top` + accumulated section offsets +
+intra-section item offset. `collectionViewContentSize` reads the last section's
+`locationHeight + additionalInsets.bottom` (with a `-0.0001` width fudge that
+works around an internal UIKit rect-check bug).
+
+### Attributes and caching
+
+`MessagesLayoutAttributes`
+(`MessagesLayoutAttributes.swift`) subclasses `UICollectionViewLayoutAttributes`
+and adds `alignment`, `interItemSpacing`, `additionalInsets`, `viewSize`,
+`layoutFrame`, etc., with a deep `copy(with:)` and an extended `isEqual`.
+
+The controller keeps two caches: a fast-path `cachedAttributesState`
+(last `(rect, [attributes])` block) and a persistent
+`cachedAttributeObjects[state][kind][ItemPath]` of the actual attribute *objects*
+— reusing and mutating the same instance rather than reallocating. Reusing the
+identical object is what keeps insert/delete animation copies in sync (see §11).
+
+Horizontal placement is applied in `itemFrame(for:kind:at:isFinal:)`
+(`MessagesLayoutStateController.swift:314`) based on the item's alignment
+(`MessagesListItemAlignment`, `Storage/Models/MessagesListItemType.swift:3`):
+`.leading`, `.trailing`, `.center`, or `.fullWidth`. Per
+`MessagesListItemType.alignment` (`:172`), invite / conversationInfo / builder /
+activating cards are `.center`; **everything else, including `.messages`, is
+`.fullWidth`.** That means message rows are full-width cells and **left/right
+bubble placement is done inside SwiftUI**, not by the layout (see §8).
+
+### Invalidation
+
+`MessagesLayoutInvalidationContext`
+(`MessagesLayoutInvalidationContext.swift`) adds one flag,
+`invalidateLayoutMetrics` (default `true`); when `false` the layout skips the
+expensive full resize/reassemble — used for pure content-offset/bounds changes
+(a scroll should not re-measure everything).
+
+`invalidateLayout(with:)` (`MessagesCollectionLayout.swift:633`) translates
+context flags into a `PrepareActions` OptionSet (`:102`):
+`.recreateSectionModels`, `.updateLayoutMetrics`, `.cachePreviousWidth`,
+`.cachePreviousContentInsets`, `.switchStates`. `prepare()` (`:260`) then acts on
+them — recreating the section tree from the data source, or (metrics-only)
+resetting each item's size and re-assembling sections concurrently.
+
+Visible-range search is not a linear scan: `allAttributes(at:visibleRect:)`
+(`MessagesLayoutStateController.swift:981`) uses a binary search
+(`RandomAccessCollection+Extension.swift`) to find the first visible item per
+section, then walks forward until items leave the viewport. On animated batch
+updates it can further restrict to items visible before *or* after the update
+when `processOnlyVisibleItemsOnAnimatedBatchUpdates` is set.
+
+---
+
+## 7. Self-sizing, estimated heights, and bottom-anchoring
+
+### Estimated vs. exact sizes
+
+Sizes originate from the delegate's `sizeForItem` returning an `ItemSize`
+(`Models/ItemSize.swift`): `.auto`, `.estimated(CGSize)`, or `.exact(CGSize)`.
+`ItemModel` stores both the estimated `preferredSize` and an optional
+`calculatedSize` (the measured value), returning `calculatedSize ?? preferredSize`.
+
+`DefaultMessagesLayoutDelegate`
+(`.../Data Source/DefaultMessagesLayoutDelegate.swift:23`) returns `.estimated`
+for cells and `.exact(.zero)` for the (always-present, invisible) header/footer.
+Estimates are hand-tuned per kind (invite 348, conversationInfo 300, date/update
+48, agentBuilderSummary 320, agentDmInfo 260, typing 48, etc.), and message
+groups get a detailed estimate from `estimatedHeight(for:width:)` (`:69`), which
+sums per-message estimates from `messageHeight` (`:182`) — text scaled by
+~35 chars/line × 21pt, attachments by aspect ratio, reply headers, reactions,
+transcript rows, and the sent-status row. Accuracy matters: the comment (`:74`)
+warns that a card-only group that self-sizes ~10× larger than its estimate can't
+be absorbed by the bottom anchor during the open transition, so the estimate must
+be close.
+
+### Self-sizing report-back
+
+Cells report their measured size via `preferredLayoutAttributesFitting`
+(overridden to `layoutAttributesForHorizontalFittingRequired` — height measured,
+width fixed). UIKit then calls:
+
+- `shouldInvalidateLayout(forPreferredLayoutAttributes:withOriginalAttributes:)`
+  (`MessagesCollectionLayout.swift:453`). The predicate (`:479`) invalidates when
+  the item has never been calculated, or the measured height differs (rounded)
+  **and the item is not exactly sized**, or alignment/spacing changed. The
+  exact-sized exclusion (`isExactlySized`, `:1062`) is a Convos-specific fix for
+  an infinite recursive-layout loop when an empty-state cell hosts taller than
+  the delegate's fixed height.
+- `invalidationContext(forPreferredLayoutAttributes:...)` (`:488`) writes the
+  measured size back into the model via `controller.update(preferredSize:...)`,
+  computes the height difference, and keeps pending-animation attributes in sync
+  so an insert/delete animation doesn't start from the stale estimate.
+
+### Bottom-anchoring (chat style)
+
+The list is **not inverted and not transformed**. The model tree is top-down
+(oldest at top); "stick to bottom" is achieved with explicit content-offset
+compensation, gated by the protocol flag `keepContentOffsetAtBottomOnBatchUpdates`
+(read throughout `MessagesLayoutStateController.swift`, e.g. `:519`, `:659`,
+`:885`).
+
+- **In-band growth.** When a visible item grows/shrinks during self-sizing,
+  `invalidationContext(forPreferredLayoutAttributes:...)` adds the delta to
+  `context.contentOffsetAdjustment.y` (`MessagesCollectionLayout.swift:569`) so
+  the scroll offset moves in lockstep and the visible content stays put.
+- **Out-of-band bottom growth.** For a large one-shot growth of the *last* item
+  outside a batch update (media finishing async load, a sent message appending),
+  compensating in one frame would snap the whole list. The layout detects this
+  (`:557`, threshold `Constant.outOfBandGrowthRevealThreshold = 12.0`) and instead
+  fires `onOutOfBandBottomGrowth`, letting the controller reveal the growth with
+  an animated scroll. `compensatesAllSelfSizingGrowth` stays `true` until
+  `viewDidAppear` to avoid a conversation-open flicker.
+- **Batch updates.** `targetContentOffsetForProposedContentOffset` (`:710`)
+  overrides the proposed offset when `controller.proposedCompensatingOffset != 0`;
+  `finalizeCollectionViewUpdates()` (`:775`) applies any leftover
+  `batchUpdateCompensatingOffset` via a fresh invalidation context.
+
+### Position snapshots (pagination)
+
+`MessagesLayoutPositionSnapshot`
+(`MessagesLayoutPositionSnapshot.swift`) captures `{indexPath, kind, edge, offset}`.
+`getContentOffsetSnapshot(from:)` / `restoreContentOffset(with:)`
+(`MessagesCollectionLayout.swift:193`/`:233`) record and restore the position of a
+reference item, so when older messages load *above* the viewport the visible
+content stays logically stationary. During batch updates the controller also
+records an `ItemToRestore` (last visible item + its offset from the visible
+bottom) and adjusts its index as inserts/deletes shift it, computing a
+`proposedCompensatingOffset` so the anchor item ends at the same screen position.
+
+### Quiescent layout passes
+
+`MessagesCollectionView.layoutSubviews`
+(`.../View Controller/MessagesCollectionView.swift:23`) wraps
+`super.layoutSubviews()` in `performWithoutAnimation` **unless** the layout is
+mid-batch-update or inside an explicit `UIView` animation. This prevents a
+SwiftUI-render-triggered self-sizing invalidation from inheriting an in-flight CA
+transaction, which would make content dip by half the height delta for a few
+frames. The view also exposes `onDidLayoutSubviews`, which the controller uses to
+report content-height changes back to the host (`onContentHeightChanged`).
+
+---
+
+## 8. Cells and SwiftUI hosting
+
+### Two registered cell classes
+
+Only two cell classes are registered
+(`MessagesCollectionViewDataSource.registerCells`, `:65`):
+`MessagesListItemTypeCell` and `TypingIndicatorCollectionCell`.
+`CellFactory.createCell` (`.../Data Source/CellFactory.swift:104`) branches on
+the item: `.typingIndicator` → `TypingIndicatorCollectionCell`; **every other
+case** → the single `MessagesListItemTypeCell` via `cell.setup(item:config:)`.
+(The enum's per-case `cellReuseIdentifier` values exist but the composer only
+ever dequeues these two.)
+
+`CellConfig` (`CellFactory.swift:7`) is the immutable bundle of everything a cell
+needs — the item id, resolvers, and all `on…` closures — rebuilt fresh per
+`cellForItemAt` in the data source with `[weak self]` trampolines back to the
+data source's handlers.
+
+### Cells host SwiftUI via `UIHostingConfiguration`
+
+`MessagesListItemTypeCell.setup(item:config:)`
+(`.../Cells/MessagesListItemTypeCell.swift:63`) assigns
+`contentConfiguration = UIHostingConfiguration { … }` with a `switch` over the
+item case to the SwiftUI view — `MessagesGroupView` for `.messages`, `InviteView`,
+`ConversationInfoPreview`, `AgentLostPowerStatus`, and so on. The root gets
+`.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: rootAlignment)`, an
+`.id("message-cell-\(item.differenceIdentifier)")` (`:173`) that resets per-cell
+SwiftUI state across reuse, and injected `.environment` values (context menu,
+resolvers, link router, Space URL).
+
+Note this is `UIHostingConfiguration`, **not** `UIHostingController` — the cell
+carries no child view controller.
+
+Because message cells are full-width, **the bubble's left/right placement lives
+in SwiftUI**: `MessagesGroupView` branches on `sender.isCurrentUser` to add
+avatar-width leading padding for others and `HStack` + `Spacer()` right-alignment
+for the current user.
+
+The hosting root uses top alignment (`rootAlignment` = `.top` for centered items,
+`.topLeading` otherwise, `:73`) rather than centering, so in-cell growth
+animations don't produce a half-delta vertical jump (comment at `:64`).
+
+### No `prepareForReuse` clearing — deliberate
+
+There is intentionally **no** `prepareForReuse` that clears the configuration
+(comment at `MessagesListItemTypeCell.swift:45`). `setup(item:)` runs on every
+dequeue and assigns a fresh `UIHostingConfiguration` of the same generic type,
+which UIKit applies as an *in-place update* of the existing hosting controller
+rather than a teardown-and-rebuild. Per-item SwiftUI state still resets via the
+content's `.id(...)`. Clearing the configuration on reuse measurably cost scroll
+time. `TypingIndicatorCollectionCell.prepare(with:)` follows the same pattern,
+hosting `TypingIndicatorView` keyed on the joined typer inbox ids.
+
+`preferredLayoutAttributesFitting` (`:185`) calls
+`layoutAttributesForHorizontalFittingRequired` so self-sizing measures height for
+a fixed width (see §7).
+
+---
+
+## 9. Scroll behavior, pagination, and keyboard
+
+### Scroll-to-bottom decision matrix
+
+The decision runs in the `state.didSet` completion, after the diff applies
+(`MessagesViewController.swift:163`):
+
+```swift
+if isInitialLoad {
+    scrollToBottom(animated: false)                       // jump to bottom, no animation
+} else if isNewMessage {
+    if lastGroup.isMessagesGroupSentByCurrentUser {
+        scrollToBottom()                                  // my message: always
+    } else if nearBottom && !userScrolling {
+        scrollToBottom()                                  // someone else's: only if near bottom
+    }
+} else if isPinnedToBottom && !userScrolling {
+    scrollToBottom()                                      // in-place bottom growth: re-pin
+}
+```
+
+`isNewMessage` compares `state.messages.lastMessageId` to the previous last id.
+
+Gating flags:
+
+- `isUserInitiatedScrolling` (`:100`) = `collectionView.isDragging || isDecelerating`.
+- `isNearBottom` (`:115`) = `distanceFromBottom <= collectionView.frame.height`
+  (within one screen).
+- `isPinnedToBottom` (`:127`) is a **latched** flag, updated in
+  `handleScrollViewDidScroll` (`:1305`) as
+  `distanceFromBottom <= Constant.pinnedToBottomTolerance` (8pt). Being latched
+  (not a live distance check) means it answers "was the user pinned *before* this
+  update?", so read receipts / reactions / typing growth never yank a user who
+  had scrolled up back to the bottom.
+
+### Long vs. short scroll
+
+`scrollToBottom(animated:completion:)` (`:913`) flushes pending insets, computes
+`contentOffsetAtBottom` clamped to `lowestOffset = -adjustedContentInset.top`
+(not zero — sheet hosts inset content off the top), and early-returns if within
+0.5pt. Then:
+
+- `performLongScrollToBottom` (`:979`) for jumps larger than one screen — a
+  `ManualAnimator` (`Helpers/ManualAnimator.swift`, a `CADisplayLink`-driven
+  custom-duration animator) over 0.25s ease-in-out, because UIKit can't set a
+  custom scroll duration.
+- `performShortScrollToBottom` (`:995`) otherwise — `UIView.animate` +
+  `setContentOffset(animated: true)`.
+
+There is **no floating "scroll to bottom" button**; scrolling is entirely
+programmatic, surfaced to hosts through the representable's trigger closure.
+
+### Top pagination ("load previous")
+
+`scrollViewDidScrollToTop` (`:1292`) and `handleScrollViewDidScroll` (`:1301`)
+trigger `loadPreviousMessages()` when
+`contentOffset.y <= -adjustedContentInset.top` (the very top), gated so it
+doesn't fire during initial/previous loads or programmatic scrolls.
+`loadPreviousMessages` (`:891`) no-ops if `hasLoadedAllMessages`, else inserts
+`.loadingPreviousMessages` and calls the host closure; the flag clears on the
+next update (the repo may decide there are no more and never emit again). The
+custom layout's offset compensation keeps the visible content stationary while
+the older messages insert above.
+
+### Keyboard
+
+The controller is a `KeyboardListenerDelegate` (`:1387`, registered in
+`setupUI`). `keyboardWillChangeFrame` (`:1388`) stashes the frame change, inserts
+`.changingKeyboardFrame`, computes the new bottom inset via
+`calculateNewBottomInset` (`max(keyboardInset, bottomBarHeight)` in the
+collection view's coordinate space), and — if the inset is growing — sets
+`pendingScrollToBottomAfterKeyboard`. `keyboardDidChangeFrame` clears the flag
+and performs the deferred scroll. `updateCollectionViewInsets(to:with:)` (`:1524`)
+animates `contentInset.bottom` inside `performBatchUpdates` while restoring a
+position snapshot so content doesn't jump. `keyboardDismissMode = .interactive`.
+
+### Sheet hosts and safe area
+
+`ignoredSafeAreaRegions` is chosen in `MessagesView.body` as
+`hostsBottomBar ? .all : .container` (`MessagesView.swift:146`): when the
+controller owns its bar it does the keyboard math itself, so SwiftUI must not
+also inset (double-counting); external-bar hosts do the opposite. The controller
+mirrors this with `applyContentInsetAdjustmentBehavior` (`.always` when it hosts
+its own bar, `.never` otherwise) and adds `additionalSafeAreaInsets.top =
+topContentInset` for hosts that float chrome over the list. `clippedTopOverflow`
+plus a latched `shortContentTopSlack` rest short content against the bottom via a
+top inset (rather than offsetting item frames, which caused a recursive
+self-sizing crash). Bottom-bar-height writes are sometimes deferred one runloop
+tick to avoid a re-entrant-layout assertion crash when a sheet relayout arrives
+inside a UIKit layout pass.
+
+---
+
+## 10. Gestures, context menu, reactions, swipe-to-reply
+
+The message context menu is **fully custom** — raw `UIGestureRecognizer`s plus a
+SwiftUI overlay. It is **not** `UIContextMenuInteraction`, not SwiftUI
+`.contextMenu`, and there is no `UITargetedPreview`.
+
+### Gesture detection
+
+`MessageGestureModifier` (`MessagesListView/MessageContextMenuWrapper.swift:21`),
+applied to every bubble via `.messageGesture(...)`, overlays a UIKit
+`GestureOverlayView` that installs **five raw recognizers** on a custom
+`GesturePassthroughView`:
+
+- `UIPanGestureRecognizer` → swipe-to-reply.
+- `UILongPressGestureRecognizer` (`minimumPressDuration = 0.5`) → context menu.
+- `UITapGestureRecognizer` (2 taps) → double-tap react.
+- `UITapGestureRecognizer` (1 tap, `require(toFail: doubleTap)`) → single tap
+  (open invite / agent share / attachment / avatar per content type).
+- `UILongPressGestureRecognizer` (`minimumPressDuration = 0`) → a press tracker
+  driving the scale-down "pressed" feedback.
+
+`GesturePassthroughView.hitTest` (`:376`) lets taps fall through to tappable
+links (`LinkHitTestable`) and honors `excludedFrames` (avatars, reaction pills)
+so bubble gestures don't eat them. The press-scale grows the bubble to `1.03`
+(anchored to the sender's edge, `.easeInOut(0.25)`), and only activates after
+0.15s and only if the scroll view isn't dragging. The long-press handler fires a
+`UIImpactFeedbackGenerator(style: .medium)` and calls `contextMenuState.present(...)`.
+
+### Presentation state
+
+`MessageContextMenuState`
+(`MessagesListView/MessageContextMenu/MessageContextMenuState.swift`) is an
+`@Observable` holding `presentedMessage`, `bubbleFrame`, `bubbleStyle`,
+`isOutgoing`, and `presentedSegment` (`.whole` / `.splitText` / `.splitLink`, so
+a text message with an edge link presents only the pressed sub-cell). It is owned
+by `ConversationView` so the surrounding pager can react to it (below).
+
+### The menu UI and animation
+
+`MessageContextMenuOverlay`
+(`MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift`) renders as
+a SwiftUI `.overlay` in `MessagesView`, suppressed when the host renders the menu
+at its own root (the conversation sheet, to avoid clipping). It layers, in a
+`ZStack`:
+
+- **Background dimming** — `Color.black.opacity(0.15)` + `.ultraThinMaterial`,
+  tap-to-dismiss.
+- **Reactions bar** — a Liquid-Glass capsule
+  (`GlassEffectContainer` / `.glassEffect(.regular.interactive(), in: .capsule)`)
+  that scales `0.01`→`1.0` from the bubble to a floating drawer above it (spring
+  `response 0.28`, `dampingFraction 0.78`), with staggered emoji entrance (each
+  emoji blur `10`→`0`, scale `0`→`1`, rotation `-15°`→`0`, delayed
+  `0.025 * index`).
+- **Action menu** — Reply / Copy / Share / Save rows in a rounded glass card,
+  scaling from the bubble's top corner; Reply is delayed 0.22s after dismiss.
+- **Bubble preview** — a live re-render of the pressed bubble that springs from
+  its source rect to a computed end rect, with a scaling drop shadow.
+
+Drag-to-dismiss (`DragGesture(minimumDistance: 10)`) dismisses past a 150pt
+threshold; the menu and bar follow at `0.6` ratio and the dim fades by drag
+progress. If the source cell has scrolled away, dismissal "poofs" (blur + fade +
+scale) instead of flying back.
+
+### Pager lock during the menu
+
+While the menu is up, `MessagesView` fades and disables the composer, and
+`ConversationView` disables the horizontal tab pager:
+`isPagingDisabled = contextMenuState.isPresented || agentContextMenuState.isPresented`
+applied via `.scrollDisabled(...)` (`Convos/Conversation Detail/ConversationView.swift:1393`).
+This is also why the representable bounces the collection view's pan recognizer
+(§3) — so a swipe begun mid-press doesn't drag the user out of the conversation.
+
+### Reactions
+
+- **Double-tap to react** fires `UIImpactFeedbackGenerator(style: .light)` and
+  toggles the ❤️ (or the message's single existing emoji).
+- **From the reactions bar**, `selectReaction` pops the emoji (scale
+  `1.0`→`1.2`→`1.0`), collapses the drawer, and auto-dismisses.
+- **Custom emoji** via the "+" button toggles the system emoji keyboard
+  (`Reactions/EmojiPickerView.swift`, a `UIKeyInput` `UIViewRepresentable` with
+  `textInputMode = .emoji`).
+- **Display** on bubbles is `Reactions/ReactionIndicatorView.swift` — a pill below
+  the bubble; newly added emojis stagger in (blur/scale/rotation, `0.04 * index`).
+  It is wired in `MessagesGroupView.reactionRow` using the **live** reactions so
+  the height change lands inside the UIKit batch update.
+- **The full breakdown** ("who reacted") is `ReactionsDrawerView` (app target),
+  opened by tapping the pill (`onTapReactions`). A separate expandable capsule
+  component lives in `Reactions/MessageReactionsView.swift`.
+
+### Swipe-to-reply
+
+The pan recognizer (`MessageContextMenuWrapper.swift`) begins only on a
+predominantly-horizontal right-swipe, and disables the enclosing scroll view's
+pan while active. It rubber-bands past a 60pt threshold, fires
+`UIImpactFeedbackGenerator(style: .medium)` at the crossing, shows an
+`arrowshape.turn.up.left.fill` indicator that scales/fades with progress, and on
+release springs back and fires `onReply` only if it naturally ended past
+threshold. A `swipeCancellationToken` lets the pager cancel an in-flight swipe
+without firing a reply when the page changes
+(`ConversationView.swift:777`). Long-pressing a reply-parent thumbnail
+(`ReplyReferenceView.swift`) presents that parent with a medium haptic.
+
+### Haptics inventory (messages package)
+
+- `.light` — double-tap to react (`MessageContextMenuWrapper.swift:147`).
+- `.medium` — long-press to open the menu (`:153`); swipe crossing the reply
+  threshold (`:494`); long-pressing a reply parent (`ReplyReferenceView.swift:332`).
+- The explode/countdown control uses `.light`/`.heavy` impacts and an `.error`
+  notification (`ExplodeButton.swift`).
+
+All haptics are inline `UIImpactFeedbackGenerator` / `UINotificationFeedbackGenerator`
+(no shared haptics manager).
+
+---
+
+## 11. Insertion / update / deletion animations
+
+Two cooperating systems produce the "message rises and fades into place" effect.
+
+### Layout level (the cell slide)
+
+`DefaultMessagesLayoutDelegate`:
+
+- `initialLayoutAttributesForInsertedItem` (`:259`): sets `alpha = 0`; for an
+  inserted `.messages` item shifts `center.y += 120` (`applyMessageAnimation`,
+  `:326`); for `.date` / `.update` separators shifts `center.y += 40` and scales
+  to `0.1`. The new row starts 120pt lower and fades/slides up.
+- `finalLayoutAttributesForDeletedItem` (`:282`) mirrors this for removals,
+  reading `oldSections` for the pre-delete geometry.
+
+`MessagesCollectionLayout` supplies these through
+`initialLayoutAttributesForAppearingItem` (`:807`) and
+`finalLayoutAttributesForDisappearingItem` (`:856`), which undo the total
+content-offset compensation, apply the delegate hook, and — crucially — stash a
+live copy in `attributesForPendingAnimations` so that if the cell self-sizes
+mid-animation, the animation's start/target frames update instead of visibly
+jumping from the estimated height. Reloaded items additionally get `alpha = 0` +
+a scale-0 transform.
+
+### SwiftUI level (per-message spring)
+
+`MessagesGroupItemView`:
+
+- `MessageAppearanceModifier` (`:514`): a bubble's initial pose is
+  `scaleEffect(0.9)`, `rotationEffect ±0.05 rad` (direction by incoming/outgoing),
+  `offset(x: ±20, y: 40)`.
+- `.onAppear` (`:113`): if the message `origin == .inserted`, springs the pose
+  away with `.spring(response: 0.35, dampingFraction: 0.8)`; otherwise
+  `.animation(.none)` so pre-existing history does not animate. Guarded so it
+  fires once.
+
+`MessagesGroupView` mirrors this at the group level (sender label and avatar
+slide/blur in) and routes appended content through an `animatedGroup` mirror
+updated only in `onChange` (`:762`), so height changes land unanimated and the
+controller reveals them via an animated scroll (§7 out-of-band growth). Reaction
+and read-receipt rows use the same mirrored-`onChange` trick so their height
+change lands inside the UIKit batch.
+
+Content updates (reactions, status, edits) reach the cell as `reconfigureItems`
+(§4), so they animate as in-place SwiftUI transitions
+(`.blurReplace`, scale/opacity) rather than a cell teardown.
+
+### Send flow
+
+On send, `MessagesView` calls the scroll-to-bottom trigger before
+`onSendMessage()`. There is **no** "message flies up out of the composer"
+transition — the send animation is the 120pt layout slide-up + the SwiftUI spring
+plus an animated scroll-to-bottom. Optimistic messages carry `origin == .inserted`
+to gate the animation.
+
+### Typing / thinking indicators
+
+`PulsingCircleView` (`PulsingCircleView.swift`) is the dot-animation engine:
+`.typingIndicator` = 3 gray dots (size 10, 0.6s, `easeInOut.repeatForever`,
+staggered by `index * duration / count`); `.thinkingIndicator` = a single dot
+(1.2s, opacity 0.4–1.0). `TypingIndicatorBubbleView` wraps the dots in a tailed
+container; `TypingIndicatorView` adds overlapping ringed typer avatars for
+multi-typer. Indicators enter/leave with
+`.transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .bottomLeading)))`.
+
+---
+
+## 12. Constants and gotchas
+
+### Constants split
+
+- `Messages View Controller/Constants.swift` — bubble geometry: `maxWidth 0.75`,
+  `bubbleCornerRadius 20`, `minimumPressDurationForReactions 0.15`, and an iPad
+  bubble-width cap (`maxBubbleRowWidth = 440 - 16`).
+- A separate `enum Constant` nested in `MessagesViewController`
+  (`MessagesViewController.swift:1548`) — scroll/keyboard tuning:
+  `pinnedToBottomTolerance 8`, `outOfBandGrowthRevealThreshold 12`, and fallback
+  delays for context-menu inset restoration and composer settle.
+
+### Re-entrant layout crash avoidance
+
+Several mechanisms exist purely to avoid UIKit assertion crashes and open-transition
+flicker: the `SetActor` gating (§5), the deferred bottom-bar-inset updates (§9),
+the quiescent `layoutSubviews` pass (§7), and the exact-sized self-sizing
+exclusion (§7). Treat these as load-bearing — they encode hard-won fixes, not
+incidental caution.
+
+### Inactive / dead code to be aware of
+
+- `Message Models/TypingState.swift` defines `enum TypingState { case idle, typing }`
+  but nothing references it — legacy/dead.
+- The typing-indicator *path* is fully wired (enum case, `CellFactory` branch,
+  `TypingIndicatorCollectionCell`, delegate sizing) but **no site currently
+  constructs `.typingIndicator(typers:)` into the messages array**, so the
+  indicator is presently inactive. It would diff in/out like any other item if a
+  producer appended it. (The other `.typingIndicator` symbols found in the
+  codebase — in `HiddenMessagesView`, `StreamProcessor`, and the hidden-message
+  debug helpers — are an unrelated hidden-message *reason*, not this item case.)
+
+---
+
+## Appendix: how a single reaction reaches the screen
+
+A concrete trace, to tie the layers together:
+
+1. A reaction message arrives over XMTP and is persisted; GRDB's
+   `ValueObservation` fires.
+2. `MessagesRepository`'s throttled publisher emits a new
+   `ConversationMessagesResult` (≤ ~3/sec).
+3. `MessagesListProcessor` rebuilds the affected `MessagesGroup` — same `id`,
+   but its `rawMessages`/reactions differ, so its value changes.
+4. `MessagesListRepository` pushes the new `[MessagesListItemType]`;
+   `ConversationViewModel.messages` is reassigned on the main queue.
+5. SwiftUI re-renders `MessagesView`; the representable sets
+   `MessagesViewController.state`.
+6. `processUpdates` builds one `MessagesCollectionSection`; `performUpdate`
+   computes a `StagedChangeset`. The changed group has the same
+   `differenceIdentifier` but is not `isContentEqual`, so it lands in
+   `elementUpdated`.
+7. `UICollectionView+DifferenceKit.reload(using:)` calls `reconfigureItems(at:)`
+   on both the collection view and the custom layout.
+8. The cell's `setup(item:config:)` re-runs, updating the `UIHostingConfiguration`
+   in place; `ReactionIndicatorView` animates the new emoji in.
+9. The reaction row's added height self-sizes; the layout compensates the content
+   offset (or reveals it via an animated scroll if the user was pinned to the
+   bottom), keeping the reading position stable.
+
+[ChatLayout]: https://github.com/ekazaev/ChatLayout
+[DifferenceKit]: https://github.com/ra1028/DifferenceKit


### PR DESCRIPTION
## Summary

- use the generated `showAgentDm` bridge protocol now merged into `convos-shared/main`
- add a no-op-by-default `showAgentDm` destination to `HomeBridgeNavigation` and forward the generated `ChatPlugin` requirement through `HomeChatPlugin`
- wire the conversation Space home to select the existing Agent tab

No new navigator or conversation type is introduced: this opens the existing agent-DM conversation through the Agent tab.

## Stacking and merge order

This draft is intentionally stacked on Mike Roberts's context-reply work and must merge after that work reaches `dev`.

The current remote graph is:

1. `8cb5a240` — current rewritten `dev` base
2. `ca76ba07` — `Add context reply support with widget composer` (Mike Roberts)
3. `1607451d` — `Open agent DMs from the web bridge` (this PR)
4. `95d20d26` — a subsequent concurrent Mike Roberts push

Do not merge Mike's context-reply work through this PR. Once it lands on `dev`, re-fetch and rebase this branch onto the updated `dev`; `ca76ba07` should then fall out of the diff.

The later `95d20d26` commit is preserved rather than overwritten, but it also adds unrelated messages-list documentation and rewrites pairing fixtures. Those changes must land elsewhere or fall out before #1395 merges. The intended bridge commit changes only `ConvosCore/Package.swift`, both `Package.resolved` files, `ConversationView.swift`, and `HomeBridgePlugins.swift`.

## Review ownership

The [`pendingWidgetReplyContext` tab-lifecycle finding](https://github.com/xmtplabs/convos-ios/pull/1395#discussion_r3839040141) is valid but belongs to stacked commit `ca76ba07`: leaving the Agent tab clears `replyingToMessage` without clearing the pending widget context. It is deliberately not fixed in the subsequent bridge commit and has been [routed to Mike](https://github.com/xmtplabs/convos-ios/pull/1395#issuecomment-5387166764) to carry with the context-reply work.

Revalidation against the current rewritten refs also found that `expandCollapsedSheet` exists in neither `dev`, `ca76ba07`, nor this branch head; #1385 removed the conversation sheet in favor of tabs. The current bridge handler therefore uses the available native API, `selectTab(.agent)`, and does not introduce a call to a nonexistent sheet function.

## Consumer

The draft [convos-assistants consumer PR](https://github.com/xmtplabs/convos-assistants/pull/3546) declares [`showAgentDm(): void`](https://github.com/xmtplabs/convos-assistants/blob/89afa859182708b4ae6172b090cd410e74963455/packages/space-starter/template/native-bridge.ts#L58-L63) and [feature-detects/invokes it from `AskAgentButton`](https://github.com/xmtplabs/convos-assistants/blob/89afa859182708b4ae6172b090cd410e74963455/packages/space-starter/template/components/pages/ask-agent.tsx#L31-L46).

## Shared bridge dependency

[xmtplabs/convos-shared#8](https://github.com/xmtplabs/convos-shared/pull/8) has merged at `1dc9ad8c`.

The current remote head points `ConvosCore/Package.swift` and `ConvosCore/Package.resolved` to `main` at that commit. The Xcode workspace lockfile is still on the temporary PR branch at `6d04c55` after the concurrent push; it must be reconciled to `main`/`1dc9ad8c` in the final post-stack rebase.

## Verification

Verified:

- fetched force-rewritten `dev` at `8cb5a240` before acting, then re-fetched after the concurrent branch update
- current remote graph and ownership are recorded above
- the bridge commit itself changes only the intended five files
- `git diff --check` passes across the current PR diff
- SwiftPM independently resolved `convos-shared/main` at `1dc9ad8c` without unrelated package-pin churn

Could not verify locally:

- Xcode's package resolver cannot write its manifest diagnostics under `~/Library/Caches` in this sandbox; CI remains the workspace-resolution and full-app-build gate

Fresh CI on `95d20d26` passed Firebase archive/distribution, Integration Tests, SwiftLint, version alignment, Macroscope correctness, Claude review, KeychainIdentityStore, and cleanup. Unit Tests have one failure in stacked context-reply schema work: [`ConversationLastMessagePointerTests.swift:326`](https://github.com/xmtplabs/convos-ios/actions/runs/32653582502/job/97228788197) inserts the new `contextReply` column into a pre-migration table that does not contain it. That failure is not in the bridge commit and has been [routed to Mike](https://github.com/xmtplabs/convos-ios/pull/1395#issuecomment-5387246273); it is deliberately not fixed here.

This draft remains blocked on Mike's context-reply work landing on `dev`, removing the unrelated stacked changes, reconciling the workspace lockfile, and fixing that upstream migration test before merge.
