### PR TITLE
Relay: scroll to newest, drop the duplicate settings row, and rename copy-to-agent to Copy to Relay

### DIFF
--- a/Convos/Agent Chat/AgentChatView.swift
+++ b/Convos/Agent Chat/AgentChatView.swift
@@ -19,6 +19,8 @@ struct AgentChatView: View {
     @State private var copyText: AgentConversationCopy?
     @State private var showingDisconnectConfirmation: Bool = false
     @State private var showingClearHistoryConfirmation: Bool = false
+    @State private var isPinnedToBottom: Bool = true
+    @State private var hasPositionedInitialScroll: Bool = false
     @FocusState private var composerFocus: MessagesViewInputFocus?
     @Environment(\.dismiss) private var dismiss: DismissAction
 
@@ -141,11 +143,49 @@ struct AgentChatView: View {
                 .padding(DesignConstants.Spacing.step4x)
             }
             .scrollDismissesKeyboard(.interactively)
+            .onAppear { handleTranscriptAppeared(proxy: proxy) }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                isTranscriptPinnedToBottom(geometry)
+            } action: { _, isPinned in
+                isPinnedToBottom = isPinned
+            }
             .onChange(of: viewModel.turns) { _, turns in
-                guard let last = turns.last else { return }
-                withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                handleTurnsChanged(turns, proxy: proxy)
             }
         }
+    }
+
+    private func handleTranscriptAppeared(proxy: ScrollViewProxy) {
+        guard !hasPositionedInitialScroll, !viewModel.turns.isEmpty else { return }
+        scrollToLastTurn(proxy: proxy, animated: false)
+        hasPositionedInitialScroll = true
+    }
+
+    private func handleTurnsChanged(_ turns: [AgentTurn], proxy: ScrollViewProxy) {
+        guard !turns.isEmpty else { return }
+        if !hasPositionedInitialScroll {
+            scrollToLastTurn(proxy: proxy, animated: false)
+            hasPositionedInitialScroll = true
+        } else if isPinnedToBottom {
+            scrollToLastTurn(proxy: proxy, animated: true)
+        }
+    }
+
+    private func scrollToLastTurn(proxy: ScrollViewProxy, animated: Bool) {
+        guard let lastID: AgentTurn.ID = viewModel.turns.last?.id else { return }
+        if animated {
+            withAnimation { proxy.scrollTo(lastID, anchor: .bottom) }
+        } else {
+            proxy.scrollTo(lastID, anchor: .bottom)
+            // Lazy rows may not have completed their first layout yet.
+            DispatchQueue.main.async { proxy.scrollTo(lastID, anchor: .bottom) }
+        }
+    }
+
+    private func isTranscriptPinnedToBottom(_ geometry: ScrollGeometry) -> Bool {
+        let visibleBottom: CGFloat = geometry.contentOffset.y + geometry.containerSize.height
+        let distanceFromBottom: CGFloat = geometry.contentSize.height - visibleBottom
+        return distanceFromBottom <= Constant.bottomPinThreshold
     }
 
     private func turnPair(_ turn: AgentTurn) -> some View {
@@ -351,6 +391,8 @@ struct AgentChatView: View {
     }
 
     private enum Constant {
+        static let bottomPinThreshold: CGFloat = 40.0
+
         /// The conversation composer's capsule radius, so the two bars are the
         /// same shape.
         static let composerCornerRadius: CGFloat = 26.0

--- a/Convos/Agent Chat/AgentsUnavailableView.swift
+++ b/Convos/Agent Chat/AgentsUnavailableView.swift
@@ -11,7 +11,7 @@ struct AgentsUnavailableView: View {
             Text("Relay is unavailable")
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(.colorTextPrimary)
-            Text("Convos could not open its agent storage on this iPhone. Restarting the app usually clears it.")
+            Text("Convos could not open its Relay storage on this iPhone. Restarting the app usually clears it.")
                 .font(.callout)
                 .foregroundStyle(.colorTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Convos/Agent Chat/TaskletSetupView.swift
+++ b/Convos/Agent Chat/TaskletSetupView.swift
@@ -91,7 +91,7 @@ struct TaskletSetupView: View {
                 .disabled(viewModel.isBusy)
             AgentConnectionTestStatusView(state: viewModel.state, provider: .tasklet)
             if viewModel.isConnected {
-                NavigationLink("Open agent chat") {
+                NavigationLink("Open Relay") {
                     AgentChatView(provider: .tasklet, dependencies: dependencies, session: session)
                 }
                 let disconnectAction = { showingDisconnectConfirmation = true }

--- a/Convos/Agent Chat/TownSetupView.swift
+++ b/Convos/Agent Chat/TownSetupView.swift
@@ -105,7 +105,7 @@ struct TownSetupView: View {
                 .disabled(viewModel.isBusy)
             AgentConnectionTestStatusView(state: viewModel.state, provider: .town)
             if viewModel.isConnected {
-                NavigationLink("Open agent chat") {
+                NavigationLink("Open Relay") {
                     AgentChatView(provider: .town, dependencies: dependencies, session: session)
                 }
                 let disconnectAction = { showingDisconnectConfirmation = true }

--- a/Convos/App Settings/AppSettingsView.swift
+++ b/Convos/App Settings/AppSettingsView.swift
@@ -63,7 +63,6 @@ struct AppSettingsView: View {
     @State private var showingDeleteAllDataConfirmation: Bool = false
     @Environment(\.openURL) private var openURL: OpenURLAction
     @Environment(\.dismiss) private var dismiss: DismissAction
-    @Environment(\.agentRelayDependencies) private var agentRelayDependencies: AgentRelayDependencies?
     @State private var navState: AppSettingsNavigatorImpl = .init()
     @State private var navigator: AppSettingsCollector?
     @State private var versionTapCount: Int = 0
@@ -96,9 +95,6 @@ struct AppSettingsView: View {
                 myInfoSection
                 subscriptionSection
                 connectionsSection
-                if FeatureFlags.shared.agentRelayEnabled {
-                    agentsSection
-                }
                 devicesSection
                 customizeSection
                 linksSection
@@ -251,26 +247,6 @@ struct AppSettingsView: View {
             .accessibilityIdentifier("connections-row")
         } footer: {
             Text("Apps and info agents can use")
-        }
-    }
-
-    @ViewBuilder
-    private var agentsSection: some View {
-        Section {
-            if let agentRelayDependencies {
-                NavigationLink {
-                    AgentsHomeView(mode: .settingsPage, dependencies: agentRelayDependencies, session: session)
-                } label: {
-                    Label("Relay", systemImage: "sparkles")
-                        .foregroundStyle(.colorTextPrimary)
-                }
-                .accessibilityIdentifier("agents-row")
-            } else {
-                Label("Relay unavailable", systemImage: "sparkles")
-                    .foregroundStyle(.colorTextSecondary)
-            }
-        } footer: {
-            Text("Chat privately with an agent you already use")
         }
     }
 

--- a/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
+++ b/ConvosCore/Sources/ConvosComposer/MessagesListView/MessageContextMenu/MessageContextMenuOverlay.swift
@@ -533,7 +533,7 @@ public struct MessageContextMenuOverlay: View {
                             dismissMenu()
                             onCopyToAgent(text)
                         }
-                        ContextMenuRow(icon: "sparkles", title: "Copy to agent", action: agentAction)
+                        ContextMenuRow(icon: "antenna.radiowaves.left.and.right", title: "Copy to Relay", action: agentAction)
                     }
                 }
 


### PR DESCRIPTION
The Relay chat transcript could open scrolled to the middle instead of landing on the newest message. Turns get loaded synchronously at init and then re-populated by an async stream, and the transcript's only auto-scroll was an `onChange` on that turns array - which didn't fire for the initial load, and when it did fire for the stream's first emission, it raced the list's lazy layout and could land short.

Fixed by tracking whether the reader is pinned to the bottom and positioning the transcript on the newest turn as soon as the view appears or turns first populate, with a follow-up correction after layout catches up. The initial jump doesn't animate. If someone has scrolled up to read earlier history, a newly appended turn won't yank them back down.

Also dropped the "Relay" row from App Settings - it opened the exact same screen as the Relay tab behind the same flag, so it was a duplicate entry point.

Stacked on top of the agent relay work that just landed in #1410 and #1411.

Also renamed the "Copy to agent" message action to "Copy to Relay" with the relay tab's icon, and "Open agent chat" to "Open Relay" in the Town/Tasklet setup screens, plus the matching storage-unavailable copy - cleanup left over from when this was internally called "agents".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/xmtplabs/codesmith/convos-ios/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790173072&installation_model_id=20076&pr_number=1420&repository=xmtplabs%2Fconvos-ios&return_to=https%3A%2F%2Fgithub.com%2Fxmtplabs%2Fconvos-ios%2Fpull%2F1420&signature=57ef4cde87c3730759cf5321d8ee761931572fed1483ffe6c052c044847d89fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-scroll to newest in `AgentChatView`, remove duplicate Relay row, rename copy-to-agent to "Copy to Relay"
> - `AgentChatView` now scrolls to the newest turn only when the transcript is pinned to bottom; on first appear it scrolls once without animation. New helpers `handleTranscriptAppeared`, `handleTurnsChanged`, `scrollToLastTurn`, and `isTranscriptPinnedToBottom` gate this behavior using `Constant.bottomPinThreshold`.
> - Removes `agentsSection` from `AppSettingsView`, so the Settings page no longer shows a Relay row.
> - Updates user-facing copy: "agent storage" → "Relay storage" in `AgentsUnavailableView`, "Open agent chat" → "Open Relay" in `TaskletSetupView` and `TownSetupView`, and "Copy to agent" → "Copy to Relay" with a new icon in `MessageContextMenuOverlay`.
> - Behavioral Change: transcript no longer auto-scrolls on new turns when the user has scrolled up; reviewers should verify `isTranscriptPinnedToBottom` threshold logic in [AgentChatView.swift](https://github.com/xmtplabs/convos-ios/pull/1420/files#diff-df4e2dba5258ffd729843eadfd3ed0782c83adf42025513cf34b4f6b0ef63da8) behaves as expected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c433dac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
