### PR TITLE
feat: wire the agent stop button to the interrupt endpoint

### DIFF
--- a/Convos/Conversation Detail/AgentDmPageView.swift
+++ b/Convos/Conversation Detail/AgentDmPageView.swift
@@ -516,6 +516,7 @@ struct AgentDmPageView: View {
             descriptor: descriptor,
             conversation: dmVm.conversation,
             viewModel: dmVm,
+            onStop: { Task { await dmVm.interruptAgent() } },
             profileSheetForMember: { member in AnyView(memberContactDetailSheet(for: member, dmVm: dmVm)) }
         )
     }

--- a/Convos/Conversation Detail/ConversationView.swift
+++ b/Convos/Conversation Detail/ConversationView.swift
@@ -713,6 +713,7 @@ private extension ConversationView {
                     descriptor: descriptor,
                     conversation: viewModel.conversation,
                     viewModel: viewModel,
+                    onStop: { Task { await viewModel.interruptAgent() } },
                     profileSheetForMember: profileSheetForMember
                 )
             }

--- a/Convos/Conversation Detail/ConversationViewModel.swift
+++ b/Convos/Conversation Detail/ConversationViewModel.swift
@@ -1637,6 +1637,27 @@ class ConversationViewModel: Identifiable, Hashable { // swiftlint:disable:this 
         }
     }
 
+    /// Stops the turn the conversation's agents are running right now — the stop
+    /// button. A fire-once control-plane call that injects no message and
+    /// persists nothing; the backend reports how many agents were actually
+    /// running, and stopping an idle one is a successful no-op. Quiet on
+    /// failure: the thinking indicator resolves on its own from the runtime.
+    func interruptAgent() async {
+        let conversation = self.conversation
+        guard !conversation.isDraft else { return }
+        do {
+            let client = ConvosAPIClientFactory.client(
+                environment: ConfigManager.shared.currentEnvironment
+            )
+            _ = try await client.interruptAgent(
+                conversationId: conversation.id,
+                variantId: conversationAgentVariantSlug
+            )
+        } catch {
+            Log.error("agent interrupt failed: \(error)")
+        }
+    }
+
     private func scheduleAgentPowerRefresh() {
         agentPowerRefreshTask?.cancel()
         agentPowerRefreshTask = Task { [weak self] in

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient+Models.swift
@@ -436,6 +436,24 @@ public enum ConvosAPI {
             }
         }
     }
+
+    /// Result of a stop: the conversation's agents were asked to interrupt the
+    /// turn they are running now, without a chat message being sent. Nothing is
+    /// persisted — a stop is a transient signal to whatever is running.
+    public struct AgentInterruptResponse: Codable {
+        public let success: Bool
+        public let conversationId: String
+        /// How many of the conversation's agents actually had a turn running to
+        /// stop. Zero is a successful no-op — stopping an idle agent stops
+        /// nothing. Optional so a control plane that predates the field decodes.
+        public let interrupted: Int?
+
+        public init(success: Bool, conversationId: String, interrupted: Int? = nil) {
+            self.success = success
+            self.conversationId = conversationId
+            self.interrupted = interrupted
+        }
+    }
 }
 
 extension ConvosAPI {

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -127,6 +127,15 @@ public protocol ConvosAPIClientProtocol: AnyObject, Sendable {
         variantId: String?
     ) async throws -> ConvosAPI.AgentParticipationResponse
 
+    /// Stops the turn the conversation's agents are running right now, without
+    /// injecting a chat message — the stop button, not a message the user
+    /// sends. Same control-plane hop and variant routing as participation.
+    /// Idempotent: an agent with no turn running is a successful no-op.
+    func interruptAgent(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentInterruptResponse
+
     /// Mints the paste-ready Space share message for a conversation: one
     /// sentence naming the receiving agent's import skill plus a clone URL
     /// carrying an expiring read-only repository credential. The caller puts
@@ -1048,6 +1057,24 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         // Read on open; the control falls back to its default if this is slow,
         // so it must not hold the view.
         request.timeoutInterval = 10
+        return try await performRequest(request)
+    }
+
+    func interruptAgent(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentInterruptResponse {
+        // Same worker-routing constraint as participation: an agent provisioned
+        // on a variant worker only exists there, so a stop that omits the
+        // variantId lands on the default worker and stops nothing.
+        var request = try authenticatedRequest(
+            for: "v2/conversations/\(participationPathComponent(conversationId))/interrupt",
+            method: "POST",
+            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
+        )
+        // No body: the stop carries no state, it just signals whatever is
+        // running now. Bounded so a stuck call cannot leave the control spinning.
+        request.timeoutInterval = 20
         return try await performRequest(request)
     }
 

--- a/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/ConvosAPIClient.swift
@@ -1060,24 +1060,6 @@ final class ConvosAPIClient: ConvosAPIClientProtocol, Sendable {
         return try await performRequest(request)
     }
 
-    func interruptAgent(
-        conversationId: String,
-        variantId: String?
-    ) async throws -> ConvosAPI.AgentInterruptResponse {
-        // Same worker-routing constraint as participation: an agent provisioned
-        // on a variant worker only exists there, so a stop that omits the
-        // variantId lands on the default worker and stops nothing.
-        var request = try authenticatedRequest(
-            for: "v2/conversations/\(participationPathComponent(conversationId))/interrupt",
-            method: "POST",
-            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
-        )
-        // No body: the stop carries no state, it just signals whatever is
-        // running now. Bounded so a stuck call cannot leave the control spinning.
-        request.timeoutInterval = 20
-        return try await performRequest(request)
-    }
-
     private func participationPathComponent(_ conversationId: String) -> String {
         conversationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? conversationId
     }
@@ -1368,6 +1350,27 @@ extension ConvosAPIClient {
     /// stays byte-identical to the pre-variant shape.
     static func agentJoinStatusQueryParameters(variantId: String?) -> [String: String]? {
         variantId.map { ["variantId": $0] }
+    }
+
+    /// Lives in an extension (not the main class body) only to keep
+    /// `ConvosAPIClient` under SwiftLint's `type_body_length`; behaviorally it
+    /// is a sibling of `setAgentParticipation`.
+    func interruptAgent(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentInterruptResponse {
+        // Same worker-routing constraint as participation: an agent provisioned
+        // on a variant worker only exists there, so a stop that omits the
+        // variantId lands on the default worker and stops nothing.
+        var request = try authenticatedRequest(
+            for: "v2/conversations/\(participationPathComponent(conversationId))/interrupt",
+            method: "POST",
+            queryParameters: prodSafeVariantId(variantId).map { ["variantId": $0] }
+        )
+        // No body: the stop carries no state, it just signals whatever is
+        // running now. Bounded so a stuck call cannot leave the control spinning.
+        request.timeoutInterval = 20
+        return try await performRequest(request)
     }
 
     func requestAgentJoin(

--- a/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
+++ b/ConvosCore/Sources/ConvosCore/API/MockAPIClient.swift
@@ -132,6 +132,13 @@ final class MockAPIClient: ConvosAPIClientProtocol, Sendable {
         .init(success: true, conversationId: conversationId, mode: "speak")
     }
 
+    func interruptAgent(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentInterruptResponse {
+        .init(success: true, conversationId: conversationId, interrupted: 0)
+    }
+
     func shareSpace(
         conversationId: String,
         variantId: String?

--- a/ConvosCore/Tests/ConvosCoreIntegrationTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreIntegrationTests/TestStubAPIClientDefaults.swift
@@ -76,6 +76,20 @@ extension ConvosAPIClientProtocol {
         )
     }
 
+    /// Default for the stop control so pre-existing stubs don't re-stub it.
+    /// Reports the idle no-op (nothing was running to stop). Tests that
+    /// exercise the interrupt flow should override this on their fixture.
+    func interruptAgent(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentInterruptResponse {
+        ConvosAPI.AgentInterruptResponse(
+            success: true,
+            conversationId: conversationId,
+            interrupted: 0
+        )
+    }
+
     /// Default for the Space share mint so pre-existing stubs don't re-stub
     /// it. Tests that exercise the share flow should override on their
     /// fixture.

--- a/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
+++ b/ConvosCore/Tests/ConvosCoreTests/TestStubAPIClientDefaults.swift
@@ -74,6 +74,20 @@ extension ConvosAPIClientProtocol {
         )
     }
 
+    /// Default for the stop control so pre-existing stubs don't re-stub it.
+    /// Reports the idle no-op (nothing was running to stop). Tests that
+    /// exercise the interrupt flow should override this on their fixture.
+    func interruptAgent(
+        conversationId: String,
+        variantId: String?
+    ) async throws -> ConvosAPI.AgentInterruptResponse {
+        ConvosAPI.AgentInterruptResponse(
+            success: true,
+            conversationId: conversationId,
+            interrupted: 0
+        )
+    }
+
     /// Default for the Space share mint so pre-existing stubs don't re-stub
     /// it. Tests that exercise the share flow should override on their
     /// fixture.


### PR DESCRIPTION
The stop button on the agent "Thinking" sheet was **rendered but dead**. `ThinkingDetailView` already draws it (gated on the session being active) and calls its `onStop` closure — but both hosts constructed the view **without passing `onStop`**, so it defaulted to the no-op `{}`. Tapping it did nothing.

This wires it to the new server-side stop path (backend `POST /api/v2/conversations/:id/interrupt` → assistants Worker → Hermes `interrupt()`), which stops the turn the conversation's agents are running right now **without injecting a chat message**.

## What
Mirrors the existing participation control end to end:

- **`ConvosAPIClient`** — `interruptAgent(conversationId:variantId:)`, POSTing to `v2/conversations/:id/interrupt` with the same auth header and variant routing as participation; adds the `AgentInterruptResponse` model and the `MockAPIClient` stub.
- **`ConversationViewModel`** — `interruptAgent()`, a fire-once call, quiet on failure: the thinking indicator resolves itself from the runtime once the turn ends.
- **`ConversationView` / `AgentDmPageView`** — pass `onStop: { Task { await viewModel.interruptAgent() } }` into `ThinkingDetailView` so the existing button actually fires.

Nothing is persisted — a stop is a transient signal, and stopping an idle agent is a successful no-op.

## Dependencies
Needs the server side, which adds the backend route and the Worker/Hermes handler: xmtplabs/convos-assistants#3608. This iOS change is inert until that ships (the endpoint 404s), but it does no harm before then — the button just fails quietly, exactly as it does today.

## Verification
The change is minimal (+75 lines) and mirrors the proven participation path. It was authored in an environment without an Xcode/Swift toolchain, so the build and the on-device button behavior are **not locally verified** — CI and a manual check on the thinking sheet should confirm both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwzS9WTmQHxxGGM5ciGXk5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790161836&installation_model_id=20076&pr_number=1419&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1419&signature=cc4ae8de8c180a212f3372d7cc171d4650a8d56da230af7f0c428059dbbd3716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire agent stop button to `interruptAgent` endpoint
> - Adds `ConvosAPIClient.interruptAgent`, a POST to `v2/conversations/{id}/interrupt` with optional `variantId` query and a 20s timeout, plus the `AgentInterruptResponse` Codable model.
> - Adds `ConversationViewModel.interruptAgent`, a fire-and-forget async method that no-ops for draft conversations and logs failures without surfacing errors.
> - Passes an `onStop` closure into `ThinkingDetailView` from both `AgentDmPageView` and `ConversationView`, which launches a `Task` awaiting `interruptAgent()`.
> - Provides default `interruptAgent` stubs in `MockAPIClient` and test protocol extensions so existing fixtures compile.
> - Risk: `ConversationViewModel.interruptAgent` swallows failures silently — callers in `AgentDmPageView` and `ConversationView` get no user-facing feedback when the interrupt request fails or times out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c903c7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->