### PR TITLE
DNM - Add edit and share to thing detail view

### DIFF
--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1151,6 +1151,12 @@ private extension ConversationView {
             }
             if homeBrowserEntries.last?.url != nil {
                 ToolbarItem(placement: .topBarTrailing) {
+                    EditThingMenu(
+                        canAskAgent: agentDmSession?.dmViewModel != nil,
+                        onAskForChanges: { shareCurrentThing(to: .agent) }
+                    )
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     ShareThingMenu(
                         canShareToAgent: agentDmSession?.dmViewModel != nil,
                         onShareToGroup: { shareCurrentThing(to: .group) },

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1063,6 +1063,32 @@ private extension ConversationView {
         homeBrowserEntries.removeLast()
     }
 
+    /// Drops the current thing's link into a tab's composer and switches to it.
+    /// The Space page URL on top of the browsing chain is the thing's shareable
+    /// link. `selectTab` only moves the tab, so the keyboard stays down.
+    private func shareCurrentThing(to tab: ConversationTab) {
+        guard let link = homeBrowserEntries.last?.url.absoluteString else { return }
+        let target: ConversationViewModel? = (tab == .agent) ? agentDmSession?.dmViewModel : viewModel
+        guard let target else { return }
+        prefillComposer(target, withLink: link)
+        selectTab(tab)
+    }
+
+    /// An empty composer with no existing card takes the link as an immediate
+    /// preview card; anything else appends the link so a draft (or an existing
+    /// card, of which there can be only one) is never clobbered. The appended
+    /// link becomes its own card on send via edge-link extraction, and the
+    /// append path also covers URLs `LinkPreview.from` rejects (private hosts).
+    private func prefillComposer(_ viewModel: ConversationViewModel, withLink link: String) {
+        if viewModel.messageText.isEmpty, viewModel.pastedLinkPreview == nil,
+           let preview = LinkPreview.from(text: link) {
+            viewModel.pastedLinkPreview = preview
+        } else {
+            let separator = viewModel.messageText.isEmpty ? "" : "\n"
+            viewModel.messageText += "\(separator)\(link)"
+        }
+    }
+
     /// Promotes focus onto the tab whose composer just took it.
     ///
     /// The system raises the keyboard over whatever is on screen; if that was
@@ -1122,6 +1148,15 @@ private extension ConversationView {
                 }
                 .accessibilityLabel("Back")
                 .accessibilityIdentifier("home-browser-back")
+            }
+            if homeBrowserEntries.last?.url != nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ShareThingMenu(
+                        canShareToAgent: agentDmSession?.dmViewModel != nil,
+                        onShareToGroup: { shareCurrentThing(to: .group) },
+                        onShareToAgent: { shareCurrentThing(to: .agent) }
+                    )
+                }
             }
         }
         // The embedded Scan/Invite toggle owns scanning, so the lone viewfinder

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1080,13 +1080,13 @@ private extension ConversationView {
     }
 
     /// Hands the current thing to the agent to edit: drops its link into the
-    /// agent composer and leads with a "Please update this" starter prompt, then
+    /// agent composer and leads with a "Please change this" starter prompt, then
     /// switches to the Agent tab. Gated by the menu to when the agent DM is bound.
     private func askAgentToEditCurrentThing() {
         guard let target = agentDmSession?.dmViewModel,
               let link = homeBrowserEntries.last?.url.absoluteString else { return }
         prefillComposer(target, withLink: link)
-        let prompt = "Please update this"
+        let prompt = "Please change this"
         target.messageText = target.messageText.isEmpty ? prompt : "\(prompt)\n\(target.messageText)"
         selectTab(.agent)
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1074,6 +1074,18 @@ private extension ConversationView {
         selectTab(tab)
     }
 
+    /// Hands the current thing to the agent to edit: drops its link into the
+    /// agent composer and leads with a "Please update this" starter prompt, then
+    /// switches to the Agent tab. Gated by the menu to when the agent DM is bound.
+    private func askAgentToEditCurrentThing() {
+        guard let target = agentDmSession?.dmViewModel,
+              let link = homeBrowserEntries.last?.url.absoluteString else { return }
+        prefillComposer(target, withLink: link)
+        let prompt = "Please update this"
+        target.messageText = target.messageText.isEmpty ? prompt : "\(prompt)\n\(target.messageText)"
+        selectTab(.agent)
+    }
+
     /// An empty composer with no existing card takes the link as an immediate
     /// preview card; anything else appends the link so a draft (or an existing
     /// card, of which there can be only one) is never clobbered. The appended
@@ -1153,7 +1165,7 @@ private extension ConversationView {
                 ToolbarItem(placement: .topBarTrailing) {
                     EditThingMenu(
                         canAskAgent: agentDmSession?.dmViewModel != nil,
-                        onAskForChanges: { shareCurrentThing(to: .agent) }
+                        onAskForChanges: askAgentToEditCurrentThing
                     )
                 }
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -124,6 +124,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     @State private var connectionsBrowserContext: ConnectionsBrowserMode?
     /// Drives the system share sheet behind the top bar's invite-link button.
     @State private var presentingInviteShareSheet: Bool = false
+    @State private var presentingThingShareSheet: Bool = false
     @State private var navState: ConversationNavigatorImpl = .init()
     @State private var navigator: ConversationCollector?
     @Environment(\.dismiss) private var dismiss: DismissAction
@@ -667,6 +668,10 @@ private extension ConversationView {
                 items: inviteShareItems,
                 onCompletion: handleInviteShareCompletion
             )
+            .shareSheet(
+                isPresented: $presentingThingShareSheet,
+                items: thingShareItems
+            )
             .sheet(item: $viewModel.presentingNewConversationForInvite) { viewModel in
                 newConversationSheet(viewModel)
             }
@@ -1172,7 +1177,8 @@ private extension ConversationView {
                     ShareThingMenu(
                         canShareToAgent: agentDmSession?.dmViewModel != nil,
                         onShareToGroup: { shareCurrentThing(to: .group) },
-                        onShareToAgent: { shareCurrentThing(to: .agent) }
+                        onShareToAgent: { shareCurrentThing(to: .agent) },
+                        onShareExternally: { presentingThingShareSheet = true }
                     )
                 }
             }
@@ -1232,6 +1238,12 @@ private extension ConversationView {
         let invite = viewModel.invite
         guard !invite.isEmpty else { return [] }
         return [invite.inviteURLString]
+    }
+
+    /// The current thing's link, for the Share menu's system share-sheet row.
+    private var thingShareItems: [Any] {
+        guard let url = homeBrowserEntries.last?.url else { return [] }
+        return [url]
     }
 
     /// A completed share is what keeps a brand-new conversation alive: the

--- a/Convos/Conversation Detail/EditThingMenu.swift
+++ b/Convos/Conversation Detail/EditThingMenu.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Top-right edit menu on a Things detail page, sitting beside `ShareThingMenu`.
+/// "Ask for changes" hands the thing to the agent to edit; "Edit with an app"
+/// is not built yet and shows as a disabled "Soon" row.
+///
+/// "Ask for changes" is disabled until the agent DM is bound, since it has no
+/// composer to route to before then.
+struct EditThingMenu: View {
+    let canAskAgent: Bool
+    let onAskForChanges: () -> Void
+
+    var body: some View {
+        Menu {
+            Button(action: onAskForChanges) {
+                Text("Ask for changes")
+                Text("Your agent will change it")
+                Image(systemName: "bubble.left")
+            }
+            .disabled(!canAskAgent)
+            .accessibilityIdentifier("edit-thing-ask-agent")
+
+            Button(action: {}) {
+                Text("Edit with an app")
+                Text("Soon")
+                Image(systemName: "square.on.square")
+            }
+            .disabled(true)
+            .accessibilityIdentifier("edit-thing-with-app")
+        } label: {
+            Image(systemName: "pencil")
+        }
+        .accessibilityLabel("Edit")
+        .accessibilityIdentifier("edit-thing-menu")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        Text("Accommodation")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    EditThingMenu(canAskAgent: true, onAskForChanges: {})
+                }
+            }
+    }
+}

--- a/Convos/Conversation Detail/EditThingMenu.swift
+++ b/Convos/Conversation Detail/EditThingMenu.swift
@@ -15,15 +15,17 @@ struct EditThingMenu: View {
             Button(action: onAskForChanges) {
                 Text("Ask for changes")
                 Text("Your agent will change it")
-                Image(systemName: "bubble.left")
+                Image(systemName: "message")
             }
             .disabled(!canAskAgent)
             .accessibilityIdentifier("edit-thing-ask-agent")
 
+            // Disabled, so the row (icon included) renders in the faint inactive
+            // style, matching the "Soon" state.
             Button(action: {}) {
                 Text("Edit with an app")
                 Text("Soon")
-                Image(systemName: "square.on.square")
+                Image(systemName: "pencil")
             }
             .disabled(true)
             .accessibilityIdentifier("edit-thing-with-app")

--- a/Convos/Conversation Detail/ShareThingMenu.swift
+++ b/Convos/Conversation Detail/ShareThingMenu.swift
@@ -24,7 +24,7 @@ struct ShareThingMenu: View {
             if canShareToAgent {
                 Button(action: onShareToAgent) {
                     Text("Send to agent")
-                    Image(systemName: "pencil")
+                    Image(systemName: "arrowshape.turn.up.forward")
                 }
                 .accessibilityIdentifier("share-thing-to-agent")
             }

--- a/Convos/Conversation Detail/ShareThingMenu.swift
+++ b/Convos/Conversation Detail/ShareThingMenu.swift
@@ -15,14 +15,14 @@ struct ShareThingMenu: View {
     var body: some View {
         Menu {
             Button(action: onShareToGroup) {
-                Text("Share with group")
+                Text("Share to group")
                 Image(systemName: "message")
             }
             .accessibilityIdentifier("share-thing-to-group")
 
             if canShareToAgent {
                 Button(action: onShareToAgent) {
-                    Text("Work with agent")
+                    Text("Send to agent")
                     Image(systemName: "pencil")
                 }
                 .accessibilityIdentifier("share-thing-to-agent")

--- a/Convos/Conversation Detail/ShareThingMenu.swift
+++ b/Convos/Conversation Detail/ShareThingMenu.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Top-right menu on a Things detail page: shares the current thing's link into
+/// a composer. Mirrors `AddToConversationMenu`'s Menu-in-toolbar shape (a share
+/// glyph label opening title/subtitle/icon buttons) so the toolbar builder in
+/// `ConversationView` stays within the type-check budget.
+///
+/// The Agent row is shown only once the agent DM is bound; before that its
+/// composer does not exist to receive the link.
+struct ShareThingMenu: View {
+    let canShareToAgent: Bool
+    let onShareToGroup: () -> Void
+    let onShareToAgent: () -> Void
+
+    var body: some View {
+        Menu {
+            Button(action: onShareToGroup) {
+                Text("Share to Group")
+                Text("Add the link to the group chat")
+                Image(systemName: "bubble.left.and.bubble.right")
+            }
+            .accessibilityIdentifier("share-thing-to-group")
+
+            if canShareToAgent {
+                Button(action: onShareToAgent) {
+                    Text("Share to Agent")
+                    Text("Add the link to the agent chat")
+                    Image(systemName: "sparkles")
+                }
+                .accessibilityIdentifier("share-thing-to-agent")
+            }
+        } label: {
+            Image(systemName: "square.and.arrow.up")
+        }
+        .accessibilityLabel("Share")
+        .accessibilityIdentifier("share-thing-menu")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        Text("Accommodation")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ShareThingMenu(
+                        canShareToAgent: true,
+                        onShareToGroup: {},
+                        onShareToAgent: {}
+                    )
+                }
+            }
+    }
+}

--- a/Convos/Conversation Detail/ShareThingMenu.swift
+++ b/Convos/Conversation Detail/ShareThingMenu.swift
@@ -15,17 +15,15 @@ struct ShareThingMenu: View {
     var body: some View {
         Menu {
             Button(action: onShareToGroup) {
-                Text("Share to Group")
-                Text("Add the link to the group chat")
-                Image(systemName: "bubble.left.and.bubble.right")
+                Text("Share with group")
+                Image(systemName: "message")
             }
             .accessibilityIdentifier("share-thing-to-group")
 
             if canShareToAgent {
                 Button(action: onShareToAgent) {
-                    Text("Share to Agent")
-                    Text("Add the link to the agent chat")
-                    Image(systemName: "sparkles")
+                    Text("Work with agent")
+                    Image(systemName: "pencil")
                 }
                 .accessibilityIdentifier("share-thing-to-agent")
             }

--- a/Convos/Conversation Detail/ShareThingMenu.swift
+++ b/Convos/Conversation Detail/ShareThingMenu.swift
@@ -11,6 +11,7 @@ struct ShareThingMenu: View {
     let canShareToAgent: Bool
     let onShareToGroup: () -> Void
     let onShareToAgent: () -> Void
+    let onShareExternally: () -> Void
 
     var body: some View {
         Menu {
@@ -27,6 +28,12 @@ struct ShareThingMenu: View {
                 }
                 .accessibilityIdentifier("share-thing-to-agent")
             }
+
+            Button(action: onShareExternally) {
+                Text("Share ...")
+                Image(systemName: "square.and.arrow.up")
+            }
+            .accessibilityIdentifier("share-thing-externally")
         } label: {
             Image(systemName: "square.and.arrow.up")
         }
@@ -43,7 +50,8 @@ struct ShareThingMenu: View {
                     ShareThingMenu(
                         canShareToAgent: true,
                         onShareToGroup: {},
-                        onShareToAgent: {}
+                        onShareToAgent: {},
+                        onShareExternally: {}
                     )
                 }
             }


### PR DESCRIPTION
## What

Adds a top-right **Share** button on a Things (Space) detail page. Tapping it opens a menu:

- **Share to Group** — always available
- **Share to Agent** — shown only once the agent DM composer is bound

Choosing a destination switches to that tab and drops the thing's link into that tab's composer. When the composer is empty it renders as a **link preview card** (the same `pastedLinkPreview` path pasted links use); otherwise the link is appended to the existing draft with a separator so nothing is clobbered. Switching tabs does **not** raise the keyboard.

## Why

Users viewing a specific thing (e.g. an Accommodation note) had no way to surface it back into the conversation. This lets them share the thing's link straight into the group chat or the agent DM.

## How

- New `Convos/Conversation Detail/ShareThingMenu.swift` — a `Menu`-in-toolbar component mirroring `AddToConversationMenu`.
- `ConversationView.swift`:
  - `ShareThingMenu` added as a `.topBarTrailing` item inside the `isBrowsingHome` branch (previously an empty slot), gated on the current thing having a URL.
  - `shareCurrentThing(to:)` uses `homeBrowserEntries.last?.url`, prefills the destination composer, then `selectTab(tab)`.
  - `prefillComposer(_:withLink:)` chooses card vs. append based on composer state; the append path also covers URLs `LinkPreview.from` rejects (private hosts).

No changes to `AgentDmSession`, the web layer, or `ConversationViewModel` — only already-bound public composer state is set.

## Testing

- `xcodebuild` build of **Convos (Dev)** succeeds; app installs and launches on the simulator.
- Manual: open Things, tap into a thing, tap Share, pick Group/Agent -> tab switches, link lands in the composer, keyboard stays down.
- Note: the **card** rendering requires a public (dev/prod) Space host; `LinkPreview.from` rejects private hosts, so a purely local Space URL falls back to appended text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790056976&installation_model_id=20076&pr_number=1409&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1409&signature=19e2c84cd761ef7d0b1b47a608acb4c9f9d4d307c3f835d9d122d592ec6d38bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add share-to-composer and edit-request menus on Things detail page
> - Adds `EditThingMenu` and `ShareThingMenu` toolbar items to `ConversationView` when viewing a thing URL, offering in-app share to group/agent and external system share.
> - Introduces `ConversationView.shareCurrentThing(to:)` to prefill a target composer (group or agent) with the thing link and switch tabs; `askAgentToEditCurrentThing` prefixes a 'Please change this' prompt.
> - `prefillComposer(_:withLink:)` creates a `LinkPreview` card when the composer is empty, otherwise appends the URL to existing draft text.
> - Risk: `prefillComposer` overwrites `pastedLinkPreview` when the composer has no existing text or card, which could replace a previously consumed (but not yet displayed) preview if invoked twice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 344365a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->