### PR TITLE
[DO NOT MERGE][Shane Mac] Disappearing conversations in a human and agentic world

### DIFF
--- a/Convos/Conversation Detail/ConversationInfoView.swift
+++ b/Convos/Conversation Detail/ConversationInfoView.swift
@@ -387,6 +387,31 @@ struct ConversationInfoView: View {
         }
     }
 
+    private var privacySection: some View {
+        Section {
+            NavigationLink {
+                DisappearingMessagesView(viewModel: viewModel)
+            } label: {
+                FeatureRowItem(
+                    imageName: nil,
+                    symbolName: "timer",
+                    title: "Disappearing messages",
+                    subtitle: viewModel.conversation.disappearingMessagesDurationTitle ?? "Off",
+                    iconBackgroundColor: .colorFillMinimal,
+                    iconForegroundColor: .colorTextPrimary
+                ) {
+                    EmptyView()
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("disappearing-messages-row")
+        } header: {
+            Text("Privacy")
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.colorTextSecondary)
+        }
+    }
+
     var body: some View {
         infoContent
             .addFromContactsPicker(
@@ -428,6 +453,8 @@ struct ConversationInfoView: View {
                     )
                 }
             }
+
+            privacySection
 
             preferencesSection
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -62,6 +62,11 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// It lives here rather than in the composer because the level belongs to
     /// the conversation; the composer only draws the control.
     @State private var participation: AgentParticipationStore?
+    /// Pause is the moment privacy intent is clearest. When no timer is active
+    /// and the per-conversation automation is off, this presents one bounded
+    /// choice: pause only, or pause and enable the remembered timer.
+    @State private var showingPausePrivacyPrompt: Bool = false
+    @State private var disappearingMessagesError: String?
     /// The conversation sheet's selected tab, the single source of truth for
     /// both the backing view behind the sheet and the bar the sheet hosts.
     @State private var selectedTab: ConversationTab = .group
@@ -203,7 +208,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
     }
 
     private func messagesView(focus: FocusState<MessagesViewInputFocus?>.Binding) -> some View {
-        MessagesView(
+        let content = MessagesView(
             contextMenuState: contextMenuState,
             conversation: viewModel.conversation,
             messages: groupMessages,
@@ -341,6 +346,35 @@ struct ConversationView<MessagesBottomBar: View>: View {
             Button("OK", role: .cancel) { participation?.dismissError() }
         } message: {
             Text(participation?.errorMessage ?? "Please try again.")
+        }
+
+        return privacyPrompts(for: content)
+    }
+
+    private func privacyPrompts<Content: View>(for content: Content) -> some View {
+        content
+        .confirmationDialog(
+            "Pause agents?",
+            isPresented: $showingPausePrivacyPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Pause + turn on disappearing messages") {
+                pauseAgents(enableDisappearingMessages: true)
+            }
+            Button("Pause only") {
+                pauseAgents(enableDisappearingMessages: false)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Paused agents won’t see new messages. You can also make new messages disappear after your selected timer.")
+        }
+        .alert("Timer not updated", isPresented: Binding(
+            get: { disappearingMessagesError != nil },
+            set: { if !$0 { disappearingMessagesError = nil } }
+        )) {
+            Button("OK", role: .cancel) { disappearingMessagesError = nil }
+        } message: {
+            Text(disappearingMessagesError ?? "Please try again.")
         }
     }
 
@@ -1928,7 +1962,38 @@ private extension ConversationView {
             isLoading: !participation.hasLoaded,
             agentName: participationAgentName
         ) { level in
-            Task { await participation.set(level) }
+            selectParticipationLevel(level)
+        }
+    }
+
+    func selectParticipationLevel(_ level: AgentParticipationLevel) {
+        guard level == .paused,
+              !viewModel.conversation.isDisappearingMessagesEnabled else {
+            Task { await participation?.set(level) }
+            return
+        }
+
+        let conversationId = viewModel.conversation.id
+        if DisappearingMessagesPreferences.automaticallyEnableWhenAgentsPause(conversationId: conversationId) {
+            pauseAgents(enableDisappearingMessages: true)
+        } else {
+            showingPausePrivacyPrompt = true
+        }
+    }
+
+    func pauseAgents(enableDisappearingMessages: Bool) {
+        Task {
+            await participation?.set(.paused)
+            guard enableDisappearingMessages, participation?.level == .paused else { return }
+
+            let conversationId = viewModel.conversation.id
+            let duration = DisappearingMessagesPreferences.preferredDuration(conversationId: conversationId)
+            do {
+                try await viewModel.updateDisappearingMessages(duration)
+                DisappearingMessagesPreferences.remember(duration, conversationId: conversationId)
+            } catch {
+                disappearingMessagesError = error.localizedDescription
+            }
         }
     }
 

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -1782,7 +1782,8 @@ private extension ConversationView {
                 state.cancelMessageSelection()
             } catch {
                 Log.error("Failed deleting selected messages: \(error.localizedDescription)")
-                messageDeletionError = "Please try again."
+                state.cancelMessageSelection()
+                messageDeletionError = "Some messages may not have been deleted. Please try again."
             }
             isDeletingSelectedMessages = false
         }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -369,7 +369,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Paused agents won’t see new messages. You can also make new messages disappear after your selected timer.")
+            Text("Paused agents won’t see new messages. You can also make new messages disappear after your selected timer, or after 24 hours if you haven’t chosen one.")
         }
         .alert("Couldn't update disappearing messages", isPresented: Binding(
             get: { disappearingMessagesError != nil },
@@ -2129,7 +2129,7 @@ private extension ConversationView {
             guard enableDisappearingMessages, participation?.level == .paused else { return }
 
             let conversationId = viewModel.conversation.id
-            let duration = DisappearingMessagesPreferences.preferredDuration(conversationId: conversationId)
+            let duration = DisappearingMessagesPreferences.durationWhenAgentsPause(conversationId: conversationId)
             do {
                 try await viewModel.updateDisappearingMessages(duration)
                 DisappearingMessagesPreferences.remember(duration, conversationId: conversationId)

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -368,7 +368,7 @@ struct ConversationView<MessagesBottomBar: View>: View {
         } message: {
             Text("Paused agents won’t see new messages. You can also make new messages disappear after your selected timer.")
         }
-        .alert("Timer not updated", isPresented: Binding(
+        .alert("Couldn't update disappearing messages", isPresented: Binding(
             get: { disappearingMessagesError != nil },
             set: { if !$0 { disappearingMessagesError = nil } }
         )) {
@@ -1992,7 +1992,8 @@ private extension ConversationView {
                 try await viewModel.updateDisappearingMessages(duration)
                 DisappearingMessagesPreferences.remember(duration, conversationId: conversationId)
             } catch {
-                disappearingMessagesError = error.localizedDescription
+                Log.error("Failed to enable disappearing messages after pausing agents in \(conversationId): \(error)")
+                disappearingMessagesError = "Please try again."
             }
         }
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -67,6 +67,9 @@ struct ConversationView<MessagesBottomBar: View>: View {
     /// choice: pause only, or pause and enable the remembered timer.
     @State private var showingPausePrivacyPrompt: Bool = false
     @State private var disappearingMessagesError: String?
+    @State private var showingMessageDeleteConfirmation: Bool = false
+    @State private var isDeletingSelectedMessages: Bool = false
+    @State private var messageDeletionError: String?
     /// The conversation sheet's selected tab, the single source of truth for
     /// both the backing view behind the sheet and the bar the sheet hosts.
     @State private var selectedTab: ConversationTab = .group
@@ -495,6 +498,10 @@ struct ConversationView<MessagesBottomBar: View>: View {
         return dmViewModel
     }
 
+    private var activeContextMenuState: MessageContextMenuState {
+        selectedTab == .agent ? agentContextMenuState : contextMenuState
+    }
+
     /// The focus coordinator for the selected lane's composer, so a reply opens
     /// the composer the reply will be sent from.
     private var activeLaneFocusCoordinator: FocusCoordinator {
@@ -570,6 +577,31 @@ struct ConversationView<MessagesBottomBar: View>: View {
 
     var body: some View {
         conversationPresentations(conversationCore)
+        .confirmationDialog(
+            messageDeleteConfirmationTitle,
+            isPresented: $showingMessageDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            if activeContextMenuState.canDeleteSelectionForEveryone {
+                Button("Delete for everyone", role: .destructive) {
+                    deleteSelectedMessages(forEveryone: true)
+                }
+            }
+            Button("Delete for me", role: .destructive) {
+                deleteSelectedMessages(forEveryone: false)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(messageDeleteConfirmationMessage)
+        }
+        .alert("Couldn't delete messages", isPresented: Binding(
+            get: { messageDeletionError != nil },
+            set: { if !$0 { messageDeletionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { messageDeletionError = nil }
+        } message: {
+            Text(messageDeletionError ?? "Please try again.")
+        }
         .onChange(of: viewModel.messageText) { _, _ in
             viewModel.checkForInviteURL()
             viewModel.checkForAgentShareURL()
@@ -603,6 +635,8 @@ struct ConversationView<MessagesBottomBar: View>: View {
         }
         .onDisappear {
             viewModel.onConversationDisappeared()
+            contextMenuState.cancelMessageSelection()
+            agentContextMenuState.cancelMessageSelection()
             updateGroupOnScreen(isOnScreen: false)
             // The DM clears its own registration when its page unmounts, which
             // only happens if the Agent tab was ever visited. Clearing from here
@@ -800,6 +834,8 @@ private extension ConversationView {
     /// claiming the incoming one so the keyboard hands over instead of
     /// dropping.
     private func handleSelectedTabChange(from oldTab: ConversationTab, to newTab: ConversationTab) {
+        contextMenuState.cancelMessageSelection()
+        agentContextMenuState.cancelMessageSelection()
         transferKeyboard(to: newTab)
         // A right-swipe can both start a reply and switch away; cancel the
         // in-flight reply swipe so the tab change doesn't fire one.
@@ -1161,7 +1197,7 @@ private extension ConversationView {
         // The embedded Scan/Invite toggle owns scanning, so the lone viewfinder
         // toolbar item is dropped for that flow. Browser pages hide the
         // trailing item entirely.
-        if !topBarTrailingHidden && !isBrowsingHome {
+        if !topBarTrailingHidden && !isBrowsingHome && !activeContextMenuState.isSelectingMessages {
             ToolbarItem(placement: .topBarTrailing) {
                 if viewModel.isLocked {
                     lockedInfoButton
@@ -1340,14 +1376,19 @@ private extension ConversationView {
             // taller than the chrome's frame and a background would clip it.
             ConversationChromeScrim(topSafeAreaInset: windowSafeAreaInsets.top)
             ConversationTopChrome(topSafeAreaInset: windowSafeAreaInsets.top) {
-                ConversationSegmentedControl(
-                    selectedTab: $selectedTab,
-                    tabs: availableTabs,
-                    badgedTabs: badgedTabs
-                )
+                if activeContextMenuState.isSelectingMessages {
+                    messageSelectionHeader
+                } else {
+                    ConversationSegmentedControl(
+                        selectedTab: $selectedTab,
+                        tabs: availableTabs,
+                        badgedTabs: badgedTabs
+                    )
+                }
             }
         }
         .overlay { messageContextMenuOverlay }
+        .overlay(alignment: .bottom) { messageSelectionBottomBar }
         // The agent composer's own state mirrors its own coordinator. Without
         // it, `FocusCoordinator.moveFocus` still runs and still updates the
         // coordinator, but nothing takes first responder. The group composer
@@ -1424,7 +1465,10 @@ private extension ConversationView {
 
     /// True while either transcript has its long-press menu up.
     private var isPagingDisabled: Bool {
-        contextMenuState.isPresented || agentContextMenuState.isPresented
+        contextMenuState.isPresented
+            || agentContextMenuState.isPresented
+            || contextMenuState.isSelectingMessages
+            || agentContextMenuState.isSelectingMessages
     }
 
     @ViewBuilder
@@ -1645,6 +1689,103 @@ private extension ConversationView {
         // routes where the bubble's own tap routes only because of this.
         .environment(\.messageLinkRouter, routeSpaceLink(_:))
         .environment(\.conversationSpaceURL, viewModel.conversation.spaceURL)
+    }
+
+    var messageSelectionHeader: some View {
+        HStack(spacing: DesignConstants.Spacing.step3x) {
+            Text("\(activeContextMenuState.selectedMessages.count) selected")
+                .font(.headline)
+                .foregroundStyle(.colorTextPrimary)
+            Spacer()
+            Button {
+                activeContextMenuState.cancelMessageSelection()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .disabled(isDeletingSelectedMessages)
+            .accessibilityLabel("Cancel message selection")
+        }
+        .padding(.leading, DesignConstants.Spacing.step4x)
+    }
+
+    @ViewBuilder
+    var messageSelectionBottomBar: some View {
+        if activeContextMenuState.isSelectingMessages {
+            VStack(spacing: 0) {
+                Divider()
+                HStack {
+                    Text("\(activeContextMenuState.selectedMessages.count) selected")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.colorTextSecondary)
+                    Spacer()
+                    Button(role: .destructive) {
+                        showingMessageDeleteConfirmation = true
+                    } label: {
+                        Group {
+                            if isDeletingSelectedMessages {
+                                ProgressView()
+                            } else {
+                                Image(systemName: "trash.fill")
+                                    .font(.system(size: 18, weight: .semibold))
+                            }
+                        }
+                        .frame(width: 48, height: 48)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.colorCaution)
+                    .disabled(isDeletingSelectedMessages)
+                    .accessibilityLabel("Delete selected messages")
+                }
+                .padding(.horizontal, DesignConstants.Spacing.step5x)
+                .padding(.top, DesignConstants.Spacing.step3x)
+                .padding(.bottom, max(windowSafeAreaInsets.bottom, DesignConstants.Spacing.step3x))
+            }
+            .background(.ultraThinMaterial)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .zIndex(200)
+        }
+    }
+
+    var messageDeleteConfirmationTitle: String {
+        let count = activeContextMenuState.selectedMessages.count
+        return count == 1 ? "Delete message?" : "Delete \(count) messages?"
+    }
+
+    var messageDeleteConfirmationMessage: String {
+        guard activeContextMenuState.canDeleteSelectionForEveryone else {
+            return "This removes the selected messages from this device only."
+        }
+        let hasAgent = activeLaneViewModel.conversation.members.contains(where: \.isAgent)
+        if hasAgent {
+            return "This removes the selected messages for people using message deletion. Agents may still keep copies outside Convos."
+        }
+        return "This removes the selected messages for people using message deletion."
+    }
+
+    func deleteSelectedMessages(forEveryone: Bool) {
+        let state = activeContextMenuState
+        let messages = state.selectedMessages
+        let lane = activeLaneViewModel
+        guard !messages.isEmpty else { return }
+
+        isDeletingSelectedMessages = true
+        Task {
+            do {
+                if forEveryone {
+                    try await lane.deleteMessagesForEveryone(messages)
+                } else {
+                    try await lane.deleteMessagesForMe(messages)
+                }
+                state.cancelMessageSelection()
+            } catch {
+                Log.error("Failed deleting selected messages: \(error.localizedDescription)")
+                messageDeletionError = "Please try again."
+            }
+            isDeletingSelectedMessages = false
+        }
     }
 
     /// Extra rows above the group composer: the injected bottom-bar slot plus

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4004,6 +4004,14 @@ extension ConversationViewModel {
         }
     }
 
+    func deleteMessagesForMe(_ messages: [AnyMessage]) async throws {
+        try await cachedMessageWriter.deleteMessagesForMe(messages.deletionTargets)
+    }
+
+    func deleteMessagesForEveryone(_ messages: [AnyMessage]) async throws {
+        try await cachedMessageWriter.deleteMessagesForEveryone(messages.deletionTargets)
+    }
+
     func onUseProfile(_ profile: Profile, _ profileImage: UIImage?) {
         myProfileViewModel.update(using: profile, profileImage: profileImage, conversationId: conversation.id)
     }
@@ -4926,6 +4934,17 @@ extension ConversationViewModel {
             }
             group.cancelAll()
             return result
+        }
+    }
+}
+
+private extension Array where Element == AnyMessage {
+    var deletionTargets: [MessageDeletionTarget] {
+        map {
+            MessageDeletionTarget(
+                localMessageId: $0.messageId,
+                xmtpMessageId: $0.xmtpMessageId
+            )
         }
     }
 }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -4248,6 +4248,10 @@ extension ConversationViewModel {
         try await metadataWriter.updateSpaceURL(urlString, for: conversation.id)
     }
 
+    func updateDisappearingMessages(_ duration: DisappearingMessageDuration?) async throws {
+        try await metadataWriter.updateDisappearingMessages(duration, for: conversation.id)
+    }
+
     /// Presents the invite-code sheet (`InviteCodeSheet`) via
     /// `ConversationPresenter`. Used by the home page's
     /// `window.convos.showInviteCode()` bridge call.

--- a/Convos/Conversation Detail/DisappearingMessagesView.swift
+++ b/Convos/Conversation Detail/DisappearingMessagesView.swift
@@ -1,0 +1,161 @@
+import ConvosCore
+import SwiftUI
+
+enum DisappearingMessagesPreferences {
+    private static let autoEnablePrefix: String = "disappearingMessages.autoEnableOnAgentPause."
+    private static let preferredDurationPrefix: String = "disappearingMessages.preferredDuration."
+
+    static func automaticallyEnableWhenAgentsPause(conversationId: String) -> Bool {
+        UserDefaults.standard.bool(forKey: autoEnablePrefix + conversationId)
+    }
+
+    static func setAutomaticallyEnableWhenAgentsPause(_ enabled: Bool, conversationId: String) {
+        UserDefaults.standard.set(enabled, forKey: autoEnablePrefix + conversationId)
+    }
+
+    static func preferredDuration(conversationId: String) -> DisappearingMessageDuration {
+        let stored = UserDefaults.standard.object(forKey: preferredDurationPrefix + conversationId) as? NSNumber
+        return stored
+            .flatMap { DisappearingMessageDuration(rawValue: $0.int64Value) }
+            ?? .privacyDefault
+    }
+
+    static func remember(_ duration: DisappearingMessageDuration, conversationId: String) {
+        UserDefaults.standard.set(duration.rawValue, forKey: preferredDurationPrefix + conversationId)
+    }
+}
+
+struct DisappearingMessagesView: View {
+    @Bindable var viewModel: ConversationViewModel
+
+    @State private var automaticallyEnableWhenAgentsPause: Bool = false
+    @State private var isSaving: Bool = false
+    @State private var errorMessage: String?
+
+    private var selectedDuration: DisappearingMessageDuration? {
+        guard let rawValue = viewModel.conversation.disappearingMessageRetentionDurationInNs else {
+            return nil
+        }
+        return DisappearingMessageDuration(rawValue: rawValue)
+    }
+
+    private var hasActiveTimer: Bool {
+        viewModel.conversation.isDisappearingMessagesEnabled
+    }
+
+    var body: some View {
+        List {
+            Section {
+                timerRow(title: "Off", duration: nil)
+                ForEach(DisappearingMessageDuration.allCases) { duration in
+                    timerRow(title: duration.title, duration: duration)
+                }
+            } header: {
+                Text("Message timer")
+            } footer: {
+                Text("New messages in this conversation disappear for everyone after the selected duration.")
+            }
+
+            Section {
+                Toggle(
+                    "Turn on disappearing messages any time an agent is paused",
+                    isOn: $automaticallyEnableWhenAgentsPause
+                )
+                    .onChange(of: automaticallyEnableWhenAgentsPause) { _, enabled in
+                        DisappearingMessagesPreferences.setAutomaticallyEnableWhenAgentsPause(
+                            enabled,
+                            conversationId: viewModel.conversation.id
+                        )
+                    }
+                    .accessibilityIdentifier("disappearing-messages-on-pause-toggle")
+            } footer: {
+                Text("When you pause agents in this conversation, Convos will turn on your last selected timer too.")
+            }
+
+            if viewModel.conversation.hasAgent {
+                Section {
+                    Label {
+                        VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                            Text("Agents can store messages outside Convos")
+                                .foregroundStyle(.colorTextPrimary)
+                            Text("Even with disappearing messages on, agents in this chat may store messages wherever they’re connected.")
+                                .font(.footnote)
+                                .foregroundStyle(.colorTextSecondary)
+                        }
+                    } icon: {
+                        Image(systemName: "exclamationmark.shield")
+                            .foregroundStyle(.colorCaution)
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+            }
+        }
+        .disabled(isSaving)
+        .navigationTitle("Disappearing messages")
+        .navigationBarTitleDisplayMode(.inline)
+        .scrollContentBackground(.hidden)
+        .background(.colorBackgroundRaisedSecondary)
+        .onAppear {
+            automaticallyEnableWhenAgentsPause = DisappearingMessagesPreferences
+                .automaticallyEnableWhenAgentsPause(conversationId: viewModel.conversation.id)
+        }
+        .alert("Timer not updated", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "Please try again.")
+        }
+    }
+
+    private func timerRow(
+        title: String,
+        duration: DisappearingMessageDuration?
+    ) -> some View {
+        Button {
+            update(duration)
+        } label: {
+            HStack {
+                Text(title)
+                    .foregroundStyle(.colorTextPrimary)
+                Spacer()
+                if isSelected(duration) {
+                    Image(systemName: "checkmark")
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.colorTextPrimary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(isSelected(duration) ? "selected" : "")
+        .accessibilityIdentifier("disappearing-messages-timer-\(duration?.rawValue.description ?? "off")")
+    }
+
+    private func isSelected(_ duration: DisappearingMessageDuration?) -> Bool {
+        if let duration {
+            return selectedDuration == duration
+        }
+        return !hasActiveTimer
+    }
+
+    private func update(_ duration: DisappearingMessageDuration?) {
+        guard !isSelected(duration), !isSaving else { return }
+        isSaving = true
+        Task {
+            defer { isSaving = false }
+            do {
+                try await viewModel.updateDisappearingMessages(duration)
+                if let duration {
+                    DisappearingMessagesPreferences.remember(
+                        duration,
+                        conversationId: viewModel.conversation.id
+                    )
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Convos/Conversation Detail/DisappearingMessagesView.swift
+++ b/Convos/Conversation Detail/DisappearingMessagesView.swift
@@ -13,7 +13,9 @@ enum DisappearingMessagesPreferences {
         UserDefaults.standard.set(enabled, forKey: autoEnablePrefix + conversationId)
     }
 
-    static func preferredDuration(conversationId: String) -> DisappearingMessageDuration {
+    /// The timer Pause should enable. A conversation remembers the last timer
+    /// someone selected; 24 hours is the privacy-first default before that.
+    static func durationWhenAgentsPause(conversationId: String) -> DisappearingMessageDuration {
         let stored = UserDefaults.standard.object(forKey: preferredDurationPrefix + conversationId) as? NSNumber
         return stored
             .flatMap { DisappearingMessageDuration(rawValue: $0.int64Value) }
@@ -58,7 +60,7 @@ struct DisappearingMessagesView: View {
 
             Section {
                 Toggle(
-                    "Turn on disappearing messages any time an agent is paused",
+                    "Turn on disappearing messages when an agent is paused",
                     isOn: $automaticallyEnableWhenAgentsPause
                 )
                     .onChange(of: automaticallyEnableWhenAgentsPause) { _, enabled in
@@ -69,7 +71,7 @@ struct DisappearingMessagesView: View {
                     }
                     .accessibilityIdentifier("disappearing-messages-on-pause-toggle")
             } footer: {
-                Text("When you pause agents in this conversation, Convos will turn on your last selected timer too.")
+                Text("When you pause an agent, messages will disappear after 24 hours unless you’ve selected another timer.")
             }
 
             if viewModel.conversation.hasAgent {

--- a/Convos/Conversation Detail/DisappearingMessagesView.swift
+++ b/Convos/Conversation Detail/DisappearingMessagesView.swift
@@ -99,7 +99,7 @@ struct DisappearingMessagesView: View {
             automaticallyEnableWhenAgentsPause = DisappearingMessagesPreferences
                 .automaticallyEnableWhenAgentsPause(conversationId: viewModel.conversation.id)
         }
-        .alert("Timer not updated", isPresented: Binding(
+        .alert("Couldn't update disappearing messages", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }
         )) {
@@ -154,7 +154,8 @@ struct DisappearingMessagesView: View {
                     )
                 }
             } catch {
-                errorMessage = error.localizedDescription
+                Log.error("Failed to update disappearing messages for \(viewModel.conversation.id): \(error)")
+                errorMessage = "Please try again."
             }
         }
     }

--- a/ConvosCore/Sources/ConvosComposer/ConversationToolbarButton.swift
+++ b/ConvosCore/Sources/ConvosComposer/ConversationToolbarButton.swift
@@ -51,10 +51,16 @@ public struct ConversationToolbarButton: View {
                     .foregroundStyle(.colorCaution)
             }
         } else {
-            Text(subtitle)
-                .lineLimit(1)
-                .font(.caption)
-                .foregroundStyle(subtitleColor)
+            HStack(spacing: DesignConstants.Spacing.stepHalf) {
+                if conversation.isDisappearingMessagesEnabled {
+                    Image(systemName: "timer")
+                        .accessibilityHidden(true)
+                }
+                Text(subtitle)
+                    .lineLimit(1)
+            }
+            .font(.caption)
+            .foregroundStyle(subtitleColor)
         }
     }
 
@@ -95,7 +101,11 @@ public struct ConversationToolbarButton: View {
             }
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(title), \(subtitle)")
+        .accessibilityLabel(
+            [title, subtitle, conversation.disappearingMessagesDurationTitle.map { "disappearing messages \($0)" }]
+                .compactMap { $0 }
+                .joined(separator: ", ")
+        )
         .accessibilityIdentifier("conversation-toolbar-button")
     }
 }

--- a/ConvosCore/Sources/ConvosComposer/ConversationsListItem.swift
+++ b/ConvosCore/Sources/ConvosComposer/ConversationsListItem.swift
@@ -163,6 +163,9 @@ public struct ConversationsListItem: View {
         if isPendingInvite { parts.append("verifying") }
         if combinedUnread { parts.append(dmUnread ? "unread agent message" : "unread") }
         if isMuted { parts.append("muted") }
+        if let duration = conversation.disappearingMessagesDurationTitle {
+            parts.append("disappearing messages, \(duration)")
+        }
         if !previewText.isEmpty {
             parts.append(previewText)
         }
@@ -194,13 +197,23 @@ public struct ConversationsListItem: View {
                 }
             },
             accessoryContent: {
-                if let expiresAt = conversation.scheduledExplosionDate {
-                    ExplosionCountdownBadge(expiresAt: expiresAt)
-                        .transition(.scale.combined(with: .opacity))
+                HStack(spacing: DesignConstants.Spacing.stepX) {
+                    if conversation.isDisappearingMessagesEnabled {
+                        Image(systemName: "timer")
+                            .font(.caption)
+                            .foregroundStyle(.colorTextTertiary)
+                            .accessibilityHidden(true)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                    if let expiresAt = conversation.scheduledExplosionDate {
+                        ExplosionCountdownBadge(expiresAt: expiresAt)
+                            .transition(.scale.combined(with: .opacity))
+                    }
                 }
             }
         )
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: conversation.scheduledExplosionDate)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: conversation.isDisappearingMessagesEnabled)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityIdentifier("conversation-list-item-\(conversation.id)")

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -543,6 +543,22 @@ public struct MessageContextMenuOverlay: View {
                     }
                     ContextMenuRow(icon: "square.and.arrow.down", title: "Save", action: saveAction)
                 }
+
+                if !isReadOnly {
+                    let deleteAction = {
+                        let msg = message
+                        dismissMenu()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                            state.beginMessageSelection(with: msg)
+                        }
+                    }
+                    ContextMenuRow(
+                        icon: "trash",
+                        title: "Delete",
+                        isDestructive: true,
+                        action: deleteAction
+                    )
+                }
             }
             .padding(.vertical, 10)
             .foregroundStyle(.primary)
@@ -629,8 +645,8 @@ public struct MessageContextMenuOverlay: View {
         static let maxPreviewHeight: CGFloat = 75
         static let photoHorizontalInset: CGFloat = 16
         static let photoCornerRadius: CGFloat = DesignConstants.CornerRadius.photo
-        static let textMenuEstimatedHeight: CGFloat = 80
-        static let photoMenuEstimatedHeight: CGFloat = 160
+        static let textMenuEstimatedHeight: CGFloat = 132
+        static let photoMenuEstimatedHeight: CGFloat = 212
         /// Slack above and below the message preview. Applied twice by
         /// `endBubbleRect` - once inside its bottom padding and once again
         /// against the content height - so the effective reservation is double
@@ -1098,10 +1114,11 @@ private func shareFile(key: String, filename: String?) {
 private struct ContextMenuRow: View {
     let icon: String
     let title: String
+    var isDestructive: Bool = false
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button(role: isDestructive ? .destructive : nil, action: action) {
             HStack(spacing: 14) {
                 Image(systemName: icon)
                     .font(.system(size: 17, weight: .regular))
@@ -1114,6 +1131,7 @@ private struct ContextMenuRow: View {
             .padding(.vertical, 11)
             .contentShape(Rectangle())
         }
+        .foregroundStyle(isDestructive ? .colorCaution : .primary)
     }
 }
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuState.swift
@@ -34,6 +34,25 @@ public class MessageContextMenuState: @unchecked Sendable {
     public var isExpanded: Bool = false
     public var sourceID: UUID?
 
+    /// The messages currently checked in WhatsApp-style delete selection.
+    /// The values are retained so the host can perform the operation after
+    /// the transcript rows disappear from the live repository.
+    public private(set) var selectedMessagesById: [String: AnyMessage] = [:]
+
+    public var isSelectingMessages: Bool {
+        !selectedMessagesById.isEmpty
+    }
+
+    public var selectedMessages: [AnyMessage] {
+        selectedMessagesById.values.sorted { $0.date < $1.date }
+    }
+
+    public var canDeleteSelectionForEveryone: Bool {
+        !selectedMessages.isEmpty && selectedMessages.allSatisfy {
+            $0.sender.isCurrentUser && $0.status == .published && $0.xmtpMessageId != nil
+        }
+    }
+
     public var currentSourceFrame: CGRect = .zero
 
     /// Bumped to cancel any in-flight swipe-to-reply gesture on this list's
@@ -85,6 +104,24 @@ public class MessageContextMenuState: @unchecked Sendable {
         isReplyParent = false
         isExpanded = false
         sourceID = nil
+    }
+
+    public func beginMessageSelection(with message: AnyMessage) {
+        selectedMessagesById = [message.messageId: message]
+    }
+
+    public func toggleMessageSelection(_ message: AnyMessage) {
+        if selectedMessagesById.removeValue(forKey: message.messageId) == nil {
+            selectedMessagesById[message.messageId] = message
+        }
+    }
+
+    public func isMessageSelected(_ message: AnyMessage) -> Bool {
+        selectedMessagesById[message.messageId] != nil
+    }
+
+    public func cancelMessageSelection() {
+        selectedMessagesById.removeAll()
     }
 }
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/ConversationInfoPreview.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/Messages List Items/ConversationInfoPreview.swift
@@ -32,10 +32,15 @@ struct ConversationInfoPreview: View {
     }
 
     private var accessibilityLabelText: String {
-        let base = "\(resolvedDisplayName), \(conversation.membersCountString)"
-        return showsBackwardsSecrecyNote
-            ? "\(base). Earlier messages are hidden for privacy"
-            : base
+        var parts = [resolvedDisplayName, conversation.membersCountString]
+        if showsBackwardsSecrecyNote { parts.append("Earlier messages are hidden for privacy") }
+        if let duration = conversation.disappearingMessagesDurationTitle {
+            parts.append("Messages disappear after \(duration)")
+            if conversation.hasAgent, conversation.participationMode != .paused {
+                parts.append("An agent is listening and may save these messages even after they disappear from Convos")
+            }
+        }
+        return parts.joined(separator: ". ")
     }
 
     var body: some View {
@@ -85,6 +90,25 @@ struct ConversationInfoPreview: View {
                     .font(.caption)
                     .foregroundStyle(.colorTextSecondary)
                 }
+            }
+
+            if let duration = conversation.disappearingMessagesDurationTitle {
+                HStack(alignment: .top, spacing: DesignConstants.Spacing.stepX) {
+                    Image(systemName: "timer")
+                        .foregroundStyle(.colorFillTertiary)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: DesignConstants.Spacing.stepHalf) {
+                        Text("Messages disappear after \(duration).")
+                        if conversation.hasAgent, conversation.participationMode != .paused {
+                            Text("An agent is listening and may save these messages even after they disappear from Convos.")
+                        }
+                    }
+                    .multilineTextAlignment(.leading)
+                }
+                .font(.caption)
+                .foregroundStyle(.colorTextSecondary)
+                .frame(maxWidth: 294.0, alignment: .leading)
             }
         }
         .accessibilityElement(children: .combine)

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessagesGroupView.swift
@@ -56,6 +56,7 @@ struct MessagesGroupView: View {
     var memberContactOverride: (String) -> Contact? = { _ in nil }
 
     @Environment(\.displayScale) private var displayScale: CGFloat
+    @Environment(\.messageContextMenuState) private var contextMenuState: MessageContextMenuState
     @State private var isAppearing: Bool = true
     @State private var hasAnimated: Bool = false
     /// Animated mirror of `group.readByMembers` for the status row. Cell
@@ -271,7 +272,7 @@ struct MessagesGroupView: View {
             && (message.status == .published || message.status == .unpublished)
         let isFailed: Bool = message.sender.isCurrentUser && message.status == .failed
 
-        messageRowContent(
+        selectableMessageRow(
             message: message,
             bubbleType: bubbleType,
             isFailed: isFailed,
@@ -796,6 +797,53 @@ struct MessagesGroupView: View {
             }
         }
         .id("messages-group-\(displayGroup.id)")
+    }
+}
+
+private extension MessagesGroupView {
+    func selectableMessageRow(
+        message: AnyMessage,
+        bubbleType: MessageBubbleType,
+        isFailed: Bool,
+        isLast: Bool,
+        isFullWidthAttachment: Bool,
+        voiceMemoTranscriptIsTailed: Bool
+    ) -> some View {
+        let isSelecting: Bool = contextMenuState.isSelectingMessages
+        let isSelected: Bool = contextMenuState.isMessageSelected(message)
+
+        return HStack(alignment: .center, spacing: 0) {
+            if isSelecting {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(isSelected ? .colorGreen : .colorTextTertiary)
+                    .frame(width: 48)
+                    .frame(minHeight: 44)
+                    .transition(.move(edge: .leading).combined(with: .opacity))
+            }
+
+            messageRowContent(
+                message: message,
+                bubbleType: bubbleType,
+                isFailed: isFailed,
+                isLast: isLast,
+                isFullWidthAttachment: isFullWidthAttachment,
+                voiceMemoTranscriptIsTailed: voiceMemoTranscriptIsTailed
+            )
+            .allowsHitTesting(!isSelecting)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard isSelecting else { return }
+            withAnimation(.spring(response: 0.24, dampingFraction: 0.86)) {
+                contextMenuState.toggleMessageSelection(message)
+            }
+        }
+        .accessibilityElement(children: isSelecting ? .ignore : .contain)
+        .accessibilityLabel(isSelecting ? (isSelected ? "Selected message" : "Unselected message") : "")
+        .accessibilityAddTraits(isSelecting ? .isButton : [])
+        .animation(.spring(response: 0.24, dampingFraction: 0.86), value: isSelecting)
+        .animation(.spring(response: 0.2, dampingFraction: 0.8), value: isSelected)
     }
 }
 

--- a/ConvosCore/Sources/ConvosCore/Messaging/FileAttachmentCache.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/FileAttachmentCache.swift
@@ -40,6 +40,15 @@ public actor FileAttachmentCache {
         return fileURL
     }
 
+    /// Removes every downloaded file derived from an attachment key. The key
+    /// is hashed into a dedicated cache directory, so cleanup cannot escape the
+    /// FileAttachments cache root.
+    public func removeCachedFiles(for attachmentKey: String) throws {
+        let directory = cacheSubdirectory(for: attachmentKey)
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try fileManager.removeItem(at: directory)
+    }
+
     private func resolvedFileURL(for attachmentKey: String, filename: String) -> URL {
         let safeFilename = sanitizeFilename(filename)
         return cacheSubdirectory(for: attachmentKey).appendingPathComponent(safeFilename)

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -104,6 +104,9 @@ public protocol ConversationsProvider {
         consentStates: [XMTPiOS.ConsentState]?,
         onClose: (() -> Void)?
     ) -> AsyncThrowingStream<XMTPiOS.DecodedMessage, Error>
+    func streamMessageDeletions(
+        onClose: (() -> Void)?
+    ) -> AsyncThrowingStream<XMTPiOS.DecodedMessageV2, Error>
 }
 
 public protocol XMTPClientProvider: AnyObject {

--- a/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Messaging/XMTPClientProvider.swift
@@ -96,6 +96,8 @@ public protocol ConversationsProvider {
     ) async throws -> Dm
 
     func findMessage(messageId: String) throws -> XMTPiOS.DecodedMessage?
+    /// Removes a message only from this installation's libxmtp database.
+    func deleteMessageLocally(messageId: String) throws
 
     func sync() async throws
     func syncAllConversations(consentStates: [ConsentState]?) async throws -> GroupSyncSummary

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockConversationMetadataWriter.swift
@@ -15,6 +15,7 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
     public var updatedExpiresAt: [(expiresAt: Date, conversationId: String)] = []
     public var updatedParticipationModes: [(mode: ConversationParticipationMode, conversationId: String)] = []
     public var updatedSpaceURLs: [(urlString: String?, conversationId: String)] = []
+    public var updatedDisappearingMessages: [(duration: DisappearingMessageDuration?, conversationId: String)] = []
     public var updatedIncludeInfoInPublicPreview: [(enabled: Bool, conversationId: String)] = []
     public var lockedConversations: [String] = []
     public var unlockedConversations: [String] = []
@@ -74,6 +75,13 @@ public final class MockConversationMetadataWriter: ConversationMetadataWriterPro
 
     public func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {
         updatedSpaceURLs.append((urlString: urlString, conversationId: conversationId))
+    }
+
+    public func updateDisappearingMessages(
+        _ duration: DisappearingMessageDuration?,
+        for conversationId: String
+    ) async throws {
+        updatedDisappearingMessages.append((duration: duration, conversationId: conversationId))
     }
 
     public func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
@@ -189,4 +189,10 @@ public final class MockConversationsProvider: ConversationsProvider, @unchecked 
     ) -> AsyncThrowingStream<DecodedMessage, any Error> {
         AsyncThrowingStream { _ in }
     }
+
+    public func streamMessageDeletions(
+        onClose: (() -> Void)?
+    ) -> AsyncThrowingStream<DecodedMessageV2, any Error> {
+        AsyncThrowingStream { continuation in continuation.finish() }
+    }
 }

--- a/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/MockXMTPClientProvider.swift
@@ -178,6 +178,8 @@ public final class MockConversationsProvider: ConversationsProvider, @unchecked 
         nil
     }
 
+    public func deleteMessageLocally(messageId: String) throws {}
+
     public func syncAllConversations(consentStates: [ConsentState]?) async throws -> GroupSyncSummary {
         GroupSyncSummary(numEligible: 0, numSynced: 0)
     }

--- a/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
+++ b/ConvosCore/Sources/ConvosCore/Mocks/ModelMocks.swift
@@ -419,6 +419,14 @@ private func summaryFromFirstMetadataChange(
             return "\(creatorDisplayName) paused agents, so they'll never see the following messages"
         }
         return "\(creatorDisplayName) set agents to \(mode.transcriptTitle)"
+    case .disappearingMessages:
+        guard let rawValue = metadataChange.newValue,
+              let retention = Int64(rawValue),
+              retention > 0 else {
+            return "\(creatorDisplayName) turned off disappearing messages"
+        }
+        let duration = DisappearingMessageDuration.title(forRetentionDurationInNs: retention)
+        return "\(creatorDisplayName) turned on disappearing messages for \(duration). If an agent is in this chat, it can save messages outside Convos"
     case .metadata, .unknown:
         return nil
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBConversation.swift
@@ -53,6 +53,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         static let isAgentDm: Column = Column(CodingKeys.isAgentDm)
         static let participationMode: Column = Column(CodingKeys.participationMode)
         static let spaceURLString: Column = Column(CodingKeys.spaceURLString)
+        static let disappearingMessageRetentionDurationInNs: Column = Column(CodingKeys.disappearingMessageRetentionDurationInNs)
         static let addedById: Column = Column(CodingKeys.addedById)
         static let adderStatus: Column = Column(CodingKeys.adderStatus)
     }
@@ -89,6 +90,10 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
     /// group's appData. The Assistant Worker is the sole authority; clients
     /// only read it. Nil while no Space has been published.
     let spaceURLString: String?
+    /// XMTP's conversation-wide retention duration. Nil means disappearing
+    /// messages are off; a positive value is the expiry interval in
+    /// nanoseconds for application messages.
+    let disappearingMessageRetentionDurationInNs: Int64?
     /// Storage for `adder` - read that instead, and set it through `init`.
     /// The pair is kept consistent by a CHECK constraint: `addedById` is
     /// non-null exactly when `adderStatus` is `resolved`.
@@ -131,6 +136,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         isAgentDm: Bool = false,
         participationMode: ConversationParticipationMode? = nil,
         spaceURLString: String? = nil,
+        disappearingMessageRetentionDurationInNs: Int64? = nil,
         adder: AdderResolution = .notRecorded
     ) {
         self.id = id
@@ -158,6 +164,7 @@ struct DBConversation: Codable, FetchableRecord, PersistableRecord, Identifiable
         self.isAgentDm = isAgentDm
         self.participationMode = participationMode
         self.spaceURLString = spaceURLString
+        self.disappearingMessageRetentionDurationInNs = disappearingMessageRetentionDurationInNs
         self.addedById = adder.knownInboxId
         self.adderStatus = adder.status
     }
@@ -347,6 +354,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -378,6 +386,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -409,6 +418,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -440,6 +450,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -471,6 +482,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -504,6 +516,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -535,6 +548,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -566,6 +580,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -597,6 +612,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -628,6 +644,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -659,6 +676,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -690,6 +708,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -721,6 +740,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -752,6 +772,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -783,6 +804,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -814,6 +836,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -844,7 +867,8 @@ extension DBConversation {
             hasHadVerifiedAgent: hasHadVerifiedAgent,
             isAgentDm: isAgentDm,
             participationMode: participationMode,
-            spaceURLString: spaceURLString
+            spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs
         )
     }
 
@@ -875,6 +899,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -906,6 +931,39 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
+            adder: adder
+        )
+    }
+
+    func with(disappearingMessageRetentionDurationInNs: Int64?) -> Self {
+        .init(
+            id: id,
+            clientConversationId: clientConversationId,
+            inviteTag: inviteTag,
+            creatorId: creatorId,
+            kind: kind,
+            consent: consent,
+            createdAt: createdAt,
+            name: name,
+            description: description,
+            imageURLString: imageURLString,
+            publicImageURLString: publicImageURLString,
+            includeInfoInPublicPreview: includeInfoInPublicPreview,
+            expiresAt: expiresAt,
+            debugInfo: debugInfo,
+            isLocked: isLocked,
+            imageSalt: imageSalt,
+            imageNonce: imageNonce,
+            imageEncryptionKey: imageEncryptionKey,
+            conversationEmoji: conversationEmoji,
+            imageLastRenewed: imageLastRenewed,
+            isUnused: isUnused,
+            hasHadVerifiedAgent: hasHadVerifiedAgent,
+            isAgentDm: isAgentDm,
+            participationMode: participationMode,
+            spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -937,6 +995,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -968,6 +1027,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }
@@ -999,6 +1059,7 @@ extension DBConversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURLString: spaceURLString,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs,
             adder: adder
         )
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Database Models/DBMessage.swift
@@ -37,6 +37,7 @@ struct DBMessage: FetchableRecord, PersistableRecord, Hashable, Codable, Sendabl
         static let linkPreview: Column = Column(CodingKeys.linkPreview)
         static let sourceMessageId: Column = Column(CodingKeys.sourceMessageId)
         static let attachmentUrls: Column = Column(CodingKeys.attachmentUrls)
+        static let expiresAtNs: Column = Column(CodingKeys.expiresAtNs)
     }
 
     let id: String // external
@@ -59,9 +60,52 @@ struct DBMessage: FetchableRecord, PersistableRecord, Hashable, Codable, Sendabl
     let sourceMessageId: String? // replies and reactions
     let attachmentUrls: [String]
     let update: Update?
+    /// The authoritative expiry computed by libxmtp for this application
+    /// message. Nil means the message is not subject to a disappearing timer.
+    let expiresAtNs: Int64?
 
     var attachmentUrl: String? {
         attachmentUrls.first
+    }
+
+    init(
+        id: String,
+        clientMessageId: String,
+        conversationId: String,
+        senderId: String,
+        dateNs: Int64,
+        date: Date,
+        sortId: Int64?,
+        status: MessageStatus,
+        messageType: DBMessageType,
+        contentType: MessageContentType,
+        text: String?,
+        emoji: String?,
+        invite: MessageInvite?,
+        linkPreview: LinkPreview?,
+        sourceMessageId: String?,
+        attachmentUrls: [String],
+        update: Update?,
+        expiresAtNs: Int64? = nil
+    ) {
+        self.id = id
+        self.clientMessageId = clientMessageId
+        self.conversationId = conversationId
+        self.senderId = senderId
+        self.dateNs = dateNs
+        self.date = date
+        self.sortId = sortId
+        self.status = status
+        self.messageType = messageType
+        self.contentType = contentType
+        self.text = text
+        self.emoji = emoji
+        self.invite = invite
+        self.linkPreview = linkPreview
+        self.sourceMessageId = sourceMessageId
+        self.attachmentUrls = attachmentUrls
+        self.update = update
+        self.expiresAtNs = expiresAtNs
     }
 
     static let sourceMessageForeignKey: ForeignKey = ForeignKey([Columns.sourceMessageId], to: [Columns.id])
@@ -126,7 +170,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -148,7 +193,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -170,7 +216,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -192,7 +239,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -214,7 +262,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -236,7 +285,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -258,7 +308,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -280,7 +331,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -302,7 +354,8 @@ extension DBMessage {
             linkPreview: linkPreview,
             sourceMessageId: sourceMessageId,
             attachmentUrls: attachmentUrls,
-            update: update
+            update: update,
+            expiresAtNs: expiresAtNs
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Hydration/DBConversationDetails+Conversation.swift
@@ -86,7 +86,8 @@ extension DBConversationDetails {
             wasCreatedFromAgentBuilder: conversationAgentBuilderSummary != nil,
             isAgentDm: conversation.isAgentDm,
             participationMode: conversation.participationMode ?? .default,
-            spaceURL: conversation.spaceURLString.flatMap { URL(string: $0) }
+            spaceURL: conversation.spaceURLString.flatMap { URL(string: $0) },
+            disappearingMessageRetentionDurationInNs: conversation.disappearingMessageRetentionDurationInNs
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/AnyMessage.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/AnyMessage.swift
@@ -68,6 +68,17 @@ public enum AnyMessage: Hashable, Equatable, Codable, Sendable, Identifiable {
         }
     }
 
+    /// The protocol message id used for an XMTP delete-for-everyone request.
+    /// Nil until an optimistic send has been published and reconciled.
+    public var xmtpMessageId: String? {
+        switch self {
+        case .message(let message, _):
+            return message.xmtpId
+        case .reply(let reply, _):
+            return reply.xmtpId
+        }
+    }
+
     public var date: Date {
         switch self {
         case .message(let message, _):

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Conversation.swift
@@ -80,6 +80,10 @@ public struct Conversation: Codable, Hashable, Identifiable, Sendable {
     /// exists yet. Lets the list render a combined last-message preview and
     /// a DM-aware unread indicator without surfacing the DM as its own row.
     public var agentDm: AgentDmSummary?
+    /// The XMTP conversation-wide retention duration, or nil when messages do
+    /// not disappear. Mirrored into the app database so settings, chat chrome,
+    /// and the conversations list all observe the same synced state.
+    public var disappearingMessageRetentionDurationInNs: Int64?
 }
 
 // MARK: - AgentDmSummary
@@ -159,7 +163,8 @@ public extension Conversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURL: spaceURL,
-            agentDm: agentDm
+            agentDm: agentDm,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs
         )
     }
 
@@ -205,7 +210,19 @@ public extension Conversation {
             isAgentDm: isAgentDm,
             participationMode: participationMode,
             spaceURL: spaceURL,
-            agentDm: agentDm
+            agentDm: agentDm,
+            disappearingMessageRetentionDurationInNs: disappearingMessageRetentionDurationInNs
+        )
+    }
+
+    var isDisappearingMessagesEnabled: Bool {
+        guard let duration = disappearingMessageRetentionDurationInNs else { return false }
+        return duration > 0
+    }
+
+    var disappearingMessagesDurationTitle: String? {
+        disappearingMessageRetentionDurationInNs.map(
+            DisappearingMessageDuration.title(forRetentionDurationInNs:)
         )
     }
 

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/ConversationUpdate.swift
@@ -12,6 +12,7 @@ public struct ConversationUpdate: Hashable, Codable, Sendable {
                  // carries every custom field, and only a mode change in it
                  // earns a transcript row.
                  participationMode = "participation_mode",
+                 disappearingMessages = "message_disappear_in_ns",
                  unknown
 
             var showsInMessagesList: Bool {

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/DisappearingMessageDuration.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/DisappearingMessageDuration.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// The deliberately small timer set offered by the V1 disappearing-messages
+/// surface. These match the familiar WhatsApp choices and map one-to-one to
+/// libxmtp's conversation-wide retention duration.
+public enum DisappearingMessageDuration: Int64, CaseIterable, Codable, Identifiable, Sendable {
+    case twentyFourHours = 86_400_000_000_000
+    case sevenDays = 604_800_000_000_000
+    case ninetyDays = 7_776_000_000_000_000
+
+    public var id: Int64 { rawValue }
+
+    public var title: String {
+        switch self {
+        case .twentyFourHours: "24 hours"
+        case .sevenDays: "7 days"
+        case .ninetyDays: "90 days"
+        }
+    }
+
+    /// Used when Pause proactively enables disappearing messages before this
+    /// conversation has a previously selected timer.
+    public static let privacyDefault: Self = .twentyFourHours
+
+    public static func title(forRetentionDurationInNs duration: Int64) -> String {
+        if let known = Self(rawValue: duration) {
+            return known.title
+        }
+
+        let seconds = TimeInterval(duration) / 1_000_000_000
+        return Duration.seconds(seconds).formatted(.units(allowed: [.days, .hours], width: .wide))
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/DisappearingMessageDuration.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/DisappearingMessageDuration.swift
@@ -1,9 +1,13 @@
 import Foundation
 
-/// The deliberately small timer set offered by the V1 disappearing-messages
-/// surface. These match the familiar WhatsApp choices and map one-to-one to
-/// libxmtp's conversation-wide retention duration.
+/// The timer set offered by the disappearing-messages surface. These familiar
+/// Signal and WhatsApp choices map one-to-one to libxmtp's conversation-wide
+/// retention duration.
 public enum DisappearingMessageDuration: Int64, CaseIterable, Codable, Identifiable, Sendable {
+    case oneMinute = 60_000_000_000
+    case fiveMinutes = 300_000_000_000
+    case oneHour = 3_600_000_000_000
+    case eightHours = 28_800_000_000_000
     case twentyFourHours = 86_400_000_000_000
     case sevenDays = 604_800_000_000_000
     case ninetyDays = 7_776_000_000_000_000
@@ -12,6 +16,10 @@ public enum DisappearingMessageDuration: Int64, CaseIterable, Codable, Identifia
 
     public var title: String {
         switch self {
+        case .oneMinute: "1 minute"
+        case .fiveMinutes: "5 minutes"
+        case .oneHour: "1 hour"
+        case .eightHours: "8 hours"
         case .twentyFourHours: "24 hours"
         case .sevenDays: "7 days"
         case .ninetyDays: "90 days"

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/Message.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/Message.swift
@@ -4,6 +4,9 @@ import Foundation
 
 public struct Message: Hashable, Codable, Sendable {
     public let id: String
+    /// The published XMTP message id. `id` remains the stable local/client id
+    /// used by the transcript while optimistic sends are reconciled.
+    public let xmtpId: String?
     public let sender: ConversationMember
     public let source: MessageSource
     public let status: MessageStatus
@@ -14,6 +17,7 @@ public struct Message: Hashable, Codable, Sendable {
 
     public init(
         id: String,
+        xmtpId: String? = nil,
         sender: ConversationMember,
         source: MessageSource,
         status: MessageStatus,
@@ -22,6 +26,7 @@ public struct Message: Hashable, Codable, Sendable {
         reactions: [MessageReaction]
     ) {
         self.id = id
+        self.xmtpId = xmtpId
         self.sender = sender
         self.source = source
         self.status = status

--- a/ConvosCore/Sources/ConvosCore/Storage/Models/MessageReply.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Models/MessageReply.swift
@@ -4,6 +4,8 @@ import Foundation
 
 public struct MessageReply: Hashable, Codable, Sendable {
     public let id: String
+    /// The published XMTP message id. `id` is the stable local/client id.
+    public let xmtpId: String?
     public let sender: ConversationMember
     public let source: MessageSource
     public let status: MessageStatus
@@ -15,6 +17,7 @@ public struct MessageReply: Hashable, Codable, Sendable {
 
     public init(
         id: String,
+        xmtpId: String? = nil,
         sender: ConversationMember,
         source: MessageSource,
         status: MessageStatus,
@@ -24,6 +27,7 @@ public struct MessageReply: Hashable, Codable, Sendable {
         reactions: [MessageReaction]
     ) {
         self.id = id
+        self.xmtpId = xmtpId
         self.sender = sender
         self.source = source
         self.status = status

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -515,6 +515,7 @@ extension Array where Element == DBMessage {
 
                 let message = Message(
                     id: dbMessage.clientMessageId,
+                    xmtpId: dbMessage.status == .published ? dbMessage.id : nil,
                     sender: sender,
                     source: source,
                     status: dbMessage.status,
@@ -740,6 +741,7 @@ extension Array where Element == DBMessage {
               let parentSender = memberProfileCache.member(for: sourceDBMessage.senderId) else {
             let message = Message(
                 id: dbMessage.clientMessageId,
+                xmtpId: dbMessage.status == .published ? dbMessage.id : nil,
                 sender: sender, source: source, status: dbMessage.status,
                 content: replyContent, date: dbMessage.date, reactions: reactions
             )
@@ -797,12 +799,14 @@ extension Array where Element == DBMessage {
 
         let parentMessage = Message(
             id: sourceDBMessage.clientMessageId,
+            xmtpId: sourceDBMessage.status == .published ? sourceDBMessage.id : nil,
             sender: parentSender, source: parentSource, status: sourceDBMessage.status,
             content: parentContent, date: sourceDBMessage.date, reactions: []
         )
 
         let messageReply = MessageReply(
             id: dbMessage.clientMessageId,
+            xmtpId: dbMessage.status == .published ? dbMessage.id : nil,
             sender: sender, source: source, status: dbMessage.status,
             content: replyContent, date: dbMessage.date,
             parentMessage: parentMessage, reactions: reactions

--- a/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Repositories/MessagesRepository.swift
@@ -1044,7 +1044,9 @@ private extension LightweightConversationDetails {
             hasHadVerifiedAgent: conversation.hasHadVerifiedAgent,
             wasCreatedFromAgentBuilder: conversationAgentBuilderSummary != nil,
             isAgentDm: conversation.isAgentDm,
-            participationMode: conversation.participationMode ?? .default
+            participationMode: conversation.participationMode ?? .default,
+            spaceURL: conversation.spaceURLString.flatMap { URL(string: $0) },
+            disappearingMessageRetentionDurationInNs: conversation.disappearingMessageRetentionDurationInNs
         )
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/SharedDatabaseMigrator.swift
@@ -223,6 +223,27 @@ extension SharedDatabaseMigrator {
         migrator.registerMigration("addConversationParticipationMode", migrate: Self.addConversationParticipationMode)
         migrator.registerMigration("clearCutListenParticipationMode", migrate: Self.clearCutListenParticipationMode)
         migrator.registerMigration("addConversationSpaceURLString", migrate: Self.addConversationSpaceURLString)
+        migrator.registerMigration(
+            "addConversationDisappearingMessageRetention",
+            migrate: Self.addConversationDisappearingMessageRetention
+        )
+    }
+
+    /// Mirrors libxmtp's active retention interval into the app database and
+    /// records the exact expiry libxmtp computes for each application message.
+    /// The protocol remains authoritative; nil means no timer / no expiry.
+    static func addConversationDisappearingMessageRetention(_ db: Database) throws {
+        try db.alter(table: "conversation") { t in
+            t.add(column: "disappearingMessageRetentionDurationInNs", .integer)
+        }
+        try db.alter(table: "message") { t in
+            t.add(column: "expiresAtNs", .integer)
+        }
+        try db.create(
+            index: "message_on_expiresAtNs",
+            on: "message",
+            columns: ["expiresAtNs"]
+        )
     }
 
     /// The deployed Space web URL for the conversation, mirrored from the

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationMetadataWriter.swift
@@ -21,6 +21,7 @@ public protocol ConversationMetadataWriterProtocol: Sendable {
     func updateExpiresAt(_ expiresAt: Date, for conversationId: String) async throws
     func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws
     func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws
+    func updateDisappearingMessages(_ duration: DisappearingMessageDuration?, for conversationId: String) async throws
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws
     func lockConversation(for conversationId: String) async throws
     func unlockConversation(for conversationId: String) async throws
@@ -186,6 +187,45 @@ final class ConversationMetadataWriter: ConversationMetadataWriterProtocol, @unc
         }
 
         Log.info("Updated conversation space URL for \(conversationId): \(urlString ?? "nil")")
+    }
+
+    /// Writes XMTP's native conversation-wide disappearing-message settings.
+    /// Passing nil turns the timer off. libxmtp remains authoritative for each
+    /// message's computed expiry; the local conversation row only mirrors the
+    /// active duration so every surface updates immediately.
+    func updateDisappearingMessages(
+        _ duration: DisappearingMessageDuration?,
+        for conversationId: String
+    ) async throws {
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+
+        guard let conversation = try await inboxReady.client.conversation(with: conversationId) else {
+            throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
+        }
+
+        let settings = duration.map {
+            DisappearingMessageSettings(
+                disappearStartingAtNs: Date().nanosecondsSince1970,
+                retentionDurationInNs: $0.rawValue
+            )
+        }
+        try await conversation.updateDisappearingMessageSettings(settings)
+
+        try await databaseWriter.write { db in
+            guard let localConversation = try DBConversation.fetchOne(db, key: conversationId) else {
+                throw ConversationMetadataError.conversationNotFound(conversationId: conversationId)
+            }
+            try localConversation
+                .with(disappearingMessageRetentionDurationInNs: duration?.rawValue)
+                .save(db)
+        }
+
+        Log.info("Updated disappearing messages for \(conversationId): \(duration?.title ?? "off")")
+        QAEvent.emit(
+            .conversation,
+            "disappearing_messages_updated",
+            ["id": conversationId, "duration": duration?.title ?? "off"]
+        )
     }
 
     func updateDescription(_ description: String, for conversationId: String) async throws {

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/ConversationWriter.swift
@@ -810,6 +810,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
         /// metadata; nil for non-DMs or DMs without a recorded origin.
         let originConversationId: String?
         let participationMode: ConversationParticipationMode?
+        let disappearingMessageRetentionDurationInNs: Int64?
         /// The deployed Space web URL carried in the group's appData; the
         /// Assistant Worker is the sole authority. Nil until one is published.
         let spaceURLString: String?
@@ -863,6 +864,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             isAgentDm: isAgentDm,
             originConversationId: originConversationId,
             participationMode: try? conversation.participationMode,
+            disappearingMessageRetentionDurationInNs: conversation.disappearingMessageSettings?.retentionDurationInNs,
             spaceURLString: (try? conversation.spaceURL).flatMap { $0 },
             memberCount: memberCount
         )
@@ -1019,6 +1021,7 @@ class ConversationWriter: ConversationWriterProtocol, @unchecked Sendable {
             isAgentDm: metadata.isAgentDm,
             participationMode: metadata.participationMode,
             spaceURLString: metadata.spaceURLString,
+            disappearingMessageRetentionDurationInNs: metadata.disappearingMessageRetentionDurationInNs,
             // Shares one definition of the empty-vs-throw semantics with the
             // consent gate (`StreamProcessor.contactsVouch`). A failed read
             // persists as `.unresolved` rather than being flattened to "no

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/DisappearingMessageDeletionWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/DisappearingMessageDeletionWriter.swift
@@ -1,0 +1,91 @@
+import Foundation
+import GRDB
+
+/// Mirrors libxmtp's disappearing-message deletions into Convos' presentation
+/// database. Convos keeps its own message rows for UI composition, so removing
+/// a message from libxmtp alone would otherwise leave a visible local copy.
+struct DisappearingMessageDeletionWriter: Sendable {
+    private let databaseWriter: any DatabaseWriter
+
+    init(databaseWriter: any DatabaseWriter) {
+        self.databaseWriter = databaseWriter
+    }
+
+    func delete(messageId: String) async throws {
+        let attachmentKeys = try await databaseWriter.write { db in
+            try deleteMessages(matching: [messageId], db: db)
+        }
+        await removeLocalArtifacts(attachmentKeys)
+    }
+
+    /// Startup / foreground safety net for deletions that occurred while no
+    /// deletion stream was attached. `expiresAtNs` is computed by libxmtp and
+    /// persisted on ingest, so this does not reinterpret retention settings.
+    func pruneExpiredMessages(now: Date = Date()) async throws {
+        let nowNs = now.nanosecondsSince1970
+        let attachmentKeys = try await databaseWriter.write { db in
+            let expiredIds = try String.fetchAll(
+                db,
+                sql: "SELECT id FROM message WHERE expiresAtNs IS NOT NULL AND expiresAtNs <= ?",
+                arguments: [nowNs]
+            )
+            guard !expiredIds.isEmpty else { return [String]() }
+            return try deleteMessages(matching: expiredIds, db: db)
+        }
+        await removeLocalArtifacts(attachmentKeys)
+    }
+
+    private func deleteMessages(matching messageIds: [String], db: Database) throws -> [String] {
+        let records = try DBMessage
+            .filter(messageIds.contains(DBMessage.Columns.id) || messageIds.contains(DBMessage.Columns.sourceMessageId))
+            .fetchAll(db)
+        guard !records.isEmpty else { return [] }
+
+        let idsToDelete = records.map(\.id)
+        let clientMessageIds = records.map(\.clientMessageId)
+        let pendingUploads = try DBPendingPhotoUpload
+            .filter(clientMessageIds.contains(DBPendingPhotoUpload.Columns.clientMessageId))
+            .fetchAll(db)
+        let attachmentKeys = records.flatMap(\.attachmentUrls) + pendingUploads.map(\.localCacheURL)
+
+        if !attachmentKeys.isEmpty {
+            try AttachmentLocalState
+                .filter(attachmentKeys.contains(AttachmentLocalState.Columns.attachmentKey))
+                .deleteAll(db)
+        }
+
+        try DBVoiceMemoTranscript
+            .filter(idsToDelete.contains(DBVoiceMemoTranscript.Columns.messageId))
+            .deleteAll(db)
+        try DBPendingPhotoUpload
+            .filter(clientMessageIds.contains(DBPendingPhotoUpload.Columns.clientMessageId))
+            .deleteAll(db)
+        try DBMessage.filter(idsToDelete.contains(DBMessage.Columns.id)).deleteAll(db)
+        Log.debug("Deleted \(idsToDelete.count) expired local message row(s)")
+
+        return attachmentKeys
+    }
+
+    private func removeLocalArtifacts(_ attachmentKeys: [String]) async {
+        let uniqueKeys = Set(attachmentKeys)
+        ImageCacheContainer.shared.removePersistentImages(for: Array(uniqueKeys))
+
+        for key in uniqueKeys {
+            if let url = URL(string: key), url.isFileURL {
+                do {
+                    try FileManager.default.removeItem(at: url)
+                } catch CocoaError.fileNoSuchFile {
+                    // The cache may already have evicted the local file.
+                } catch {
+                    Log.warning("Failed to remove expired message attachment: \(error)")
+                }
+            }
+
+            do {
+                try await FileAttachmentCache.shared.removeCachedFiles(for: key)
+            } catch {
+                Log.warning("Failed to remove expired file cache: \(error)")
+            }
+        }
+    }
+}

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/DisappearingMessageDeletionWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/DisappearingMessageDeletionWriter.swift
@@ -12,13 +12,23 @@ struct DisappearingMessageDeletionWriter: Sendable {
     }
 
     func delete(messageId: String) async throws {
-        try await delete(messageIds: [messageId])
+        try await delete(messageIds: [messageId], includingReferences: true)
     }
 
-    func delete(messageIds: [String]) async throws {
+    /// Removes only the rows the user explicitly selected. Replies and
+    /// reactions that reference a selected message remain untouched.
+    func deleteSelectedMessages(messageIds: [String]) async throws {
+        try await delete(messageIds: messageIds, includingReferences: false)
+    }
+
+    private func delete(messageIds: [String], includingReferences: Bool) async throws {
         guard !messageIds.isEmpty else { return }
         let attachmentKeys = try await databaseWriter.write { db in
-            try deleteMessages(matching: messageIds, db: db)
+            try deleteMessages(
+                matching: messageIds,
+                includingReferences: includingReferences,
+                db: db
+            )
         }
         await removeLocalArtifacts(attachmentKeys)
     }
@@ -35,19 +45,22 @@ struct DisappearingMessageDeletionWriter: Sendable {
                 arguments: [nowNs]
             )
             guard !expiredIds.isEmpty else { return [String]() }
-            return try deleteMessages(matching: expiredIds, db: db)
+            return try deleteMessages(matching: expiredIds, includingReferences: true, db: db)
         }
         await removeLocalArtifacts(attachmentKeys)
     }
 
-    private func deleteMessages(matching messageIds: [String], db: Database) throws -> [String] {
-        let records = try DBMessage
-            .filter(
-                messageIds.contains(DBMessage.Columns.id)
-                    || messageIds.contains(DBMessage.Columns.clientMessageId)
-                    || messageIds.contains(DBMessage.Columns.sourceMessageId)
-            )
-            .fetchAll(db)
+    private func deleteMessages(
+        matching messageIds: [String],
+        includingReferences: Bool,
+        db: Database
+    ) throws -> [String] {
+        var filter = messageIds.contains(DBMessage.Columns.id)
+            || messageIds.contains(DBMessage.Columns.clientMessageId)
+        if includingReferences {
+            filter = filter || messageIds.contains(DBMessage.Columns.sourceMessageId)
+        }
+        let records = try DBMessage.filter(filter).fetchAll(db)
         guard !records.isEmpty else { return [] }
 
         let idsToDelete = records.map(\.id)

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/DisappearingMessageDeletionWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/DisappearingMessageDeletionWriter.swift
@@ -12,8 +12,13 @@ struct DisappearingMessageDeletionWriter: Sendable {
     }
 
     func delete(messageId: String) async throws {
+        try await delete(messageIds: [messageId])
+    }
+
+    func delete(messageIds: [String]) async throws {
+        guard !messageIds.isEmpty else { return }
         let attachmentKeys = try await databaseWriter.write { db in
-            try deleteMessages(matching: [messageId], db: db)
+            try deleteMessages(matching: messageIds, db: db)
         }
         await removeLocalArtifacts(attachmentKeys)
     }
@@ -37,7 +42,11 @@ struct DisappearingMessageDeletionWriter: Sendable {
 
     private func deleteMessages(matching messageIds: [String], db: Database) throws -> [String] {
         let records = try DBMessage
-            .filter(messageIds.contains(DBMessage.Columns.id) || messageIds.contains(DBMessage.Columns.sourceMessageId))
+            .filter(
+                messageIds.contains(DBMessage.Columns.id)
+                    || messageIds.contains(DBMessage.Columns.clientMessageId)
+                    || messageIds.contains(DBMessage.Columns.sourceMessageId)
+            )
             .fetchAll(db)
         guard !records.isEmpty else { return [] }
 
@@ -61,7 +70,7 @@ struct DisappearingMessageDeletionWriter: Sendable {
             .filter(clientMessageIds.contains(DBPendingPhotoUpload.Columns.clientMessageId))
             .deleteAll(db)
         try DBMessage.filter(idsToDelete.contains(DBMessage.Columns.id)).deleteAll(db)
-        Log.debug("Deleted \(idsToDelete.count) expired local message row(s)")
+        Log.debug("Deleted \(idsToDelete.count) local message row(s)")
 
         return attachmentKeys
     }
@@ -77,14 +86,14 @@ struct DisappearingMessageDeletionWriter: Sendable {
                 } catch CocoaError.fileNoSuchFile {
                     // The cache may already have evicted the local file.
                 } catch {
-                    Log.warning("Failed to remove expired message attachment: \(error)")
+                    Log.warning("Failed to remove deleted message attachment: \(error)")
                 }
             }
 
             do {
                 try await FileAttachmentCache.shared.removeCachedFiles(for: key)
             } catch {
-                Log.warning("Failed to remove expired file cache: \(error)")
+                Log.warning("Failed to remove deleted file cache: \(error)")
             }
         }
     }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -12,6 +12,22 @@ import UniformTypeIdentifiers
 /// full-resolution photo would.
 private let bundleChipThumbnailMaxPixelSize: Int = 240
 
+public struct MessageDeletionTarget: Hashable, Sendable {
+    public let localMessageId: String
+    public let xmtpMessageId: String?
+
+    public init(localMessageId: String, xmtpMessageId: String?) {
+        self.localMessageId = localMessageId
+        self.xmtpMessageId = xmtpMessageId
+    }
+}
+
+public enum MessageDeletionError: Error {
+    case unavailable
+    case conversationNotFound
+    case unpublishedMessage
+}
+
 /// One entry in a `MultiRemoteAttachment` bundle. Eager photo/video variants
 /// reference an upload that was already kicked off by the composer; voice
 /// memo and file variants point at a local URL the writer encrypts + uploads
@@ -142,6 +158,18 @@ public protocol OutgoingMessageWriterProtocol: Sendable {
 
     func retryFailedMessage(id: String) async throws
     func deleteFailedMessage(id: String) async throws
+    func deleteMessagesForMe(_ targets: [MessageDeletionTarget]) async throws
+    func deleteMessagesForEveryone(_ targets: [MessageDeletionTarget]) async throws
+}
+
+public extension OutgoingMessageWriterProtocol {
+    func deleteMessagesForMe(_ targets: [MessageDeletionTarget]) async throws {
+        throw MessageDeletionError.unavailable
+    }
+
+    func deleteMessagesForEveryone(_ targets: [MessageDeletionTarget]) async throws {
+        throw MessageDeletionError.unavailable
+    }
 }
 
 enum OutgoingMessageWriterError: Error, CustomStringConvertible {
@@ -3102,5 +3130,42 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
                 Log.warning("No failed message found to delete for clientMessageId: \(clientMessageId)")
             }
         }
+    }
+
+    func deleteMessagesForMe(_ targets: [MessageDeletionTarget]) async throws {
+        guard !targets.isEmpty else { return }
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        for target in targets {
+            guard let xmtpMessageId = target.xmtpMessageId else { continue }
+            try inboxReady.client.conversationsProvider.deleteMessageLocally(messageId: xmtpMessageId)
+        }
+
+        let identifiers = targets.flatMap { target in
+            [target.localMessageId, target.xmtpMessageId].compactMap { $0 }
+        }
+        try await DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
+            .delete(messageIds: identifiers)
+    }
+
+    func deleteMessagesForEveryone(_ targets: [MessageDeletionTarget]) async throws {
+        guard !targets.isEmpty else { return }
+        let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        guard let conversation = try await inboxReady.client.conversation(with: conversationId) else {
+            throw MessageDeletionError.conversationNotFound
+        }
+
+        for target in targets {
+            guard let xmtpMessageId = target.xmtpMessageId else {
+                throw MessageDeletionError.unpublishedMessage
+            }
+            _ = try await conversation.deleteMessage(messageId: xmtpMessageId)
+        }
+        try await conversation.publishMessages()
+
+        let identifiers = targets.flatMap { target in
+            [target.localMessageId, target.xmtpMessageId].compactMap { $0 }
+        }
+        try await DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
+            .delete(messageIds: identifiers)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/Writers/OutgoingMessageWriter.swift
@@ -3135,16 +3135,17 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
     func deleteMessagesForMe(_ targets: [MessageDeletionTarget]) async throws {
         guard !targets.isEmpty else { return }
         let inboxReady = try await sessionStateManager.waitForInboxReadyResult()
+        let localDeletionWriter = DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
         for target in targets {
-            guard let xmtpMessageId = target.xmtpMessageId else { continue }
-            try inboxReady.client.conversationsProvider.deleteMessageLocally(messageId: xmtpMessageId)
+            if let xmtpMessageId = target.xmtpMessageId {
+                try inboxReady.client.conversationsProvider.deleteMessageLocally(messageId: xmtpMessageId)
+                try await localDeletionWriter.deleteSelectedMessages(
+                    messageIds: [target.localMessageId, xmtpMessageId]
+                )
+            } else {
+                try await localDeletionWriter.deleteSelectedMessages(messageIds: [target.localMessageId])
+            }
         }
-
-        let identifiers = targets.flatMap { target in
-            [target.localMessageId, target.xmtpMessageId].compactMap { $0 }
-        }
-        try await DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
-            .delete(messageIds: identifiers)
     }
 
     func deleteMessagesForEveryone(_ targets: [MessageDeletionTarget]) async throws {
@@ -3154,18 +3155,18 @@ actor OutgoingMessageWriter: OutgoingMessageWriterProtocol {
             throw MessageDeletionError.conversationNotFound
         }
 
+        let localDeletionWriter = DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
         for target in targets {
             guard let xmtpMessageId = target.xmtpMessageId else {
                 throw MessageDeletionError.unpublishedMessage
             }
             _ = try await conversation.deleteMessage(messageId: xmtpMessageId)
+            // Publish each deletion before preparing the next. If a later
+            // deletion fails, there is no hidden partial batch left queued.
+            try await conversation.publishMessages()
+            try await localDeletionWriter.deleteSelectedMessages(
+                messageIds: [target.localMessageId, xmtpMessageId]
+            )
         }
-        try await conversation.publishMessages()
-
-        let identifiers = targets.flatMap { target in
-            [target.localMessageId, target.xmtpMessageId].compactMap { $0 }
-        }
-        try await DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
-            .delete(messageIds: identifiers)
     }
 }

--- a/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
+++ b/ConvosCore/Sources/ConvosCore/Storage/XMTP DB Representations/DecodedMessage+DBRepresentation.swift
@@ -116,7 +116,8 @@ extension XMTPiOS.DecodedMessage {
             linkPreview: components.linkPreview,
             sourceMessageId: components.sourceMessageId,
             attachmentUrls: components.attachmentUrls,
-            update: components.update
+            update: components.update,
+            expiresAtNs: expiresAtNs
         )
     }
 
@@ -482,6 +483,16 @@ extension XMTPiOS.DecodedMessage {
                             newValue: nil
                         )
                     }
+                } else if $0.fieldName == "message_disappear_from_ns" {
+                    // The start timestamp and retention interval are updated as
+                    // one setting. Only retention produces a visible row.
+                    return nil
+                } else if $0.fieldName == ConversationUpdate.MetadataChange.Field.disappearingMessages.rawValue {
+                    return .init(
+                        field: ConversationUpdate.MetadataChange.Field.disappearingMessages.rawValue,
+                        oldValue: $0.hasOldValue ? $0.oldValue : nil,
+                        newValue: $0.hasNewValue ? $0.newValue : nil
+                    )
                 } else if $0.fieldName == ConversationUpdate.MetadataChange.Field.metadata.rawValue {
                     return Self.appDataMetadataChange(
                         oldValue: $0.hasOldValue ? $0.oldValue : nil,

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -139,6 +139,7 @@ actor SyncingManager: SyncingManagerProtocol {
 
     private var messageStreamTask: Task<Void, Never>?
     private var conversationStreamTask: Task<Void, Never>?
+    private var messageDeletionStreamTask: Task<Void, Never>?
     private var syncTask: Task<Void, Never>?
 
     /// The params of the most recent `start`, retained so a session that has
@@ -213,6 +214,7 @@ actor SyncingManager: SyncingManagerProtocol {
     /// processor's `ConversationWriter`) and per-call inside the foreground
     /// batch catch-up path so metrics-emitting writes have a real sink.
     private let coreActions: any CoreActions
+    private let disappearingMessageDeletionWriter: DisappearingMessageDeletionWriter
 
     init(identityStore: any KeychainIdentityStoreProtocol,
          databaseWriter: any DatabaseWriter,
@@ -227,6 +229,7 @@ actor SyncingManager: SyncingManagerProtocol {
         self.databaseReader = databaseReader
         self.databaseWriter = databaseWriter
         self.coreActions = coreActions
+        self.disappearingMessageDeletionWriter = DisappearingMessageDeletionWriter(databaseWriter: databaseWriter)
         let enablementStore: any EnablementStore = GRDBEnablementStore(dbWriter: databaseWriter, dbReader: databaseReader)
         // The GRDB-backed subscription store is a Core-side type that doesn't
         // pull HealthKit; safe to construct unconditionally. The HKHealthStore-
@@ -261,6 +264,7 @@ actor SyncingManager: SyncingManagerProtocol {
         notificationTask?.cancel()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        messageDeletionStreamTask?.cancel()
         agentJoinPollTask?.cancel()
         currentTask?.cancel()
 
@@ -588,6 +592,7 @@ actor SyncingManager: SyncingManagerProtocol {
         Log.info("Starting message and conversation streams...")
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        messageDeletionStreamTask?.cancel()
 
         // Set up stream readiness tracking BEFORE creating tasks to avoid race conditions.
         // If we create tasks first, they might signal readiness before continuations are set up.
@@ -601,6 +606,11 @@ actor SyncingManager: SyncingManagerProtocol {
         conversationStreamTask = Task { [weak self, params] in
             guard let self else { return }
             await self.runConversationStream(params: params)
+        }
+
+        messageDeletionStreamTask = Task { [weak self, params] in
+            guard let self else { return }
+            await self.runMessageDeletionStream(params: params)
         }
 
         restartConsentReconciler(client: client)
@@ -647,6 +657,7 @@ actor SyncingManager: SyncingManagerProtocol {
             stopSessionScopedObservers()
             messageStreamTask?.cancel()
             conversationStreamTask?.cancel()
+            messageDeletionStreamTask?.cancel()
 
             if let task = messageStreamTask {
                 _ = await task.value
@@ -655,6 +666,10 @@ actor SyncingManager: SyncingManagerProtocol {
             if let task = conversationStreamTask {
                 _ = await task.value
                 conversationStreamTask = nil
+            }
+            if let task = messageDeletionStreamTask {
+                _ = await task.value
+                messageDeletionStreamTask = nil
             }
             emitStateChange(.paused(params))
             Log.debug("syncAllConversations completed, transitioned to paused (pause was requested during starting)")
@@ -871,6 +886,7 @@ actor SyncingManager: SyncingManagerProtocol {
         stopSessionScopedObservers()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        messageDeletionStreamTask?.cancel()
 
         if let task = messageStreamTask {
             _ = await task.value
@@ -879,6 +895,10 @@ actor SyncingManager: SyncingManagerProtocol {
         if let task = conversationStreamTask {
             _ = await task.value
             conversationStreamTask = nil
+        }
+        if let task = messageDeletionStreamTask {
+            _ = await task.value
+            messageDeletionStreamTask = nil
         }
 
         emitStateChange(.paused(params))
@@ -896,6 +916,7 @@ actor SyncingManager: SyncingManagerProtocol {
         // Restart streams
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        messageDeletionStreamTask?.cancel()
 
         // Set up stream readiness tracking BEFORE creating tasks to avoid race conditions.
         let streams = setupStreamReadinessTracking()
@@ -908,6 +929,11 @@ actor SyncingManager: SyncingManagerProtocol {
         conversationStreamTask = Task { [weak self, params] in
             guard let self else { return }
             await self.runConversationStream(params: params)
+        }
+
+        messageDeletionStreamTask = Task { [weak self, params] in
+            guard let self else { return }
+            await self.runMessageDeletionStream(params: params)
         }
 
         restartConsentReconciler(client: params.client)
@@ -1003,6 +1029,7 @@ actor SyncingManager: SyncingManagerProtocol {
         syncTask?.cancel()
         messageStreamTask?.cancel()
         conversationStreamTask?.cancel()
+        messageDeletionStreamTask?.cancel()
         agentJoinPollTask?.cancel()
 
         if let task = syncTask {
@@ -1016,6 +1043,10 @@ actor SyncingManager: SyncingManagerProtocol {
         if let task = conversationStreamTask {
             _ = await task.value
             conversationStreamTask = nil
+        }
+        if let task = messageDeletionStreamTask {
+            _ = await task.value
+            messageDeletionStreamTask = nil
         }
         if let task = agentJoinPollTask {
             _ = await task.value
@@ -1092,6 +1123,43 @@ actor SyncingManager: SyncingManagerProtocol {
         if !Task.isCancelled && retryCount >= maxStreamRetries {
             Log.error("Message stream: max retries (\(maxStreamRetries)) exceeded, giving up")
             enqueueAction(.streamFailed)
+        }
+    }
+
+    /// Mirrors libxmtp's deletion events into the separate Convos UI database.
+    /// The initial prune covers expiry that happened while the process was not
+    /// subscribed (terminated/backgrounded); live events provide exact removal
+    /// while the app is running.
+    private func runMessageDeletionStream(params: SyncClientParams) async {
+        var retryCount = 0
+
+        while !Task.isCancelled && retryCount < maxStreamRetries {
+            do {
+                if retryCount > 0 {
+                    let delay = TimeInterval.calculateExponentialBackoff(for: retryCount)
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                }
+
+                try await disappearingMessageDeletionWriter.pruneExpiredMessages()
+                let stream = params.client.conversationsProvider.streamMessageDeletions {
+                    Log.debug("Message deletion stream closed via onClose callback")
+                }
+                for try await message in stream {
+                    try Task.checkCancellation()
+                    try await disappearingMessageDeletionWriter.delete(messageId: message.id)
+                    retryCount = 0
+                }
+                retryCount += 1
+            } catch is CancellationError {
+                break
+            } catch {
+                retryCount += 1
+                Log.error("Message deletion stream error: \(error)")
+            }
+        }
+
+        if !Task.isCancelled && retryCount >= maxStreamRetries {
+            Log.error("Message deletion stream: max retries exceeded; cleanup will retry on next resume")
         }
     }
 

--- a/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
+++ b/ConvosCore/Sources/ConvosCore/Syncing/SyncingManager.swift
@@ -1140,10 +1140,13 @@ actor SyncingManager: SyncingManagerProtocol {
                     try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                 }
 
-                try await disappearingMessageDeletionWriter.pruneExpiredMessages()
                 let stream = params.client.conversationsProvider.streamMessageDeletions {
                     Log.debug("Message deletion stream closed via onClose callback")
                 }
+                // Subscribe first, then close the foreground/startup gap with
+                // a prune. A deletion that lands during pruning is observed by
+                // the live stream instead of waiting for the next resume.
+                try await disappearingMessageDeletionWriter.pruneExpiredMessages()
                 for try await message in stream {
                     try Task.checkCancellation()
                     try await disappearingMessageDeletionWriter.delete(messageId: message.id)
@@ -1159,7 +1162,8 @@ actor SyncingManager: SyncingManagerProtocol {
         }
 
         if !Task.isCancelled && retryCount >= maxStreamRetries {
-            Log.error("Message deletion stream: max retries exceeded; cleanup will retry on next resume")
+            Log.error("Message deletion stream: max retries exceeded")
+            enqueueAction(.streamFailed)
         }
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/ConversationExplosionWriterTests.swift
@@ -346,6 +346,7 @@ private final class RecordingMetadataWriter: ConversationMetadataWriterProtocol,
 
     func updateParticipationMode(_ mode: ConversationParticipationMode, for conversationId: String) async throws {}
     func updateSpaceURL(_ urlString: String?, for conversationId: String) async throws {}
+    func updateDisappearingMessages(_ duration: DisappearingMessageDuration?, for conversationId: String) async throws {}
     func updateIncludeInfoInPublicPreview(_ enabled: Bool, for conversationId: String) async throws {}
     func lockConversation(for conversationId: String) async throws {}
     func unlockConversation(for conversationId: String) async throws {}

--- a/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
@@ -178,15 +178,35 @@ struct DisappearingMessagesTests {
                 update: nil
             )
             try message.insert(db)
+            let reply = DBMessage(
+                id: "reply-xmtp-id",
+                clientMessageId: "reply-local-id",
+                conversationId: conversationId,
+                senderId: senderId,
+                dateNs: now.addingTimeInterval(1).nanosecondsSince1970,
+                date: now.addingTimeInterval(1),
+                sortId: nil,
+                status: .published,
+                messageType: .reply,
+                contentType: .text,
+                text: "keep me",
+                emoji: nil,
+                invite: nil,
+                linkPreview: nil,
+                sourceMessageId: "published-xmtp-id",
+                attachmentUrls: [],
+                update: nil
+            )
+            try reply.insert(db)
         }
 
         let writer = DisappearingMessageDeletionWriter(databaseWriter: databaseManager.dbWriter)
-        try await writer.delete(messageIds: ["stable-local-id"])
+        try await writer.deleteSelectedMessages(messageIds: ["stable-local-id"])
 
-        let remainingCount = try await databaseManager.dbReader.read { db in
-            try DBMessage.fetchCount(db)
+        let remainingIds = try await databaseManager.dbReader.read { db in
+            try String.fetchAll(db, sql: "SELECT id FROM message ORDER BY id")
         }
-        #expect(remainingCount == 0)
+        #expect(remainingIds == ["reply-xmtp-id"])
     }
 
     private func makeMessage(

--- a/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
@@ -5,9 +5,26 @@ import Testing
 
 @Suite("Disappearing messages", .serialized)
 struct DisappearingMessagesTests {
-    @Test("V1 timer choices match the product contract")
+    @Test("Timer choices match the product contract")
     func timerChoices() {
-        #expect(DisappearingMessageDuration.allCases.map(\.title) == ["24 hours", "7 days", "90 days"])
+        #expect(DisappearingMessageDuration.allCases.map(\.title) == [
+            "1 minute",
+            "5 minutes",
+            "1 hour",
+            "8 hours",
+            "24 hours",
+            "7 days",
+            "90 days",
+        ])
+        #expect(DisappearingMessageDuration.allCases.map(\.rawValue) == [
+            60_000_000_000,
+            300_000_000_000,
+            3_600_000_000_000,
+            28_800_000_000_000,
+            86_400_000_000_000,
+            604_800_000_000_000,
+            7_776_000_000_000_000,
+        ])
         #expect(DisappearingMessageDuration.privacyDefault == .twentyFourHours)
     }
 

--- a/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
@@ -123,6 +123,72 @@ struct DisappearingMessagesTests {
         #expect(remaining.2 == 0)
     }
 
+    @Test("A local client id resolves to its published message row")
+    func localClientMessageIdIsDeleted() async throws {
+        let databaseManager = MockDatabaseManager.makeTestDatabase()
+        let now = Date()
+        let conversationId = "manual-deletion-conversation"
+        let senderId = "sender"
+
+        try await databaseManager.dbWriter.write { db in
+            try DBMember(inboxId: senderId).save(db, onConflict: .ignore)
+            try DBConversation(
+                id: conversationId,
+                clientConversationId: "client-\(conversationId)",
+                inviteTag: "tag-\(conversationId)",
+                creatorId: senderId,
+                kind: .group,
+                consent: .allowed,
+                createdAt: now,
+                name: "Private conversation",
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAgent: false,
+                disappearingMessageRetentionDurationInNs: nil
+            ).insert(db)
+
+            let message = DBMessage(
+                id: "published-xmtp-id",
+                clientMessageId: "stable-local-id",
+                conversationId: conversationId,
+                senderId: senderId,
+                dateNs: now.nanosecondsSince1970,
+                date: now,
+                sortId: nil,
+                status: .published,
+                messageType: .original,
+                contentType: .text,
+                text: "delete me",
+                emoji: nil,
+                invite: nil,
+                linkPreview: nil,
+                sourceMessageId: nil,
+                attachmentUrls: [],
+                update: nil
+            )
+            try message.insert(db)
+        }
+
+        let writer = DisappearingMessageDeletionWriter(databaseWriter: databaseManager.dbWriter)
+        try await writer.delete(messageIds: ["stable-local-id"])
+
+        let remainingCount = try await databaseManager.dbReader.read { db in
+            try DBMessage.fetchCount(db)
+        }
+        #expect(remainingCount == 0)
+    }
+
     private func makeMessage(
         id: String,
         conversationId: String,

--- a/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/DisappearingMessagesTests.swift
@@ -1,0 +1,155 @@
+@testable import ConvosCore
+import Foundation
+import GRDB
+import Testing
+
+@Suite("Disappearing messages", .serialized)
+struct DisappearingMessagesTests {
+    @Test("V1 timer choices match the product contract")
+    func timerChoices() {
+        #expect(DisappearingMessageDuration.allCases.map(\.title) == ["24 hours", "7 days", "90 days"])
+        #expect(DisappearingMessageDuration.privacyDefault == .twentyFourHours)
+    }
+
+    @Test("Transcript notice communicates agent retention")
+    func transcriptNotice() {
+        let update = ConversationUpdate(
+            creator: .mock(isCurrentUser: true),
+            addedMembers: [],
+            removedMembers: [],
+            metadataChanges: [
+                .init(
+                    field: .disappearingMessages,
+                    oldValue: nil,
+                    newValue: String(DisappearingMessageDuration.sevenDays.rawValue)
+                ),
+            ]
+        )
+
+        #expect(update.summary.contains("turned on disappearing messages for 7 days"))
+        #expect(update.summary.contains("agent"))
+        #expect(update.summary.contains("outside Convos"))
+    }
+
+    @Test("Expired source messages and their replies leave the Convos database")
+    func expiredMessagesArePruned() async throws {
+        let databaseManager = MockDatabaseManager.makeTestDatabase()
+        let now = Date()
+        let conversationId = "disappearing-conversation"
+        let senderId = "sender"
+
+        try await databaseManager.dbWriter.write { db in
+            try DBMember(inboxId: senderId).save(db, onConflict: .ignore)
+            try DBConversation(
+                id: conversationId,
+                clientConversationId: "client-\(conversationId)",
+                inviteTag: "tag-\(conversationId)",
+                creatorId: senderId,
+                kind: .group,
+                consent: .allowed,
+                createdAt: now,
+                name: "Private conversation",
+                description: nil,
+                imageURLString: nil,
+                publicImageURLString: nil,
+                includeInfoInPublicPreview: false,
+                expiresAt: nil,
+                debugInfo: .empty,
+                isLocked: false,
+                imageSalt: nil,
+                imageNonce: nil,
+                imageEncryptionKey: nil,
+                conversationEmoji: nil,
+                imageLastRenewed: nil,
+                isUnused: false,
+                hasHadVerifiedAgent: false,
+                disappearingMessageRetentionDurationInNs: DisappearingMessageDuration.twentyFourHours.rawValue
+            ).insert(db)
+
+            try makeMessage(
+                id: "expired",
+                conversationId: conversationId,
+                senderId: senderId,
+                date: now.addingTimeInterval(-60),
+                expiresAtNs: now.addingTimeInterval(-1).nanosecondsSince1970
+            ).insert(db)
+            try makeMessage(
+                id: "reply-to-expired",
+                conversationId: conversationId,
+                senderId: senderId,
+                date: now,
+                sourceMessageId: "expired",
+                expiresAtNs: now.addingTimeInterval(60).nanosecondsSince1970
+            ).insert(db)
+            try makeMessage(
+                id: "still-present",
+                conversationId: conversationId,
+                senderId: senderId,
+                date: now,
+                expiresAtNs: now.addingTimeInterval(60).nanosecondsSince1970
+            ).insert(db)
+            try DBVoiceMemoTranscript(
+                messageId: "expired",
+                conversationId: conversationId,
+                attachmentKey: "file:///already-removed.m4a",
+                status: VoiceMemoTranscriptStatus.completed.rawValue,
+                text: "private transcript",
+                errorDescription: nil,
+                createdAt: now,
+                updatedAt: now
+            ).insert(db)
+            try DBPendingPhotoUpload(
+                id: "stale-upload",
+                clientMessageId: "expired",
+                conversationId: conversationId,
+                localCacheURL: "file:///already-removed.jpg",
+                state: .completed,
+                createdAt: now,
+                updatedAt: now
+            ).insert(db)
+        }
+
+        let writer = DisappearingMessageDeletionWriter(databaseWriter: databaseManager.dbWriter)
+        try await writer.pruneExpiredMessages(now: now)
+
+        let remaining = try await databaseManager.dbReader.read { db in
+            let messages = try String.fetchAll(db, sql: "SELECT id FROM message ORDER BY id")
+            let transcriptCount = try DBVoiceMemoTranscript.fetchCount(db)
+            let pendingUploadCount = try DBPendingPhotoUpload.fetchCount(db)
+            return (messages, transcriptCount, pendingUploadCount)
+        }
+        #expect(remaining.0 == ["still-present"])
+        #expect(remaining.1 == 0)
+        #expect(remaining.2 == 0)
+    }
+
+    private func makeMessage(
+        id: String,
+        conversationId: String,
+        senderId: String,
+        date: Date,
+        sourceMessageId: String? = nil,
+        expiresAtNs: Int64?
+    ) -> DBMessage {
+        DBMessage(
+            id: id,
+            clientMessageId: id,
+            conversationId: conversationId,
+            senderId: senderId,
+            dateNs: date.nanosecondsSince1970,
+            date: date,
+            sortId: nil,
+            status: .published,
+            messageType: sourceMessageId == nil ? .original : .reply,
+            contentType: .text,
+            text: "private",
+            emoji: nil,
+            invite: nil,
+            linkPreview: nil,
+            sourceMessageId: sourceMessageId,
+            attachmentUrls: [],
+            update: nil,
+            expiresAtNs: expiresAtNs
+        )
+    }
+}

--- a/ConvosCore/Tests/ConvosCoreTests/MessageDeletionSelectionTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/MessageDeletionSelectionTests.swift
@@ -1,0 +1,70 @@
+#if canImport(UIKit)
+@testable import ConvosComposer
+@testable import ConvosCore
+import Foundation
+import Testing
+
+@MainActor
+@Suite("Message deletion selection")
+struct MessageDeletionSelectionTests {
+    @Test("selection starts, toggles multiple messages, and cancels")
+    func selectionLifecycle() {
+        let first = makeMessage(id: "first", isCurrentUser: true)
+        let second = makeMessage(id: "second", isCurrentUser: false)
+        let state = MessageContextMenuState()
+
+        state.beginMessageSelection(with: first)
+        #expect(state.isSelectingMessages)
+        #expect(state.isMessageSelected(first))
+
+        state.toggleMessageSelection(second)
+        #expect(state.selectedMessages.count == 2)
+        #expect(state.isMessageSelected(second))
+
+        state.toggleMessageSelection(first)
+        #expect(state.selectedMessages == [second])
+
+        state.cancelMessageSelection()
+        #expect(!state.isSelectingMessages)
+        #expect(state.selectedMessages.isEmpty)
+    }
+
+    @Test("delete for everyone requires published messages authored by the user")
+    func deleteForEveryoneEligibility() {
+        let mine = makeMessage(id: "mine", isCurrentUser: true)
+        let incoming = makeMessage(id: "incoming", isCurrentUser: false)
+        let unpublished = makeMessage(id: "pending", isCurrentUser: true, status: .unpublished)
+        let state = MessageContextMenuState()
+
+        state.beginMessageSelection(with: mine)
+        #expect(state.canDeleteSelectionForEveryone)
+
+        state.toggleMessageSelection(incoming)
+        #expect(!state.canDeleteSelectionForEveryone)
+
+        state.beginMessageSelection(with: unpublished)
+        #expect(!state.canDeleteSelectionForEveryone)
+    }
+
+    private func makeMessage(
+        id: String,
+        isCurrentUser: Bool,
+        status: MessageStatus = .published
+    ) -> AnyMessage {
+        let sender = ConversationMember.mock(isCurrentUser: isCurrentUser)
+        return .message(
+            Message(
+                id: "local-\(id)",
+                xmtpId: status == .published ? "aabb\(id.utf8.count)" : nil,
+                sender: sender,
+                source: isCurrentUser ? .outgoing : .incoming,
+                status: status,
+                content: .text(id),
+                date: Date(),
+                reactions: []
+            ),
+            .existing
+        )
+    }
+}
+#endif

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -284,6 +284,12 @@ class TestableMockConversations: ConversationsProvider, @unchecked Sendable {
             }
         }
     }
+
+    func streamMessageDeletions(
+        onClose: (() -> Void)?
+    ) -> AsyncThrowingStream<DecodedMessageV2, any Error> {
+        AsyncThrowingStream { continuation in continuation.finish() }
+    }
 }
 
 class TestableMockGroupConversationSender: GroupConversationSender {

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -237,6 +237,8 @@ class TestableMockConversations: ConversationsProvider, @unchecked Sendable {
         nil
     }
 
+    func deleteMessageLocally(messageId: String) throws {}
+
     func findOrCreateDm(with peerInboxId: String) async throws -> XMTPiOS.Dm {
         fatalError("not implemented in test mock")
     }

--- a/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/SyncingManagerTests.swift
@@ -290,7 +290,24 @@ class TestableMockConversations: ConversationsProvider, @unchecked Sendable {
     func streamMessageDeletions(
         onClose: (() -> Void)?
     ) -> AsyncThrowingStream<DecodedMessageV2, any Error> {
-        AsyncThrowingStream { continuation in continuation.finish() }
+        let behavior = streamBehavior
+        return AsyncThrowingStream { continuation in
+            switch behavior {
+            case .neverClose, .delayedStart:
+                break
+            case .throwImmediately:
+                continuation.finish(
+                    throwing: NSError(
+                        domain: "test",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Deletion stream failed"]
+                    )
+                )
+            case .empty, .emitOneThenClose, .emitMultipleThenClose:
+                onClose?()
+                continuation.finish()
+            }
+        }
     }
 }
 

--- a/ConvosTests/DisappearingMessagesPreferencesTests.swift
+++ b/ConvosTests/DisappearingMessagesPreferencesTests.swift
@@ -1,0 +1,24 @@
+@testable import Convos
+import ConvosCore
+import XCTest
+
+final class DisappearingMessagesPreferencesTests: XCTestCase {
+    func testAgentPauseDefaultsToTwentyFourHours() {
+        let conversationId = UUID().uuidString
+
+        XCTAssertEqual(
+            DisappearingMessagesPreferences.durationWhenAgentsPause(conversationId: conversationId),
+            .twentyFourHours
+        )
+    }
+
+    func testAgentPauseUsesTheLastSelectedTimer() {
+        let conversationId = UUID().uuidString
+        DisappearingMessagesPreferences.remember(.sevenDays, conversationId: conversationId)
+
+        XCTAssertEqual(
+            DisappearingMessagesPreferences.durationWhenAgentsPause(conversationId: conversationId),
+            .sevenDays
+        )
+    }
+}


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE — Shane Mac product/design exploration.** This draft is for hands-on validation of the V1 experience and privacy language.

## Product intent

A deliberately small disappearing-conversations MVP that borrows the familiar WhatsApp/Signal model and adds only the privacy communication required for chats that include agents.

## V1 experience

- Adds a **Disappearing messages** row to conversation settings.
- Offers only **Off, 1 minute, 5 minutes, 1 hour, 8 hours, 24 hours, 7 days, and 90 days**.
- Adds **Turn on disappearing messages when an agent is paused** as a per-conversation, per-device toggle. It uses the last selected timer or defaults to **24 hours**.
- When someone pauses agents without an active timer, asks once whether to **Pause only** or **Pause + turn on disappearing messages**.
- Shows timer metadata in the conversation list and chat toolbar.
- Adds transcript/settings communication that agents can save messages outside Convos, including: **“An agent is listening and may save these messages even after they disappear from Convos.”**


## Message deletion

- Long-press a message, choose **Delete**, check one or more messages, then tap the trash button.
- **Delete for me** removes the selected messages from this installation only.
- **Delete for everyone** appears only when every selected message was sent by the current user and has finished publishing; it sends XMTP message-deletion events.
- The confirmation warns that agents may still retain copies outside Convos.
- This V1 does not expose super-admin deletion of other people’s messages and does not add an Undo flow.

## XMTP implementation

This uses XMTP's native conversation-wide disappearing-message support instead of a Convos-only timer:

- The SDK models a start timestamp plus retention duration in [`DisappearingMessageSettings`](https://github.com/xmtp/libxmtp/blob/e5f29a646cf6eef7a29a932e459e31d46428c168/sdks/ios/Sources/XMTPiOS/Libxmtp/DisappearingMessageSettings.swift).
- Group changes call XMTP's native [`updateDisappearingMessageSettings`](https://github.com/xmtp/libxmtp/blob/e5f29a646cf6eef7a29a932e459e31d46428c168/sdks/ios/Sources/XMTPiOS/Group.swift#L371).
- Convos persists XMTP's exact per-message [`expiresAtNs`](https://github.com/xmtp/libxmtp/blob/e5f29a646cf6eef7a29a932e459e31d46428c168/sdks/ios/Sources/XMTPiOS/Libxmtp/DecodedMessage.swift#L127) and mirrors XMTP's [`streamMessageDeletions`](https://github.com/xmtp/libxmtp/blob/e5f29a646cf6eef7a29a932e459e31d46428c168/sdks/ios/Sources/XMTPiOS/Conversations.swift#L753) into the separate Convos UI database.
- Expiry cleanup also removes replies/reactions attached to the vanished message, voice transcripts, pending attachment state, persistent image data, and downloaded file caches.

## Privacy boundary

Disappearing messages remove XMTP/Convos copies on the selected schedule. They **cannot revoke a copy already stored outside Convos** by an agent integration, screenshot, export, notification surface, or another external system. The V1 communicates that limitation; it does not claim to enforce deletion in systems an agent is connected to.

## Explicit non-goals

- Custom timers or kept-message exceptions
- A global default timer for every new conversation
- Remote deletion guarantees for agent-connected storage
- New agent controls beyond the existing pause interaction
- Product invention beyond the requested privacy communication

## Validation

- Focused disappearing-message and message-deletion suites — 7 tests passed
- `xcodebuild` Dev scheme, arm64 iOS Simulator — build succeeded twice
- SwiftFormat — clean
- SwiftLint strict on all changed Swift files — clean
- Impeccable product-design detector on all changed UI surfaces — no findings

Base verified against the latest fetched `dev`: `8cb5a240b9addb37419bc27a3e578ca938dc19cd`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790096434&installation_model_id=20076&pr_number=1413&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1413&signature=b984aeb6cc4076b3ddf5e29392efad0b9edfa633649b0870959dcddd0776c9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add disappearing messages for human and agentic conversations
> - Adds `DisappearingMessagesView` to configure message retention durations (Off, 24 hours, 7 days, 90 days) and persist per-conversation preferences.
> - Introduces `DisappearingMessageDeletionWriter` and a message deletion stream in `SyncingManager` to prune expired messages locally and process live deletions, cleaning up local file and image caches.
> - Extends `DBConversation` and `DBMessage` to persist `disappearingMessageRetentionDurationInNs` and `expiresAtNs`, backed by a new DB migration in `SharedDatabaseMigrator`.
> - Updates conversation list, toolbar, and info views to display timer icons, accessibility labels, and agent-listening warnings when disappearing messages are active.
> - Behavioral Change: `ConversationView.selectParticipationLevel` now conditionally prompts or auto-enables disappearing messages before pausing agents, instead of immediately pausing.
> - Risk: `ConversationsProvider` protocol gains `streamMessageDeletions(onClose:)` requirement in `XMTPClientProvider.swift`; out-of-tree implementations must add this method.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b01c876. 24 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->