### PR TITLE
fix(conversation): rename the Context tab to Things

### DIFF
--- a/Convos/Conversation Detail/ConversationSegmentedControl.swift
+++ b/Convos/Conversation Detail/ConversationSegmentedControl.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// The conversation's Group | Agent | Context selector, floating in the top
+/// The conversation's Group | Agent | Things selector, floating in the top
 /// chrome under the conversation's title capsule.
 ///
 /// A pill segmented control rather than the system's: the design (Figma
@@ -11,7 +11,7 @@ import SwiftUI
 /// The selection chip is one view moved between slots by
 /// `matchedGeometryEffect`, not a background drawn per slot. That is what lets
 /// the slots size to their own labels - the previous bar could hard-code equal
-/// 102pt slots because it drew icons, and "Context" is not the width of
+/// 102pt slots because it drew icons, and "Things" is not the width of
 /// "Agent".
 struct ConversationSegmentedControl: View {
     @Binding var selectedTab: ConversationTab

--- a/Convos/Conversation Detail/ConversationTab.swift
+++ b/Convos/Conversation Detail/ConversationTab.swift
@@ -23,7 +23,7 @@ enum ConversationTab: String, CaseIterable, Identifiable, Hashable {
         switch self {
         case .group: "Group"
         case .agent: "Agent"
-        case .context: "Context"
+        case .context: "Things"
         }
     }
 

--- a/ConvosTests/ConversationInitialTabTests.swift
+++ b/ConvosTests/ConversationInitialTabTests.swift
@@ -99,6 +99,6 @@ final class ConversationInitialTabTests: XCTestCase {
     func testTitlesMatchTheDesign() {
         XCTAssertEqual(ConversationTab.group.title, "Group")
         XCTAssertEqual(ConversationTab.agent.title, "Agent")
-        XCTAssertEqual(ConversationTab.context.title, "Context")
+        XCTAssertEqual(ConversationTab.context.title, "Things")
     }
 }


### PR DESCRIPTION
Renames the third conversation tab from **Context** to **Things** in the Group | Agent | Things segmented control.

`ConversationTab.title` is the single source for both the visible label and the accessibility label, and the control's slots size to their own labels rather than hard-coded widths, so the narrower string needs no layout change. Also updates `testTitlesMatchTheDesign`, which pins the visible titles, and two doc comments that quoted the old label verbatim.

The `ConversationTab.context` case and the `conversation-tab-context` accessibility identifier are deliberately unchanged, so existing QA selectors keep matching — renaming the case would reach into the read-state machinery and initial-tab logic, which belongs in its own PR.

Verified by running `ConvosTests/ConversationInitialTabTests` (10/10 pass) and launching the app in the simulator to confirm the tab reads "Things".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789942126&installation_model_id=20076&pr_number=1397&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1397&signature=7f93ab517f488dfadb07a50eb987d82cffe4f96e837b0978a12bd8e5baf8c480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename the `Context` tab to `Things` in conversation detail
> Changes the string returned by the `.context` case of `ConversationTab.title` from "Context" to "Things", and updates doc comments and test assertions to match. No tab semantics or routing are affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4af9d55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->