### PR TITLE
fix(conversation): reword the participation menu and mode copy

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1841,10 +1841,18 @@ private extension ConversationView {
         guard let participation else { return nil }
         return AgentParticipationContext(
             level: participation.level,
-            isLoading: !participation.hasLoaded
+            isLoading: !participation.hasLoaded,
+            agentName: participationAgentName
         ) { level in
             Task { await participation.set(level) }
         }
+    }
+
+    /// The name shown in the Listen level's caption. A room with several agents
+    /// uses the first one's name to stand for them; falls back to "Agent" when
+    /// no agent member is resolved yet.
+    var participationAgentName: String {
+        viewModel.conversation.members.first(where: \.isAgent)?.displayName ?? "Agent"
     }
 
     /// Keys the participation `.task` on the conversation AND on whether it has

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipation.swift
@@ -18,25 +18,31 @@ public enum AgentParticipationLevel: String, CaseIterable, Identifiable, Sendabl
 
     public var id: String { rawValue }
 
-    /// The levels the menu offers — every level there is.
-    public static var selectableCases: [AgentParticipationLevel] { allCases }
+    /// The levels the menu offers, in the order the menu draws them: Listen
+    /// first, then Chat, then Pause. This is the menu's own order and is
+    /// deliberately not `allCases` order (which the wire/default logic keeps).
+    public static var selectableCases: [AgentParticipationLevel] {
+        [.mentionsOnly, .speakFreely, .paused]
+    }
 
     /// User-visible name of the level. `.mentionsOnly` (wire value `"mention"`)
-    /// reads as "Listen mode" — the label and the wire value are the same mode
-    /// under two names; there is no separate `listen` mode.
+    /// reads as "Listen" — the label and the wire value are the same mode under
+    /// two names; there is no separate `listen` mode.
     public var title: String {
         switch self {
-        case .speakFreely: "Speak freely"
-        case .mentionsOnly: "Listen mode"
+        case .speakFreely: "Chat"
+        case .mentionsOnly: "Listen"
         case .paused: "Pause"
         }
     }
 
-    public var caption: String {
+    /// The level's one-line description. `.mentionsOnly` names the agent it
+    /// speaks for, so the caption reads "...mentions "<agent name>"".
+    public func caption(agentName: String) -> String {
         switch self {
-        case .speakFreely: "Chime in any time"
-        case .mentionsOnly: "Only speaks if you @mention or say name"
-        case .paused: "Won't see messages sent while paused, even later"
+        case .speakFreely: "Chime in anytime"
+        case .mentionsOnly: "Only speak when someone mentions \"\(agentName)\""
+        case .paused: "Can never see messages, uses no credits"
         }
     }
 

--- a/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentParticipationEnvironment.swift
@@ -14,11 +14,16 @@ public struct AgentParticipationContext {
     /// only a placeholder until then, so the bubble shows a resting dot instead
     /// of an icon that might be about to change under the member's eyes.
     public let isLoading: Bool
+    /// The agent's display name, shown in the Listen level's caption ("Only
+    /// speak when someone mentions "<agentName>""). A room with several agents
+    /// uses the first one's name to stand for them.
+    public let agentName: String
     public let onSelect: (AgentParticipationLevel) -> Void
 
-    public init(level: AgentParticipationLevel, isLoading: Bool = false, onSelect: @escaping (AgentParticipationLevel) -> Void) {
+    public init(level: AgentParticipationLevel, isLoading: Bool = false, agentName: String, onSelect: @escaping (AgentParticipationLevel) -> Void) {
         self.level = level
         self.isLoading = isLoading
+        self.agentName = agentName
         self.onSelect = onSelect
     }
 }

--- a/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesBottomBar.swift
@@ -517,6 +517,7 @@ public struct MessagesBottomBar<BottomBarContent: View, QuickEdit: View, FilePre
                     ParticipationMenuControl(
                         level: participation.level,
                         isLoading: isLoading,
+                        agentName: participation.agentName,
                         onSelect: participation.onSelect
                     )
                     .equatable()
@@ -753,10 +754,11 @@ private struct AttachmentsMenuControl: View, Equatable {
 private struct ParticipationMenuControl: View, Equatable {
     let level: AgentParticipationLevel
     let isLoading: Bool
+    let agentName: String
     let onSelect: (AgentParticipationLevel) -> Void
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.level == rhs.level && lhs.isLoading == rhs.isLoading
+        lhs.level == rhs.level && lhs.isLoading == rhs.isLoading && lhs.agentName == rhs.agentName
     }
 
     var body: some View {
@@ -787,7 +789,7 @@ private struct ParticipationMenuControl: View, Equatable {
         )
         return Toggle(isOn: isOn) {
             Text(option.title)
-            Text(option.caption)
+            Text(option.caption(agentName: agentName))
             Image(systemName: option.iconSystemName)
         }
         .accessibilityIdentifier("participation-\(option.rawValue)-row")

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -416,9 +416,9 @@ private func summaryFromFirstMetadataChange(
         guard let newValue = metadataChange.newValue,
               let mode = ConversationParticipationMode(rawValue: newValue) else { return nil }
         if mode == .paused {
-            return "\(creatorDisplayName) paused the agents. They'll never see messages sent while paused"
+            return "\(creatorDisplayName) paused agents, so they'll never see the following messages"
         }
-        return "\(creatorDisplayName) set the participation mode to \"\(mode.title)\""
+        return "\(creatorDisplayName) set agents to \(mode.transcriptTitle)"
     case .metadata, .unknown:
         return nil
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationParticipationMode.swift
@@ -42,14 +42,28 @@ public enum ConversationParticipationMode: String, CaseIterable, Codable, Sendab
         }
     }
 
-    /// User-visible name of the mode, as it reads in the participation menu and
-    /// in the transcript row a change leaves behind. Note `.mentionsOnly`
-    /// (wire value `"mention"`) reads as "Listen mode" here — the label and the
-    /// wire vocabulary are deliberately different names for one mode.
+    /// User-visible name of the mode, as it reads in the participation menu.
+    /// Note `.mentionsOnly` (wire value `"mention"`) reads as "Listen mode"
+    /// here - the label and the wire vocabulary are deliberately different
+    /// names for one mode.
     public var title: String {
         switch self {
         case .speakFreely: "Speak freely"
         case .mentionsOnly: "Listen mode"
+        case .paused: "Pause"
+        }
+    }
+
+    /// The mode's name as it reads in the transcript row a change leaves
+    /// behind ("Shane set agents to Listen"). Shorter than `title`, which
+    /// carries menu-length wording the sentence does not want.
+    ///
+    /// `.paused` renders its own full sentence rather than this label, so its
+    /// value here is never the one a reader sees.
+    public var transcriptTitle: String {
+        switch self {
+        case .speakFreely: "Chat"
+        case .mentionsOnly: "Listen"
         case .paused: "Pause"
         }
     }

--- a/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
@@ -236,7 +236,7 @@ struct ParticipationModeSyncTests {
             ]
         )
 
-        #expect(update.summary == "Shane set the participation mode to \"Listen mode\"")
+        #expect(update.summary == "Shane set agents to Listen")
     }
 
     @Test("a paused update warns that messages will not be seen later")
@@ -254,6 +254,6 @@ struct ParticipationModeSyncTests {
             ]
         )
 
-        #expect(update.summary == "Shane paused the agents. They'll never see messages sent while paused")
+        #expect(update.summary == "Shane paused agents, so they'll never see the following messages")
     }
 }


### PR DESCRIPTION
Follow-up copy work that didn't make it into #1397 (which merged just the "rename the Context tab to Things" change) before the branch was merged.

## Changes
- **Shorten the participation-mode transcript copy** (`ConversationParticipationMode.swift`, mocks, sync tests)
- **Reword and reorder the participation menu** (`ConversationView`, `AgentParticipation`, `AgentParticipationEnvironment`, `MessagesBottomBar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789946477&installation_model_id=20076&pr_number=1398&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1398&signature=6e72c97f6203caf9d74316ebda41306c03da657ae52d2df853270de50cf1d524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reword participation menu titles, captions, and transcript copy for agent participation
> - Reorders `AgentParticipationLevel.selectableCases` to `[.mentionsOnly, .speakFreely, .paused]` and renames titles to "Listen", "Chat", and "Pause".
> - Replaces the `caption` computed property with a `caption(agentName:)` method; the Listen caption now includes the agent's display name and the paused caption now reads "Can never see messages, uses no credits".
> - Adds `agentName` to `AgentParticipationContext` and threads it from `ConversationView` through `MessagesBottomBar.ParticipationMenuControl` so menus render agent-specific captions.
> - Adds `ConversationParticipationMode.transcriptTitle` and updates `summaryFromFirstMetadataChange` to produce cleaner transcript summaries (e.g. "set agents to Listen").
> - Behavioral Change: callers of `AgentParticipationContext` must now supply `agentName`; participation menu option ordering and all caption/title strings are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8a523d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->