### PR TITLE
fix(conversation): make the empty states get out of the keyboard's way

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -60,6 +60,8 @@ struct AgentDmPageView: View {
 
     private var agentName: String { session.agentName }
 
+    @Environment(\.safeAreaInsets) private var windowSafeAreaInsets: EdgeInsets
+    @State private var emptyStateKeyboardHeight: CGFloat = 0.0
     @State private var emptyStateSettled: Bool = false
 
     /// Centred over the page and faded rather than inserted into the list, so
@@ -69,9 +71,15 @@ struct AgentDmPageView: View {
         if case .ready(let dmVm) = phase {
             let shows: Bool = emptyStateSettled && !dmVm.hasAnyMessages
             let opacity: Double = shows ? 1.0 : 0.0
-            AgentDmEmptyStateView(variant: agentVariant(in: dmVm))
+            let chromeInset: CGFloat = windowSafeAreaInsets.top + ConversationChromeMetrics.contentClearance
+            let shift: CGFloat = EmptyStateKeyboard.shift(chromeInset: chromeInset, keyboardHeight: emptyStateKeyboardHeight)
+            AgentDmEmptyStateView(variant: agentVariant(in: dmVm), hidesText: emptyStateKeyboardHeight > 0.0)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea()
+                .offset(y: shift)
+                .trackingKeyboardHeight($emptyStateKeyboardHeight)
+                // `.container` only, same as the group's: the unqualified form
+                // ignores the keyboard too, leaving the block centred behind it.
+                .ignoresSafeArea(.container)
                 .opacity(opacity)
                 .allowsHitTesting(false)
                 .animation(.easeInOut(duration: 0.25), value: shows)

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -110,6 +110,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// floating sheet so browsing never leaves the conversation screen.
     /// While non-empty, the top bar swaps the system back button for one
     /// that pops pages, and hides the add-members item.
+    @State private var emptyStateKeyboardHeight: CGFloat = 0.0
     @State private var groupEmptyStateSettled: Bool = false
     @State private var homeBrowserEntries: [HomeBrowserEntry] = []
     @State private var showingDebugInjector: Bool = false
@@ -1429,15 +1430,26 @@ private extension ConversationView {
     /// `GroupEmptyStateView` makes its text transparent to touches for the same
     /// reason - only the button takes them.
     private var groupEmptyStateOverlay: some View {
-        GroupEmptyStateView(
+        let chromeInset: CGFloat = windowSafeAreaInsets.top + ConversationChromeMetrics.contentClearance
+        let shift: CGFloat = EmptyStateKeyboard.shift(chromeInset: chromeInset, keyboardHeight: emptyStateKeyboardHeight)
+        return GroupEmptyStateView(
             isInviteEnabled: messagesTopBarTrailingItemEnabled && !effectiveReadOnly,
+            hidesText: emptyStateKeyboardHeight > 0.0,
             onInvite: handleAddFromContactsTap
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .offset(y: shift)
+        .trackingKeyboardHeight($emptyStateKeyboardHeight)
         // Centres against the screen rather than the page's inset box, which
         // would land the block ~46pt low. The frame carries no background, so
         // its empty area stays transparent to the pager's pan.
-        .ignoresSafeArea()
+        //
+        // `.container` only: the unqualified `ignoresSafeArea()` covers every
+        // region, keyboard included, so the block stayed centred on the whole
+        // screen while the keyboard took the bottom half of it. Ignoring only
+        // the container insets keeps the resting position and lets the
+        // keyboard shrink the box it centres in.
+        .ignoresSafeArea(.container)
         .opacity(showsGroupEmptyState ? 1.0 : 0.0)
         .allowsHitTesting(showsGroupEmptyState)
         .animation(.easeInOut(duration: 0.25), value: showsGroupEmptyState)

--- a/Convos/Conversation Detail/EmptyStateKeyboardCentering.swift
+++ b/Convos/Conversation Detail/EmptyStateKeyboardCentering.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import UIKit
+
+/// Keyboard support for the conversation's empty states.
+///
+/// The transcript underneath is a UIKit view that owns its own keyboard
+/// tracking, so the SwiftUI keyboard safe area never reaches an overlay above
+/// it - without this the block stays centred on the whole screen with the
+/// keyboard over the bottom of it.
+enum EmptyStateKeyboard {
+    /// How far to move a screen-centred block so it sits centred in the space
+    /// between the top chrome and the keyboard.
+    ///
+    /// A shift rather than a resize: padding around a `maxHeight: .infinity`
+    /// frame resolves against the parent's proposal in ways that moved the
+    /// block the wrong way and squeezed its text. At rest the block sits at the
+    /// screen's centre, `H / 2`. The space left with the keyboard up runs from
+    /// `chromeInset` to `H - keyboardHeight`, whose centre is
+    /// `(chromeInset + H - keyboardHeight) / 2`, so the difference is
+    /// `(chromeInset - keyboardHeight) / 2` and `H` drops out.
+    static func shift(chromeInset: CGFloat, keyboardHeight: CGFloat) -> CGFloat {
+        guard keyboardHeight > 0.0 else { return 0.0 }
+        return (chromeInset - keyboardHeight) / 2.0
+    }
+}
+
+private struct KeyboardHeightModifier: ViewModifier {
+    @Binding var height: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+                guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
+                    return
+                }
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    height = frame.height
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                    height = 0.0
+                }
+            }
+    }
+}
+
+extension View {
+    /// Writes the keyboard's height into `height`, animating with the same
+    /// spring `MessageContextMenuOverlay` uses so the two move alike.
+    func trackingKeyboardHeight(_ height: Binding<CGFloat>) -> some View {
+        modifier(KeyboardHeightModifier(height: height))
+    }
+}

--- a/Convos/Conversation Detail/GroupEmptyStateView.swift
+++ b/Convos/Conversation Detail/GroupEmptyStateView.swift
@@ -12,6 +12,9 @@ import SwiftUI
 /// padding, a 52pt lava button, then 17/15/13pt text.
 struct GroupEmptyStateView: View {
     let isInviteEnabled: Bool
+    /// Drops the copy, leaving the CTA on its own. While the keyboard is up
+    /// there is not room for it without crowding the composer.
+    let hidesText: Bool
     let onInvite: () -> Void
 
     var body: some View {
@@ -22,18 +25,20 @@ struct GroupEmptyStateView: View {
         // pan, so a drag starting on the copy could not change tab.
         VStack(spacing: DesignConstants.Spacing.step3x) {
             inviteButton
-            Text("Your group has an agent, too")
-                .font(.body)
-                .foregroundStyle(.colorTextPrimary)
-                .allowsHitTesting(false)
-            Text("Mention @agent if you’d like them to speak up. Or pause them and they won’t listen at all.")
-                .font(.subheadline)
-                .foregroundStyle(.colorTextSecondary)
-                .allowsHitTesting(false)
-            Text("Tap @ to control their participation")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
-                .allowsHitTesting(false)
+            if !hidesText {
+                Text("Your group has an agent, too")
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                    .allowsHitTesting(false)
+                Text("Mention @agent if you’d like them to speak up. Or pause them and they won’t listen at all.")
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                    .allowsHitTesting(false)
+                Text("Tap @ to control their participation")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+                    .allowsHitTesting(false)
+            }
         }
         .multilineTextAlignment(.center)
         .padding(.horizontal, DesignConstants.Spacing.step8x)
@@ -65,5 +70,5 @@ struct GroupEmptyStateView: View {
 }
 
 #Preview {
-    GroupEmptyStateView(isInviteEnabled: true, onInvite: {})
+    GroupEmptyStateView(isInviteEnabled: true, hidesText: false, onInvite: {})
 }

--- a/ConvosCore/Sources/ConvosComposer/AgentDmEmptyStateView.swift
+++ b/ConvosCore/Sources/ConvosComposer/AgentDmEmptyStateView.swift
@@ -19,9 +19,14 @@ import SwiftUI
 /// indistinguishable from a default one until its behavior disagrees.
 public struct AgentDmEmptyStateView: View {
     let variant: AgentVariantStamp?
+    /// Drops the copy while the keyboard is up - same reason as the group's
+    /// empty state. This one is all copy, so it leaves nothing on screen, which
+    /// is the point: there is no room for it over the keyboard.
+    let hidesText: Bool
 
-    public init(variant: AgentVariantStamp? = nil) {
+    public init(variant: AgentVariantStamp? = nil, hidesText: Bool = false) {
         self.variant = variant
+        self.hidesText = hidesText
     }
 
     public var body: some View {
@@ -37,15 +42,17 @@ public struct AgentDmEmptyStateView: View {
                     .fixedSize(horizontal: true, vertical: false)
                     .clipShape(Capsule())
             }
-            Text("1:1 with your Agent")
-                .font(.body)
-                .foregroundStyle(.colorTextPrimary)
-            Text("Drop anything here, or ask your agent to privately ping other members")
-                .font(.subheadline)
-                .foregroundStyle(.colorTextSecondary)
-            Text("Everything shared here can be shared with others in the group, so don’t share anything private.")
-                .font(.footnote)
-                .foregroundStyle(.colorTextSecondary)
+            if !hidesText {
+                Text("1:1 with your Agent")
+                    .font(.body)
+                    .foregroundStyle(.colorTextPrimary)
+                Text("Drop anything here, or ask your agent to privately ping other members")
+                    .font(.subheadline)
+                    .foregroundStyle(.colorTextSecondary)
+                Text("Everything shared here can be shared with others in the group, so don’t share anything private.")
+                    .font(.footnote)
+                    .foregroundStyle(.colorTextSecondary)
+            }
         }
         .multilineTextAlignment(.center)
         .padding(.horizontal, DesignConstants.Spacing.step8x)


### PR DESCRIPTION
Opening an empty conversation with the keyboard already up left both empty states centred on the whole screen, with the keyboard over the bottom half of the block.

## Why the obvious fix doesn't work

The transcript underneath is a UIKit view that owns its own keyboard tracking, so the SwiftUI keyboard safe area never reaches an overlay above it. Scoping `ignoresSafeArea` to `.container` (rather than the default, which covers `.keyboard` too) is the right shape and does nothing here for that reason — measured, not assumed. The overlay has to read the keyboard itself.

## Behaviour with the keyboard up

- **Group** — the copy is dropped and the "Invite people" button stands alone, centred between the top chrome and the keyboard.
- **Agent DM** — that view is all copy, so it hides entirely.

There isn't room for the text without crowding the composer, and the CTA still says what the screen is. Everything returns when the keyboard goes down, on the same spring `MessageContextMenuOverlay` uses so the two move alike.

## The shift is closed-form, not a resize

Padding around a `maxHeight: .infinity` frame resolves against the parent's proposal in ways that moved the block the *wrong* way and squeezed its text into a single truncated line. Two attempts at that got backed out.

At rest the block sits at the screen's centre, `H / 2`. The space left with the keyboard up runs from the chrome's clearance to `H - keyboardHeight`, whose centre is `(chromeInset + H - keyboardHeight) / 2`. The difference is:

```
shift = (chromeInset - keyboardHeight) / 2
```

`H` drops out, so it needs no geometry reader and no per-device constant.

## Verification

Predicted a 52pt button at y=270 with the keyboard up; measured **271.7**, and clear of the scrim, which ends at 264. Pixel-measured from simulator screenshots, not eyeballed.

- `xcodebuild` `Convos (Dev)` / `Dev` — BUILD SUCCEEDED
- SwiftLint clean, full tree

## Notes

- The "Notify me of new messages" banner sits close under the block with the keyboard up (~9pt in the last capture). No overlap now the copy is hidden, and that banner only appears before notification permission is granted.
- Hiding the agent DM's title was a judgement call, not a stated requirement: leaving "1:1 with your Agent" alone over the keyboard read as orphaned. Easy to keep it if that's wrong.
- **Not in #1402.** That branch was cut before this work, so if 2.5.0 should carry this fix it needs to land on dev and then be brought across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789955540&installation_model_id=20076&pr_number=1403&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1403&signature=c05b3b8cda198c4d7daf7ab1d8a5add7a540dffc807ffc5ec0a29bd9a4653a48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-center conversation empty states above keyboard and hide their text
> - Adds `EmptyStateKeyboard.shift` and a `trackingKeyboardHeight` view modifier to compute a centering offset and track keyboard height with a spring animation.
> - Applies this centering to the agent DM and group empty-state overlays in `AgentDmPageView` and `ConversationView`.
> - Adds a `hidesText` flag to `GroupEmptyStateView` and `AgentDmEmptyStateView` to suppress explanatory text while the keyboard is visible.
> - Behavioral Change: `ignoresSafeArea()` is narrowed to `.ignoresSafeArea(.container)` so overlays now respect the keyboard safe area instead of centering behind it.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a9d1c01. 5 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->