### PR TITLE
feat(conversation): default new group convos to Listen participation

### DIFF
--- a/Convos/Conversation Detail/GroupEmptyStateView.swift
+++ b/Convos/Conversation Detail/GroupEmptyStateView.swift
@@ -30,7 +30,7 @@ struct GroupEmptyStateView: View {
                     .font(.body)
                     .foregroundStyle(.colorTextPrimary)
                     .allowsHitTesting(false)
-                Text("Mention \"Agent\" by name if you’d like them to speak up. Or pause them and they won’t listen at all.")
+                Text("Mention \"Agent\" by name, and they’ll chime in. Or Pause them, and they can’t see a thing.")
                     .font(.subheadline)
                     .foregroundStyle(.colorTextSecondary)
                     .allowsHitTesting(false)

--- a/Convos/Conversation Detail/GroupEmptyStateView.swift
+++ b/Convos/Conversation Detail/GroupEmptyStateView.swift
@@ -30,7 +30,7 @@ struct GroupEmptyStateView: View {
                     .font(.body)
                     .foregroundStyle(.colorTextPrimary)
                     .allowsHitTesting(false)
-                Text("Mention @agent if you’d like them to speak up. Or pause them and they won’t listen at all.")
+                Text("Mention \"Agent\" by name if you’d like them to speak up. Or pause them and they won’t listen at all.")
                     .font(.subheadline)
                     .foregroundStyle(.colorTextSecondary)
                     .allowsHitTesting(false)

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -210,11 +210,18 @@ extension XMTPiOS.Group {
     }
 
     /// Seeds every piece of creator-authored metadata in one commit: the
-    /// invite tag, the image encryption key, and (when a seed is provided)
-    /// the conversation emoji. Each individual `ensure*` call publishes its
-    /// own MLS commit with a network round trip, so the creation path calls
-    /// this instead of chaining them. No-ops without a commit when every
-    /// field is already present.
+    /// invite tag, the image encryption key, (when a seed is provided) the
+    /// conversation emoji, and the initial participation mode. Each individual
+    /// `ensure*` call publishes its own MLS commit with a network round trip,
+    /// so the creation path calls this instead of chaining them. No-ops without
+    /// a commit when every field is already present.
+    ///
+    /// The participation mode is seeded to Listen (`.mentionsOnly`) so a new
+    /// conversation's agents stay quiet until addressed. This only reaches group
+    /// chats: agent DMs are created by the agent, so their `creatorInboxId` is
+    /// never this client and they never call this creator-only method. An
+    /// already-set mode is left untouched, so a second call (prewarm then a
+    /// later emoji commit) never overwrites a mode a member has since changed.
     ///
     /// Only the conversation creator should call this - it authors the
     /// invite tag (see `ensureInviteTag`).
@@ -223,7 +230,8 @@ extension XMTPiOS.Group {
         let needsTag = current.tag.isEmpty
         let needsKey = !current.hasImageEncryptionKey
         let needsEmoji = emojiSeed != nil && (!current.hasEmoji || current.emoji.isEmpty)
-        guard needsTag || needsKey || needsEmoji else { return }
+        let needsParticipationMode = current.conversationParticipationMode == nil
+        guard needsTag || needsKey || needsEmoji || needsParticipationMode else { return }
 
         // Generate the tag only when it's actually missing so a transient
         // SecRandomCopyBytes failure can't abort an emoji- or key-only update.
@@ -251,10 +259,14 @@ extension XMTPiOS.Group {
             if let newEmoji, !metadata.hasEmoji || metadata.emoji.isEmpty {
                 metadata.emoji = newEmoji
             }
+            if metadata.conversationParticipationMode == nil {
+                metadata.participationMode = ConversationParticipationMode.mentionsOnly.proto
+            }
         } verify: { metadata in
             guard !metadata.tag.isEmpty else { return false }
             guard newKey == nil || metadata.hasImageEncryptionKey else { return false }
-            return newEmoji == nil || (metadata.hasEmoji && !metadata.emoji.isEmpty)
+            guard newEmoji == nil || (metadata.hasEmoji && !metadata.emoji.isEmpty) else { return false }
+            return metadata.conversationParticipationMode != nil
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
+++ b/ConvosCore/Sources/ConvosCore/Invites & Custom Metadata/XMTPGroup+CustomMetadata.swift
@@ -219,9 +219,12 @@ extension XMTPiOS.Group {
     /// The participation mode is seeded to Listen (`.mentionsOnly`) so a new
     /// conversation's agents stay quiet until addressed. This only reaches group
     /// chats: agent DMs are created by the agent, so their `creatorInboxId` is
-    /// never this client and they never call this creator-only method. An
-    /// already-set mode is left untouched, so a second call (prewarm then a
-    /// later emoji commit) never overwrites a mode a member has since changed.
+    /// never this client and they never call this creator-only method. The seed
+    /// is tied to authoring the invite tag -- the one field written exactly once,
+    /// at creation -- so it never fires when this method re-runs on an already
+    /// established group (e.g. `StreamProcessor` reprocessing a legacy
+    /// creator-owned conversation), which would otherwise flip that room off the
+    /// legacy default and publish a spurious commit.
     ///
     /// Only the conversation creator should call this - it authors the
     /// invite tag (see `ensureInviteTag`).
@@ -230,8 +233,12 @@ extension XMTPiOS.Group {
         let needsTag = current.tag.isEmpty
         let needsKey = !current.hasImageEncryptionKey
         let needsEmoji = emojiSeed != nil && (!current.hasEmoji || current.emoji.isEmpty)
-        let needsParticipationMode = current.conversationParticipationMode == nil
-        guard needsTag || needsKey || needsEmoji || needsParticipationMode else { return }
+        // Only seed the initial mode in the same commit that first authors the
+        // invite tag, i.e. a brand-new group. An established group (tag already
+        // present) that happens to carry no mode must keep rendering as the
+        // legacy default, untouched.
+        let seedsParticipationMode = needsTag && current.conversationParticipationMode == nil
+        guard needsTag || needsKey || needsEmoji else { return }
 
         // Generate the tag only when it's actually missing so a transient
         // SecRandomCopyBytes failure can't abort an emoji- or key-only update.
@@ -259,14 +266,14 @@ extension XMTPiOS.Group {
             if let newEmoji, !metadata.hasEmoji || metadata.emoji.isEmpty {
                 metadata.emoji = newEmoji
             }
-            if metadata.conversationParticipationMode == nil {
+            if seedsParticipationMode, metadata.conversationParticipationMode == nil {
                 metadata.participationMode = ConversationParticipationMode.mentionsOnly.proto
             }
         } verify: { metadata in
             guard !metadata.tag.isEmpty else { return false }
             guard newKey == nil || metadata.hasImageEncryptionKey else { return false }
             guard newEmoji == nil || (metadata.hasEmoji && !metadata.emoji.isEmpty) else { return false }
-            return metadata.conversationParticipationMode != nil
+            return !seedsParticipationMode || metadata.conversationParticipationMode != nil
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -409,7 +409,18 @@ extension XMTPiOS.DecodedMessage {
 
         let oldMode = oldCustomValue?.conversationParticipationMode
         let newMode = newCustomValue?.conversationParticipationMode
-        if let newMode, newMode != oldMode {
+        // The creator seeds the initial mode (Listen) in the same commit that
+        // first authors the invite tag (see ensureCreatorMetadata). That is the
+        // room's starting state, not a change a member chose, so it must not
+        // leave a "set agents to ..." row. The tag going from unset to set marks
+        // that seed commit; a real mode change always happens with the tag
+        // already set, so it still renders. When suppressed, this falls through
+        // to the silent metadata row, exactly like the tag/key/emoji seeded
+        // alongside it.
+        let tagWasUnset = oldCustomValue.map { $0.tag.isEmpty } ?? true
+        let tagNowSet = newCustomValue.map { !$0.tag.isEmpty } ?? false
+        let isCreatorSeedCommit = tagWasUnset && tagNowSet
+        if let newMode, newMode != oldMode, !isCreatorSeedCommit {
             return .init(
                 field: ConversationUpdate.MetadataChange.Field.participationMode.rawValue,
                 oldValue: oldMode?.rawValue,

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/EnsureCreatorMetadataParticipationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/EnsureCreatorMetadataParticipationTests.swift
@@ -1,0 +1,63 @@
+import ConvosAppData
+@testable import ConvosCore
+import Foundation
+import Testing
+@preconcurrency import XMTPiOS
+
+@Suite("Creator Metadata Participation Mode Tests")
+struct EnsureCreatorMetadataParticipationTests {
+    private enum TestError: Error {
+        case missingClients
+    }
+
+    @Test("ensureCreatorMetadata seeds Listen as the initial participation mode")
+    func seedsListenParticipationMode() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB else {
+            throw TestError.missingClients
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxId],
+            name: "Test Group",
+            imageUrl: "",
+            description: ""
+        )
+        #expect(try group.participationMode == nil)
+
+        try await group.ensureCreatorMetadata(emojiSeed: "seed")
+
+        #expect(try group.participationMode == .mentionsOnly)
+
+        try? await fixtures.cleanup()
+    }
+
+    @Test("ensureCreatorMetadata leaves an already-set participation mode untouched")
+    func preservesExistingParticipationMode() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB else {
+            throw TestError.missingClients
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxId],
+            name: "Test Group",
+            imageUrl: "",
+            description: ""
+        )
+        try await group.updateParticipationMode(.paused)
+        #expect(try group.participationMode == .paused)
+
+        try await group.ensureCreatorMetadata(emojiSeed: "seed")
+
+        #expect(try group.participationMode == .paused)
+
+        try? await fixtures.cleanup()
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/EnsureCreatorMetadataParticipationTests.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/EnsureCreatorMetadataParticipationTests.swift
@@ -60,4 +60,33 @@ struct EnsureCreatorMetadataParticipationTests {
 
         try? await fixtures.cleanup()
     }
+
+    @Test("ensureCreatorMetadata does not seed a mode on an already-established group")
+    func doesNotSeedModeOnEstablishedGroup() async throws {
+        let fixtures = TestFixtures()
+        try await fixtures.createTestClients()
+
+        guard let clientA = fixtures.clientA as? Client,
+              let clientB = fixtures.clientB else {
+            throw TestError.missingClients
+        }
+
+        let group = try await clientA.conversations.newGroup(
+            with: [clientB.inboxId],
+            name: "Test Group",
+            imageUrl: "",
+            description: ""
+        )
+        // A legacy creator-owned group: the invite tag is already authored, but
+        // no participation mode was ever set. Re-running ensureCreatorMetadata
+        // (as StreamProcessor does on reprocessing) must not flip it to Listen.
+        try await group.ensureInviteTag()
+        #expect(try group.participationMode == nil)
+
+        try await group.ensureCreatorMetadata(emojiSeed: "seed")
+
+        #expect(try group.participationMode == nil)
+
+        try? await fixtures.cleanup()
+    }
 }

--- a/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ParticipationModeSyncTests.swift
@@ -171,6 +171,22 @@ struct ParticipationModeSyncTests {
         #expect(ConversationUpdate.MetadataChange.Field.participationMode.showsInMessagesList)
     }
 
+    @Test("the creator seed (tag and mode set together) leaves no participation row")
+    func creatorSeedStaysSilent() throws {
+        let before = ConversationCustomMetadata()
+        var after = before
+        after.tag = "tag"
+        after.participationMode = ConversationParticipationMode.mentionsOnly.proto
+
+        let change = XMTPiOS.DecodedMessage.appDataMetadataChange(
+            oldValue: try before.toCompactString(),
+            newValue: try after.toCompactString()
+        )
+
+        #expect(change.field == ConversationUpdate.MetadataChange.Field.metadata.rawValue)
+        #expect(!ConversationUpdate.MetadataChange.Field.metadata.showsInMessagesList)
+    }
+
     @Test("appData changes that are not the mode stay out of the transcript")
     func otherAppDataChangesStaySilent() throws {
         var before = ConversationCustomMetadata()


### PR DESCRIPTION
## What

New **group** conversations now start with their agent participation mode set to **Listen** (`mentionsOnly`) instead of Speak freely — agents stay quiet until they're addressed (@mention or name).

## Why / how it's scoped

- Seeded in `XMTPGroup.ensureCreatorMetadata(...)`, which is **creator-only** and rides the same MLS commit that already writes the invite tag / image key / emoji (no extra round-trip). It's idempotent — an already-set mode is left untouched.
- This reaches **group chats exclusively, by construction**: 1:1 agent DMs are created server-side by the agent (their `creatorInboxId` is never this client), so they never call `ensureCreatorMetadata` and keep replying normally.
- `ConversationParticipationMode.default` stays `.speakFreely` — the new behavior comes from *persisting* the mode at creation, not from flipping the fallback (which would wrongly re-render every existing unset room as Listen).

## Transcript row suppression

Seeding the mode initially made the transcript render a **"You set agents to Listen"** system row on every new conversation. That's the room's starting state, not a change a member chose, so it's suppressed for the creator seed commit only — detected by the invite tag going from unset → set in that same appData commit. Real, later mode changes (tag already established) still render a row, so nothing user-facing is lost.

## Tests

- `creatorSeedStaysSilent` — tag+mode written together decodes to the silent `.metadata` field (no row).
- Existing `modeChangeProducesParticipationChange` (tag already set, real change) still renders the row — validates the discriminator doesn't over-suppress.
- `EnsureCreatorMetadataParticipationTests` (integration) — fresh group seeds `.mentionsOnly`; a mode already changed to `.paused` is left untouched (idempotency).

## Verification

- ✅ Builds for `Convos (Dev)` on the simulator; SwiftLint clean
- ✅ ConvosCore unit tests pass (full Participation suite)
- ⚠️ The two integration tests need a Docker/XMTP node — not runnable in my local env (`Connection refused :5556`); relying on CI to run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default new group convos to `mentionsOnly` participation
> - Seeds `participationMode` to `mentionsOnly` inside [XMTPGroup+CustomMetadata.swift](https://github.com/xmtplabs/convos-ios/pull/1405/files#diff-35053f59de2f9203f7233b5ab1da286f7a754c2f03c64829c0ccd3951762a01f) atomically with the invite tag for new creator-owned groups.
> - Suppresses emitting a `participationMode` change event inside [DecodedMessage+DBRepresentation.swift](https://github.com/xmtplabs/convos-ios/pull/1405/files#diff-506364f62b39595ed5e23f0dcfed112f9c4cf3e1f1fd7b263dbe1e386dbf2934) when the invite tag transitions from unset to set, preventing a visible state change message on group creation.
> - Updates empty group state view copy in [GroupEmptyStateView.swift](https://github.com/xmtplabs/convos-ios/pull/1405/files#diff-ce647631a96a13402972dde5b5bf2c60322fed9ce93145fed52c04f8fc628b30) to reflect the new behavior.
> - Behavioral Change: The initial seed commit no longer generates a visible `participationMode` metadata change message. Established groups or groups with a mode already set are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d43893c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->